### PR TITLE
Documentation updates + resolve several tarball issues in txzchk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Form an **IOCCC** entry as a compressed tarball file.
 
+For examples and more information, try:
+
+
+	    man ./mkiocccentry.1
+
+
 ## iocccsize
 
 The official **IOCCC** entry Rule 2b size tool.
@@ -14,3 +20,28 @@ This code is based on code by @SirWumpus (*Anthony Howe*):
 
 [See @SirWumpus's iocccsize repo](https://github.com/SirWumpus/iocccsize)
 
+For more information and examples, try:
+
+	    
+	    man ./iocccsize.1
+
+
+## txzchk
+
+The official **IOCCC** tarball validation checker.
+
+
+For more information and examples, try:
+
+
+	    man ./txzchk.1
+
+
+##  fnamchk
+
+The official **IOCCC** compressed tarball filename sanity checker tool.
+
+For more information and examples, try:
+
+
+	    man ./fnamechk.1

--- a/fnamchk.1
+++ b/fnamchk.1
@@ -1,0 +1,76 @@
+.TH fnamchk 1 "06 February 2022" "fnamchk" "IOCCC tools"
+.SH NAME
+fnamchk \- IOCCC compressed tarball filename sanity check tool
+.SH SYNOPSIS
+\fBfnamchk fnamchk [\-h] [\-v level] [\-V] filepath
+.SH DESCRIPTION
+\fBfnamchk\fP verifies that an IOCCC compressed tarball is properly named.
+.PP
+The program validates that the filename is correct, in either the form of \fI"entry." ("test" or a valid UUID) "." entry_number "." timestamp ".txz"
+\fP where \fBentry_number\fP is an integer between 0 and MAX_ENTRY_NUM (see \fIlimit_ioccc.h\fP) and where \fBtimestamp\fP is an integer number of seconds since the epoch.
+.PP
+More specifically, the filename must:
+.RS
+Start with "entry."
+.PP
+Followed by either test or a UUID string of the form xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx
+Where "x" are [0-9-f] characters. And yes, there is a "4" (UUID version 4) and an "a" (UUID variant 1) in there.
+.PP
+Followed by "."
+.PP
+Followed by an decimal entry number between 0 and MAX_ENTRY_NUM (see \fIlimit_ioccc.h\fP) inclusive.
+.PP
+Followed by "."
+.PP
+Followed by a positive non-zero 64-bit decimal integer.
+.PP
+End with ".txz".
+.RE
+.PP
+It is indirectly invoked via the \fBtxzchk(1)\fP utility (which is called by \fBmkiocccentry(1)\fP) and it will also be directly executed by the judges during the judging process of the contests.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-V\fP
+Show version and exit.
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 0 on success; if there's an error the end is not reached.
+.SH FILES
+\fIfnamchk.c\fP
+.RS
+Source file to the \fBfnamchk\fP tool.
+.RE
+\fIlimit_ioccc.h\fP
+.RS
+Header file with limits related to the IOCCC.
+.RE
+.SH BUGS
+.PP
+More than 0 humans work on it! :)
+.PP
+If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+.SH EXAMPLES
+.PP
+.nf
+Run the program on the tarball \fIentry.test.0.1644094311.txz\fP:
+
+.RS
+\fB
+ ./fnamchk entry.test.0.1644094311.txz\fP
+.fi
+.RE
+.PP
+.nf
+Run the program on the tarball \fItest.tar\fP, which will fail:
+
+.RS
+\fB
+ ./fnamchk test.tar
+.fi
+.RE

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -182,10 +182,10 @@ main(int argc, char *argv[])
 	not_reached();
     }
     if (strcmp(entry, "entry") != 0) {
-	err(3, __func__, "filename does not start with entry.: %s", filepath);
+	err(3, __func__, "filename does not start with \"entry.\": %s", filepath);
 	not_reached();
     }
