### PR TITLE
Resolve issue #47 + add ignore warnings option

### DIFF
--- a/mkiocccentry-test.sh
+++ b/mkiocccentry-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# A simple mkioccccentry test,
-# or an example of how to automate the process!
+# A simple mkiocccentry test, or an example of how
+# to automate the process!
 
 # working locations - adjust as needed
 #
@@ -10,40 +10,38 @@ src_dir="test_src"
 
 # be sure the working locations exist
 #
-mkdir -p -- "$work_dir" "$src_dir"
-status="$?"
-if [[ $status -ne 0 ]]; then
-    echo "$0: FATAL: error in crearing working dirs: mkdir -p -- $work_dir $src_dir" 1>&2
+mkdir -p -- "${work_dir}" "${src_dir}"
+if [[ $? -ne 0 ]]; then
+    echo "$0: FATAL: error in creating working dirs: mkdir -p -- ${work_dir} ${src_dir}" 1>&2
     exit 250
 fi
 
-# cleanout the under work_dir area
-#
-work_dir_esc="$work_dir"
-test "${work_dir:0:1}" = "-" && work_dir_esc=./"$work_dir"
-find "$work_dir_esc" -mindepth 1 -depth -delete
+# clean out the work_dir area
+work_dir_esc="${work_dir}"
+test "${work_dir:0:1}" = "-" && work_dir_esc=./"${work_dir}"
+find "${work_dir_esc}" -mindepth 1 -depth -delete
 
-# Form an entry that is unlikely to win the IOCCC :-)
+# Form entries that are unlikely to win the IOCCC :-)
 #
-test -f "$src_dir"/prog.c || {
-cat > "$src_dir"/prog.c << "EOF"
+test -f "${src_dir}"/prog.c || {
+cat >"${src_dir}"/prog.c <<"EOF"
 #include <stdio.h>
 int main() { puts("Hello, World!"); }
 EOF
 }
+rm -f "${src_dir}"/empty.c
+> "${src_dir}"/empty.c
 
 # fake some required files
 #
-test -f "$src_dir"/Makefile || cat Makefile.example > "$src_dir"/Makefile
-test -f "$src_dir"/remarks.md || cat README.md > "$src_dir"/remarks.md
-test -f "$src_dir"/extra1 || echo "123" > "$src_dir"/extra1
-test -f "$src_dir"/extra2 || echo "456" > "$src_dir"/extra2
+test -f "${src_dir}"/Makefile || cat Makefile.example >"${src_dir}"/Makefile
+test -f "${src_dir}"/remarks.md || cat README.md >"${src_dir}"/remarks.md
+test -f "${src_dir}"/extra1 || echo "123" >"${src_dir}"/extra1
+test -f "${src_dir}"/extra2 || echo "456" >"${src_dir}"/extra2
 
 # Answers as of mkiocccentry version: v0.33 2022-02-03
-# The first line retrieves the answers version from mkiocccentry.c
 answers() {
-echo $(grep -E '^#define MKIOCCCENTRY_ANSWERS_VER' mkiocccentry.c|cut -d' ' -f3|sed 's/"//g')
-cat << "EOF"
+cat <<"EOF"
 test
 0
 title
@@ -60,16 +58,29 @@ ANSWERS_EOF
 EOF
 }
 rm -f answers.txt
-answers > answers.txt
+# Retrieve the answers version from mkiocccentry.c and write to answers file:
+grep -E '^#define MKIOCCCENTRY_ANSWERS_VER' mkiocccentry.c | cut -d' ' -f3 | sed 's/"//g' >answers.txt
+# Append answers + EOF marker
+answers >>answers.txt
 
 # run the test, looking for an exit
 #
-yes | ./mkiocccentry -i answers.txt -- "$work_dir" "$src_dir"/{prog.c,Makefile,remarks.md,extra1,extra2}
-status="$?"
-if [[ $status -ne 0 ]]; then
+yes | ./mkiocccentry -i answers.txt -- "${work_dir}" "${src_dir}"/{prog.c,Makefile,remarks.md,extra1,extra2}
+if [[ $? -ne 0 ]]; then
     echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
     exit "$status"
 fi
+
+# delete the work directory for next test
+find "${work_dir_esc}" -mindepth 1 -depth -delete
+# test empty prog.c, ignoring the warning about it
+yes | ./mkiocccentry -W -i answers.txt -- "${work_dir}" "${src_dir}"/{empty.c,Makefile,remarks.md,extra1,extra2}
+if [[ $? -ne 0 ]]; then
+    echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
+    exit "$status"
+fi
+
+
 
 # All Done!!! -- Jessica Noll, Age 2
 #

--- a/mkiocccentry-test.sh
+++ b/mkiocccentry-test.sh
@@ -11,7 +11,8 @@ src_dir="test_src"
 # be sure the working locations exist
 #
 mkdir -p -- "${work_dir}" "${src_dir}"
-if [[ $? -ne 0 ]]; then
+status=$?
+if [[ ${status} -ne 0 ]]; then
     echo "$0: FATAL: error in creating working dirs: mkdir -p -- ${work_dir} ${src_dir}" 1>&2
     exit 250
 fi
@@ -30,6 +31,7 @@ int main() { puts("Hello, World!"); }
 EOF
 }
 rm -f "${src_dir}"/empty.c
+# shellcheck disable=SC2188
 > "${src_dir}"/empty.c
 
 # fake some required files
@@ -66,18 +68,20 @@ answers >>answers.txt
 # run the test, looking for an exit
 #
 yes | ./mkiocccentry -i answers.txt -- "${work_dir}" "${src_dir}"/{prog.c,Makefile,remarks.md,extra1,extra2}
-if [[ $? -ne 0 ]]; then
+status=$?
+if [[ ${status} -ne 0 ]]; then
     echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
-    exit "$status"
+    exit "${status}"
 fi
 
 # delete the work directory for next test
 find "${work_dir_esc}" -mindepth 1 -depth -delete
 # test empty prog.c, ignoring the warning about it
 yes | ./mkiocccentry -W -i answers.txt -- "${work_dir}" "${src_dir}"/{empty.c,Makefile,remarks.md,extra1,extra2}
-if [[ $? -ne 0 ]]; then
+status=$?
+if [[ ${status} -ne 0 ]]; then
     echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
-    exit "$status"
+    exit "${status}"
 fi
 
 


### PR DESCRIPTION
If -a is specified and -A is NOT specified, warn the user if the answers
file already exists and ask them if they want to overwrite it. If they
say yes the answers file will be overwritten. If -A is specified or the
answers file does not already exist, the answers file is written to
whether or not it exists. -A implies -a (falls through in switch).

To make it easier to test add an option that allows the user to ignore
warnings. When this option -W is specified, ignore warnings once and
warn them that they're doing this, telling them how to fix this (in case
they did it by accident) and reminding them that the judges will not
ignore the warnings.