### PR TITLE
txzchk: portability, bug fixes and enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,10 @@ CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O3 -g3
 
 # where and what to install
 #
+MANDIR = /usr/local/share/man/man1
 DESTDIR= /usr/local/bin
 TARGETS= mkiocccentry iocccsize dbg_test limit_ioccc.sh fnamchk txzchk
+MANPAGES = mkiocccentry.1 txzchk.1 fnamchk.1 iocccsize.1
 TEST_TARGETS= dbg_test
 OBJFILES = dbg.o util.o
 SRCFILES = $(patsubst %.o,%.c,$(OBJFILES))
@@ -259,6 +261,7 @@ clobber: clean
 
 install: all
 	${INSTALL} -m 0555 ${TARGETS} ${DESTDIR}
+	${INSTALL} -m 0644 ${MANPAGES} ${MANDIR}
 
 test: ./iocccsize-test.sh iocccsize dbg_test mkiocccentry ./mkiocccentry-test.sh Makefile
 	@echo "RUNNING: iocccsize-test.sh"

--- a/Makefile
+++ b/Makefile
@@ -84,27 +84,29 @@ TRUE= true
 
 # how to compile
 #
-CFLAGS= -O3 -g3 -pedantic -Wall -Wextra
+# note the feature test macros are required to compile on more systems e.g.
+# CentOS
+CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O3 -g3 -pedantic -Wall -Wextra
 
 # We test by forcing warnings to be errors so you don't have to (allegedly :-) )
 #
-#CFLAGS= -O3 -g3 -pedantic -Wall -Wextra -Werror
+#CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O3 -g3 -pedantic -Wall -Wextra -Werror
 
 # NOTE: There are some things clang -Weverything warns about that are not relevant
 # 	and this for the -Weverything case, we exclude several directives
 #
-#CFLAGS= -O3 -g3 -pedantic -Wall -Wextra -Werror -Weverything \
+#CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O3 -g3 -pedantic -Wall -Wextra -Werror -Weverything \
 #     -Wno-poison-system-directories -Wno-unreachable-code-break -Wno-padded
 
 # NOTE: If you use ASAN, set this environment var:
 #	ASAN_OPTIONS="detect_stack_use_after_return=1"
 #
-#CFLAGS= -O0 -g -pedantic -Wall -Wextra -Werror -fsanitize=address -fno-omit-frame-pointer
+#CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O0 -g -pedantic -Wall -Wextra -Werror -fsanitize=address -fno-omit-frame-pointer
 
 # NOTE: For valgrind, run with:
 #	valgrind --leak-check=yes --track-origins=yes --leak-resolution=high --read-var-info=yes
 #