-    dbg(DBG_LOW, "filename starts with entry.: %s", filename);
+    dbg(DBG_LOW, "filename starts with \"entry.\": %s", filename);
 
     /*
      * 2nd .-separated token must be test or a UUID

--- a/iocccsize.1
+++ b/iocccsize.1
@@ -1,0 +1,74 @@
+.TH iocccsize 1 "06 February 2022" "iocccsize" "IOCCC tools"
+.SH NAME
+iocccsize \- IOCCC Source Size Tool
+.SH SYNOPSIS
+\fBiocccsize iocccsize [-h] [-i] [-v ...] [-V] prog.c\fP 
+.SH DESCRIPTION
+.PP
+Reading a C source file from standard input or a file arg, apply the IOCCC source size rules as explained in the Guidelines.
+.PP
+The source's Rule 2b length is written to stdout; with -v option the Rule 2b length, gross (Rule 2a) length, and matched keyword count are written to stdout.
+.PP
+The size tool counts most C reserved words (keyword, secondary, and selected preprocessor keywords) as 1.
+The size tool counts all other octets as 1 excluding ASCII whitespace, and excluding any ';', '{' or '}' followed by ASCII whitespace, and excluding any ';', '{' or '}' octet immediately before the end of file.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-i\fP
+Ignored for backward compatibility.
+.PP
+\fB\-v\fP
+Turn on some debugging to stderr; \-vv or \-vvv for more
+.PP
+\fB\-V\fP
+Show version and exit 3.
+.SH EXIT STATUS
+.PP
+Exit codes:
+.RS
+.PP
+0 \- source code is within Rule 2a and Rule 2b limits
+.PP
+1 \- source code larger than Rule 2a and/or Rule 2b limits
+.PP
+2 \- \-h used and help printed
+.PP
+3 \- \-V used and version printed
+.PP
+>= 4 \- some internal error occurred
+.RE
+.SH FILES
+\fIiocccsize.c\fP
+.RS
+Source file to the \fBiocccsize\fP tool.
+.RE
+\fIiocccsize-test.sh\fP
+.RS
+Script that tests the \fBiocccsize\fP tool.
+.RE
+.SH BUGS
+.PP
+There are no bugs: "You are not expected to understand this" :\-)
+.PP
+But if you think you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/iocccsize/issues\>\fP.
+.SH EXAMPLES
+.PP
+.nf
+Run test script:
+
+.RS
+\fB
+ ./iocccsize-test.sh\fP
+.fi
+.RE
+.PP
+.nf
+Test if prog.c fits within the IOCCC 2a and 2b rules, only showing output if there's a problem:
+.RS
+\fB
+ ./iocccsize < prog.c 
+ ./iocccsize prog.c
+.fi
+.RE

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -1,4 +1,4 @@
-.TH mkiocccentry 1 "05 February 2022" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "06 February 2022" "mkiocccentry" "IOCCC tools"
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
@@ -104,5 +104,14 @@ Use the answers file from the previous invocation to quickly update the entry wi
 .RS
 \fB
  ./mkiocccentry -i answers work_dir prog.c Makefile remarks.md data.txt
+.fi
+.RE
+.PP
+.nf
+Run program, specifying alternative path to \fBtar\fP and \fBtxzchk\fP:
+
+.RS
+\fB
+ ./mkiocccentry -t /path/to/tar -C /path/to/txzchk
 .fi
 .RE

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -5804,6 +5804,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
 	not_reached();
     }
 
+
     /*
      * verify entry directory contents
      */
@@ -5904,9 +5905,20 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     }
 
     /*
+     * switch back to parent directory
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = chdir("..");
+    if (ret < 0) {
+	errp(203, __func__, "cannot cd ..");
+	not_reached();
+    }
+
+
+    /*
      * form the txzchk command
      */
-    cmd = cmdprintf("../% -q -f % %", txzchk, fnamchk, basename_tarball_path);
+    cmd = cmdprintf("% -q -F % %/../%", txzchk, fnamchk, entry_dir, basename_tarball_path);
     if (cmd == NULL) {
 	err(212, __func__, "failed to cmdprintf: txzchk -q tarball_path");
 	not_reached();

--- a/txzchk.1
+++ b/txzchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-f fnamchk] txzpath
+\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked indirectly through \fBmkiocccentry(1)\fP.
 .PP
