### PR TITLE
Various updates and fixes

### DIFF
--- a/fnamchk.1
+++ b/fnamchk.1
@@ -1,8 +1,8 @@
-.TH fnamchk 1 "06 February 2022" "fnamchk" "IOCCC tools"
+.TH fnamchk 1 "13 February 2022" "fnamchk" "IOCCC tools"
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
-\fBfnamchk fnamchk [\-h] [\-v level] [\-V] filepath
+\fBfnamchk [\-h] [\-v level] [\-V] filepath
 .SH DESCRIPTION
 \fBfnamchk\fP verifies that an IOCCC compressed tarball is properly named.
 .PP

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -62,7 +62,7 @@
 /*
  * fnamchk version
  */
-#define FILENAMECHECK_VERSION "0.2 2022-02-07"	/* use format: major.minor YYYY-MM-DD */
+#define FNAMCHK_VERSION "0.2 2022-02-07"	/* use format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -146,9 +146,9 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", FILENAMECHECK_VERSION);
+	    ret = printf("%s\n", FNAMCHK_VERSION);
 	    if (ret <= 0) {
-		warnp(__func__, "printf error printing version string: %s", FILENAMECHECK_VERSION);
+		warnp(__func__, "printf error printing version string: %s", FNAMCHK_VERSION);
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();
@@ -342,7 +342,7 @@ usage(int exitcode, char const *str, char const *prog)
      * print the formatted usage stream
      */
     vfprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
-    vfprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, FILENAMECHECK_VERSION);
+    vfprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, FNAMCHK_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/iocccsize.1
+++ b/iocccsize.1
@@ -1,8 +1,8 @@
-.TH iocccsize 1 "11 February 2022" "iocccsize" "IOCCC tools"
+.TH iocccsize 1 "13 February 2022" "iocccsize" "IOCCC tools"
 .SH NAME
 iocccsize \- IOCCC Source Size Tool
 .SH SYNOPSIS
-\fBiocccsize iocccsize [-h] [-i] [-v ...] [-V] prog.c\fP 
+\fBiocccsize [-h] [-i] [-v ...] [-V] prog.c\fP
 .SH DESCRIPTION
 .PP
 Reading a C source file from standard input or a file arg, apply the IOCCC source size rules as explained in the Guidelines.

--- a/jauthchk.1
+++ b/jauthchk.1
@@ -1,0 +1,44 @@
+.TH jauthchk 1 "13 February 2022" "jauthchk" "IOCCC tools"
+.SH NAME
+jauthchk \- IOCCC tool to validate .author.json file found within an entry directory
+.SH SYNOPSIS
+\fBjauthchk [\-h] [\-v level] [\-V] [\-q] file
+.SH DESCRIPTION
+\fBjauthchk\fP is primarily used by other tools (not humans).
+As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
+If there are problems found with the \fI.author.json\fP file, then warning messages should be printed to \fBstderr\fP AND the \fBjauthchk\fP tool should exit with a non-zero status.
+The use of a -v level may be use to assist in debugging.
+.PP
+The \fBjauthchk\fP tool is primarily a stand alone tool.
+As a sanity check, the \fBmkiocccentry(1)\fP program executes \fBjauthchk\fP AFTER the \fI.author.json\fP file has been created and before the compressed tarball is formed.
+If \fBmkiocccentry\fP program sees a 0 exit status, then all is well.
+For a non-zero exit code, the tool aborts because any problems detected by \fBjauthchk\fP based on what \fBmkiocccentry\fP wrote into \fI.author.json\fP indicates there is a serious mismatch between what \fBmkiocccentry\fP is doing and what \fBjauthchk\fP expects.
+.PP
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-V\fP
+Show version and exit.
+.PP
+\fB\-q\fP
+Quiet mode: don't show welcome messages etc. (primarily used with \fBmkiocccentry\fP).
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 0 on success; if there's an error non-zero is returned.
+.SH FILES
+\fIjauthchk.c\fP
+.RS
+Source file to the \fBjauthchk\fP tool.
+.RE
+\fIjson.h\fP
+.RS
+Header file with JSON data and function prototypes.
+.RE
+.SH BUGS
+.PP
+If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.

