### PR TITLE
jinfochk and jauthchk updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,11 @@ fnamchk: fnamchk.c dbg.o util.o Makefile
 txzchk: txzchk.c txzchk.h rule_count.o dbg.o util.o Makefile
 	${CC} ${CFLAGS} txzchk.c rule_count.o dbg.o util.o -o $@
 
-jauthchk: jauthchk.c json.h rule_count.o dbg.o util.o Makefile
-	${CC} ${CFLAGS} jauthchk.c rule_count.o dbg.o util.o -o $@
+jauthchk: jauthchk.c jauthchk.h json.h rule_count.o json.o dbg.o util.o Makefile
+	${CC} ${CFLAGS} jauthchk.c rule_count.o json.o dbg.o util.o -o $@
 
-jinfochk: jinfochk.c rule_count.o dbg.o util.o Makefile
-	${CC} ${CFLAGS} jinfochk.c rule_count.o dbg.o util.o -o $@
+jinfochk: jinfochk.c jinfochk.h rule_count.o json.o dbg.o util.o Makefile
+	${CC} ${CFLAGS} jinfochk.c rule_count.o json.o dbg.o util.o -o $@
 
 jstrencode: jstrencode.c jstrencode.h dbg.o json.o util.o Makefile
 	${CC} ${CFLAGS} jstrencode.c dbg.o json.o util.o -o $@
@@ -331,8 +331,8 @@ mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h json.h dbg.h \
 iocccsize.o: iocccsize.c
 fnamchk.o: fnamchk.c limit_ioccc.h dbg.h util.h
 txzchk.o: txzchk.c txzchk.h util.h dbg.h limit_ioccc.h
-jauthchk.o: jauthchk.c limit_ioccc.h dbg.h util.h json.h
-jinfochk.o: jinfochk.c limit_ioccc.h dbg.h util.h json.h
+jauthchk.o: jauthchk.c jauthchk.h limit_ioccc.h dbg.h util.h json.h
+jinfochk.o: jinfochk.c jinfochk.h limit_ioccc.h dbg.h util.h json.h
 json.o: json.c dbg.h util.h json.h
 jstrencode.o: jstrencode.c jstrencode.h limit_ioccc.h dbg.h util.h json.h
 jstrdecode.o: jstrdecode.c jstrdecode.h limit_ioccc.h dbg.h util.h json.h

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -5,84 +5,17 @@
  * "Because sometimes even the IOCCC Judges need some help." :-)
  */
 
+#define JAUTHCHK_C
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 
-
 /*
- * IOCCC size and rule related limitations
+ * Our header file - #includes the header files we need
  */
-#include "limit_ioccc.h"
-
-
-/*
- * dbg - debug, warning and error reporting facility
- */
-#include "dbg.h"
-
-
-/*
- * util - utility functions and definitions
- */
-#include "util.h"
-
-/*
- * json - json file structs
- */
-#include "json.h"
-
-
-/*
- * jauthchk version
- */
-#define JAUTHCHK_VERSION "0.2 2022-02-13"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * definitions
- */
-#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
-
-
-/*
- * usage message
- *
- * Use the usage() function to print the these usage_msgX strings.
- */
-static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] file\n"
-"\n"
-"\t-h\t\tprint help message and exit 0\n"
-"\t-v level\tset verbosity level: (def level: %d)\n"
-"\t-V\t\tprint version string and exit\n"
-"\t-q\t\tquiet mode\n"
-"\n"
-"\tfile\t\tpath to a .author.json file\n"
-"\n"
-"exit codes:\n"
-"\n"
-"\t0\t\tno errors or warnings detected\n"
-"\t>0\t\tsome error(s) and/or warning(s) were detected\n"
-"\n"
-"jauthchk version: %s\n";
-
-
-/*
- * globals
- */
-int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
-char const *program = NULL;		    /* our name */
-static bool quiet = false;		    /* true ==> quiet mode */
-static struct author author;
-
-/*
- * forward declarations
- */
-static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
-static void sanity_chk(char const *file);
-static void check_author_json(char const *file);
+#include "jauthchk.h"
 
 
 int
