### PR TITLE
Changed "U+2013 EN DASH" to "U+002D HYPHEN-MINUS".

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3864,7 +3864,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		      "",
 		      "The basename of an extra file can only consist of POSIX Fully portable characters and +:",
 		      "",
-		      "    A–Z a–z 0–9 . _ - +",
+		      "    A-Z a-z 0-9 . _ - +",
 		      "",
 		      NULL);
 		err(146, __func__, "basename of %s character %ld is NOT a POSIX Fully portable character nor +", args[i], (long)j);


### PR DESCRIPTION
The TenDRA compiler found another issue: 

`		      "    A–Z a–z 0–9 . _ - +",`

```
mkiocccentry.c, line 3868: Error:
  [C90 6.1.3.4]: Character out of range.
```

And finally mkioccccentry is compiled with TenDRA but I can't link it properly. 