### PR TITLE
txzchk: bug fixes and man page updates

### DIFF
--- a/iocccsize.1
+++ b/iocccsize.1
@@ -48,6 +48,10 @@ Source file to the \fBiocccsize\fP tool.
 .RS
 Script that tests the \fBiocccsize\fP tool.
 .RE
+\fIlimit_ioccc.h\fP
+.RS
+Header file with limits related to the IOCCC.
+.RE
 .SH BUGS
 .PP
 There are no bugs: "You are not expected to understand this" :\-)

--- a/iocccsize.1
+++ b/iocccsize.1
@@ -1,4 +1,4 @@
-.TH iocccsize 1 "06 February 2022" "iocccsize" "IOCCC tools"
+.TH iocccsize 1 "11 February 2022" "iocccsize" "IOCCC tools"
 .SH NAME
 iocccsize \- IOCCC Source Size Tool
 .SH SYNOPSIS

--- a/txzchk.1
+++ b/txzchk.1
@@ -46,7 +46,7 @@ Source file to the \fBtxzchk\fP tool.
 .RE
 .SH BUGS
 .PP
-More than 0 humans work on it! :)
+Cody Boone Ferguson wrote it! :)
 .PP
 If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,4 +1,4 @@
-.TH txzchk 1 "06 February 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "11 February 2022" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS

--- a/txzchk.1
+++ b/txzchk.1
@@ -44,6 +44,10 @@ Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of
 .RS
 Source file to the \fBtxzchk\fP tool.
 .RE
+\fIlimit_ioccc.h\fP
+.RS
+Header file with limits related to the IOCCC.
+.RE
 .SH BUGS
 .PP
 Cody Boone Ferguson wrote it! :)

--- a/txzchk.c
+++ b/txzchk.c
@@ -659,7 +659,7 @@ check_all_files(off_t file_sizes, char const *dir_name)
      */
 
     if (info.dot_files > 0) {
-	warn("txzchk", "%s: found a total of %u unacceptable dot files", txzpath, info.dot_files);
+	warn("txzchk", "%s: found a total of %u unacceptable dot file%s", txzpath, info.dot_files, info.dot_files==1?"":"s");
     }
 
     /*
@@ -704,14 +704,15 @@ check_directories(struct file *file, char const *dir_name, char const *txzpath)
     if (strchr(file->filename, '/') == NULL) {
 	warn("txzchk", "%s: no directory found in filename %s", txzpath, file->filename);
 	++total_issues;
-    } else if (strstr(file->filename, "../")) { /* check for '../' in path */
+    }
+    if (strstr(file->filename, "..")) { /* check for '..' in path */
 	/*
 	 * Note that this check does NOT detect a file in the form of "../.file"
 	 * but since the basename of each file is checked in check_file() this
 	 * is okay.
 	 */
 	++total_issues;
-	warn("txzchk", "%s: found file with ../ in the path: %s", txzpath, file->filename);
+	warn("txzchk", "%s: found file with .. in the path: %s", txzpath, file->filename);
     }
     if (*(file->filename) == '/') {
 	++total_issues;

--- a/txzchk.c
+++ b/txzchk.c
@@ -115,7 +115,7 @@ static void parse_line(char *linep, char *line_dup, char const *dir_name, char c
 static void parse_linux_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, off_t *file_sizes, char **saveptr);
 static void parse_bsd_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, off_t *file_sizes, char **saveptr);
 static unsigned check_tarball(char const *tar, char const *fnamchk);
-static void check_empty_file(char const *txzpath, off_t file_size, struct file *file);
+static void check_empty_file(char const *txzpath, off_t size, struct file *file);
 static void check_file(char const *txzpath, char *p, char const *dir_name, struct file *file);
 static void check_all_files(off_t file_sizes, char const *dir_name);
 static void check_directories(struct file *file, char const *dir_name, char const *txzpath);
@@ -516,7 +516,7 @@ check_file(char const *txzpath, char *p, char const *dir_name, struct file *file
  * given:
  *
  *	txzpath		- the tarball (or text file) we're checking
- *	file_size	- size of the file
+ *	size		- size of the file
  *	file		- the struct file we're checking
  *
  * Returns void.
@@ -524,7 +524,7 @@ check_file(char const *txzpath, char *p, char const *dir_name, struct file *file
  * Does not return on error (NULL pointers passed in).
  */
 static void
-check_empty_file(char const *txzpath, off_t file_size, struct file *file)
+check_empty_file(char const *txzpath, off_t size, struct file *file)
 {
     /*
      * firewall
@@ -535,7 +535,7 @@ check_empty_file(char const *txzpath, off_t file_size, struct file *file)
 	not_reached();
     }
 
-    if (file_size == 0) {
+    if (size == 0) {
 	if (!strcmp(file->basename, ".author.json")) {
 	    ++total_issues;
 	    warn("txzchk", "%s: found empty .author.json file", txzpath);

--- a/txzchk.c
+++ b/txzchk.c
@@ -38,7 +38,7 @@
 /*
  * txzchk version
  */
-#define TXZCHK_VERSION "0.5 2022-02-10"    /* use format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "0.6 2022-02-11"    /* use format: major.minor YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
I've updated the code to use `strtok_r`() instead of `strtok()`.

The self-deprecating humour in the man page fits me well as I enjoy laughing at myself.

I also removed some ambiguity in a variable name.

Changed the detection of `../` in paths a bit (now checks for just `..`) and fixed the dot file warning to say only 'file' if only one dot file was found (i.e. it used to say files but now it only shows that if > 1 found).