-#CFLAGS= -O0 -g -pedantic -Wall -Wextra -Werror
+#CFLAGS= -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -std=c99 -O0 -g -pedantic -Wall -Wextra -Werror
 
 # where and what to install
 #

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -103,7 +103,7 @@ static void usage(int exitcode, char const *name, char const *str) __attribute__
 int
 main(int argc, char *argv[])
 {
-    char *program = NULL;	/* our name */
+    char const *program = NULL;	/* our name */
     extern char *optarg;	/* option argument */
     extern int optind;		/* argv index of the next arg */
     char *filepath;		/* filepath argument to check */

--- a/limit_ioccc.h
+++ b/limit_ioccc.h
@@ -30,6 +30,7 @@
 #if !defined(INCLUDE_LIMIT_IOCCC_H)
 #define INCLUDE_LIMIT_IOCCC_H
 
+#include <time.h>
 
 #undef DIGRAPHS		/* digraphs count a 2 for Rule 2b */
 #undef TRIGRAPHS	/* trigraphs count a 3 for Rule 2b */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -325,7 +325,7 @@ static void remind_user(char const *work_dir, char const *entry_dir, char const 
 int
 main(int argc, char *argv[])
 {
-    char *program = NULL;	/* our name */
+    char const *program = NULL;	/* our name */
     extern char *optarg;	/* option argument */
     extern int optind;		/* argv index of the next arg */
     struct timeval tp;		/* gettimeofday time value */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -4855,7 +4855,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	errp(172, __func__, "popen for reading failed for: %s", cmd);
 	not_reached();
     }
-    setlinebuf(ls_stream);
+    setvbuf(ls_stream, (char *)NULL, _IOLBF, 0);
 
     /*
      * read the 1st line - contains the total kibibyte (2^10) block line

--- a/txzchk.1
+++ b/txzchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] txzpath
+\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked indirectly through \fBmkiocccentry(1)\fP.
 .PP
@@ -21,18 +21,21 @@ Set verbosity level.
 .PP
 \fB\-q\fP
 Suppresses some of the output.
-This does not include warnings, errors or the output of the tar command.
+This does not include warnings, errors or the output of the \fBtar\fP command.
 .PP
 \fB\-V\fP
 Show version and exit.
 .PP
 \fB\-t\fP
-Specify path to tar that accepts the \fB\-J\fP option.
+Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 \fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
 .PP
 \fB\-F\fP
 Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
+.PP
+\fB\-T\fP
+Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 0 if no issues are found and 1 if there are issues found; if there's an error the end is not reached.

--- a/txzchk.c
+++ b/txzchk.c
@@ -41,10 +41,11 @@
 /*
  * globals
  */
-char *program = NULL;			    /* our name */
+char const *program = NULL;		    /* our name */
 int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
 static int total_issues = 0;		    /* total number of issues with tarball found */
 static bool quiet = false;		    /* true ==> only show errors and warnings */
+static bool text_file_flag_used = false;    /* true ==> assume txzpath is a text file */
 char const *txzpath = NULL;		    /* the current tarball being checked */
 
 struct info {
@@ -78,7 +79,7 @@ struct file *files;
  * Use the usage() function to print the usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] txzpath\n"
+    "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] [-T] txzpath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
@@ -87,6 +88,7 @@ static const char * const usage_msg =
     "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
     "\t-F /path/to/fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
     "\t\t\t\tfilename (def: %s)\n\n"
+    "\t-T\t\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
     "\ttxzpath\t\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "txzchk version: %s\n";
@@ -116,7 +118,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqF:t:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqF:t:T")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(0, "-h help mode", program, TAR_PATH_0, FNAMCHK_PATH_0);
@@ -153,6 +155,9 @@ int main(int argc, char **argv)
 	case 'q':
 	    quiet = true;
 	    break;
+	case 'T':
+	    text_file_flag_used = true; /* don't rely on tar: just read file as if it was a text file */
+	    break;
 	default:
 	    usage(1, "invalid -flag", program, TAR_PATH_0, TXZCHK_PATH_0); /*ooo*/
 	    not_reached();
@@ -187,8 +192,15 @@ int main(int argc, char **argv)
      *
      * On some systems where /usr/bin != /bin, the distribution made the mistake of
      * moving historic critical applications, look to see if the alternate path works instead.
+     *
+     * If -T was used we don't actually need tar(1) so we test for that
+     * specifically.
      */
-    find_utils(tar_flag_used, &tar, false, NULL, false, NULL, false, NULL, fnamchk_flag_used, &fnamchk);
+
+    if (!text_file_flag_used)
+	find_utils(tar_flag_used, &tar, false, NULL, false, NULL, false, NULL, fnamchk_flag_used, &fnamchk);
+    else
+	find_utils(false, NULL, false, NULL, false, NULL, false, NULL, fnamchk_flag_used, &fnamchk);
 
 
     /*
@@ -287,65 +299,67 @@ sanity_chk(char const *tar, char const *fnamchk)
     /*
      * firewall
      */
-    if (tar == NULL || fnamchk == NULL || txzpath == NULL) {
+    if ((tar == NULL && !text_file_flag_used) || fnamchk == NULL || txzpath == NULL) {
 	err(3, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     /*
-     * tar must be executable
+     * if text file flag not used tar must be executable
      */
-    if (!exists(tar)) {
-	fpara(stderr,
-	      "",
-	      "We cannot find a tar program.",
-	      "",
-	      "A tar program that supports the -J (xz) option is required to build an compressed tarball.",
-	      "Perhaps you need to use:",
-	      "",
-	      "    txzchk -t /path/to/tar ...",
-	      "",
-	      "and/or install a tar program?  You can find the source for tar:",
-	      "",
-	      "    https://www.gnu.org/software/tar/",
-	      "",
-	      NULL);
-	err(4, __func__, "tar does not exist: %s", tar);
-	not_reached();
-    }
-    if (!is_file(tar)) {
-	fpara(stderr,
-	      "",
-	      "The tar, whilst it exists, is not a file.",
-	      "",
-	      "Perhaps you need to use another path:",
-	      "",
-	      "    txzchk -t /path/to/tar ...",
-	      "",
-	      "and/or install a tar program?  You can find the source for tar:",
-	      "",
-	      "    https://www.gnu.org/software/tar/",
-	      "",
-	      NULL);
-	err(5, __func__, "tar is not a file: %s", tar);
-	not_reached();
-    }
-    if (!is_exec(tar)) {
-	fpara(stderr,
-	      "",
-	      "The tar, whilst it is a file, is not executable.",
-	      "",
-	      "We suggest you check the permissions on the tar program, or use another path:",
-	      "",
-	      "    txzchk -t /path/to/tar ...",
-	      "",
-	      "and/or install a tar program?  You can find the source for tar:",
-	      "",
-	      "    https://www.gnu.org/software/tar/",
-	      "",
-	      NULL);
-	err(6, __func__, "tar is not an executable program: %s", tar);
-	not_reached();
+    if (!text_file_flag_used) {
+	if (!exists(tar)) {
+	    fpara(stderr,
+		  "",
+		  "We cannot find a tar program.",
+		  "",
+		  "A tar program that supports the -J (xz) option is required to build an compressed tarball.",
+		  "Perhaps you need to use:",
+		  "",
+		  "    txzchk -t /path/to/tar ...",
+		  "",
+		  "and/or install a tar program?  You can find the source for tar:",
+		  "",
+		  "    https://www.gnu.org/software/tar/",
+		  "",
+		  NULL);
+	    err(4, __func__, "tar does not exist: %s", tar);
+	    not_reached();
+	}
+	if (!is_file(tar)) {
+	    fpara(stderr,
+		  "",
+		  "The tar, whilst it exists, is not a file.",
+		  "",
+		  "Perhaps you need to use another path:",
+		  "",
+		  "    txzchk -t /path/to/tar ...",
+		  "",
+		  "and/or install a tar program?  You can find the source for tar:",
+		  "",
+		  "    https://www.gnu.org/software/tar/",
+		  "",
+		  NULL);
+	    err(5, __func__, "tar is not a file: %s", tar);
+	    not_reached();
+	}
+	if (!is_exec(tar)) {
+	    fpara(stderr,
+		  "",
+		  "The tar, whilst it is a file, is not executable.",
+		  "",
+		  "We suggest you check the permissions on the tar program, or use another path:",
+		  "",
+		  "    txzchk -t /path/to/tar ...",
+		  "",
+		  "and/or install a tar program?  You can find the source for tar:",
+		  "",
+		  "    https://www.gnu.org/software/tar/",
+		  "",
+		  NULL);
+	    err(6, __func__, "tar is not an executable program: %s", tar);
+	    not_reached();
+	}
     }
 
     /*
@@ -373,7 +387,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(8, __func__, "fnamchk is not a file: %s", tar);
+	err(8, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -385,7 +399,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(9, __func__, "fnamchk is not an executable program: %s", tar);
+	err(9, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -441,7 +455,8 @@ sanity_chk(char const *tar, char const *fnamchk)
  *
  * given:
  *
- *	tar		- path to executable tar program
+ *	tar		- path to executable tar program (if -T was not
+ *			  specified)
  *	fnamchk		- path to fnamchk tool
  *
  *  Returns the number of total number of issues found (total_issues).
@@ -457,7 +472,7 @@ check_tarball(char const *tar, char const *fnamchk)
     off_t rounded_file_size = 0; /* file sizes rounded up to 1024 multiple */
     unsigned line_num = 0; /* line number of tar output */
     char *cmd = NULL;	/* fnamchk and tar -tJvf */
-    FILE *tar_stream = NULL; /* pipe for tar output */
+    FILE *input_stream = NULL; /* pipe for tar output (or if -T specified read as a text file) */
     FILE *fnamchk_stream = NULL; /* pipe for fnamchk output */
     char *linep = NULL;		/* allocated line read from tar */
     char *line_dup = NULL;	/* duplicated line from readline */
@@ -473,12 +488,12 @@ check_tarball(char const *tar, char const *fnamchk)
     /*
      * firewall
      */
-    if (tar == NULL || fnamchk == NULL || txzpath == NULL) {
+    if ((!text_file_flag_used && tar == NULL) || fnamchk == NULL || txzpath == NULL) {
 	err(13, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
-    /* 
+    /*
      * First of all we have to run fnamchk on the tarball: this is important
      * because we have to know the actual directory name the files should be in
      * within the tarball and we cannot use strtok(3) on the strdup()'d strings
@@ -532,7 +547,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	fnamchk_okay = true;
     }
 
-    /* 
+    /*
      * If fnamchk went okay we have to retrieve the directory name that's
      * expected and compare it to what's in the filenames of the tarball. Since
      * it's the only output we shouldn't have to loop at all. If the output
@@ -559,7 +574,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	if (readline_len < 0) {
 	    warn("txzchk", "%s: unexpected EOF from fnamchk", txzpath);
 	}
-	
+
 	/*
 	 * close down pipe
 	 */
@@ -604,82 +619,94 @@ check_tarball(char const *tar, char const *fnamchk)
     dbg(DBG_MED, "txzchk: %s size in bytes: %lu", txzpath, (unsigned long)size);
 
     /*
-     * free cmd for tar command
+     * free cmd for tar (if -T wasn't specified) command
      */
-    free(cmd); 
+    free(cmd);
+    cmd = NULL;
 
-    errno = 0;			/* pre-clear errno for errp() */
-    cmd = cmdprintf("% -tJvf %", tar, txzpath);
-    if (cmd == NULL) {
-	err(16, __func__, "failed to cmdprintf: tar -tJvf txzpath");
-	not_reached();
+    if (text_file_flag_used) {
+	input_stream = fopen(txzpath, "r");
+	errno = 0;
+	if (input_stream == NULL) {
+	    errp(122, __func__, "fopen of %s failed", txzpath);
+	    not_reached();
+	}
     }
-    dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
+    else { /* if -T not specified we have to do more to set up input stream */
 
-    /*
-     * pre-flush to avoid system() buffered stdio issues
-     */
-    clearerr(stdout);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stdout);
-    if (ret < 0) {
-	errp(17, __func__, "fflush(stdout) error code: %d", ret);
-	not_reached();
-    }
-    errno = 0;			/* pre-clear errno for errp() */
-    clearerr(stderr);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stderr);
-    if (ret < 0) {
-	errp(18, __func__, "fflush(stderr) #1: error code: %d", ret);
-	not_reached();
-    }
+	errno = 0;			/* pre-clear errno for errp() */
+	cmd = cmdprintf("% -tJvf %", tar, txzpath);
+	if (cmd == NULL) {
+	    err(16, __func__, "failed to cmdprintf: tar -tJvf txzpath");
+	    not_reached();
+	}
+	dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
 
-    /*
-     * execute the tar command
-     */
-    errno = 0;			/* pre-clear errno for errp() */
-    exit_code = system(cmd);
-    if (exit_code < 0) {
-	errp(19, __func__, "error calling system(%s)", cmd);
-	not_reached();
-    } else if (exit_code == 127) {
-	errp(20, __func__, "execution of the shell failed for system(%s)", cmd);
-	not_reached();
-    } else if (exit_code != 0) {
-	err(21, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
-	not_reached();
-    }
+	/*
+	 * pre-flush to avoid system() buffered stdio issues
+	 */
+	clearerr(stdout);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stdout);
+	if (ret < 0) {
+	    errp(17, __func__, "fflush(stdout) error code: %d", ret);
+	    not_reached();
+	}
+	errno = 0;			/* pre-clear errno for errp() */
+	clearerr(stderr);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stderr);
+	if (ret < 0) {
+	    errp(18, __func__, "fflush(stderr) #1: error code: %d", ret);
+	    not_reached();
+	}
 
-    /*
-     * pre-flush to avoid popen() buffered stdio issues
-     */
-    dbg(DBG_HIGH, "about to perform: popen(%s, r)", cmd);
-    clearerr(stdout);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stdout);
-    if (ret < 0) {
-	errp(22, __func__, "fflush(stdout) #0: error code: %d", ret);
-	not_reached();
-    }
-    clearerr(stderr);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stderr);
-    if (ret < 0) {
-	errp(23, __func__, "fflush(stderr) #1: error code: %d", ret);
-	not_reached();
-    }
+	/*
+	 * execute the tar command
+	 */
+	errno = 0;			/* pre-clear errno for errp() */
+	exit_code = system(cmd);
+	if (exit_code < 0) {
+	    errp(19, __func__, "error calling system(%s)", cmd);
+	    not_reached();
+	} else if (exit_code == 127) {
+	    errp(20, __func__, "execution of the shell failed for system(%s)", cmd);
+	    not_reached();
+	} else if (exit_code != 0) {
+	    err(21, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	    not_reached();
+	}
 
-    /*
-     * form pipe to the tar command
-     */
-    errno = 0;			/* pre-clear errno for errp() */
-    tar_stream = popen(cmd, "r");
-    if (tar_stream == NULL) {
-	errp(24, __func__, "popen for reading failed for: %s", cmd);
-	not_reached();
+	/*
+	 * pre-flush to avoid popen() buffered stdio issues
+	 */
+	dbg(DBG_HIGH, "about to perform: popen(%s, r)", cmd);
+	clearerr(stdout);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stdout);
+	if (ret < 0) {
+	    errp(22, __func__, "fflush(stdout) #0: error code: %d", ret);
+	    not_reached();
+	}
+	clearerr(stderr);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stderr);
+	if (ret < 0) {
+	    errp(23, __func__, "fflush(stderr) #1: error code: %d", ret);
+	    not_reached();
+	}
+
+	/*
+	 * If we get here -T was not specified so open pipe to tar command.
+	 */
+	errno = 0;			/* pre-clear errno for errp() */
+	input_stream = popen(cmd, "r");
+	if (input_stream == NULL) {
+	    errp(24, __func__, "popen for reading failed for: %s", cmd);
+	    not_reached();
+	}
     }
-    setvbuf(tar_stream, (char *)NULL, _IOLBF, 0);
+    setvbuf(input_stream, (char *)NULL, _IOLBF, 0);
 
     /*
      * process all tar lines listed
@@ -695,10 +722,18 @@ check_tarball(char const *tar, char const *fnamchk)
 	/*
 	 * read the next listing line
 	 */
-	readline_len = readline(&linep, tar_stream);
+	readline_len = readline(&linep, input_stream);
         if (readline_len < 0) {
 	    dbg(DBG_HIGH, "reached EOF of tarball %s", txzpath);
 	    break;
+	}
+
+	if (text_file_flag_used) {
+	    errno = 0;
+	    ret = printf("%s\n", linep);
+	    if (ret <= 0) {
+		warnp(__func__, "unable to printf line from text file");
+	    }
 	}
 
 	/*
@@ -799,7 +834,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 	file_sizes += current_file_size;
 
-	/* 
+	/*
 	 * the next three fields we don't care about but we loop four times to
 	 * get the following field which we do care about.
 	 */
@@ -832,7 +867,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	    not_reached();
 	}
 
-	/* 
+	/*
 	 * although we could check these later we check here because the
 	 * add_file_to_list() function doesn't add the same file (basename) more
 	 * than once: it simply increments the times it's been seen.
@@ -857,7 +892,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 	add_file_to_list(file);
 
-	/* 
+	/*
 	 * Now we have to run some tests on the directory name which we obtained
 	 * from fnamchk earlier on - but only if fnamchk did not return an
 	 * error! If it did we'll report other issues but we won't check
@@ -886,16 +921,26 @@ check_tarball(char const *tar, char const *fnamchk)
      * close down pipe
      */
     errno = 0;		/* pre-clear errno for errp() */
-    ret = pclose(tar_stream);
+    if (text_file_flag_used)
+	ret = fclose(input_stream);
+    else
+	ret = pclose(input_stream);
     if (ret < 0) {
-	warnp(__func__, "%s: pclose error on tar stream", txzpath);
+	warnp(__func__, "%s: %s error on tar stream", txzpath, text_file_flag_used?"fclose":"pclose");
     }
-    tar_stream = NULL;
+    input_stream = NULL;
+
+    /*
+     * free cmd (it'll be NULL if -T was specified but this is safe)
+     */
+    free(cmd);
+    cmd = NULL;
 
 
-    /* 
+
+    /*
      * now go through the files list and detect any additional issues
-     */ 
+     */
     for (file = files; file != NULL; file = file->next) {
 	if (!strcmp(file->basename, ".info.json")) {
 	    info.has_info_json = true;
@@ -914,7 +959,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	    info.dot_files++;
 	}
 	if (strstr(file->filename, "../")) {
-	    /* 
+	    /*
 	     * note that this check does NOT detect a file in the form of
 	     * "../.file" but since the basename of each file is checked above
 	     * this is okay.
@@ -955,7 +1000,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	++total_issues;
     }
 
-    /* 
+    /*
      * Report total number of non .author.json and .info.json dot files.
      * Don't increment the number of issues as this was done when iterating
      * through the linked list above.
@@ -985,12 +1030,6 @@ check_tarball(char const *tar, char const *fnamchk)
 	printf("txzchk: %s total size of files %lu rounded up to 1024 multiple: %lu OK\n", txzpath, (unsigned long) file_sizes,
 		(unsigned long) rounded_file_size);
     }
-
-    /*
-     * free cmd
-     */
-    free(cmd);
-    cmd = NULL;
 
     /*
      * report total issues found
@@ -1027,7 +1066,7 @@ has_special_bits(char const *str)
     return str[strspn(str, "-drwx")]!='\0';
 }
 /*
- * add_file_to_list - add a filename to the linked list 
+ * add_file_to_list - add a filename to the linked list
  *
  * given:
  *

--- a/txzchk.c
+++ b/txzchk.c
@@ -553,7 +553,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	    errp(24, __func__, "popen for reading failed for: %s", cmd);
 	    not_reached();
 	}
-	setlinebuf(fnamchk_stream);
+	setvbuf(fnamchk_stream, (char *)NULL, _IOLBF, 0);
 
 	readline_len = readline(&dir_name, fnamchk_stream);
 	if (readline_len < 0) {
@@ -596,7 +596,7 @@ check_tarball(char const *tar, char const *fnamchk)
     }
     else if (!quiet) {
 	errno = 0;
-	ret = printf("txzchk: %s size of %lld bytes OK\n", txzpath, (off_t) size);
+	ret = printf("txzchk: %s size of %lu bytes OK\n", txzpath, (unsigned long) size);
 	if (ret <= 0) {
 	    warn("txzchk", "unable to tell user how big the tarball %s is", txzpath);
 	}
@@ -679,7 +679,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errp(24, __func__, "popen for reading failed for: %s", cmd);
 	not_reached();
     }
-    setlinebuf(tar_stream);
+    setvbuf(tar_stream, (char *)NULL, _IOLBF, 0);
 
     /*
      * process all tar lines listed
@@ -974,14 +974,16 @@ check_tarball(char const *tar, char const *fnamchk)
 	++total_issues;
     }
     rounded_file_size = round_to_multiple(file_sizes, 1024);
-    if (rounded_file_size > MAX_DIR_KSIZE) {
-	warn("txzchk", "%s: total size of files %lld rounded up to multiple of 1024 %lld > %d", txzpath, file_sizes, rounded_file_size, MAX_DIR_KSIZE);
-	++total_issues;
-    } else if (rounded_file_size < 0) {
+    if (rounded_file_size < 0) {
 	err(30, __func__, "%s: total size of all files rounded up to multiple of 1024 < 0!", txzpath);
 	not_reached();
+    } else if (rounded_file_size > MAX_DIR_KSIZE) {
+	warn("txzchk", "%s: total size of files %lu rounded up to multiple of 1024 %lu > %d", txzpath, (unsigned long) file_sizes,
+		(unsigned long) rounded_file_size, MAX_DIR_KSIZE);
+	++total_issues;
     } else if (!quiet) {
-	printf("txzchk: %s total size of files %lld rounded up to 1024 multiple: %lld OK\n", txzpath, file_sizes, rounded_file_size);
+	printf("txzchk: %s total size of files %lu rounded up to 1024 multiple: %lu OK\n", txzpath, (unsigned long) file_sizes,
+		(unsigned long) rounded_file_size);
     }
 
     /*

--- a/util.c
+++ b/util.c
@@ -1452,7 +1452,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
     /*
      * strip trailing whitespace if requested
      */
-    if (strip == true) {
+    if (strip) {
 	if (len > 0) {
 	    for (i = len - 1; i >= 0; --i) {
 		if (isascii(ret[i]) && isspace(ret[i])) {
@@ -1508,25 +1508,25 @@ find_utils(bool tar_flag_used, char **tar, bool cp_flag_used, char **cp, bool ls
      * On some systems where /usr/bin != /bin, the distribution made the mistake of
      * moving historic critical applications, look to see if the alternate path works instead.
      */
-    if (tar != NULL && tar_flag_used == false && !is_exec(TAR_PATH_0) && is_exec(TAR_PATH_1)) {
+    if (tar != NULL && !tar_flag_used && !is_exec(TAR_PATH_0) && is_exec(TAR_PATH_1)) {
 	*tar = TAR_PATH_1;
 	dbg(DBG_MED, "tar is not in historic location: %s : will try alternate location: %s", TAR_PATH_0, *tar);
     }
-    if (cp != NULL && cp_flag_used == false && !is_exec(CP_PATH_0) && is_exec(CP_PATH_1)) {
+    if (cp != NULL && !cp_flag_used && !is_exec(CP_PATH_0) && is_exec(CP_PATH_1)) {
 	*cp = CP_PATH_1;
 	dbg(DBG_MED, "cp is not in historic location: %s : will try alternate location: %s", CP_PATH_0, *cp);
     }
-    if (ls != NULL && ls_flag_used == false && !is_exec(LS_PATH_0) && is_exec(LS_PATH_1)) {
+    if (ls != NULL && !ls_flag_used && !is_exec(LS_PATH_0) && is_exec(LS_PATH_1)) {
 	*ls = LS_PATH_1;
 	dbg(DBG_MED, "ls is not in historic location: %s : will try alternate location: %s", LS_PATH_0, *ls);
     }
 
     /* now do the same for our utilities: txzchk and fnamchk */
-    if (txzchk != NULL && txzchk_flag_used == false && !is_exec(TXZCHK_PATH_0) && is_exec(TXZCHK_PATH_1)) {
+    if (txzchk != NULL && !txzchk_flag_used && !is_exec(TXZCHK_PATH_0) && is_exec(TXZCHK_PATH_1)) {
 	*txzchk = TXZCHK_PATH_1;
 	dbg(DBG_MED, "using default txzchk path: %s", TXZCHK_PATH_1);
     }
-    if (fnamchk != NULL && fnamchk_flag_used == false && !is_exec(FNAMCHK_PATH_0) && is_exec(FNAMCHK_PATH_1)) {
+    if (fnamchk != NULL && !fnamchk_flag_used && !is_exec(FNAMCHK_PATH_0) && is_exec(FNAMCHK_PATH_1)) {
 	*fnamchk = FNAMCHK_PATH_1;
 	dbg(DBG_MED, "using default fnamchk path: %s", FNAMCHK_PATH_1);
     }

--- a/util.c
+++ b/util.c
@@ -1479,7 +1479,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
 }
 
 
-/* find_utils - find tar, cp and ls utilities
+/* find_utils - find tar, cp, ls, txzchk and fnamchk utilities
  *
  * given:
  *


### PR DESCRIPTION
This commit changes the C standard to C99. This in turn required that some feature test macros be enabled for CentOS but making these changes some other fixes had to be made for macOS. Since the Makefile is a dependency for the C files one should simply be able to pull these commits and recompile cleanly under both CentOS (and other Linux distributions) and macOS.

What this *does not fix* is a problem discovered yesterday where **tar(1)** has a different format under macOS/BSD and Linux. This will be fixed in the near future but for for now the `txzchk` will only succeed under macOS/BSD (which in turn means `mkiocccentry` will not work under Linux).

Sorry for this inconvenience! I hope to have this resolved today but I do not know when it will be other than it should be soon - in a day or two and no more hopefully (but hopefully today).