### PR TITLE
Compatibility with other compilers.

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -240,7 +240,7 @@ struct info {
      * time
      */
     time_t tstamp;		/* seconds since epoch when .info json was formed (see gettimeofday(2)) */
-    suseconds_t usec;		/* microseconds since the tstamp second */
+    int usec;			/* microseconds since the tstamp second */
     char *epoch;		/* epoch of tstamp, currently: Thr Jan 1 00:00:00 1970 UTC */
     char *gmtime;		/* UTC converted string for tstamp (see asctime(3)) */
 };
@@ -979,7 +979,7 @@ main(int argc, char *argv[])
     /*
      * All Done!!! - Jessica Noll, age 2
      */
-    exit(0); /*ooo*/
+    return 0; /*ooo*/
 }
 
 
@@ -1508,7 +1508,7 @@ file_size(char const *path)
     ret = stat(path, &buf);
     if (ret < 0) {
 	dbg(DBG_HIGH, "path %s does not exist, stat returned: %d", path, ret);
-	return -1;
+	return ~(size_t)0;
     }
 
     /*


### PR DESCRIPTION
TenDRA:

`  [C90 6.5.2]: The type 'suseconds_t' hasn't been declared.`

Better to avoid this type, it's uncommon. But `int` type is enough to hold microseconds.

Little C compiler:

`mkiocccentry.c:984: warning: missing return value`

Also needed for C89 compilers that don't know that exit() doesn't return.

Little C compiler:

```
mkiocccentry.c:1512: warning: overflow in converting constant expression from `int' to `unsigned long'
```

```c
static size_t
file_size(char const *path)
```
Here:
```c
	return -1;
```
I did this:
```c
	return ~(size_t)0;
```

I can't still fully compile with TenDRA due to the missing `ssize_t`. And linking with LCC is failed, but at least it compiles. 