### PR TITLE
Initial txzchk (issue #42)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ CFLAGS= -O3 -g3 -pedantic -Wall -Wextra
 # where and what to install
 #
 DESTDIR= /usr/local/bin
-TARGETS= mkiocccentry iocccsize dbg_test limit_ioccc.sh filenamechk
+TARGETS= mkiocccentry iocccsize dbg_test limit_ioccc.sh filenamechk txzchk
 TEST_TARGETS= dbg_test
 OBJFILES = dbg.o util.o
 SRCFILES = $(patsubst %.o,%.c,$(OBJFILES))
@@ -138,6 +138,9 @@ dbg_test: dbg.c dbg.h Makefile
 
 filenamechk: filenamechk.c limit_ioccc.h dbg.o util.o
 	${CC} ${CFLAGS} filenamechk.c dbg.o util.o -o $@
+
+txzchk: txzchk.c limit_ioccc.h rule_count.o dbg.o util.o Makefile
+	${CC} ${CFLAGS} txzchk.c rule_count.o dbg.o util.o -o $@
 
 limit_ioccc.sh: limit_ioccc.h Makefile
 	${RM} -f $@
@@ -243,7 +246,7 @@ configure:
 	@echo nothing to configure
 
 clean:
-	${RM} -f mkiocccentry.o iocccsize.o rule_count.o dbg_test.o dbg.o
+	${RM} -f mkiocccentry.o iocccsize.o rule_count.o dbg_test.o dbg.o util.o
 	${RM} -rf mkiocccentry.dSYM iocccsize.dSYM dbg_test.dSYM filenamechk.dSYM
 
 clobber: clean

--- a/filenamechk.c
+++ b/filenamechk.c
@@ -2,7 +2,6 @@
 /*
  * filenamechk - IOCCC compressed tarball filename sanity check tool
  *
- * Verify that the
  *
  * "Because even printf has a return value worth paying attention to." :-)
  *
@@ -55,7 +54,7 @@
 
 
 /*
- * util - utility functions
+ * util - utility functions and definitions
  */
 #include "util.h"
 
@@ -69,7 +68,6 @@
 /*
  * definitions
  */
-#define LITLEN(x) (sizeof(x)-1)	/* length of a literal string w/o the NUL byte */
 #define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
 
 
@@ -85,7 +83,7 @@ static const char * const usage_msg =
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
     "\n"
-    "filepath\t\tpath to a IOCCC compressed tarball\n"
+    "\tfilepath\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "filenamechk version: %s\n";
 

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -1,8 +1,8 @@
-.TH mkiocccentry 1 "04 February 2022" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "05 February 2022" "mkiocccentry" "IOCCC tools"
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
-\fBmkiocccentry [-h] [-v level] [-V] [-t tar] [-c cp] [-l ls] [{-a|-A|-i} answers] [-W] work_dir prog.c Makefile remarks.md [file ...]\fP
+\fBmkiocccentry [\-h] [\-v level] [\-V] [\-t tar] [\-c cp] [\-l ls] [\-C txzchk] [{\-a|\-A|\-i} answers] [\-W] work_dir prog.c Makefile remarks.md [file ...]\fP
 .SH DESCRIPTION
 \fBmkiocccentry\fP gathers your source file, Makefile, remarks as well as any other files and creates a XZ compressed tarball.
 The tool runs \fBiocccsize\fP and it also runs a test on the Makefile to verify that everything seems in order. 
@@ -23,15 +23,19 @@ Show version and exit.
 .PP
 \fB\-t\fP
 Specify path to tar that accepts the \fB\-J\fP option.
-\fBmkiocccentry\fP checks \fI/usr/bin\fP and \fI/bin\fP if this option is not specified.
+\fBmkiocccentry\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
 .PP
 \fB\-c\fP
 Specify path to cp program.
-\fBmkiocccentry\fP checks \fI/usr/bin\fP and \fI/bin\fP if this option is not specified.
+\fBmkiocccentry\fP checks \fI/usr/bin/cp\fP and \fI/bin/cp\fP if this option is not specified.
 .PP
 \fB\-l\fP
 Specify path to ls program.
-\fBmkiocccentry\fP checks \fI/usr/bin\fP and \fI/bin\fP if this option is not specified.
+\fBmkiocccentry\fP checks \fI/usr/bin/ls\fP and \fI/bin/ls\fP if this option is not specified.
+.PP
+\fP\-C\fP
+Specify path to \fBtxzchk\fP tool.
+\fBmkiocccentry\fP checks \fI./txzchk\fP and \fI/usr/local/bin/txzchk\fP if this option is not specified.
 .PP
 \fB\-a\fP
 Write to file specified the answers for easier updating the entry (via the \fB\-i\fP option).

--- a/txzchk.c
+++ b/txzchk.c
@@ -1,0 +1,552 @@
+/*
+ * txzchk: the IOCCC tarball validation checker
+ *
+ * Invoked by mkiocccentry; txzchk in turn uses filenamechk to make sure that
+ * the tarball was correctly named and formed (i.e. the mkiocccentry tool was
+ * used).
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+/*
+ * IOCCC size and rule related limitations
+ */
+#include "limit_ioccc.h"
+
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
+
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+
+/*
+ * txzchk version
+ */
+#define TXZCHK_VERSION "0.1 2022-02-05"	/* use format: major.minor YYYY-MM-DD */
+
+
+/*
+ * globals
+ */
+int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
+int issues = 0;				/* issues with tarball found */
+static bool quiet = false;		/* true ==> only show errors and warnings */
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the these usage_msgX strings.
+ */
+static const char * const usage_msg =
+    "usage: %s [-h] [-v level] [-V] [-t tar] [-f filenamechk] txzpath\n"
+    "\n"
+    "\t-h\t\t\tprint help message and exit 0\n"
+    "\t-v level\t\tset verbosity level: (def level: %d)\n"
+    "\t-V\t\t\tprint version string and exit\n"
+    "\n"
+    "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n\n"
+    "\t-f filenamechk\t\tpath to tool that checks if filename.txz is a valid compressed tarball\n"
+    "\t\t\t\tfilename (def: %s)\n\n"
+    "\ttxzpath\t\t\tpath to an IOCCC compressed tarball\n"
+    "\n"
+    "txzchk version: %s\n";
+
+/*
+ * forward declarations
+ */
+static void usage(int exitcode, char const *name, char const *str, char const *tar, char const *filenamechk) __attribute__((noreturn));
+static void sanity_chk(char const *tar, char const *filenamechk, char const *txzpath);
+static int check_tarball(char const *tar, char const *filenamechk, char const *txzpath);
+
+int main(int argc, char **argv)
+{
+    char *program = NULL;		    /* our name */
+    extern char *optarg;		    /* option argument */
+    extern int optind;			    /* argv index of the next arg */
+    char *tar = TAR_PATH_0;		    /* path to tar executable that supports the -J (xz) option */
+    char *txzpath;			    /* txzpath argument to check */
+    char *filenamechk = FILENAMECHK_PATH_0;   /* path to filenamechk tool */
+    bool filenamechk_flag_used = true;	    /* if -f option used */
+    bool t_flag_used = false;		    /* true ==> -t /path/to/tar was given */
+    int ret;				    /* libc return code */
+    int i;
+
+
+    /*
+     * parse args
+     */
+    program = argv[0];
+    while ((i = getopt(argc, argv, "hv:Vqf:t:")) != -1) {
+	switch (i) {
+	case 'h':		/* -h - print help to stderr and exit 0 */
+	    usage(0, "-h help mode", program, TAR_PATH_0, FILENAMECHK_PATH_0);
+	    not_reached();
+	    break;
+	case 'v':		/* -v verbosity */
+	    /*
+	     * parse verbosity
+	     */
+	    errno = 0;		/* pre-clear errno for errp() */
+	    verbosity_level = (int)strtol(optarg, NULL, 0);
+	    if (errno != 0) {
+		errp(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno));
+		not_reached();
+	    }
+	    break;
+	case 'V':		/* -V - print version and exit */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", TXZCHK_VERSION);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing version string: %s", TXZCHK_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'f':
+	    filenamechk_flag_used = true;
+	    filenamechk = optarg;
+	    break;
+	case 't':
+	    tar = optarg;
+	    t_flag_used = true;
+	    break;
+	case 'q':
+	    quiet = true;
+	    break;
+	default:
+	    usage(1, "invalid -flag", program, TAR_PATH_0, TXZCHK_PATH_0); /*ooo*/
+	    not_reached();
+	 }
+    }
+    /* must have the exact required number of args */
+    if (argc - optind != REQUIRED_ARGS) {
+	usage(1, "wrong number of arguments", program, TAR_PATH_0, TXZCHK_PATH_0); /*ooo*/
+	not_reached();
+    }
+    txzpath = argv[optind];
+    dbg(DBG_LOW, "txzpath: %s", txzpath);
+
+    if (!quiet) {
+	/*
+	 * Welcome
+	 */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = printf("Welcome to txzchk version: %s\n", TXZCHK_VERSION);
+	if (ret <= 0) {
+	    errp(2, __func__, "printf error printing the welcome string");
+	    not_reached();
+	}
+    }
+
+    /*
+     * guess where tar is
+     *
+     * If the user did not give a -t /path/to/tar then look at the historic
+     * location for the utility.  If the historic location of the utility isn't
+     * executable, look for an executable in the alternate location.
+     *
+     * On some systems where /usr/bin != /bin, the distribution made the mistake of
+     * moving historic critical applications, look to see if the alternate path works instead.
+     */
+    find_utils(t_flag_used, &tar, false, NULL, false, NULL, false, NULL, filenamechk_flag_used, &filenamechk);
+
+
+    /*
+     * environment sanity checks
+     */
+    if (!quiet) {
+	para("", "Performing sanity checks on your environment ...", NULL);
+    }
+    sanity_chk(tar, filenamechk, txzpath);
+    if (!quiet) {
+	para("... environment looks OK", "", NULL);
+    }
+
+    /*
+     * check the tarball
+     */
+    if (!quiet) {
+	para("", "Performing checks on tarball ...", NULL);
+    }
+    issues = check_tarball(tar, filenamechk, txzpath);
+    if (!quiet) {
+	para("All checks passed.", "", NULL);
+    }
+
+
+
+    /*
+     * All Done!!! - Jessica Noll, age 2
+     */
+    exit(0); /*ooo*/
+}
+/*
+ * usage - print usage to stderr
+ *
+ * Example:
+ *      usage(3, "missing required argument(s), program: %s", program);
+ *
+ * given:
+ *	exitcode        value to exit with
+ *	str		top level usage message
+ *	program		our program name
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *       Normally one should NOT include newlines in warn messages.
+ *
+ * This function does not return.
+ */
+static void
+usage(int exitcode, char const *str, char const *prog, char const *tar, char const *filenamechk)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	str = "((NULL str))";
+	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", str);
+    }
+    if (prog == NULL) {
+	prog = "((NULL prog))";
+	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
+    }
+    if (tar == NULL) {
+	tar = "((NULL tar))";
+	warn(__func__, "\nin usage: tar was NULL, forcing it to be: %s\n", tar);
+    }
+
+    /*
+     * print the formatted usage stream
+     */
+    vfprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
+    vfprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, tar, filenamechk, TXZCHK_VERSION);
+    exit(exitcode); /*ooo*/
+    not_reached();
+}
+
+/*
+ * sanity_chk - perform basic sanity checks
+ *
+ * We perform basic sanity checks on paths.
+ *
+ * given:
+ *
+ *      tar             - path to tar that supports the -J (xz) option
+ *	filenamechk	- path to the filenamechk utility
+ *	txzpath		- path to txz tarball to check
+ *
+ * NOTE: This function does not return on error or if things are not sane.
+ */
+static void
+sanity_chk(char const *tar, char const *filenamechk, char const *txzpath)
+{
+    /*
+     * firewall
+     */
+    if (tar == NULL || filenamechk == NULL || txzpath == NULL) {
+	err(3, __func__, "called with NULL arg(s)");
+	not_reached();
+    }
+
+    /*
+     * tar must be executable
+     */
+    if (!exists(tar)) {
+	fpara(stderr,
+	      "",
+	      "We cannot find a tar program.",
+	      "",
+	      "A tar program that supports the -J (xz) option is required to build an compressed tarball.",
+	      "Perhaps you need to use:",
+	      "",
+	      "    txzchk -t /path/to/tar ...",
+	      "",
+	      "and/or install a tar program?  You can find the source for tar:",
+	      "",
+	      "    https://www.gnu.org/software/tar/",
+	      "",
+	      NULL);
+	err(4, __func__, "tar does not exist: %s", tar);
+	not_reached();
+    }
+    if (!is_file(tar)) {
+	fpara(stderr,
+	      "",
+	      "The tar, whilst it exists, is not a file.",
+	      "",
+	      "Perhaps you need to use another path:",
+	      "",
+	      "    txzchk -t /path/to/tar ...",
+	      "",
+	      "and/or install a tar program?  You can find the source for tar:",
+	      "",
+	      "    https://www.gnu.org/software/tar/",
+	      "",
+	      NULL);
+	err(5, __func__, "tar is not a file: %s", tar);
+	not_reached();
+    }
+    if (!is_exec(tar)) {
+	fpara(stderr,
+	      "",
+	      "The tar, whilst it is a file, is not executable.",
+	      "",
+	      "We suggest you check the permissions on the tar program, or use another path:",
+	      "",
+	      "    txzchk -t /path/to/tar ...",
+	      "",
+	      "and/or install a tar program?  You can find the source for tar:",
+	      "",
+	      "    https://www.gnu.org/software/tar/",
+	      "",
+	      NULL);
+	err(6, __func__, "tar is not an executable program: %s", tar);
+	not_reached();
+    }
+
+    /*
+     * txzpath must be readable
+     */
+    if (!exists(txzpath)) {
+	fpara(stderr,
+	      "",
+	      "The tarball path specified does not exist. Perhaps you made a typo?",
+	      "Please check the path and try again."
+	      "",
+	      "    txzchk [options] <txzpath>"
+	      "",
+	      NULL);
+	err(7, __func__, "txzpath does not exist: %s", txzpath);
+	not_reached();
+    }
+    if (!is_file(txzpath)) {
+	fpara(stderr,
+	      "",
+	      "The file specified, whilst it exists, is not a regular file.",
+	      "",
+	      "Perhaps you need to use another path:",
+	      "",
+	      "    txzchk [...] <txzpath>",
+	      "",
+	      NULL);
+	err(8, __func__, "txzpath is not a file: %s", txzpath);
+	not_reached();
+    }
+    if (!is_read(txzpath)) {
+	fpara(stderr,
+	      "",
+	      "The tarball path, whilst it is a file, is not readable.",
+	      "",
+	      "We suggest you check the permissions on the path or use another path:",
+	      "",
+	      "    txzchk [...] <txzpath>"
+	      "",
+	      NULL);
+	err(9, __func__, "txzpath is not readable: %s", txzpath);
+	not_reached();
+    }
+
+    return;
+}
+
+/* check_tarball - perform tests on tarball, validating it for the IOCCC
+ *
+ * given:
+ *
+ *	tar	    - path to executable tar program
+ *	filenamechk - path to filenamechk tool
+ *	txzpath	    - path to tarball to check
+ *
+ *  Returns the number of issues found.
+ */
+static int 
+check_tarball(char const *tar, char const *filenamechk, char const *txzpath)
+{
+    off_t size = 0; /* file size of tarball */
+    unsigned line_num = 0; /* line number of tar output */
+    char *cmd = NULL;	/* tar -tJvf */
+    FILE *tar_stream = NULL; /* pipe for tar output */
+    char *linep = NULL;		/* allocated line read from iocccsize */
+    ssize_t readline_len;	/* readline return length */
+    int ret;			/* libc function return */
+    int exit_code;
+
+    /*
+     * firewall
+     */
+    if (tar == NULL || filenamechk == NULL || txzpath == NULL) {
+	err(10, __func__, "called with NULL arg(s)");
+	not_reached();
+    }
+
+    /* determine size of tarball */
+    size = file_size(txzpath);
+    /* report size (if too big) */
+    if (size < 0) {
+	err(11, __func__, "impossible error: sanity_chk found tarball but file_size() did not");
+	not_reached();
+    }
+    else if (size > MAX_TARBALL_LEN) {
+	++issues;
+	fpara(stderr,
+	      "",
+	      "The compressed tarball exceeds the maximum allowed size, sorry.",
+	      "",
+	      NULL);
+	err(12, __func__, "The compressed tarball: %s size: %lu > %ld",
+		 txzpath, (unsigned long)size, (long)MAX_TARBALL_LEN);
+	not_reached();
+    }
+    else if (!quiet) {
+	errno = 0;
+	ret = printf("tarball %s size of %d bytes OK\n", txzpath, (int) size);
+	if (ret <= 0) {
+	    warn(__func__, "unable to tell user how big the tarball is");
+	}
+    }
+    dbg(DBG_MED, "tarball %s size in bytes: %d", txzpath, (int)size);
+
+    errno = 0;			/* pre-clear errno for errp() */
+    cmd = cmdprintf("% -tJvf %", tar, txzpath);
+    if (cmd == NULL) {
+	err(14, __func__, "failed to cmdprintf: tar -tJvf txzpath");
+	not_reached();
+    }
+    dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
+
+    /*
+     * pre-flush to avoid system() buffered stdio issues
+     */
+    clearerr(stdout);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stdout);
+    if (ret < 0) {
+	errp(15, __func__, "fflush(stdout) error code: %d", ret);
+	not_reached();
+    }
+    errno = 0;			/* pre-clear errno for errp() */
+    clearerr(stderr);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stderr);
+    if (ret < 0) {
+	errp(16, __func__, "fflush(stderr) #1: error code: %d", ret);
+	not_reached();
+    }
+
+    /*
+     * execute the tar command
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    exit_code = system(cmd);
+    if (exit_code < 0) {
+	errp(17, __func__, "error calling system(%s)", cmd);
+	not_reached();
+    } else if (exit_code == 127) {
+	errp(18, __func__, "execution of the shell failed for system(%s)", cmd);
+	not_reached();
+    } else if (exit_code != 0) {
+	err(19, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	not_reached();
+    }
+
+    /*
+     * pre-flush to avoid popen() buffered stdio issues
+     */
+    dbg(DBG_HIGH, "about to perform: popen(%s, r)", cmd);
+    clearerr(stdout);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stdout);
+    if (ret < 0) {
+	errp(20, __func__, "fflush(stdout) #0: error code: %d", ret);
+	not_reached();
+    }
+    clearerr(stderr);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stderr);
+    if (ret < 0) {
+	errp(21, __func__, "fflush(stderr) #1: error code: %d", ret);
+	not_reached();
+    }
+
+    /*
+     * form pipe to the tar command
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    tar_stream = popen(cmd, "r");
+    if (tar_stream == NULL) {
+	errp(22, __func__, "popen for reading failed for: %s", cmd);
+	not_reached();
+    }
+    setlinebuf(tar_stream);
+
+    /*
+     * read the 1st line - should contain the directory name
+     */
+    dbg(DBG_HIGH, "reading 1st line from popen(%s, r)", cmd);
+    readline_len = readline(&linep, tar_stream);
+    if (readline_len < 0) {
+	err(23, __func__, "EOF while reading 1st line from tar: %s", tar);
+	not_reached();
+    } else {
+	dbg(DBG_HIGH, "tar 1st line read length: %ld buffer: %s", (long)readline_len, linep);
+	if (strncmp(linep, "drwxr-xr-x", 10) != 0) {
+	    if (*linep == 'd') {
+		err(24, __func__, "although the first file in the tarball is a directory, the permissions are incorrect\n");
+	    } else {
+		err(25, __func__, "first entry in the tarball is not a directory\n");
+	    }
+	    ++issues;
+	}
+    }
+    
+    ++line_num;
+
+    do {
+	readline_len = readline(&linep, tar_stream);
+	if (readline_len < 0) {
+	    dbg(DBG_VVHIGH, "reached EOF of tarball");
+	} else {
+	    /* perform various tests */
+	    if (*linep != '-') {
+		err(26, __func__, "found entry in tarball that's not a regular file\n");
+		++issues;
+	    }
+	}
+	++line_num;
+    } while (readline_len >= 0);
+
+    /*
+     * close down pipe
+     */
+    errno = 0;		/* pre-clear errno for errp() */
+    ret = pclose(tar_stream);
+    if (ret < 0) {
+	warnp(__func__, "pclose error on tar stream");
+    }
+    tar_stream = NULL;
+
+    if (issues > 0) {
+	fprintf(stderr, "check_tarball() found %u issue%s\n", issues, issues==1?"":"s");
+    }
+
+    return issues;
+}

