### PR TITLE
Fix signed/unsigned comparison in get_contest_id

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3125,7 +3125,7 @@ get_contest_id(struct info *infop, bool *testp)
     unsigned int a, b, c, d, e, f;	/* parts of the UUID string */
     unsigned int version = 0;	/* UUID version hex character */
     unsigned int variant = 0;	/* UUID variant hex character */
-    int i;
+    size_t i;
 
     /*
      * firewall


### PR DESCRIPTION
This fixes the following compiler warning:

```
mkiocccentry.c: In function ‘get_contest_id’:
mkiocccentry.c:3222:16: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  for (i = 0; i < len; ++i) {
                ^
```