@@ -30,7 +30,7 @@ Show version and exit.
 Specify path to tar that accepts the \fB\-J\fP option.
 \fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
 .PP
-\fB\-f\fP
+\fB\-F\fP
 Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
 .SH EXIT STATUS
@@ -62,6 +62,6 @@ Run the program on the tarball \fIentry.test.0.1644094311.txz\fP, specifying an 
 
 .RS
 \fB
- ./txzchk -t /path/to/tar -f ./filenamechk entry.test.0.1644094311.txz\fP
+ ./txzchk -t /path/to/tar -F ./filenamechk entry.test.0.1644094311.txz\fP
 .fi
 .RE

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,0 +1,67 @@
+.TH txzchk 1 "06 February 2022" "txzchk" "IOCCC tools"
+.SH NAME
+txzchk \- sanity checker tool used on IOCCC compressed tarballs
+.SH SYNOPSIS
+\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-f fnamchk] txzpath
+.SH DESCRIPTION
+\fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked indirectly through \fBmkiocccentry(1)\fP.
+.PP
+The program runs \fB\-tJvf\fP on the \fItxzpath\fP to list (it does NOT extract) and parses the output of \fBtar(1)\fP, performing a variety of tests on the tarball.
+It also runs the IOCCC tool \fBfnamchk(1)\fP on the file, verifying that the tarball is properly named.
+.PP
+It will also be directly executed by the judges during the judging process of the contests.
+This is an important part of the judging process.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-q\fP
+Suppresses some of the output.
+This does not include warnings, errors or the output of the tar command.
+.PP
+\fB\-V\fP
+Show version and exit.
+.PP
+\fB\-t\fP
+Specify path to tar that accepts the \fB\-J\fP option.
+\fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
+.PP
+\fB\-f\fP
+Specify path to the IOCCC \fBfnamchk(1)\fP tool.
+If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 0 on success; if there's an error the end is not reached.
+.SH FILES
+\fItxzchk.c\fP
+.RS
+Source file to the \fBtxzchk\fP tool.
+.RE
+.SH BUGS
+.PP
+More than 0 humans work on it! :)
+.PP
+If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+.SH EXAMPLES
+.PP
+.nf
+Run the program on the tarball \fIentry.test.0.1644094311.txz\fP:
+
+.RS
+\fB
+ ./txzchk entry.test.0.1644094311.txz\fP
+.fi
+.RE
+.PP
+.nf
+Run the program on the tarball \fIentry.test.0.1644094311.txz\fP, specifying an alternate path to \fBtar\fP and \fBfnamchk\fP:
+
+.RS
+\fB
+ ./txzchk -t /path/to/tar -f ./filenamechk entry.test.0.1644094311.txz\fP
+.fi
+.RE

--- a/txzchk.c
+++ b/txzchk.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <ctype.h>
 
 /*
  * IOCCC size and rule related limitations
@@ -57,14 +58,14 @@ static bool quiet = false;		/* true ==> only show errors and warnings */
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-t tar] [-f fnamchk] txzpath\n"
+    "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] txzpath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
     "\n"
     "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
-    "\t-f fnamchk\t\tpath to tool that checks if filename.txz is a valid compressed tarball\n"
+    "\t-F fnamchk\t\tpath to tool that checks if filename.txz is a valid compressed tarball name\n"
     "\t\t\t\tfilename (def: %s)\n\n"
     "\ttxzpath\t\t\tpath to an IOCCC compressed tarball\n"
     "\n"
@@ -76,6 +77,7 @@ static const char * const usage_msg =
 static void usage(int exitcode, char const *name, char const *str, char const *tar, char const *fnamchk) __attribute__((noreturn));
 static void sanity_chk(char const *tar, char const *fnamchk, char const *txzpath);
 static int check_tarball(char const *tar, char const *fnamchk, char const *txzpath);