--- a/jinfochk.1
+++ b/jinfochk.1
@@ -1,0 +1,44 @@
+.TH jinfochk 1 "13 February 2022" "jinfochk" "IOCCC tools"
+.SH NAME
+jinfochk \- IOCCC tool to validate .info.json file found within an entry directory
+.SH SYNOPSIS
+\fBjinfochk [\-h] [\-v level] [\-V] [\-q] file
+.SH DESCRIPTION
+\fBjinfochk\fP is primarily used by other tools (not humans).
+As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
+If there are problems found with the \fI.info.json\fP file, then warning messages should be printed to \fBstderr\fP AND the \fBjinfochk\fP tool should exit with a non-zero status.
+The use of a -v level may be use to assist in debugging.
+.PP
+The \fBjinfochk\fP tool is primarily a stand alone tool.
+As a sanity check, the \fBmkiocccentry(1)\fP program executes \fBjinfochk\fP AFTER the \fI.info.json\fP file has been created and before the compressed tarball is formed.
+If \fBmkiocccentry\fP program sees a 0 exit status, then all is well.
+For a non-zero exit code, the tool aborts because any problems detected by \fBjinfochk\fP based on what \fBmkiocccentry\fP wrote into \fI.info.json\fP indicates there is a serious mismatch between what \fBmkiocccentry\fP is doing and what \fBjinfochk\fP expects.
+.PP
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-V\fP
+Show version and exit.
+.PP
+\fB\-q\fP
+Quiet mode: don't show welcome messages etc. (primarily used with \fBmkiocccentry\fP).
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 0 on success; if there's an error non-zero is returned.
+.SH FILES
+\fIjinfochk.c\fP
+.RS
+Source file to the \fBjinfochk\fP tool.
+.RE
+\fIjson.h\fP
+.RS
+Header file with JSON data and function prototypes.
+.RE
+.SH BUGS
+.PP
+If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1,6 +1,6 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * jinfochk - IOCCC JSON .author.json checker and validator
+ * jinfochk - IOCCC JSON .info.json checker and validator
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  */

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,8 +1,8 @@
-.TH txzchk 1 "11 February 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "13 February 2022" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk usage: ./txzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
+\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked indirectly through \fBmkiocccentry(1)\fP.
 .PP

--- a/txzchk.c
+++ b/txzchk.c
@@ -66,11 +66,13 @@ struct txz_info {
     bool empty_remarks_md;		    /* true ==> remarks.md size == 0 */
     bool has_Makefile;			    /* true ==> has a Makefile */
     bool empty_Makefile;		    /* true ==> Makefile size == 0 */
+    unsigned invalid_chars;		    /* > 0 ==> invalid characters found in one or more files */
     off_t size;				    /* size of the tarball itself */
     off_t file_sizes;			    /* total size of all the files combined */
     off_t rounded_file_size;		    /* file sizes rounded up to 1024 multiple */
     unsigned correct_directory;		    /* number of files in the correct directory */
     unsigned dot_files;			    /* number of dot files that aren't .author.json and .info.json */
+    unsigned named_dot;			    /* number of files called just '.' */
     unsigned total_files;		    /* total files in the tarball */
     int total_issues;			    /* number of total issues in tarball */
 } txz_info;
@@ -300,16 +302,18 @@ show_txz_info(char const *txzpath)
 	dbg(DBG_HIGH, "txzchk: %s: empty .author.json:\t\t%d", txzpath, txz_info.empty_author_json);
 	dbg(DBG_MED, "txzchk: %s: has prog.c:\t\t\t%d", txzpath, txz_info.has_prog_c);
 	dbg(DBG_HIGH, "txzchk: %s: empty prog.c:\t\t\t%d", txzpath, txz_info.empty_prog_c);
-	dbg(DBG_MED, "txzchk: %s: has remarks.md:\t\t%d", txzpath, txz_info.has_remarks_md);
+	dbg(DBG_MED, "txzchk: %s: has remarks.md:\t\t\t%d", txzpath, txz_info.has_remarks_md);
 	dbg(DBG_HIGH, "txzchk: %s: empty remarks.md:\t\t%d", txzpath, txz_info.empty_remarks_md);
 	dbg(DBG_MED, "txzchk: %s: has Makefile:\t\t\t%d", txzpath, txz_info.has_Makefile);
-	dbg(DBG_HIGH, "txzchk: %s: empty Makefile:\t\t%d", txzpath, txz_info.empty_Makefile);
+	dbg(DBG_HIGH, "txzchk: %s: empty Makefile:\t\t\t%d", txzpath, txz_info.empty_Makefile);
 	dbg(DBG_MED, "txzchk: %s: size:\t\t\t\t%lld", txzpath, (long long)txz_info.size);
 	dbg(DBG_MED, "txzchk: %s: size of all files:\t\t%lld", txzpath, (long long)txz_info.file_sizes);
 	dbg(DBG_MED, "txzchk: %s: rounded files size:\t\t%lld", txzpath, (long long)txz_info.rounded_file_size);
 	dbg(DBG_MED, "txzchk: %s: total files:\t\t\t%d", txzpath, txz_info.total_files);
 	dbg(DBG_MED, "txzchk: %s: incorrect directory found:\t%d", txzpath, txz_info.correct_directory != txz_info.total_files);
