### PR TITLE
txzchk: Clean up, bug fixes and more tests added

### DIFF
--- a/txzchk.1
+++ b/txzchk.1
@@ -35,7 +35,7 @@ Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
 .SH EXIT STATUS
 .PP
-\fBmain()\fP returns 0 on success; if there's an error the end is not reached.
+\fBmain()\fP returns 0 if no issues are found and 1 if there are issues found; if there's an error the end is not reached.
 .SH FILES
 \fItxzchk.c\fP
 .RS

--- a/txzchk.c
+++ b/txzchk.c
@@ -759,7 +759,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 	/*
 	 * attempt to find !isdigit() chars (i.e. the tarball listing includes
-	 * the owner name of the files
+	 * the owner name of the file).
 	 */
 	for (; p && *p && isdigit(*p); )
 	    ++p; /* satisfy warnings */

--- a/txzchk.c
+++ b/txzchk.c
@@ -871,6 +871,10 @@ check_tarball(char const *tar, char const *fnamchk)
 		++total_issues;
 	    }
 	}
+	if (strchr(p, '/') == NULL) {
+	    warn("txzchk", "%s: no directory found in filename %s", txzpath, p);
+	    ++total_issues;
+	}
 
 
 	free(line_dup);

--- a/txzchk.c
+++ b/txzchk.c
@@ -956,7 +956,7 @@ check_tarball(char const *tar, char const *fnamchk)
     }
 
     /* 
-     * Report total number of non .author.json and .info.json files.
+     * Report total number of non .author.json and .info.json dot files.
      * Don't increment the number of issues as this was done when iterating
      * through the linked list above.
      */

--- a/txzchk.c
+++ b/txzchk.c
@@ -981,7 +981,7 @@ check_tarball(char const *tar, char const *fnamchk)
     }
 
     /*
-     * free cmd for next command
+     * free cmd
      */
     free(cmd);
     cmd = NULL;
@@ -992,11 +992,6 @@ check_tarball(char const *tar, char const *fnamchk)
     if (total_issues > 0) {
 	warn("txzchk", "%s: txzchk found %u issue%s\n", txzpath, total_issues, total_issues==1?"":"s");
     }
-
-
-
-    free(cmd);
-    cmd = NULL;
 
     free_file_list();
 