+static bool has_special_bits(char const *str);
 
 int main(int argc, char **argv)
 {
@@ -85,7 +87,7 @@ int main(int argc, char **argv)
     char *tar = TAR_PATH_0;		    /* path to tar executable that supports the -J (xz) option */
     char *txzpath;			    /* txzpath argument to check */
     char *fnamchk = FNAMCHK_PATH_0;   	    /* path to fnamchk tool */
-    bool fnamchk_flag_used = true;	    /* if -f option used */
+    bool fnamchk_flag_used = false;	    /* if -F option used */
     bool t_flag_used = false;		    /* true ==> -t /path/to/tar was given */
     int ret;				    /* libc return code */
     int i;
@@ -94,7 +96,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:Vqf:t:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqF:t:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(0, "-h help mode", program, TAR_PATH_0, FNAMCHK_PATH_0);
@@ -120,7 +122,7 @@ int main(int argc, char **argv)
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;
-	case 'f':
+	case 'F':
 	    fnamchk_flag_used = true;
 	    fnamchk = optarg;
 	    break;
@@ -187,7 +189,7 @@ int main(int argc, char **argv)
 	para("", "Performing checks on tarball ...", NULL);
     }
     issues = check_tarball(tar, fnamchk, txzpath);
-    if (!quiet) {
+    if (!quiet && !issues) {
 	para("All checks passed.", "", NULL);
     }
 
@@ -328,6 +330,48 @@ sanity_chk(char const *tar, char const *fnamchk, char const *txzpath)
     }
 
     /*
+     * fnamchk must be executable
+     */
+    if (!exists(fnamchk)) {
+	fpara(stderr,
+	      "",
+	      "We cannot find fnamchk.",
+	      "",
+	      "This tool is required to test the tarball.",
+	      "Perhaps you need to use:",
+	      "",
+	      "    txzchk -F /path/to/fnamchk ...",
+	      NULL);
+	err(4, __func__, "fnamchk does not exist: %s", fnamchk);
+	not_reached();
+    }
+    if (!is_file(fnamchk)) {
+	fpara(stderr,
+	      "",
+	      "The fnamchk, whilst it exists, is not a file.",
+	      "",
+	      "Perhaps you need to use another path:",
+	      "",
+	      "    txzchk -F /path/to/fnamchk ...",
+	      NULL);
+	err(5, __func__, "fnamchk is not a file: %s", tar);
+	not_reached();
+    }
+    if (!is_exec(fnamchk)) {
+	fpara(stderr,
+	      "",
+	      "The fnamchk, whilst it is a file, is not executable.",
+	      "",
+	      "We suggest you check the permissions on the fnamchk program, or use another path:",
+	      "",
+	      "    txzchk -F /path/to/fnamchk ...",
+	      NULL);
+	err(6, __func__, "fnamchk is not an executable program: %s", tar);
+	not_reached();
+    }
+
+
+    /*
      * txzpath must be readable
      */
     if (!exists(txzpath)) {
@@ -383,6 +427,8 @@ sanity_chk(char const *tar, char const *fnamchk, char const *txzpath)
  *	txzpath		- path to tarball to check
  *
  *  Returns the number of issues found.
+ *
+ *  Does not return on error.
  */
 static int
 check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
@@ -392,6 +438,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
     char *cmd = NULL;	/* fnamchk and tar -tJvf */
     FILE *tar_stream = NULL; /* pipe for tar output */
     char *linep = NULL;		/* allocated line read from iocccsize */
+    char *line_dup = NULL;	/* duplicated line from readline */
     ssize_t readline_len;	/* readline return length */
     int dir_count = 0;		/* number of directories detected */
     int ret;			/* libc function return */
@@ -432,55 +479,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
     }
     dbg(DBG_MED, "tarball %s size in bytes: %lu", txzpath, (unsigned long)size);
 
