### PR TITLE
Fix compiler warning: type qualifiers ignored on function return type

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -765,7 +765,7 @@ static bool json_fprintf_value_long(FILE *stream, char const *lead, char const *
 				    char const *tail);
 static bool json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char const *middle, bool value,
 				    char const *tail);
-static char const * const strnull(char const * const str);
+static char const * strnull(char const * const str);
 static void write_info(struct info *infop, char const *entry_dir, bool test_mode);
 static void write_author(struct info *infop, int author_count, struct author *authorp, char const *entry_dir);
 static void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar, char const *ls);


### PR DESCRIPTION
This fixes the following compiler warning:

```
mkiocccentry.c:768:13: error: type qualifiers ignored on function return type [-Wignored-qualifiers]
 static char const * const strnull(char const * const str);
             ^~~~~
```