### PR TITLE
Ignoring warnings with answer file fixes

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1032,17 +1032,19 @@ main(int argc, char *argv[])
     /*
      * finalize the answers file
      */
-    if (answerp != NULL && a_flag_used == true) {
-	errno = 0;			/* pre-clear errno for errp() */
-	ret = fprintf(answerp, "y\n");
-	if (ret <= 0) {
-	    warnp(__func__, "unable to write confirming y to the answers file");
-	}
-	errno = 0;			/* pre-clear errno for errp() */
-	ret = fflush(answerp);
-	if (ret != 0) {
-	    errp(6, __func__, "error in flushing data to the answers file");
-	    not_reached();
+    if (answerp != NULL) {
+	if (a_flag_used == true) {
+	    errno = 0;			/* pre-clear errno for errp() */
+	    ret = fprintf(answerp, "y\n");
+	    if (ret <= 0) {
+		warnp(__func__, "unable to write confirming y to the answers file");
+	    }
+	    errno = 0;			/* pre-clear errno for errp() */
+	    ret = fflush(answerp);
+	    if (ret != 0) {
+		errp(6, __func__, "error in flushing data to the answers file");
+		not_reached();
+	    }
 	}
 	ret = fclose(answerp);
 	if (ret != 0) {

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1030,7 +1030,8 @@ main(int argc, char *argv[])
     para("... completed .author.json file.", "", NULL);
 
     /*
-     * finalize the answers file
+     * finalize the answers file, writing final answers (if writing answers) and
+     * then closing the stream.
      */
     if (answerp != NULL) {
 	if (a_flag_used == true) {


### PR DESCRIPTION
If answer file specified and user ignores warnings write the
confirmation to the answers file.

When ignoring warnings and specifying the answers file we print a
warning that if they change this (fix the warnings or cause additional
warnings) that the results are likely to be incorrect and strongly
recommend that they re-enter the answers.

When showing how to use the answers file to update an entry warn them
that if they had ignored warnings and fixed them (or if new warnings are
triggered) then they are strongly recommended to re-enter the answers.