-    /* form command line to fnamchk */
-    errno = 0;			/* pre-clear errno for errp() */
-    cmd = cmdprintf("../% %", fnamchk, txzpath);
-    if (cmd == NULL) {
-	err(13, __func__, "failed to cmdprintf: fnamchk txzpath");
-	not_reached();
-    }
-    dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
-
-    /*
-     * pre-flush to avoid system() buffered stdio issues
-     */
-    clearerr(stdout);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stdout);
-    if (ret < 0) {
-	errp(14, __func__, "fflush(stdout) error code: %d", ret);
-	not_reached();
-    }
-    errno = 0;			/* pre-clear errno for errp() */
-    clearerr(stderr);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stderr);
-    if (ret < 0) {
-	errp(15, __func__, "fflush(stderr) #1: error code: %d", ret);
-	not_reached();
-    }
-
-    /*
-     * execute the fnamchk command
-     */
-    errno = 0;			/* pre-clear errno for errp() */
-    exit_code = system(cmd);
-    if (exit_code < 0) {
-	errp(16, __func__, "error calling system(%s)", cmd);
-	not_reached();
-    } else if (exit_code == 127) {
-	errp(17, __func__, "execution of the shell failed for system(%s)", cmd);
-	not_reached();
-    } else if (exit_code != 0) {
-	err(18, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
-	not_reached();
-    }
-
-
-    /* free cmd for tar */
-    free(cmd);
-
-    errno = 0;			/* pre-clear errno for errp() */
+   errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% -tJvf %", tar, txzpath);
     if (cmd == NULL) {
 	err(13, __func__, "failed to cmdprintf: tar -tJvf txzpath");
@@ -557,6 +556,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
      * process all tar lines listed
      */
     do {
+	char *p = NULL;
 
 	/*
 	 * count this line
@@ -567,7 +567,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	 * read the next listing line
 	 */
 	readline_len = readline(&linep, tar_stream);
-	if (readline_len < 0) {
+        if (readline_len < 0) {
 	    dbg(DBG_HIGH, "reached EOF of tarball");
 	    break;
 	}
@@ -590,6 +590,64 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	    warn(__func__, "found a non-directory non-regular non-hard-lined item: %s", linep);
 	    ++issues;
 	}
+	line_dup = strdup(linep);
+	if (line_dup == NULL) {
+	    err(11, __func__, "duplicating %s failed", linep);
+	    not_reached();
+	}
+	/* extract each field, one at a time, to do various tests */
+	p = strtok(linep, " \t");
+	if (p == NULL) {
+	    err(18, __func__, "NULL pointer encountered trying to parse line");
+	    not_reached();
+	}
+	if (has_special_bits(p)) {
+	    warn(__func__, "found special bits on line: %s", line_dup);
+	    ++issues;
+	}
+	/* we don't need this next field */
+	p = strtok(NULL, " \t");
+
+	if (p == NULL) {
+	    err(19, __func__, "NULL pointer encountered trying to parse line");
+	    not_reached();
+	}
+	p = strtok(NULL, " \t");
+	if (p == NULL) {
+	    err(20, __func__, "NULL pointer encountered trying to parse line");
+	    not_reached();
+	}
+	/* 
+	 * attempt to find !isdigit() chars (i.e. the tarball listing includes
+	 * the owner of the files
+	 */
+	for (; p && *p && isdigit(*p); )
+	    ++p; /* satisfy warnings */
+
+	if (*p) {
+	    warn(__func__, "found non-digit UID in file in line: %s", line_dup);
+	    ++issues;
+	}
+
+	/*
+	 * now do the same for group
+	 */
+	p = strtok(NULL, " \t");
+	if (p == NULL) {
+	    err(21, __func__, "NULL pointer encountered trying to parse line");
+	    not_reached();
+	}
+	for (; p && *p && isdigit(*p); )
+	    ++p; /* satisfy warnings */
+
+	if (*p) {
+	    warn(__func__, "found non-digit GID in file in line: %s", line_dup);
+	    ++issues;
+	}
+
+	free(line_dup);
+	line_dup = NULL;
+
     } while (readline_len >= 0);
 
     /*
@@ -602,10 +660,91 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
     }
     tar_stream = NULL;
 
+    /* 
+     * report issues found before running fnamchk so that it's easy to see how
+     * many problems we found (if the fnamchk fails it errors out so this won't
+     * be seen).
+     */
     if (issues > 0) {
-	fprintf(stderr, "check_tarball() found %u issue%s\n", issues, issues==1?"":"s");
+	fprintf(stderr, "txzchk found %u issue%s\n", issues, issues==1?"":"s");
     }
+
+    /* 
+     * free cmd for next command
+     */
+    free(cmd);
+    cmd = NULL;
+
+    /* form command line to fnamchk */
+    errno = 0;			/* pre-clear errno for errp() */
+    cmd = cmdprintf("% %", fnamchk, txzpath);
+    if (cmd == NULL) {
+	err(13, __func__, "failed to cmdprintf: fnamchk txzpath");
+	not_reached();
+    }
+    dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
+
+    /*
+     * pre-flush to avoid system() buffered stdio issues
+     */
+    clearerr(stdout);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stdout);
+    if (ret < 0) {
+	errp(14, __func__, "fflush(stdout) error code: %d", ret);
+	not_reached();
+    }
+    errno = 0;			/* pre-clear errno for errp() */
+    clearerr(stderr);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stderr);
+    if (ret < 0) {
+	errp(15, __func__, "fflush(stderr) #1: error code: %d", ret);
+	not_reached();
+    }
+
+    /*
+     * execute the fnamchk command
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    exit_code = system(cmd);
+    if (exit_code < 0) {
+	errp(16, __func__, "error calling system(%s)", cmd);
+	not_reached();
+    } else if (exit_code == 127) {
+	errp(17, __func__, "execution of the shell failed for system(%s)", cmd);
+	not_reached();
+    } else if (exit_code != 0) {
+	err(18, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	not_reached();
+    }
+
+
+    /* free cmd for tar */
+    free(cmd);
 
     return issues;
 }
 