--- a/util.h
+++ b/util.h
@@ -46,6 +46,25 @@ typedef unsigned char bool;
 #endif
 
 /*
+ * definitions
+ */
+#define LITLEN(x) (sizeof(x)-1)	/* length of a literal string w/o the NUL byte */
+
+/*
+ * paths to utilities the IOCCC tools use (including filenamechk and txzchk)
+ */
+#define TAR_PATH_0 "/usr/bin/tar"		/* historic path for tar */
+#define TAR_PATH_1 "/bin/tar"			/* alternate tar path for some systems where /usr/bin/tar != /bin/tar */
+#define CP_PATH_0 "/bin/cp"			/* historic path for cp */
+#define CP_PATH_1 "/usr/bin/cp"			/* alternate cp path for some systems where /bin/cp != /usr/bin/cp */
+#define LS_PATH_0 "/bin/ls"			/* historic path for ls */
+#define LS_PATH_1 "/usr/bin/ls"			/* alternate ls path for some systems where /bin/ls != /usr/bin/ls */
+#define FILENAMECHK_PATH_0 "./filenamechk"	/* default path to filenamechk tool */
+#define FILENAMECHK_PATH_1 "/usr/local/bin/filenamechk"	/* default path to filenamechk tool if installed */
+#define TXZCHK_PATH_0 "./txzchk"		/* default path to txzchk tool */
+#define TXZCHK_PATH_1 "/usr/local/bin/txzchk"	/* default path to txzchk tool if installed */
+
+/*
  * external function declarations
  */
 extern char *base_name(char const *path);