@@ -99,7 +32,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:Vq")) != -1) {
+    while ((i = getopt(argc, argv, "hv:Vqs")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -127,6 +60,9 @@ main(int argc, char **argv)
 	    break;
 	case 'q':
 	    quiet = true;
+	    break;
+	case 's':
+	    strict = true;
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/
@@ -255,10 +191,10 @@ check_author_json(char const *file)
 {
     FILE *stream;
     int ret;
-    unsigned line_num = 0; /* line number */
-    char *linep = NULL;	/* allocated line read */
-    char *line_dup = NULL; /* currently last line read */
-    ssize_t readline_len;	/* readline return length */
+    char *data;		/* .author.json contents */
+    char *data_dup;	/* contents of file strdup()d */
+    size_t length;	/* length of input buffer */
+    char *p;
 
 
     /*
@@ -274,64 +210,55 @@ check_author_json(char const *file)
 	not_reached();
     }
 
-    errno = 0;
-    ret = setvbuf(stream, (char *)NULL, _IOLBF, 0);
-    if (ret != 0) {
-	warnp(__func__, "setvbuf for %s", file);
-    }
-    /* process lines until EOF */
-    do {
-	char *p = NULL;
-
-	++line_num;
-
-	readline_len = readline(&linep, stream);
-	if (readline_len < 0) {
-	    dbg(DBG_HIGH, "reached EOF of file %s", file);
-	    break;
-	} else if (readline_len == 0) {
-	    dbg(DBG_HIGH, "found empty line in file %s", file);
-	    continue;
-	}
-
-	/*
-	 * scan for embedded NUL bytes (before end of line)
-	 *
-	 */
-	errno = 0;			/* pre-clear errno for errp() */
-	p = (char *)memchr(linep, 0, (size_t)readline_len);
-	if (p != NULL) {
-	    warn("jauthchk", "found NUL before end of line, reading next line");
-	    continue;
-	}
-	dbg(DBG_VHIGH, "line %d: %s", line_num, linep);
-
-	/* free previous line's copy for current line (if this is the first line
-	 * it's still safe because it's safe to free a NULL pointer).
-	 */
-	free(line_dup);
-
-	/* now make a copy of the line */
-	errno = 0;
-	line_dup = strdup(linep);
-	if (line_dup == NULL) {
-	    errp(11, __func__, "unable to strdup line %s", linep);
-	    not_reached();
-	}
-
-	if (line_num == 1 && *linep != '{') {
-	    ++author.issues;
-	    err(12, __func__, "first character in file is not '{'");
-	    not_reached();
-	}
-    } while (readline_len >= 0);
-
-    /* verify that the very last character is a '}' */
-    if (line_dup == NULL || line_dup[strlen(line_dup)-1]!= '}') {
-	++author.issues;
-	err(13, __func__, "last character in file not '}': \"%c\"", line_dup?line_dup[strlen(line_dup)-1]:'\0');
+    /* read in the file */
+    data = read_all(stream, &length);
+    if (data == NULL) {
+	err(11, __func__, "error while reading data in %s", file);
 	not_reached();
     }
+    dbg(DBG_MED, "%s read length: %lu", file, (unsigned long)length);
+
+    /*
+     * scan for embedded NUL bytes (before end of line)
+     *
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    p = (char *)memchr(data, 0, (size_t)length);
+    if (p != NULL) {
+	err(15, __func__, "found NUL before end of file %s", file);
+	not_reached();
+    }
+   
+    errno = 0;
+    data_dup = strdup(data);
+    if (data_dup == NULL) {
+	errp(11, __func__, "unable to strdup file contents");
+	not_reached();
+    }
+
+    /* verify that the very first character is a '{' */
+    if (check_first_json_char(file, data_dup, strict, &p)) {
+	err(12, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	not_reached();
+    }
+    dbg(DBG_MED, "first character: '%c'", *p);
+
+    /* verify that the very last character is a '}' */
+    if (check_last_json_char(file, data_dup, strict, &p)) {
+	err(13, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	not_reached();
+    }
+    dbg(DBG_MED, "last character: '%c'", *p);
+
+
+    /* free data */
+    free(data);
+    data = NULL;
+
+    /* free strdup()d data */
+    free(data_dup);
+    data_dup = NULL;
+
 
     errno = 0;
     ret = fclose(stream);

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -34,7 +34,7 @@
 /*
  * jauthchk version
  */
-#define JAUTHCHK_VERSION "0.2 2022-02-13"	/* use format: major.minor YYYY-MM-DD */
+#define JAUTHCHK_VERSION "0.3 2022-02-17"	/* use format: major.minor YYYY-MM-DD */
 
 
 

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -1,0 +1,84 @@
+#ifndef JAUTHCHK_H
+#define JAUTHCHK_H
+
+#ifdef JAUTHCHK_C
+
+/*
+ * IOCCC size and rule related limitations
+ */
+#include "limit_ioccc.h"
+
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
+
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+/*
+ * json - json file structs
+ */
+#include "json.h"
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+/*
+ * jauthchk version
+ */
+#define JAUTHCHK_VERSION "0.2 2022-02-13"	/* use format: major.minor YYYY-MM-DD */
+
+
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the these usage_msgX strings.
+ */
+static const char * const usage_msg =
+"usage: %s [-h] [-v level] [-V] [-q] [-s] file\n"
+"\n"
+"\t-h\t\tprint help message and exit 0\n"
+"\t-v level\tset verbosity level: (def level: %d)\n"
+"\t-V\t\tprint version string and exit\n"
+"\t-q\t\tquiet mode\n"
+"\t-s\t\tstrict mode: disallow whitespace before '{' and after '}' except\n"
+"\t\t\tone newline after '}' (def: true in mkiocccentry, else false)\n"
+"\n"
+"\tfile\t\tpath to a .author.json file\n"
+"\n"
+"exit codes:\n"
+"\n"
+"\t0\t\tno errors or warnings detected\n"
+"\t>0\t\tsome error(s) and/or warning(s) were detected\n"
+"\n"
+"jauthchk version: %s\n";
+
+
+/*
+ * globals
+ */
+int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
+char const *program = NULL;		    /* our name */
+static bool quiet = false;		    /* true ==> quiet mode */
+static struct author author;		    /* the .author.json struct */
+static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' */
+
+/*
+ * forward declarations
+ */
+static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
+static void sanity_chk(char const *file);
+static void check_author_json(char const *file);
+
+
+#endif /* JAUTHCHK_C */
+#endif /* JAUTHCHK_H */

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -5,85 +5,17 @@
  * "Because sometimes even the IOCCC Judges need some help." :-)
  */
 
+#define JINFOCHK_C
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 
-
 /*
- * IOCCC size and rule related limitations
+ * Our header file - #includes the header files we need
  */
-#include "limit_ioccc.h"
-
-
-/*
- * dbg - debug, warning and error reporting facility
- */
-#include "dbg.h"
-
-
-/*
- * util - utility functions and definitions
- */
-#include "util.h"
-
-/*
- * json - json file structs
- */
-#include "json.h"
-
-
-/*
- * jinfochk version
- */
-#define JINFOCHK_VERSION "0.2 2022-02-13"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * definitions
- */
-#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
-
-
-/*
- * usage message
- *
- * Use the usage() function to print the these usage_msgX strings.
- */
-static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] file\n"
-"\n"
-"\t-h\t\tprint help message and exit 0\n"
-"\t-v level\tset verbosity level: (def level: %d)\n"
-"\t-V\t\tprint version string and exit\n"
-"\t-q\t\tquiet mode\n"
-"\n"
-"\tfile\t\tpath to a .info.json file\n"
-"\n"
-"exit codes:\n"
-"\n"
-"\t0\t\tno errors or warnings detected\n"
-"\t>0\t\tsome error(s) and/or warning(s) were detected\n"
-"\n"
-"jinfochk version: %s\n";
-
-
-/*
- * globals
- */
-int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
-char const *program = NULL;		    /* our name */
-static bool quiet = false;		    /* true ==> quiet mode */
-static struct info info;
-
-/*
- * forward declarations
- */
-static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
-static void sanity_chk(char const *file);
-static void check_info_json(char const *file);
-
+#include "jinfochk.h"
 
 int
 main(int argc, char **argv)
@@ -98,7 +30,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:Vq")) != -1) {
+    while ((i = getopt(argc, argv, "hv:Vqs")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -126,6 +58,9 @@ main(int argc, char **argv)
 	    break;
 	case 'q':
 	    quiet = true;
+	    break;
+	case 's':
+	    strict = true;
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/
@@ -253,10 +188,10 @@ check_info_json(char const *file)
 {
     FILE *stream;
     int ret;
-    unsigned line_num = 0; /* line number */
-    char *linep = NULL;	/* allocated line read */
-    char *line_dup = NULL; /* currently last line read */
-    ssize_t readline_len;	/* readline return length */
+    char *data;		/* .info.json contents */
+    char *data_dup;	/* contents of file strdup()d */
+    size_t length;	/* length of input buffer */
+    char *p;
 
     /*
      * firewall
@@ -271,70 +206,56 @@ check_info_json(char const *file)
 	err(10, __func__, "couldn't open %s", file);
 	not_reached();
     }
-    errno = 0;
-    ret = setvbuf(stream, (char *)NULL, _IOLBF, 0);
-    if (ret != 0) {
-	warnp(__func__, "setvbuf for %s", file);
+
+    /* read in the file */
+    data = read_all(stream, &length);
+    if (data == NULL) {
+	err(11, __func__, "error while reading data in %s", file);
+	not_reached();
+    } else if (!strlen(data)) {
+	err(12, __func__, "zero length data in file %s", file);
+	not_reached();
     }
+    dbg(DBG_MED, "%s read length: %lu", file, (unsigned long)length);
 
-    /* process lines until EOF */
-    do {
-	char *p = NULL;
-
-	++line_num;
-
-	readline_len = readline(&linep, stream);
-	if (readline_len < 0) {
-	    dbg(DBG_HIGH, "reached EOF of file %s", file);
-	    break;
-	} else if (readline_len == 0) {
-	    dbg(DBG_HIGH, "found empty line in file %s", file);
-	    continue;
-	}
-
-	/*
-	 * scan for embedded NUL bytes (before end of line)
-	 *
-	 */
-	errno = 0;			/* pre-clear errno for errp() */
-	p = (char *)memchr(linep, 0, (size_t)readline_len);
-	if (p != NULL) {
-	    warn("jinfochk", "found NUL before end of line, reading next line");
-	    continue;
-	}
-	dbg(DBG_VHIGH, "line %d: %s", line_num, linep);
-
-	/* free previous line's copy for current line (if this is the first line
-	 * it's still safe because it's safe to free a NULL pointer).
-	 */
-	free(line_dup);
-
-	/* now make a copy of this line */
-	errno = 0;
-	line_dup = strdup(linep);
-	if (line_dup == NULL) {
-	    errp(11, __func__, "unable to strdup line %s", linep);
-	    not_reached();
-	}
-
-	if (line_num == 1 && *linep != '{') {
-	    ++info.issues;
-	    err(12, __func__, "first character in file is not '{'");
-	    not_reached();
-	}
-
-    } while (readline_len >= 0);
-
-    /* verify that the very last character is a '}' */
-    if (line_dup == NULL || line_dup[strlen(line_dup)-1]!= '}') {
-	++info.issues;
-	err(13, __func__, "last character in file not '}': \"%c\"", line_dup?line_dup[strlen(line_dup)-1]:'\0');
+    /*
+     * scan for embedded NUL bytes (before end of line)
+     *
+     */
+    errno = 0;			/* pre-clear errno for errp() */
+    p = (char *)memchr(data, 0, (size_t)length);
+    if (p != NULL) {
+	err(15, __func__, "found NUL before end of file %s", file);
+	not_reached();
+    }
+   
+    errno = 0;
+    data_dup = strdup(data);
+    if (data_dup == NULL) {
+	errp(11, __func__, "unable to strdup file %s contents", file);
 	not_reached();
     }
 
-    /* free line_dup */
-    free(line_dup);
-    line_dup = NULL;
+    /* verify that the very first character is a '{' */
+    if (check_first_json_char(file, data_dup, strict, &p)) {
+	err(12, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	not_reached();
+    }
+    dbg(DBG_MED, "first character: '%c'", *p);
+    /* verify that the very last character is a '}' */
+    if (check_last_json_char(file, data_dup, strict, &p)) {
+	err(13, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	not_reached();
+    }
+    dbg(DBG_MED, "last character: '%c'", *p);
+
+    /* free data */
+    free(data);
+    data = NULL;
+
+    /* free strdup()d data */
+    free(data_dup);
+    data_dup = NULL;
 
     errno = 0;
     ret = fclose(stream);

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -1,0 +1,88 @@
+/* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
+/*
+ * jinfochk - IOCCC JSON .info.json checker and validator
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ */
+
+#ifndef JINFOCHK_H
+#define JINFOCHK_H
+
+#ifdef JINFOCHK_C
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+/*
+ * jinfochk version
+ */
+#define JINFOCHK_VERSION "0.3 2022-02-17"	/* use format: major.minor YYYY-MM-DD */
+
+/*
+ * IOCCC size and rule related limitations
+ */
+#include "limit_ioccc.h"
+
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
+
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+/*
+ * json - json file structs
+ */
+#include "json.h"
+
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the these usage_msgX strings.
+ */
+static const char * const usage_msg =
+"usage: %s [-h] [-v level] [-V] [-q] [-s] file\n"
+"\n"
+"\t-h\t\tprint help message and exit 0\n"
+"\t-v level\tset verbosity level: (def level: %d)\n"
+"\t-V\t\tprint version string and exit\n"
+"\t-q\t\tquiet mode\n"
+"\t-s\t\tstrict mode: disallow whitespace before '{' and after '}' except\n"
+"\t\t\tone newline after '}' (def: true in mkiocccentry, else false)\n"
+"\n"
+"\tfile\t\tpath to a .info.json file\n"
+"\n"
+"exit codes:\n"
+"\n"
+"\t0\t\tno errors or warnings detected\n"
+"\t>0\t\tsome error(s) and/or warning(s) were detected\n"
+"\n"
+"jinfochk version: %s\n";
+
+
+/*
+ * globals
+ */
+int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
+char const *program = NULL;		    /* our name */
+static bool quiet = false;		    /* true ==> quiet mode */
+static struct info info;		    /* .info.json struct */
+static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' in the file */
+
+/*
+ * forward declarations
+ */
+static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
+static void sanity_chk(char const *file);
+static void check_info_json(char const *file);
+
+
+#endif /* JINFOCHK_C */
+#endif /* JINFOCHK_H */

--- a/json.c
+++ b/json.c
@@ -33,6 +33,7 @@
  * Share and enjoy! :-)
  */
 
+#define JSON_C
 
 /* special comments for the seqcexit tool */
 /*ooo*/ /* exit code out of numerical order - ignore in sequencing */
@@ -1527,4 +1528,93 @@ malloc_json_decode_str(char const *str, size_t *retlen, bool strict)
      * return decoded result or NULL
      */
     return ret;
+}
+
+/* check_first_json_char - check if first char is '{'
+ *
+ * given:
+ *
+ *	file		- path to file
+ *	data		- the data read in from the file
+ *	strict		- true ==> disallow anything (including whitespace) before the first '{'.
+ *	first		- if != NULL set *first to the first character
+ *
+ *  Returns 0 if first character is '{' and 1 if it is not.
+ *
+ *  Sets *first to the first character (for debugging purposes).
+ *
+ *  Does not return on NULL.
+ */
+int
+check_first_json_char(char const *file, char *data, bool strict, char **first)
+{
+    /*
+     * firewall
+     */
+    if (data == NULL || strlen(data) == 0) {
+	err(214, __func__, "passed NULL or zero length data");
+	not_reached();
+    } else if (file == NULL || first == NULL) {
+	err(215, __func__, "passed NULL arg(s)");
+	not_reached();
+    }
+
+    if (!strict) {
+	while (*data && isspace(*data))
+	    ++data;
+    }
+    if (first != NULL) {
+	*first = data;
+    }
+
+    if (*data != '{')
+	return 1;
+    return 0;
+}
+
+/* check_last_json_char - check if last char is '}'
+ *
+ * given:
+ *
+ *	file		- path to file
+ *	data		- the data read in from the file
+ *	strict		- true ==> permit only a single trailing newline ("\n") after the last '}'.
+ *	last		- if != NULL set *last to last char
+ *
+ *  Returns 0 if last character is '}' and 1 if it is not.
+ *
+ *  Does not return on error.
+ */
+int
+check_last_json_char(char const *file, char *data, bool strict, char **last)
+{
+    char *p;
+
+    /*
+     * firewall
+     */
+    if (data == NULL || strlen(data) == 0) {
+	err(214, __func__, "passed NULL or zero length data");
+	not_reached();
+    } else if (file == NULL || last == NULL) {
+	err(215, __func__, "passed NULL arg(s)");
+	not_reached();
+    }
+
+    p = data + strlen(data) - 1;
+
+    if (!strict) {
+	if (*p && isspace(*p))
+	    --p;
+    }
+    else if (*p && *p == '\n') {
+	--p;
+    }
+    if (last != NULL) {
+	*last = p;
+    }
+    if (*p != '}')
+	return 1;
+
+    return 0;
 }

--- a/json.h
+++ b/json.h
@@ -136,6 +136,7 @@ extern void jencchk(void);
 extern bool json_putc(uint8_t const c, FILE *stream);
 extern char *malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict);
 extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict);
-
+extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
+extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 
 #endif /* JSON_H */

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -254,7 +254,7 @@ main(int argc, char *argv[])
  *
  * This function does not return.
  */
-void
+static void
 usage(int exitcode, char const *str, char const *prog)
 {
     /*

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -63,7 +63,7 @@
  *
  * Use the usage() function to print the these usage_msgX strings.
  */
-const char * const usage_msg =
+static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-t] [-n] [-s] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
@@ -87,7 +87,7 @@ int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
 /*
  * function prototypes
  */
-void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
+static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 
 
 #endif /* JSTRDECODE_C */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -718,7 +718,7 @@ main(int argc, char *argv[])
  *
  * This function does not return.
  */
-void
+static void
 usage(int exitcode, char const *str, char const *program, char const *tar, char const *cp, char const *ls,
       char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk)
 {
@@ -786,7 +786,7 @@ usage(int exitcode, char const *str, char const *program, char const *tar, char 
  *
  * This function does not return.
  */
-void
+static void
 free_info(struct info *infop)
 {
     int i;
@@ -871,7 +871,7 @@ free_info(struct info *infop)
  *      author_set      - pointer to a struct author array
  *      author_count    - length of author array
  */
-void
+static void
 free_author_array(struct author *author_set, int author_count)
 {
     int i;
@@ -944,7 +944,7 @@ free_author_array(struct author *author_set, int author_count)
  *
  * NOTE: This function does not return on error or if things are not sane.
  */
-void
+static void
 sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp, char const *ls,
 	   char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk)
 {
@@ -1422,7 +1422,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
  *
  * This function does not return on error.
  */
-char *
+static char *
 prompt(char const *str, size_t *lenp)
 {
     char *linep = NULL;		/* readline_dup line buffer */
@@ -1536,7 +1536,7 @@ prompt(char const *str, size_t *lenp)
  *
  * This function does not return on error or if the contest ID is malformed.
  */
-char *
+static char *
 get_contest_id(struct info *infop, bool *testp, bool *read_answers_flag_used)
 {
     char *malloc_ret;		/* malloced return string */
@@ -1727,7 +1727,7 @@ get_contest_id(struct info *infop, bool *testp, bool *read_answers_flag_used)
  * returns:
  *      entry number >= 0 <= MAX_ENTRY_NUM
  */
-int
+static int
 get_entry_num(struct info *infop)
 {
     int entry_num;		/* entry number */
@@ -1829,7 +1829,7 @@ get_entry_num(struct info *infop)
  *
  * This function does not return on error or if the entry directory cannot be formed.
  */
-char *
+static char *
 mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **tarball_path, time_t tstamp)
 {
     size_t entry_dir_len;	/* length of entry directory */
@@ -1935,7 +1935,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
  *
  * This function does not return on error.
  */
-void
+static void
 warn_empty_prog(char const *prog_c)
 {
     bool yorn = false;
@@ -1987,7 +1987,7 @@ warn_empty_prog(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_rule2a_size(struct info *infop, char const *prog_c, int mode)
 {
     bool yorn = false;
@@ -2070,7 +2070,7 @@ warn_rule2a_size(struct info *infop, char const *prog_c, int mode)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_high_bit(char const *prog_c)
 {
     int ret, yorn;
@@ -2112,7 +2112,7 @@ warn_high_bit(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_nul_chars(char const *prog_c)
 {
     int ret, yorn;
@@ -2154,7 +2154,7 @@ warn_nul_chars(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_trigraph(char const *prog_c)
 {
     bool yorn = false;
@@ -2197,7 +2197,7 @@ warn_trigraph(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_wordbuf(char const *prog_c)
 {
     int ret, yorn;
@@ -2240,7 +2240,7 @@ warn_wordbuf(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_ungetc(char const *prog_c)
 {
     bool yorn = false;
@@ -2284,7 +2284,7 @@ warn_ungetc(char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_rule2b_size(struct info *infop, char const *prog_c)
 {
     int ret, yorn;
@@ -2342,7 +2342,7 @@ warn_rule2b_size(struct info *infop, char const *prog_c)
  *
  * This function does not return on error.
  */
-void
+static void
 check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char const *prog_c)
 {
     FILE *prog_stream;		/* prog.c open file stream */
@@ -2605,7 +2605,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
  *
  * This function does not return on error.
  */
-bool
+static bool
 inspect_Makefile(char const *Makefile, struct info *infop)
 {
     FILE *stream;		/* open file stream */
@@ -2800,7 +2800,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
  *
  * This function does not return on error.
  */
-void
+static void
 warn_Makefile(char const *Makefile, struct info *infop)
 {
     bool yorn = false;
@@ -2911,7 +2911,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
  *
  * This function does not return on error.
  */
-void
+static void
 check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char const *Makefile)
 {
     off_t filesize = 0;		/* size of Makefile */
@@ -3057,7 +3057,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
  *
  * This function does not return on error.
  */
-void
+static void
 check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char const *remarks_md)
 {
     off_t filesize = 0;		/* size of remarks.md */
@@ -3192,7 +3192,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
  *
  * This function does not return on error.
  */
-void
+static void
 check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp, int count, char **args)
 {
     char *base;			/* basename of extra data file */
@@ -3427,7 +3427,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
  *
  * This function does not return on error.
  */
-char const *
+static char const *
 lookup_location_name(char const *upper_code)
 {
     struct location *p;		/* entry in the location table */
@@ -3467,7 +3467,7 @@ lookup_location_name(char const *upper_code)
  *      true ==> input is yes in some form,
  *      false ==> input is not yes
  */
-bool
+static bool
 yes_or_no(char const *question)
 {
     char *response;		/* response to the question */
@@ -3580,7 +3580,7 @@ yes_or_no(char const *question)
  *
  * This function does not return on error.
  */
-char *
+static char *
 get_title(struct info *infop)
 {
     char *title = NULL;		/* entry title to return or NULL */
@@ -3763,7 +3763,7 @@ get_title(struct info *infop)
  *
  * This function does not return on error.
  */
-char *
+static char *
 get_abstract(struct info *infop)
 {
     char *abstract = NULL;	/* entry abstract to return or NULL */
@@ -3879,7 +3879,7 @@ get_abstract(struct info *infop)
  *
  * This function does not return on error.
  */
-int
+static int
 get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p)
 {
     struct author *author_set = NULL;	/* allocated author set */
@@ -4688,7 +4688,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
  *
  * This function does not return on error.
  */
-void
+static void
 verify_entry_dir(char const *entry_dir, char const *ls)
 {
     int exit_code;		/* exit code from system(cmd) */
@@ -4910,7 +4910,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
  *
  * This function does not return on error.
  */
-bool
+static bool
 json_fprintf_str(FILE *stream, char const *str)
 {
     int ret;			/* libc function return */
@@ -4994,7 +4994,7 @@ json_fprintf_str(FILE *stream, char const *str)
  *
  * This function does not return on error.
  */
-bool
+static bool
 json_fprintf_value_string(FILE *stream, char const *lead, char const *name, char const *middle, char const *value,
 			  char const *tail)
 {
@@ -5081,7 +5081,7 @@ json_fprintf_value_string(FILE *stream, char const *lead, char const *name, char
  *
  * This function does not return on error.
  */
-bool
+static bool
 json_fprintf_value_long(FILE *stream, char const *lead, char const *name, char const *middle, long value,
 			char const *tail)
 {
@@ -5167,7 +5167,7 @@ json_fprintf_value_long(FILE *stream, char const *lead, char const *name, char c
  *	true ==> stream print was OK,
  *	false ==> error printing to stream
  */
-bool
+static bool
 json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char const *middle, bool value,
 			char const *tail)
 {
@@ -5249,7 +5249,7 @@ json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char c
  *
  * This function does not return on error.
  */
-void
+static void
 write_info(struct info *infop, char const *entry_dir, bool test_mode, char const *jinfochk)
 {
     struct tm *timeptr;		/* localtime return */
@@ -5448,7 +5448,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     /*
      * form the jinfochk command
      */
-    cmd = cmdprintf("% -q %", jinfochk, info_path);
+    cmd = cmdprintf("% -q -s %", jinfochk, info_path);
     if (cmd == NULL) {
 	err(202, __func__, "failed to cmdprintf: jinfochk %s", info_path);
 	not_reached();
@@ -5522,7 +5522,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
  *
  * This function does not return on error.
  */
-void
+static void
 write_author(struct info *infop, int author_count, struct author *authorp, char const *entry_dir, char const *jauthchk)
 {
     char *author_path;		/* path to .author.json file */
@@ -5639,7 +5639,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     /*
      * form the jauthchk command
      */
-    cmd = cmdprintf("% -q %", jauthchk, author_path);
+    cmd = cmdprintf("% -q -s %", jauthchk, author_path);
     if (cmd == NULL) {
 	err(216, __func__, "failed to cmdprintf: jauthchk %s", author_path);
 	not_reached();
@@ -5718,7 +5718,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
  *
  * This function does not return on error.
  */
-void
+static void
 form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
 	     char const *ls, char const *txzchk, char const *fnamchk)
 {
@@ -5944,7 +5944,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
  *      answers		- path to the answers file (if specified)
  *      infop		- pointer to info structure
  */
-void
+static void
 remind_user(char const *work_dir, char const *entry_dir, char const *tar, char const *tarball_path, bool test_mode)
 {
     int ret;			/* libc function return */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -89,7 +89,7 @@
  *
  * Use the usage() function to print the these usage_msgX strings.
  */
-const char * const usage_msg0 =
+static const char * const usage_msg0 =
     "usage: %s [options] work_dir prog.c Makefile remarks.md [file ...]\n"
     "\noptions:\n"
     "\t-h\t\t\tprint help message and exit 0\n"
@@ -97,16 +97,16 @@ const char * const usage_msg0 =
     "\t-V\t\t\tprint version string and exit\n"
     "\t-W\t\t\tignore all warnings (this does NOT mean the judges will! :) )\n";
 
-const char * const usage_msg1 =
+static const char * const usage_msg1 =
     "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
     "\t-c /path/to/cp\t\tpath to cp executable (def: %s)\n"
     "\t-l /path/to/ls\t\tpath to ls executable (def: %s)\n"
     "\t-C /path/to/txzchk\tpath to txzchk executable (def: %s)\n"
     "\t-F /path/to/fnamchk\tpath to fnamchk executable used by txzchk (def: %s)";
-const char * const usage_msg2 =
+static const char * const usage_msg2 =
     "\t-j /path/to/jinfochk	path to jinfochk executable used by txzchk (def: %s)\n"
     "\t-J /path/to/jauthchk	path to jauthchk executable used by txzchk (def: %s)\n";
-const char * const usage_msg3 =
+static const char * const usage_msg3 =
     "\t-a answers\t\twrite answers to a file for easier updating of an entry\n"
     "\t-A answers\t\twrite answers file even if it already exists\n"
     "\t-i answers\t\tread answers from file previously written by -a|-A answers\n\n"
@@ -114,7 +114,7 @@ const char * const usage_msg3 =
     "\n"
     "\twork_dir\tdirectory where the entry directory and tarball are formed\n"
     "\tprog.c\t\tpath to the C source for your entry\n";
-const char * const usage_msg4 =
+static const char * const usage_msg4 =
     "\n"
     "\tMakefile\tMakefile to build (make all) and cleanup (make clean & make clobber)\n"
     "\n"
@@ -131,59 +131,59 @@ const char * const usage_msg4 =
  * globals
  */
 int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
-bool need_confirm = true;	/* true ==> ask for confirmations */
-bool need_hints = true;		/* true ==> show hints */
-bool need_retry = true;
-bool ignore_warnings = false;	/* true ==> ignore all warnings (this does NOT mean the judges will! :) */
-FILE *input_stream = NULL;
-struct iocccsize size;	/* rule_count() processing results */
+static bool need_confirm = true;	/* true ==> ask for confirmations */
+static bool need_hints = true;		/* true ==> show hints */
+static bool need_retry = true;
+static bool ignore_warnings = false;	/* true ==> ignore all warnings (this does NOT mean the judges will! :) */
+static FILE *input_stream = NULL;
+static struct iocccsize size;	/* rule_count() processing results */
 
 
 /*
  * forward declarations
  */
-void usage(int exitcode, char const *str, char const *program, char const *tar, char const *cp, char const *ls,
+static void usage(int exitcode, char const *str, char const *program, char const *tar, char const *cp, char const *ls,
 		  char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk);
-void free_info(struct info *infop);
-void free_author_array(struct author *authorp, int author_count);
-void warn_empty_prog(char const *prog_c);
-void warn_rule2a_size(struct info *infop, char const *prog_c, int mode);
-void warn_high_bit(char const *prog_c);
-void warn_nul_chars(char const *prog_c);
-void warn_trigraph(char const *prog_c);
-void warn_wordbuf(char const *prog_c);
-void warn_ungetc(char const *prog_c);
-void warn_rule2b_size(struct info *infop, char const *prog_c);
-void check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char const *prog_c);
-void sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp,
+static void free_info(struct info *infop);
+static void free_author_array(struct author *authorp, int author_count);
+static void warn_empty_prog(char const *prog_c);
+static void warn_rule2a_size(struct info *infop, char const *prog_c, int mode);
+static void warn_high_bit(char const *prog_c);
+static void warn_nul_chars(char const *prog_c);
+static void warn_trigraph(char const *prog_c);
+static void warn_wordbuf(char const *prog_c);
+static void warn_ungetc(char const *prog_c);
+static void warn_rule2b_size(struct info *infop, char const *prog_c);
+static void check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char const *prog_c);
+static void sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp,
 		       char const *ls, char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk);
-char *prompt(char const *str, size_t *lenp);
-char *get_contest_id(struct info *infop, bool *testp, bool *read_answers_flag_used);
-int get_entry_num(struct info *infop);
-char *mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **tarball_path, time_t tstamp);
-bool inspect_Makefile(char const *Makefile, struct info *infop);
-void warn_Makefile(char const *Makefile, struct info *infop);
-void check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char const *Makefile);
-void check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char const *remarks_md);
-void check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp, int count, char **args);
-char const *lookup_location_name(char const *upper_code);
-bool yes_or_no(char const *question);
-char *get_title(struct info *infop);
-char *get_abstract(struct info *infop);
-int get_author_info(struct info *infop, char *ioccc_id, struct author **author_set);
-void verify_entry_dir(char const *entry_dir, char const *ls);
-bool json_fprintf_str(FILE *stream, char const *str);
-bool json_fprintf_value_string(FILE *stream, char const *lead, char const *name, char const *middle, char const *value,
+static char *prompt(char const *str, size_t *lenp);
+static char *get_contest_id(struct info *infop, bool *testp, bool *read_answers_flag_used);
+static int get_entry_num(struct info *infop);
+static char *mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **tarball_path, time_t tstamp);
+static bool inspect_Makefile(char const *Makefile, struct info *infop);
+static void warn_Makefile(char const *Makefile, struct info *infop);
+static void check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char const *Makefile);
+static void check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char const *remarks_md);
+static void check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp, int count, char **args);
+static char const *lookup_location_name(char const *upper_code);
+static bool yes_or_no(char const *question);
+static char *get_title(struct info *infop);
+static char *get_abstract(struct info *infop);
+static int get_author_info(struct info *infop, char *ioccc_id, struct author **author_set);
+static void verify_entry_dir(char const *entry_dir, char const *ls);
+static bool json_fprintf_str(FILE *stream, char const *str);
+static bool json_fprintf_value_string(FILE *stream, char const *lead, char const *name, char const *middle, char const *value,
 				      char const *tail);
-bool json_fprintf_value_long(FILE *stream, char const *lead, char const *name, char const *middle, long value,
+static bool json_fprintf_value_long(FILE *stream, char const *lead, char const *name, char const *middle, long value,
 				    char const *tail);
-bool json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char const *middle, bool value,
+static bool json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char const *middle, bool value,
 				    char const *tail);
-void write_info(struct info *infop, char const *entry_dir, bool test_mode, char const *jinfochk);
-void write_author(struct info *infop, int author_count, struct author *authorp, char const *entry_dir, char const *jauthchk);
-void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
+static void write_info(struct info *infop, char const *entry_dir, bool test_mode, char const *jinfochk);
+static void write_author(struct info *infop, int author_count, struct author *authorp, char const *entry_dir, char const *jauthchk);
+static void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk);
-void remind_user(char const *work_dir, char const *entry_dir, char const *tar, char const *tarball_path, bool test_mode);
+static void remind_user(char const *work_dir, char const *entry_dir, char const *tar, char const *tarball_path, bool test_mode);
 
 
 

--- a/txzchk.c
+++ b/txzchk.c
@@ -33,7 +33,6 @@
 #define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
 
 
-
 int
 main(int argc, char **argv)
 {
@@ -174,7 +173,7 @@ main(int argc, char **argv)
  *
  * Returns void. Does not return on error.
  */
-void
+static void
 show_txz_info(char const *txzpath)
 {
     /*
@@ -227,7 +226,7 @@ show_txz_info(char const *txzpath)
  *
  * This function does not return.
  */
-void
+static void
 usage(int exitcode, char const *str, char const *prog, char const *tar, char const *fnamchk)
 {
     /*
@@ -272,7 +271,7 @@ usage(int exitcode, char const *str, char const *prog, char const *tar, char con
  *
  * NOTE: This function does not return on error or if things are not sane.
  */
-void
+static void
 sanity_chk(char const *tar, char const *fnamchk)
 {
     /*
@@ -443,7 +442,7 @@ sanity_chk(char const *tar, char const *fnamchk)
  * Returns void. Does not return on error.
  *
  */
-void
+static void
 check_file(char const *txzpath, char *p, char const *dir_name, struct file *file)
 {
     size_t j;
@@ -507,7 +506,7 @@ check_file(char const *txzpath, char *p, char const *dir_name, struct file *file
  *
  * Does not return on error (NULL pointers passed in).
  */
-void
+static void
 check_empty_file(char const *txzpath, off_t size, struct file *file)
 {
     /*
@@ -561,7 +560,7 @@ check_empty_file(char const *txzpath, off_t size, struct file *file)
  * all).
  *
  */
-void
+static void
 check_all_files(char const *dir_name)
 {
     struct file *file; /* to iterate through files list */
@@ -674,7 +673,7 @@ check_all_files(char const *dir_name)
  *
  * Does not return on error.
  */
-void
+static void
 check_directories(struct file *file, char const *dir_name, char const *txzpath)
 {
     unsigned dir_count = 0; /* number of directories in the path */
@@ -793,7 +792,7 @@ check_directories(struct file *file, char const *dir_name, char const *txzpath)
  *
  * This function does not return on error.
  */
-void
+static void
 parse_linux_line(char *p, char *linep, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr)
 {
     off_t current_file_size = 0;
@@ -897,7 +896,7 @@ parse_linux_line(char *p, char *linep, char *line_dup, char const *dir_name, cha
  *
  * This function does not return on error.
  */
-void
+static void
 parse_bsd_line(char *p, char *linep, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr)
 {
     off_t current_file_size = 0;
@@ -1003,7 +1002,7 @@ parse_bsd_line(char *p, char *linep, char *line_dup, char const *dir_name, char 
  *
  *  Function does not return on error.
  */
-void
+static void
 parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count)
 {
     char *p = NULL; /* each field in the line extracted from strtok_r() */
@@ -1076,7 +1075,7 @@ parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpat
  *
  *  Does not return on error.
  */
-unsigned
+static unsigned
 check_tarball(char const *tar, char const *fnamchk)
 {
     unsigned line_num = 0; /* line number of tar output */
@@ -1426,7 +1425,7 @@ check_tarball(char const *tar, char const *fnamchk)
  *
  * This function does not return on NULL pointer passed into the function.
  */
-bool
+static bool
 has_special_bits(char const *str)
 {
     /*
@@ -1455,7 +1454,7 @@ has_special_bits(char const *str)
  *
  * This function returns void.
  */
-void
+static void
 add_line(char const *str, int line_num)
 {
     struct line *line;
@@ -1502,7 +1501,7 @@ add_line(char const *str, int line_num)
  *
  * This function does not return on error.
  */
-void
+static void
 parse_all_lines(char const *dir_name, char const *txzpath)
 {
     struct line *line = NULL;	/* for lines list */
@@ -1547,7 +1546,7 @@ parse_all_lines(char const *dir_name, char const *txzpath)
  *
  * This function returns void.
  */
-void
+static void
 free_lines(void)
 {
     struct line *line, *next_line;
@@ -1578,7 +1577,7 @@ free_lines(void)
  *
  * This function does not return on error.
  */
-struct file *
+static struct file *
 alloc_file(char const *p)
 {
     struct file *file; /* the file structure */
@@ -1628,7 +1627,7 @@ alloc_file(char const *p)
  *
  * This function does not return on error.
  */
-void
+static void
 add_file_to_list(struct file *file)
 {
     struct file *ptr; /* used to iterate through list to find duplicate files */
@@ -1664,7 +1663,7 @@ add_file_to_list(struct file *file)
  * free_file_list - free the file linked list
  *
  */
-void
+static void
 free_file_list(void)
 {
     struct file *file, *next_file;

--- a/txzchk.h
+++ b/txzchk.h
@@ -41,11 +41,11 @@
 
 
 /* variable specific to txzchk */
-char const *txzpath = NULL;		    /* the current tarball being checked */
-char const *program = NULL;		    /* our name */
+static char const *txzpath = NULL;		    /* the current tarball being checked */
+static char const *program = NULL;		    /* our name */
 int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
-bool quiet = false;			    /* true ==> only show errors and warnings */
-bool text_file_flag_used = false;	    /* true ==> assume txzpath is a text file */
+static bool quiet = false;			    /* true ==> only show errors and warnings */
+static bool text_file_flag_used = false;	    /* true ==> assume txzpath is a text file */
 
 /*
  * information about the tarball
@@ -70,7 +70,9 @@ struct txz_info {
     unsigned named_dot;			    /* number of files called just '.' */
     unsigned total_files;		    /* total files in the tarball */
     int total_issues;			    /* number of total issues in tarball */
-} txz_info;
+};
+
+static struct txz_info txz_info;
 
 struct file {
     char *basename;
@@ -79,7 +81,7 @@ struct file {
     struct file *next;
 };
 
-struct file *files;
+static struct file *files;
 
 struct line {
     char *line;
@@ -87,7 +89,7 @@ struct line {
     struct line *next;
 };
 
-struct line *lines;
+static struct line *lines;
 
 /*
  * txzchk version
@@ -100,7 +102,7 @@ struct line *lines;
  *
  * Use the usage() function to print the usage_msgX strings.
  */
-const char * const usage_msg =
+static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] [-T] txzpath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
@@ -120,24 +122,24 @@ const char * const usage_msg =
 /*
  * function prototypes
  */
-void usage(int exitcode, char const *name, char const *str, char const *tar, char const *fnamchk) __attribute__((noreturn));
-void sanity_chk(char const *tar, char const *fnamchk);
-void parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count);
-void parse_linux_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);
-void parse_bsd_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);
-unsigned check_tarball(char const *tar, char const *fnamchk);
-void show_txz_info(char const *txzpath);
-void check_empty_file(char const *txzpath, off_t size, struct file *file);
-void check_file(char const *txzpath, char *p, char const *dir_name, struct file *file);
-void check_all_files(char const *dir_name);
-void check_directories(struct file *file, char const *dir_name, char const *txzpath);
-bool has_special_bits(char const *str);
-void add_line(char const *str, int line_num);
-void parse_all_lines(char const *dir_name, char const *txzpath);
-void free_lines(void);
-struct file *alloc_file(char const *p);
-void add_file_to_list(struct file *file);
-void free_file_list(void);
+static void usage(int exitcode, char const *name, char const *str, char const *tar, char const *fnamchk) __attribute__((noreturn));
+static void sanity_chk(char const *tar, char const *fnamchk);
+static void parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count);
+static void parse_linux_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);
+static void parse_bsd_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);
+static unsigned check_tarball(char const *tar, char const *fnamchk);
+static void show_txz_info(char const *txzpath);
+static void check_empty_file(char const *txzpath, off_t size, struct file *file);
+static void check_file(char const *txzpath, char *p, char const *dir_name, struct file *file);
+static void check_all_files(char const *dir_name);
+static void check_directories(struct file *file, char const *dir_name, char const *txzpath);
+static bool has_special_bits(char const *str);
+static void add_line(char const *str, int line_num);
+static void parse_all_lines(char const *dir_name, char const *txzpath);
+static void free_lines(void);
+static struct file *alloc_file(char const *p);
+static void add_file_to_list(struct file *file);
+static void free_file_list(void);
 
 
 #endif /* TXZCHK_C */

--- a/util.h
+++ b/util.h
@@ -108,6 +108,6 @@ extern char *malloc_json_encode(char const *ptr, size_t len, size_t *retlen);
 extern char *malloc_json_str(char const *str, size_t *retlen);
 extern void jencchk(void);
 extern void *read_all(FILE *stream, size_t *psize);
-char const * strnull(char const * const str);
+extern char const * strnull(char const * const str);
 
 #endif				/* INCLUDE_UTIL_H */


### PR DESCRIPTION
Strict mode added (`mkiocccentry` uses this mode) to both `jinfochk` and `jauthchk` and the checks for the proper first and last char in the files are added.

There were some other clean-ups in the files as well (so far two commits to this pull request).