-	dbg(DBG_MED, "txzchk: %s: invalid dot files found:\t%d", txzpath, txz_info.dot_files > 0);
+	dbg(DBG_MED, "txzchk: %s: invalid dot files found:\t\t%d", txzpath, txz_info.dot_files);
+	dbg(DBG_MED, "txzchk: %s: files named '.':\t\t\t%d", txzpath, txz_info.named_dot);
+	dbg(DBG_MED, "txzchk: %s: files with invalid chars:\t%u", txzpath, txz_info.invalid_chars);
 	dbg(DBG_VHIGH, "txzchk: %s: issues found:\t\t\t%d", txzpath, txz_info.total_issues);
 
     }
@@ -550,6 +554,8 @@ sanity_chk(char const *tar, char const *fnamchk)
 static void
 check_file(char const *txzpath, char *p, char const *dir_name, struct file *file)
 {
+    size_t j;
+
     /*
      * firewall
      */
@@ -558,14 +564,41 @@ check_file(char const *txzpath, char *p, char const *dir_name, struct file *file
 	not_reached();
     }
 
+    /* 
+     * check for dot files but note that a basename of only '.' also counts as a
+     * filename with just '.': so if the file starts with a '.' and it's not
+     * ".author.json" and not ".info.json" then it's a dot file; if it's ONLY
+     * '.' it counts as BOTH a dot file AND a file called just '.' (which would
+     * likely be a directory but is abuse nonetheless).
+     */
     if (*(file->basename) == '.' && strcmp(file->basename, ".info.json") && strcmp(file->basename, ".author.json")) {
 	++txz_info.total_issues;
 	warn("txzchk", "%s: found non .author.json and .info.json dot file %s", txzpath, file->basename);
 	txz_info.dot_files++;
     }
+    /* check for files called '.' without anything after the full stop */
+    if (*(file->basename) == '.' && !file->basename[1]) {
+	++txz_info.total_issues;
+	++txz_info.named_dot;
+	warn("txzchk", "%s: found file called '.' in path %s", txzpath, file->filename);
+    }
+
+    /* 
+     * filename (full path) must only use POSIX Fully portable characters: A-Z
+     * a-z 0-9 . _ - + characters and (for directories) '/'.
+     */
+    for (j = 0; j < strlen(file->filename); ++j) {
+	if (!isascii(file->filename[j]) ||
+	    (!isalnum(file->filename[j]) && file->filename[j] != '.' && file->filename[j] != '_' && 
+	     file->filename[j] != '-' && file->filename[j] != '+' && file->filename[j] != '/')) {
+		++txz_info.total_issues; /* report it once and consider it only one issue */
+		++txz_info.invalid_chars;
+		warn("txzchk", "%s: found non portable characters in file %s", txzpath, file->filename);
+		break; /* only count one character per filename */
+	}
+    }
 
     check_directories(file, dir_name, txzpath);
-
 }
 
 

--- a/txzchk.c
+++ b/txzchk.c
@@ -799,7 +799,7 @@ check_directories(struct file *file, char const *dir_name, char const *txzpath)
     }
 
     /* check that there is a directory */
-    if (strchr(file->filename, '/') == NULL) {
+    if (strchr(file->filename, '/') == NULL && strcmp(file->filename, ".")) {
 	warn("txzchk", "%s: no directory found in filename %s", txzpath, file->filename);
 	++txz_info.total_issues;
     }


### PR DESCRIPTION
txzchk now checks for invalid chars in filenames (full path): that is it
now only allows fully POSIX portable chars (see mkiocccentry.c) as well
as '/' (since we check on the full path and not just the basename). I.e.
it checks on the field 'char *filename' in struct file. Note that as
soon as an invalid char is detected it breaks out of the loop (so a file
with two invalid chars only triggers one warning and issue).

txzchk also now checks for files called just '.'. These files are
counted as BOTH an invalidly named dot file AND a file called just '.'
(which is clearly abuse).

The show_txz_info() function has been updated for both of these changes.
As well instead of showing if there were any unacceptable dot files it
shows how many.