--- a/txzchk.c
+++ b/txzchk.c
@@ -899,13 +899,13 @@ check_tarball(char const *tar, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(33, __func__, "error calling system(%s)", cmd);
+	errp(33, __func__, "%s: error calling system(%s)", txzpath, cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(34, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(34, __func__, "%s: execution of the shell failed for system(%s)", txzpath, cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	warn("txzchk", "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	warn("txzchk", "%s: %s failed with exit code: %d", txzpath, cmd, WEXITSTATUS(exit_code));
 	++total_issues;
     }
     /*

--- a/txzchk.c
+++ b/txzchk.c
@@ -35,15 +35,17 @@
 /*
  * txzchk version
  */
-#define TXZCHK_VERSION "0.4 2022-02-07"	/* use format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "0.41 2022-02-08"    /* use format: major.minor YYYY-MM-DD */
 
 
 /*
  * globals
  */
-int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
-int issues = 0;				/* issues with tarball found */
-static bool quiet = false;		/* true ==> only show errors and warnings */
+char *program = NULL;			    /* our name */
+int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
+static int total_issues = 0;		    /* total number of issues with tarball found */
+static bool quiet = false;		    /* true ==> only show errors and warnings */
+char const *txzpath = NULL;		    /* the current tarball being checked */
 
 struct info {
     bool has_info_json;
@@ -73,7 +75,7 @@ struct file *files;
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the usage_msgX strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] txzpath\n"
@@ -83,7 +85,7 @@ static const char * const usage_msg =
     "\t-V\t\t\tprint version string and exit\n"
     "\n"
     "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
-    "\t-F fnamchk\t\tpath to tool that checks if filename.txz is a valid compressed tarball name\n"
+    "\t-F /path/to/fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
     "\t\t\t\tfilename (def: %s)\n\n"
     "\ttxzpath\t\t\tpath to an IOCCC compressed tarball\n"
     "\n"
@@ -93,20 +95,17 @@ static const char * const usage_msg =
  * forward declarations
  */
 static void usage(int exitcode, char const *name, char const *str, char const *tar, char const *fnamchk) __attribute__((noreturn));
-static void sanity_chk(char const *tar, char const *fnamchk, char const *txzpath);
-static int check_tarball(char const *tar, char const *fnamchk, char const *txzpath);
+static void sanity_chk(char const *tar, char const *fnamchk);
+static unsigned check_tarball(char const *tar, char const *fnamchk);
 static bool has_special_bits(char const *str);
 static void add_file_to_list(struct file *file);
-static unsigned check_files(void);
 static void free_file_list(void);
 
 int main(int argc, char **argv)
 {
-    char *program = NULL;		    /* our name */
     extern char *optarg;		    /* option argument */
     extern int optind;			    /* argv index of the next arg */
     char *tar = TAR_PATH_0;		    /* path to tar executable that supports the -J (xz) option */
-    char *txzpath;			    /* txzpath argument to check */
     char *fnamchk = FNAMCHK_PATH_0;   	    /* path to fnamchk tool */
     bool fnamchk_flag_used = false;	    /* if -F option used */
     bool tar_flag_used = false;		    /* true ==> -t /path/to/tar was given */
@@ -198,7 +197,7 @@ int main(int argc, char **argv)
     if (!quiet) {
 	para("", "Performing sanity checks on your environment ...", NULL);
     }
-    sanity_chk(tar, fnamchk, txzpath);
+    sanity_chk(tar, fnamchk);
     if (!quiet) {
 	para("... environment looks OK", NULL);
     }
@@ -209,15 +208,15 @@ int main(int argc, char **argv)
     if (!quiet) {
 	para("", "Performing checks on tarball ...", NULL);
     }
-    issues = check_tarball(tar, fnamchk, txzpath);
-    if (!quiet && !issues) {
+    total_issues = check_tarball(tar, fnamchk);
+    if (!quiet && !total_issues) {
 	para("All checks passed.", "", NULL);
     }
 
     /*
      * All Done!!! - Jessica Noll, age 2
      */
-    exit(0); /*ooo*/
+    exit(total_issues != 0); /*ooo*/
 }
 
 
@@ -245,19 +244,19 @@ usage(int exitcode, char const *str, char const *prog, char const *tar, char con
      */
     if (str == NULL) {
 	str = "((NULL str))";
-	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", str);
+	warn("txzchk", "\nin usage(): program was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
 	prog = "((NULL prog))";
-	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
+	warn("txzchk", "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
     }
     if (tar == NULL) {
 	tar = "((NULL tar))";
-	warn(__func__, "\nin usage: tar was NULL, forcing it to be: %s\n", tar);
+	warn("txzchk", "\nin usage: tar was NULL, forcing it to be: %s\n", tar);
     }
     if (fnamchk == NULL) {
 	fnamchk = "((NULL fnamchk))";
-	warn(__func__, "\nin usage(): fnamchk was NULL, forcing it to be: %s\n", fnamchk);
+	warn("txzchk", "\nin usage(): fnamchk was NULL, forcing it to be: %s\n", fnamchk);
     }
 
     /*
@@ -279,12 +278,11 @@ usage(int exitcode, char const *str, char const *prog, char const *tar, char con
  *
  *      tar             - path to tar that supports the -J (xz) option
  *	fnamchk		- path to the fnamchk utility
- *	txzpath		- path to txz tarball to check
  *
  * NOTE: This function does not return on error or if things are not sane.
  */
 static void
-sanity_chk(char const *tar, char const *fnamchk, char const *txzpath)
+sanity_chk(char const *tar, char const *fnamchk)
 {
     /*
      * firewall
@@ -445,14 +443,13 @@ sanity_chk(char const *tar, char const *fnamchk, char const *txzpath)
  *
  *	tar		- path to executable tar program
  *	fnamchk		- path to fnamchk tool
- *	txzpath		- path to tarball to check
  *
- *  Returns the number of issues found.
+ *  Returns the number of total number of issues found (total_issues).
  *
  *  Does not return on error.
  */
-static int
-check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
+static unsigned
+check_tarball(char const *tar, char const *fnamchk)
 {
     off_t size = 0; /* file size of tarball */
     off_t file_sizes = 0; /* accumulation of file sizes within the tarball */
@@ -482,28 +479,28 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
     size = file_size(txzpath);
     /* report size (if too big) */
     if (size < 0) {
-	err(14, __func__, "impossible error: sanity_chk() found tarball but file_size() did not");
+	err(14, __func__, "%s: impossible error: sanity_chk() found tarball but file_size() did not", txzpath);
 	not_reached();
     }
     else if (size > MAX_TARBALL_LEN) {
-	++issues;
+	++total_issues;
 	fpara(stderr,
 	      "",
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(15, __func__, "The compressed tarball: %s size: %lu > %ld",
+	err(15, __func__, "%s: The compressed tarball size %lu > %ld",
 		 txzpath, (unsigned long)size, (long)MAX_TARBALL_LEN);
 	not_reached();
     }
     else if (!quiet) {
 	errno = 0;
-	ret = printf("tarball %s size of %d bytes OK\n", txzpath, (int) size);
+	ret = printf("txzchk: %s size of %lld bytes OK\n", txzpath, (off_t) size);
 	if (ret <= 0) {
-	    warn(__func__, "unable to tell user how big the tarball is");
+	    warn("txzchk", "unable to tell user how big the tarball %s is", txzpath);
 	}
     }
-    dbg(DBG_MED, "tarball %s size in bytes: %lu", txzpath, (unsigned long)size);
+    dbg(DBG_MED, "txzchk: %s size in bytes: %lu", txzpath, (unsigned long)size);
 
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% -tJvf %", tar, txzpath);
@@ -594,10 +591,10 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	 */
 	readline_len = readline(&linep, tar_stream);
         if (readline_len < 0) {
-	    dbg(DBG_HIGH, "reached EOF of tarball");
+	    dbg(DBG_HIGH, "reached EOF of tarball %s", txzpath);
 	    break;
 	}
-	dbg(DBG_VHIGH, "line %d: <%s>", line_num, linep);
+	dbg(DBG_VHIGH, "line %d: %s", line_num, linep);
 
 	/*
 	 * look for more than one directory
@@ -605,54 +602,54 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	if (*linep == 'd') {
 	    ++dir_count;
 	    if (dir_count > 1) {
-		warn(__func__, "found more than one directory entry: %s", linep);
-		++issues;
+		warn("txzchk", "%s: found more than one directory entry: %s", txzpath, linep);
+		++total_issues;
 	    }
 
 	/*
 	 * look for non-directory non-regular non-hard-lined items
 	 */
 	} else if (*linep != '-') {
-	    warn(__func__, "found a non-directory non-regular non-hard-lined item: %s", linep);
-	    ++issues;
+	    warn("txzchk", "%s: found a non-directory non-regular non-hard-lined item: %s", txzpath, linep);
+	    ++total_issues;
 	}
 	line_dup = strdup(linep);
 	if (line_dup == NULL) {
-	    err(25, __func__, "duplicating %s failed", linep);
+	    err(25, __func__, "%s: duplicating %s failed", txzpath, linep);
 	    not_reached();
 	}
 	/* extract each field, one at a time, to do various tests */
 	p = strtok(linep, " \t");
 	if (p == NULL) {
-	    err(26, __func__, "NULL pointer encountered trying to parse line");
+	    err(26, __func__, "%s: NULL pointer encountered trying to parse line", txzpath);
 	    not_reached();
 	}
 	if (has_special_bits(p)) {
-	    warn(__func__, "found special bits on line: %s", line_dup);
-	    ++issues;
+	    warn("txzchk", "%s: found special bits on line: %s", txzpath, line_dup);
+	    ++total_issues;
 	}
 	/* we don't need this next field */
 	p = strtok(NULL, " \t");
 
 	if (p == NULL) {
-	    err(27, __func__, "NULL pointer encountered trying to parse line");
+	    err(27, __func__, "%s: NULL pointer encountered trying to parse line", txzpath);
 	    not_reached();
 	}
 	p = strtok(NULL, " \t");
 	if (p == NULL) {
-	    err(28, __func__, "NULL pointer encountered trying to parse line");
+	    err(28, __func__, "%s: NULL pointer encountered trying to parse line", txzpath);
 	    not_reached();
 	}
 	/*
 	 * attempt to find !isdigit() chars (i.e. the tarball listing includes
-	 * the owner of the files
+	 * the owner name of the files
 	 */
 	for (; p && *p && isdigit(*p); )
 	    ++p; /* satisfy warnings */
 
 	if (*p) {
-	    warn(__func__, "found non-digit UID in file in line: %s", line_dup);
-	    ++issues;
+	    warn("txzchk", "%s: found non-digit UID in file in line %s", txzpath, line_dup);
+	    ++total_issues;
 	}
 
 	/*
@@ -660,27 +657,27 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	 */
 	p = strtok(NULL, " \t");
 	if (p == NULL) {
-	    err(29, __func__, "NULL pointer encountered trying to parse line");
+	    err(29, __func__, "%s: NULL pointer encountered trying to parse line", txzpath);
 	    not_reached();
 	}
 	for (; p && *p && isdigit(*p); )
 	    ++p; /* satisfy warnings */
 
 	if (*p) {
-	    warn(__func__, "found non-digit GID in file in line: %s", line_dup);
-	    ++issues;
+	    warn("txzchk", "%s: found non-digit GID in file in line: %s", txzpath, line_dup);
+	    ++total_issues;
 	}
 
 	p = strtok(NULL, " \t");
 	if (p == NULL) {
-	    err(30, __func__, "NULL pointer encountered trying to parse line");
+	    err(30, __func__, "%s: NULL pointer encountered trying to parse line", txzpath);
 	    not_reached();
 	}
 
 	errno = 0;
 	current_file_size = strtoll(p, NULL, 10);
 	if (errno != 0) {
-	    err(31, __func__, "trying to parse file size in tarball on line: %s, string: %s", line_dup, p);
+	    err(31, __func__, "%s: trying to parse file size in on line: %s, string: %s", txzpath, line_dup, p);
 	    not_reached();
 	}
 	file_sizes += current_file_size;
@@ -692,7 +689,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	for (i = 0; i < 4; ++i) {
 	    p = strtok(NULL, " \t");
 	    if (p == NULL) {
-		err(32, __func__, "NULL pointer trying to parse line");
+		err(32, __func__, "%s: NULL pointer trying to parse line", txzpath);
 		not_reached();
 	    }
 	}
@@ -700,53 +697,46 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	errno = 0;
 	file = calloc(1, sizeof *file);
 	if (file == NULL) {
-	    err(32, __func__, "unable to allocate a struct file *");
+	    err(32, __func__, "%s: unable to allocate a struct file *", txzpath);
 	    not_reached();
 	}
 
 	errno = 0;
 	file->filename = strdup(p);
 	if (!file->filename) {
-	    err(33, __func__, "unable to strdup filename %s", p);
+	    err(33, __func__, "%s: unable to strdup filename %s", txzpath, p);
 	    not_reached();
 	}
 
 	errno = 0;
 	file->basename = strdup(base_name(p)?base_name(p):"");
 	if (!file->basename || !strlen(file->basename)) {
-	    err(34, __func__, "unable to strdup basename of filename %s", p);
+	    err(34, __func__, "%s: unable to strdup basename of filename %s", txzpath, p);
 	    not_reached();
 	}
 
 	/* 
-	 * although we could check these in check_file() we check here because
-	 * the add_file_to_list() function doesn't add the same file (basename)
-	 * more than once: it simply increments the times it's been seen.
+	 * although we could check these later we check here because the
+	 * add_file_to_list() function doesn't add the same file (basename) more
+	 * than once: it simply increments the times it's been seen.
 	 */
 	if (current_file_size == 0) {
 	    if (!strcmp(file->basename, ".author.json")) {
-		++issues;
-		warn(__func__, "found empty .author.json file");
+		++total_issues;
+		warn("txzchk", "%s: found empty .author.json file", txzpath);
 	    }
 	    else if (!strcmp(file->basename, ".info.json")) {
-		++issues;
-		warn(__func__, "found empty .info.json file");
+		++total_issues;
+		warn("txzchk", "%s: found empty .info.json file", txzpath);
 	    }
 	    else if (!strcmp(file->basename, "remarks.md")) {
-		++issues;
-		warn(__func__, "found empty remarks.md");
+		++total_issues;
+		warn("txzchk", "%s: found empty remarks.md", txzpath);
 	    }
 	    else if (!strcmp(file->basename, "Makefile")) {
-		++issues;
-		warn(__func__, "found empty Makefile");
+		++total_issues;
+		warn("txzchk", "%s: found empty Makefile", txzpath);
 	    }
-	}
-	if (strstr(file->filename, "../")) {
-	    ++issues;
-	    warn(__func__, "found file with ../ in the path: %s", file->filename);
-	} else if (!strncmp(file->filename, "/", 1)) {
-	    ++issues;
-	    warn(__func__, "found absolute path %s", file->filename);
 	}
 
 	add_file_to_list(file);
@@ -762,35 +752,100 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
     errno = 0;		/* pre-clear errno for errp() */
     ret = pclose(tar_stream);
     if (ret < 0) {
-	warnp(__func__, "pclose error on tar stream");
+	warnp(__func__, "%s: pclose error on tar stream", txzpath);
     }
     tar_stream = NULL;
 
 
-    /* check the file list, reporting any issues */
-    issues += check_files();
+    /* 
+     * now go through the files list and detect any additional issues
+     */ 
+    for (file = files; file != NULL; file = file->next) {
+	if (!strcmp(file->basename, ".info.json")) {
+	    info.has_info_json = true;
+	} else if (!strcmp(file->basename, ".author.json")) {
+	    info.has_author_json = true;
+	} else if (!strcmp(file->basename, "Makefile")) {
+	    info.has_Makefile = true;
+	} else if (!strcmp(file->basename, "prog.c")) {
+	    info.has_prog_c = true;
+	} else if (!strcmp(file->basename, "remarks.md")) {
+	    info.has_remarks_md = true;
+	}
+	if (*(file->basename) == '.' && strcmp(file->basename, ".info.json") && strcmp(file->basename, ".author.json")) {
+	    ++total_issues;
+	    warn("txzchk", "%s: found non .author.json and .info.json dot file %s", txzpath, file->basename);
+	    info.dot_files++;
+	}
+	if (strstr(file->filename, "../")) {
+	    /* 
+	     * note that this check does NOT detect a file in the form of
+	     * "../.file" but since the basename of each file is checked above
+	     * this is okay.
+	     */
+	    ++total_issues;
+	    warn("txzchk", "%s: found file with ../ in the path: %s", txzpath, file->filename);
+	}
+	if (*(file->filename) == '/') {
+	    ++total_issues;
+	    warn("txzchk", "%s: found absolute path %s", txzpath, file->filename);
+	}
 
-    /* report total file size */
-    rounded_file_size = round_to_multiple(file_sizes, 1024);
-    if (rounded_file_size > MAX_DIR_KSIZE) {
-	warn(__func__, "accumulated size of all files %lld rounded up to multiple of 1024 %lld > %d", file_sizes, rounded_file_size, MAX_DIR_KSIZE);
-	++issues;
-    } else if (rounded_file_size < 0) {
-	err(30, __func__, "accumulated file size < 0!");
-	not_reached();
-    } else if (!quiet) {
-	printf("total size of files %lld rounded up to 1024 multiple: %lld OK\n", file_sizes, rounded_file_size);
+	if (file->count > 1) {
+	    warn("txzchk", "%s: found a total of %u files with the name %s", txzpath, file->count, file->basename);
+	    total_issues += file->count - 1;
+	}
     }
 
+    /* determine if the required files are there */
+    if (!info.has_info_json) {
+	warn("txzchk", "%s: no .info.json found", txzpath);
+	++total_issues;
+    }
+    if (!info.has_author_json) {
+	warn("txzchk", "%s: no .author.json found", txzpath);
+	++total_issues;
+    }
+    if (!info.has_prog_c) {
+	warn("txzchk", "%s: no prog.c found", txzpath);
+	++total_issues;
+    }
+    if (!info.has_Makefile) {
+	warn("txzchk", "%s: no Makefile found", txzpath);
+	++total_issues;
+    }
+    if (!info.has_remarks_md) {
+	warn("txzchk", "%s: no remarks.md found", txzpath);
+	++total_issues;
+    }
 
-
-    /*
-     * report issues found before running fnamchk so that it's easy to see how
-     * many problems we found (if the fnamchk fails it errors out so this won't
-     * be seen).
+    /* 
+     * Report total number of non .author.json and .info.json files.
+     * Don't increment the number of issues as this was done when iterating
+     * through the linked list above.
      */
-    if (issues > 0) {
-	fprintf(stderr, "txzchk found %u issue%s\n", issues, issues==1?"":"s");
+
+    if (info.dot_files > 0) {
+	warn("txzchk", "%s: found a total of %u unacceptable dot files", txzpath, info.dot_files);
+    }
+
+    /* report total file size */
+    if (file_sizes < 0) {
+	err(32, __func__, "%s: total size of all files < 0!", txzpath);
+	not_reached();
+    } else if (file_sizes == 0) {
+	warn("txzchk", "%s: total size of all files 0", txzpath);
+	++total_issues;
+    }
+    rounded_file_size = round_to_multiple(file_sizes, 1024);
+    if (rounded_file_size > MAX_DIR_KSIZE) {
+	warn("txzchk", "%s: total size of files %lld rounded up to multiple of 1024 %lld > %d", txzpath, file_sizes, rounded_file_size, MAX_DIR_KSIZE);
+	++total_issues;
+    } else if (rounded_file_size < 0) {
+	err(30, __func__, "%s: total size of all files rounded up to multiple of 1024 < 0!", txzpath);
+	not_reached();
+    } else if (!quiet) {
+	printf("txzchk: %s total size of files %lld rounded up to 1024 multiple: %lld OK\n", txzpath, file_sizes, rounded_file_size);
     }
 
     /*
@@ -839,9 +894,16 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 	errp(34, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(35, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
-	not_reached();
+	warn("txzchk", "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	++total_issues;
     }
+    /*
+     * report total issues found
+     */
+    if (total_issues > 0) {
+	warn("txzchk", "%s: txzchk found %u issue%s\n", txzpath, total_issues, total_issues==1?"":"s");
+    }
+
 
 
     free(cmd);
@@ -849,7 +911,7 @@ check_tarball(char const *tar, char const *fnamchk, char const *txzpath)
 
     free_file_list();
 
-    return issues;
+    return total_issues;
 }
 
 /*
@@ -915,64 +977,6 @@ add_file_to_list(struct file *file)
     files = file;
 }
 
-/* check_files	- check the files list, reporting issues (that aren't reported elsewhere)
- *
- * Returns the number of issues that _this_ function finds.
- */
-static unsigned
-check_files(void)
-{
-    unsigned issues = 0;
-    struct file *file = NULL;
-
-    for (file = files; file; file = file->next) {
-	if (!strcmp(file->basename, ".info.json")) {
-	    info.has_info_json = true;
-	} else if (!strcmp(file->basename, ".author.json")) {
-	    info.has_author_json = true;
-	} else if (!strcmp(file->basename, "Makefile")) {
-	    info.has_Makefile = true;
-	} else if (!strcmp(file->basename, "prog.c")) {
-	    info.has_prog_c = true;
-	} else if (!strcmp(file->basename, "remarks.md")) {
-	    info.has_remarks_md = true;
-	} else if (*(file->basename) == '.' && strcmp(file->basename, ".info.json") && strcmp(file->basename, ".author.json")) {
-	    ++issues;
-	    warn(__func__, "found non .author.json and .info.json dot file %s", file->basename);
-	    info.dot_files++;
-	}
-
-	if (file->count > 1) {
-	    warn(__func__, "found a total of %u files with the name %s", file->count, file->basename);
-	    issues += file->count - 1;
-	}
-    }
-
-    /* determine if the required files are there */
-    if (!info.has_info_json) {
-	warn(__func__, "tarball has no .info.json file");
-	++issues;
-    }
-    if (!info.has_author_json) {
-	warn(__func__, "tarball has no .author.json file");
-	++issues;
-    }
-    if (!info.has_prog_c) {
-	warn(__func__, "tarball has no prog.c file");
-	++issues;
-    }
-    if (!info.has_Makefile) {
-	warn(__func__, "tarball has no Makefile");
-	++issues;
-    }
-    if (!info.has_remarks_md) {
-	warn(__func__, "tarball has no remarks.md file");
-	++issues;
-    }
-
-
-    return issues;
-}
 /*
  * free_file_list - free the file linked list
  *

--- a/txzchk.c
+++ b/txzchk.c
@@ -594,6 +594,17 @@ check_tarball(char const *tar, char const *fnamchk)
 	    dbg(DBG_HIGH, "reached EOF of tarball %s", txzpath);
 	    break;
 	}
+
+	/*
+	 * scan for embedded NUL bytes (before end of line)
+	 *
+	 */
+	errno = 0;			/* pre-clear errno for errp() */
+	p = (char *)memchr(linep, 0, (size_t)readline_len);
+	if (p != NULL) {
+	    errp(237, __func__, "found NUL before end of line");
+	    not_reached();
+	}
 	dbg(DBG_VHIGH, "line %d: %s", line_num, linep);
 
 	/*


### PR DESCRIPTION
* Clean up and bug fix txzchk
    
Make warning messages more consistent in format: always show the tool's name and the txzpath. For example if there's no .info.json file it'll now show e.g.: 
    
            Warning: txzchk: test.txz: no .info.json found
    
...whereas before it showed the function name and did not show the tarball path (in this case the fnamchk would issue an error). I feel that showing the utility name is more useful than 'check_tarball()'.  It's possible I have missed a warning. I tried to do the same with errors but I spent less time working on those as those are fatal and the program ends.
    
Removed the check_files() function; the tests are now all in check_tarball().
    
check_tarball() now issues a warning if fnamchk fails so that we can continue if it does fail (though currently it's the last step of the function).
    
txzchk now always shows how many warnings were issued even if fnamchk fails (which is considered an issue).
    
txzchk now exits with 1 if there are issues found.

* txzchk: Check for NUL bytes before end of line

