### PR TITLE
Remove redundant tarball listing output

### DIFF
--- a/util.h
+++ b/util.h
@@ -73,7 +73,7 @@ struct location {
 #define TXZCHK_PATH_1 "/usr/local/bin/txzchk"	/* default path to txzchk tool if installed */
 
 /*
- * global vairables
+ * global variables
  */
 extern struct location loc[];			/* location/country codes */
 


### PR DESCRIPTION
Since the txzchk is always executed by mkiocccentry and since txzchk
prints out the contents of the tarball (since it has to parse the output
of tar) there's no need to explicitly invoke tar -tJvf. If the txzchk
tool is changed so it doesn't show the output of the tar listing then
this will have to be added back but this way it's no longer showing the
same information twice.

Typo fix(es).