### PR TITLE
Many updates to the tools

### DIFF
--- a/jauthchk.h
+++ b/jauthchk.h
@@ -34,7 +34,7 @@
 /*
  * jauthchk version
  */
-#define JAUTHCHK_VERSION "0.4 2022-02-18"	/* use format: major.minor YYYY-MM-DD */
+#define JAUTHCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
 
 
 

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -17,7 +17,7 @@
 /*
  * jinfochk version
  */
-#define JINFOCHK_VERSION "0.4 2022-02-18"	/* use format: major.minor YYYY-MM-DD */
+#define JINFOCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
 
 /*
  * IOCCC size and rule related limitations


### PR DESCRIPTION
I apologise for the long commit log: I made a lot of commits and some
had elaborate details (some important and others less important) and
unfortunately the logs did not carry over. I've removed my name, the
date and the commit id as GitHub does to make it as short as possible
and I also removed other text.

*   MAX_WINNER_HANDLE -> MAX_HANDLE
*   num_authors -> author_count
*   txzchk: Minor rewording message for !exists(tar)
*   jinfochk and jauthchk: Add formed_timestamp check
*   jinfochk/jauthchk: Add formed_timestamp_usec test
*   Add min_timestamp check to jinfochk and jauthchk
*   Add seqcexit rule to Makefile + run make seqcexit

    Checks for seqcexit tool being installed and if it is it runs it on the
    source files. Now whenever source files are updated one can simply run
    make seqcexit and the job will be done.

*   Add timestamp_epoch check to jinfochk and jauthchk
*   Fix test_JSON/good/info.json.sorted

    Outdated mkiocccentry_version caused that test to fail.

*   Two bug fixes in jinfochk and jauthchk

    Array infinite loop when array is first: although arrays are not handled
    yet this commit should prevent the tools from entering an infinite loop
    when they are in the file ahead of everything else; it only happened if
    the array was first because when extracting the value if it (the array)
    wasn't first the strtok_r() call would be passed in NULL as expected:
    when the array is first it happily continued to call strtok_r(p, ":",
    &savefield); which means that p would once again be the same value until
    the program was terminated.

    Remove trailing whitespace from the value. This fixes the problem where
    a valid value of false (as a boolean) triggered an error since using
    strcmp() on it did not exactly match "false" (or "true"). Only happens
    at the end of the file i.e. when not with a ',' at the end (this because
    of the second argument passed into strtok_r() being ",\0" which does not
    have a newline - which I think was the problem).

*   Fix bug where asking for IOCCC winner handle fails

    To test the jauthchk (when I get to the arrays part) I have made the
    mkiocccentry-test.sh write five authors to the entry. But this in turn
    revealed a bug: "IOCCC winner handle of author #3 does not start with an
    alpha numeric character." I added the printing of the actual string
    (seems helpful to the user) and it most certainly did start with an