### PR TITLE
NULL pointer checks in txzchk.c

### DIFF
--- a/txzchk.c
+++ b/txzchk.c
@@ -815,7 +815,7 @@ parse_linux_line(char *p, char *linep, char *line_dup, char const *dir_name, cha
      * firewall
      */
 
-    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || file_sizes == NULL) {
+    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || file_sizes == NULL || saveptr == NULL) {
 	err(18, __func__, "called with NULL arg(s)");
 	not_reached();
     }
@@ -920,7 +920,7 @@ parse_bsd_line(char *p, char *linep, char *line_dup, char const *dir_name, char 
      * firewall
      */
 
-    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || file_sizes == NULL) {
+    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || file_sizes == NULL || saveptr == NULL) {
 	err(19, __func__, "called with NULL arg(s)");
 	not_reached();
     }


### PR DESCRIPTION
The pointer saveptr should never be NULL but I've added it to the NULL
pointers check in both parse_bsd_line() and parse_linux_line() to be
complete (I forgot to do this when changing strtok() to strtok_r()).