+/*
+ * has_special_bits - determine if the string has any special bits
+ *
+ * given:
+ *
+ *	str	    - the string to test
+ *
+ * This function does not return on NULL pointer passed into the function.
+ */
+static bool
+has_special_bits(char const *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	err(3, __func__, "called with NULL arg(s)");
+	not_reached();
+    }
+
+    return str[strspn(str, "-drwx")]!='\0';
+}

--- a/txzchk.c
+++ b/txzchk.c
@@ -35,7 +35,7 @@
 /*
  * txzchk version
  */
-#define TXZCHK_VERSION "0.2 2022-02-06"	/* use format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "0.3 2022-02-06"	/* use format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/util.h
+++ b/util.h
@@ -67,7 +67,7 @@ struct location {
 #define CP_PATH_1 "/usr/bin/cp"			/* alternate cp path for some systems where /bin/cp != /usr/bin/cp */
 #define LS_PATH_0 "/bin/ls"			/* historic path for ls */
 #define LS_PATH_1 "/usr/bin/ls"			/* alternate ls path for some systems where /bin/ls != /usr/bin/ls */
-#define FNAMCHK_PATH_0 "./fnamchk"	/* default path to fnamchk tool */
+#define FNAMCHK_PATH_0 "./fnamchk"		/* default path to fnamchk tool */
 #define FNAMCHK_PATH_1 "/usr/local/bin/fnamchk"	/* default path to fnamchk tool if installed */
 #define TXZCHK_PATH_0 "./txzchk"		/* default path to txzchk tool */
 #define TXZCHK_PATH_1 "/usr/local/bin/txzchk"	/* default path to txzchk tool if installed */


### PR DESCRIPTION
Man pages for the iocccsize(1), fnamchk(1) and txzchk(1) tools have been
added.

README.md now tells the user how to get more information and examples of
the tools by referring to the man pages (this includes mkiocccentry).