### PR TITLE
Fix txzchk man page and typo fix in txzchk.c

### DIFF
--- a/txzchk.1
+++ b/txzchk.1
@@ -52,19 +52,19 @@ If you have an issue with the tool you can open an issue at \fI\<https://github.
 .SH EXAMPLES
 .PP
 .nf
-Run the program on the tarball \fIentry.test.0.1644094311.txz\fP:
+Run the program on the tarball \fIentry.test-1.1644094311.txz\fP:
 
 .RS
 \fB
- ./txzchk entry.test.0.1644094311.txz\fP
+ ./txzchk entry.test-1.1644094311.txz\fP
 .fi
 .RE
 .PP
 .nf
-Run the program on the tarball \fIentry.test.0.1644094311.txz\fP, specifying an alternate path to \fBtar\fP and \fBfnamchk\fP:
+Run the program on the tarball \fIentry.test-1.1644094311.txz\fP, specifying an alternate path to \fBtar\fP and \fBfnamchk\fP:
 
 .RS
 \fB
- ./txzchk -t /path/to/tar -F ./filenamechk entry.test.0.1644094311.txz\fP
+ ./txzchk -t /path/to/tar -F ./filenamechk entry.test-1.1644094311.txz\fP
 .fi
 .RE

--- a/txzchk.c
+++ b/txzchk.c
@@ -604,7 +604,7 @@ parse_linux_line(char *p, char *linep, char *line_dup, char *dir_name, char cons
 
 }
 /*
- * parse_linux_line	- parse macOS/BSD tar output
+ * parse_bsd_line	- parse macOS/BSD tar output
  *
  * given:
  *


### PR DESCRIPTION
I forgot to update `txzchk.1` after changing the filename format of the entry tarballs and I also had a typo in the comments in `txzchk.c`.