@@ -57,5 +76,11 @@ extern bool is_read(char const *path);
 extern bool is_write(char const *path);
 extern ssize_t file_size(char const *path);
 extern char *cmdprintf(char const *format, ...);
-
+extern void para(char const *line, ...);
+extern void fpara(FILE * stream, char const *line, ...);
+extern ssize_t readline(char **linep, FILE * stream);
+extern char *readline_dup(char **linep, bool strip, size_t *lenp, FILE * stream);
+extern void find_utils(bool tar_flag_used, char **tar, bool cp_flag_used, char **cp,
+	bool ls_flag_used, char **ls, bool txzchk_flag_used, char **txzchk,
+	bool filenamechk_flag_used, char **filenamechk);
 #endif				/* INCLUDE_UTIL_H */


### PR DESCRIPTION
This is incomplete but the following changes were made for this commit.
It's a lot and if there are any problems (as is possible with such
changes) I will fix them. I've tested various tarballs (size, not
starting with a directory, having any special files etc.) but much could
be done still. Because there's a lot I'm going to make a comment in the
GitHub pull request. I'm sorry if for all the text there but I think
it's important! I'll fix any problems and I'll tackle the things not
completed another time (probably not today) if the judges (or someone
else) does not (there are a number of things left to do).

* mkiocccentry

    Change usage message a bit: since the line was so long for the
    synopsis I just have [options] and below the options are shown (as
    they always were).

    The tool now runs (in the form_tarball() function) the txzchk tool
    (see below).

    The locating of the tools (tar, cp, ls) were moved to util.c/util.h
    in a separate function (that also finds other tools).

* mkiocccentry.1

    Formatting fixes.

* txzchk

For discussion here see the comment in the pull request. This will
include possible issues as well as things that aren't yet implemented.

* Makefile

    Add missing util.o to make clean rule.

    Add txzchk to Makefile.

Additionally there were some typo fixes.