### PR TITLE
IOCCC tools versions mods + bug fix winner handles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,13 @@ jstrdecode: jstrdecode.c jstrdecode.h dbg.o json.o util.o Makefile
 limit_ioccc.sh: limit_ioccc.h Makefile
 	${RM} -f $@
 	@echo '#' > $@
-	@echo '# Copies of select limit_ioccc.h values for shell script use' >> $@
+	@echo '# Copies of select limit_ioccc.h and version.h values for shell script use' >> $@
 	@echo '#' >> $@
-	${GREP} -E '^#define (RULE_|MAX_|UUID_|MIN_|_VERSION|IOCCC_)' limit_ioccc.h | \
+	${GREP} -E '^#define (RULE_|MAX_|UUID_|MIN_|IOCCC_)' limit_ioccc.h | \
 	    ${AWK} '{print $$2 "=\"" $$3 "\"" ;}' | ${TR} -d '[a-z]()' | \
 	    ${SED} -e 's/"_/"/' -e 's/""/"/g' -e 's/^/export /' >> $@
-	${GREP} -E '^#define (IOCCCSIZE_VERSION|MKIOCCCENTRY_VERSION|TIMESTAMP_EPOCH)' limit_ioccc.h | \
+	${GREP} -hE '^#define (.*_VERSION|TIMESTAMP_EPOCH)' version.h limit_ioccc.h | \
+	    ${GREP} -v 'UUID_VERSION' | \
 	    ${SED} -e 's/^#define/export/' -e 's/ "/="/' -e 's/"[	 ].*$$/"/' >> $@
 	-if ${GREP} -q '^#define DIGRAPHS' limit_ioccc.h; then \
 	    echo "export DIGRAPHS='yes'"; \
@@ -350,13 +351,17 @@ depend:
 dbg.o: dbg.c dbg.h
 util.o: util.c dbg.h util.h
 mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h json.h dbg.h \
-  limit_ioccc.h iocccsize.h
+  limit_ioccc.h version.h iocccsize.h
 iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
-fnamchk.o: fnamchk.c dbg.h util.h limit_ioccc.h
-txzchk.o: txzchk.c txzchk.h util.h dbg.h limit_ioccc.h
-jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h json.h limit_ioccc.h
-jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h json.h limit_ioccc.h
-json.o: json.c dbg.h util.h limit_ioccc.h json.h
-jstrencode.o: jstrencode.c jstrencode.h dbg.h util.h json.h limit_ioccc.h
-jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h json.h limit_ioccc.h
+fnamchk.o: fnamchk.c dbg.h util.h limit_ioccc.h version.h
+txzchk.o: txzchk.c txzchk.h util.h dbg.h limit_ioccc.h version.h
+jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h json.h limit_ioccc.h \
+  version.h
+jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h json.h limit_ioccc.h \
+  version.h
+json.o: json.c dbg.h util.h limit_ioccc.h version.h json.h
+jstrencode.o: jstrencode.c jstrencode.h dbg.h util.h json.h limit_ioccc.h \
+  version.h
+jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h json.h limit_ioccc.h \
+  version.h
 rule_count.o: rule_count.c iocccsize_err.h iocccsize.h

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -35,7 +35,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqsF:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqsF:t")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -70,6 +70,9 @@ main(int argc, char **argv)
 	case 'F':
 	    fnamchk_flag_used = true;
 	    fnamchk = optarg;
+	    break;
+	case 't':
+	    test = true;
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -34,12 +34,6 @@
 #define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
 
 
-/*
- * jauthchk version
- */
-#define JAUTHCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
-
-
 
 /*
  * usage message
@@ -47,7 +41,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] file\n"
+"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] [-t] file\n"
 "\n"
 "\t-h\t\tprint help message and exit 0\n"
 "\t-v level\tset verbosity level: (def level: %d)\n"
@@ -55,6 +49,7 @@ static const char * const usage_msg =
 "\t-q\t\tquiet mode\n"
 "\t-s\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"
+"\t-t\t\t\ttest mode: only issue warnings in some cases\n"
 "\n"
 "\tfile\t\tpath to a .author.json file\n"
 "\n"
@@ -73,6 +68,7 @@ char const *program = NULL;		    /* our name */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct author author;		    /* the .author.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' */
+static bool test = false;		    /* true ==> issue warnings instead of errors in some cases (N.B.: not yet used) */
 
 /*
  * forward declarations

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -33,7 +33,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqsF:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqsF:t")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -68,6 +68,9 @@ main(int argc, char **argv)
 	case 'F':
 	    fnamchk_flag_used = true;
 	    fnamchk = optarg;
+	    break;
+	case 't':
+	    test = true;
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -14,11 +14,6 @@
  */
 #define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
 
-/*
- * jinfochk version
- */
-#define JINFOCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
-
 
 /*
  * dbg - debug, warning and error reporting facility
@@ -48,7 +43,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] file\n"
+"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] [-t] file\n"
 "\n"
 "\t-h\t\t\tprint help message and exit 0\n"
 "\t-v level\t\tset verbosity level: (def level: %d)\n"
@@ -56,6 +51,7 @@ static const char * const usage_msg =
 "\t-q\t\t\tquiet mode\n"
 "\t-s\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"
+"\t-t\t\t\ttest mode: only issue warnings in some cases\n"
 "\n"
 "\tfile\t\t\tpath to a .info.json file\n"
 "\n"
@@ -74,6 +70,7 @@ char const *program = NULL;		    /* our name */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct info info;		    /* .info.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' in the file */
+static bool test = false;		    /* true ==> issue warnings instead of errors in some cases (N.B.: not yet used) */
 
 /*
  * forward declarations

--- a/limit_ioccc.h
+++ b/limit_ioccc.h
@@ -32,6 +32,12 @@
 
 #include <time.h>
 
+/* 
+ * version.h - official version for all the IOCCC tools
+ */
+#include "version.h"
+
+
 #undef DIGRAPHS		/* digraphs count a 2 for Rule 2b */
 #undef TRIGRAPHS	/* trigraphs count a 3 for Rule 2b */
 
@@ -61,52 +67,6 @@
  * Be careful to change this value as it will invalidate all IOCCC timestamps < this value
  */
 #define MIN_TIMESTAMP ((time_t)1643987926)
-
-
-/*
- * official iocccsize version
- */
-#define IOCCCSIZE_VERSION "28.8 2022-02-20"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * official mkiocccentry version
- */
-#define MKIOCCCENTRY_VERSION "0.36 2022-02-18"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * Version of info for JSON the .info.json file.
- *
- * The following is NOT the version of this mkiocccentry tool!
- */
-#define INFO_VERSION "1.8 2022-02-13"		/* version of the .info.json file to produce */
-
-
-/*
- * Version of info for JSON the .author.json file.
- *
- * The following is NOT the version of this mkiocccentry tool!
- */
-#define AUTHOR_VERSION "1.10 2022-02-18"	/* version of the .author.json file to produce */
-
-
-/*
- * fnamchk version
- */
-#define FNAMCHK_VERSION "0.2 2022-02-07"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * jstrencode version
- */
-#define JSTRENCODE_VERSION "0.1 2022-02-14"	/* use format: major.minor YYYY-MM-DD */
-
-
-/*
- * jstrdecode version
- */
-#define JSTRDECODE_VERSION "0.1 2022-02-14"	/* use format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -88,29 +88,19 @@
  * Answers file constants.
  *
  * Version of answers file.
- * Use format: MKIOCCCENTRY_ANSWERS-YYYY-major.minor
+ * Use format:
+ *
+ *	    MKIOCCCENTRY_ANSWERS-IOCCCMOCK-major.minor
+ *	    MKIOCCCENTRY_ANSWERS-IOCCC[0-9[0-9]-major.minor
  *
  * The following is NOT the version of this mkiocccentry tool!
+ *
+ * XXX These MUST be here and **NOT** in version.h!
  */
-#define MKIOCCCENTRY_ANSWERS_VER "MKIOCCCENTRY_ANSWERS-2022-0.0"
+#define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS-IOCCCMOCK-1.0"
 /* Answers file EOF marker */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF"
 
-
-/*
- * definitions
- */
-#define REQUIRED_ARGS (4)	/* number of required arguments on the command line */
-#define ISO_3166_1_CODE_URL0 "https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements"
-#define ISO_3166_1_CODE_URL1 "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
-#define ISO_3166_1_CODE_URL2 "https://www.iso.org/obp/ui/#iso:pub:PUB500001:en"
-#define ISO_3166_1_CODE_URL3 "https://www.iso.org/obp/ui/#search"
-#define ISO_3166_1_CODE_URL4 "https://www.iso.org/glossary-for-iso-3166.html"
-#define TAIL_TITLE_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_+-"	/* [a-z0-9_+-] */
-#define IOCCC_REGISTER_URL "https://register.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
-#define IOCCC_SUBMIT_URL "https://submit.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
-#define RULE_2A_BIG_FILE_WARNING (0)	/* warn that prog.c appears to be too big under Rule 2a */
-#define RULE_2A_IOCCCSIZE_MISMATCH (1)	/* warn that prog.c iocccsize size differs from the file size */
 
 
 
@@ -410,7 +400,7 @@ main(int argc, char *argv[])
 	    errp(10, __func__, "cannot create answers file: %s", answers);
 	    not_reached();
 	}
-        ret = fprintf(answerp, "%s\n", MKIOCCCENTRY_ANSWERS_VER);
+        ret = fprintf(answerp, "%s\n", MKIOCCCENTRY_ANSWERS_VERSION);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing header to the answers file");
 	}
@@ -627,13 +617,13 @@ main(int argc, char *argv[])
 			warn_empty_prog(prog_c);
 		    }
 		    if (info.rule_2a_override) {
-			warn_rule2a_size(&info, prog_c, RULE_2A_BIG_FILE_WARNING, size);
+			warn_rule_2a_size(&info, prog_c, RULE_2A_BIG_FILE_WARNING, size);
 		    }
 		    if (info.rule_2a_mismatch) {
-			warn_rule2a_size(&info, prog_c, RULE_2A_IOCCCSIZE_MISMATCH, size);
+			warn_rule_2a_size(&info, prog_c, RULE_2A_IOCCCSIZE_MISMATCH, size);
 		    }
 		    if (info.rule_2b_override) {
-			warn_rule2b_size(&info, prog_c);
+			warn_rule_2b_size(&info, prog_c);
 		    }
 		    if (info.highbit_warning) {
 			warn_high_bit(prog_c);
@@ -1566,7 +1556,7 @@ get_contest_id(struct info *infop, bool *testp, bool *read_answers_flag_used)
 	 * prompt for the contest ID
 	 */
 	malloc_ret = prompt("Enter IOCCC contest ID or test", &len);
-	if (!seen_answers_header && !strcmp(malloc_ret, MKIOCCCENTRY_ANSWERS_VER)) {
+	if (!seen_answers_header && !strcmp(malloc_ret, MKIOCCCENTRY_ANSWERS_VERSION)) {
 	    dbg(DBG_HIGH, "found answers header");
 	    seen_answers_header = true;
 	    *read_answers_flag_used = true;
@@ -1950,7 +1940,7 @@ warn_empty_prog(char const *prog_c)
 
 
 /*
- * warn_rule2a_size - warn if prog.c is too large under Rule 2a
+ * warn_rule_2a_size - warn if prog.c is too large under Rule 2a
  *
  * given:
  *      infop           - pointer to info structure
@@ -1962,7 +1952,7 @@ warn_empty_prog(char const *prog_c)
  * This function does not return on error.
  */
 static void
-warn_rule2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size)
+warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size)
 {
     bool yorn = false;
     int ret;
@@ -2250,7 +2240,7 @@ warn_ungetc(char const *prog_c)
 
 
 /*
- * warn_rule2b_size - warn user that prog.c triggered an ungetc error
+ * warn_rule_2b_size - warn user that prog.c triggered an ungetc error
  *
  * given:
  *
@@ -2259,7 +2249,7 @@ warn_ungetc(char const *prog_c)
  * This function does not return on error.
  */
 static void
-warn_rule2b_size(struct info *infop, char const *prog_c)
+warn_rule_2b_size(struct info *infop, char const *prog_c)
 {
     int ret, yorn;
 
@@ -2416,7 +2406,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
      * warn if prog.c is too large under Rule 2a
      */
     } else if (infop->rule_2a_size > RULE_2A_SIZE) {
-	warn_rule2a_size(infop, prog_c, RULE_2A_BIG_FILE_WARNING, size);
+	warn_rule_2a_size(infop, prog_c, RULE_2A_BIG_FILE_WARNING, size);
 	infop->empty_override = false;
 	infop->rule_2a_override = true;
     } else {
@@ -2428,7 +2418,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
      * sanity check on file size vs rule_count function size for Rule 2a
      */
     if (infop->rule_2a_size != size.rule_2a_size) {
-	warn_rule2a_size(infop, prog_c, RULE_2A_IOCCCSIZE_MISMATCH, size);
+	warn_rule_2a_size(infop, prog_c, RULE_2A_IOCCCSIZE_MISMATCH, size);
 	infop->rule_2a_mismatch = true;
     } else {
 	infop->rule_2a_mismatch = false;
@@ -2488,7 +2478,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
      * inspect the Rule 2b size
      */
     if (infop->rule_2b_size > RULE_2B_SIZE) {
-	warn_rule2b_size(infop, prog_c);
+	warn_rule_2b_size(infop, prog_c);
 	infop->rule_2b_override = true;
     } else {
 	infop->rule_2b_override = false;
@@ -3273,7 +3263,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	if (!isascii(base[0]) || !isalnum(base[0])) {
 	    fpara(stderr,
 		  "",
-		  "The first character is the basename of an extra file must be alpha numeric:",
+		  "The first character is the basename of an extra file must be alphanumeric:",
 		  "",
 		  NULL);
 	    err(140, __func__, "basename of extra data file: %s start with in invalid character: %s", args[i], base);
@@ -4664,17 +4654,19 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	     * IOCCC winner handle, if given, must start with a alphanumeric character
 	     */
 	    if (len > 0 &&
-		(!isascii(author_set[i].winner_handle[j]) || !isalnum(author_set[i].winner_handle[j]))) {
+		(!isascii(author_set[i].winner_handle[0]) || !isalnum(author_set[i].winner_handle[0]))) {
 		fpara(stderr,
 		      "",
-		      "IOCCC winner handles just start with an alpha numeric character:",
+		      "IOCCC winner handles must start with an alphanumeric character:",
 		      "",
 		      "    A-Z a-z 0-9",
 		      "",
 		      NULL);
-		err(168, __func__, "IOCCC winner handle of author #%d '%s' does not start with an alpha numeric character", i,
-			author_set[i].winner_handle);
-		not_reached();
+		if (author_set[i].winner_handle != NULL) {
+		    free(author_set[i].winner_handle);
+		    author_set[i].winner_handle = NULL;
+		}
+		continue;
 	    }
 
 	    /*
@@ -4694,14 +4686,16 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 			  "    A-Z a-z 0-9 . _ - +",
 			  "",
 			  NULL);
-		    err(169, __func__, "IOCCC winner handle of author #%d character %lu is NOT a POSIX Fully portable character nor +",
-				       i, (unsigned long)j);
-		    not_reached();
+		    if (author_set[i].winner_handle != NULL) {
+			free(author_set[i].winner_handle);
+			author_set[i].winner_handle = NULL;
+		    }
+		    break;
 		}
 	    }
 	} while (author_set[i].winner_handle == NULL && need_retry);
 	if (author_set[i].winner_handle == NULL) {
-	    errp(170, __func__, "retry prompt is disabled");
+	    errp(168, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d IOCCC winner handle: %s", i, author_set[i].winner_handle);
@@ -4721,11 +4715,11 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 						  printf("Twitter handle: %s\n", author_set[i].twitter)) <= 0 ||
 	    ((author_set[i].github[0] == '\0') ? printf("GitHub username not given\n") :
 						 printf("GitHub username: %s\n", author_set[i].github)) <= 0 ||
-	    ((author_set[i].affiliation[0] == '\0') ? printf("Affiliation not given\n\n") :
-						      printf("Affiliation: %s\n\n", author_set[i].affiliation)) <= 0 ||
+	    ((author_set[i].affiliation[0] == '\0') ? printf("Affiliation not given\n") :
+						      printf("Affiliation: %s\n", author_set[i].affiliation)) <= 0 ||
 	    ((author_set[i].winner_handle[0] == '\0') ? printf("IOCCC winner handle\n\n") :
 						        printf("IOCCC winner handle: %s\n\n", author_set[i].winner_handle)) <= 0) {
-	    errp(171, __func__, "error while printing author #%d information\n", i);
+	    errp(169, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -4778,7 +4772,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      * firewall
      */
     if (entry_dir == NULL || ls == NULL) {
-	err(172, __func__, "called with NULL arg(s)");
+	err(170, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4800,7 +4794,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("cd -- % && % -lak .", entry_dir, ls);
     if (cmd == NULL) {
-	err(173, __func__, "failed to cmdprintf: cd entry_dir && ls -lak .");
+	err(171, __func__, "failed to cmdprintf: cd entry_dir && ls -lak .");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -4812,7 +4806,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(174, __func__, "fflush(stdout) error code: %d", ret);
+	errp(172, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
@@ -4820,7 +4814,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(175, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(173, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -4830,13 +4824,13 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(176, __func__, "error calling system(%s)", cmd);
+	errp(174, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(177, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(175, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(178, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(176, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -4848,14 +4842,14 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(179, __func__, "fflush(stdout) #0: error code: %d", ret);
+	errp(177, __func__, "fflush(stdout) #0: error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(180, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(178, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -4865,7 +4859,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ls_stream = popen(cmd, "r");
     if (ls_stream == NULL) {
-	errp(181, __func__, "popen for reading failed for: %s", cmd);
+	errp(179, __func__, "popen for reading failed for: %s", cmd);
 	not_reached();
     }
 
@@ -4881,7 +4875,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     dbg(DBG_HIGH, "reading 1st line from popen(%s, r)", cmd);
     readline_len = readline(&linep, ls_stream);
     if (readline_len < 0) {
-	err(182, __func__, "EOF while reading 1st line from ls: %s", ls);
+	err(180, __func__, "EOF while reading 1st line from ls: %s", ls);
 	not_reached();
     } else {
 	dbg(DBG_HIGH, "ls 1st line read length: %ld buffer: %s", (long)readline_len, linep);
@@ -4892,11 +4886,11 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      */
     ret = sscanf(linep, "total %d%c", &kdirsize, &guard);
     if (ret != 1) {
-	err(183, __func__, "failed to parse block line from ls: %s", linep);
+	err(181, __func__, "failed to parse block line from ls: %s", linep);
 	not_reached();
     }
     if (kdirsize <= 0) {
-	err(184, __func__, "ls k block value: %d <= 0", kdirsize);
+	err(182, __func__, "ls k block value: %d <= 0", kdirsize);
 	not_reached();
     }
     if (kdirsize > MAX_DIR_KSIZE) {
@@ -4909,10 +4903,10 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	ret = fprintf(stderr, "The entry directory %s is %d kibibyte (1024 byte blocks) in length.\n"
 			      "It must be <= %d kibibyte (1024 byte blocks).\n\n", entry_dir, kdirsize, MAX_DIR_KSIZE);
 	if (ret <= 0) {
-	    errp(185, __func__, "fprintf error while printing entry directory kibibyte sizes");
+	    errp(183, __func__, "fprintf error while printing entry directory kibibyte sizes");
 	    not_reached();
 	}
-	err(186, __func__, "The entry directory is too large: %s", entry_dir);
+	err(184, __func__, "The entry directory is too large: %s", entry_dir);
 	not_reached();
     }
     dbg(DBG_LOW, "entry directory %s size in kibibyte (1024 byte blocks): %d", entry_dir, kdirsize);
@@ -4937,7 +4931,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	      "We suggest you remove the existing entry directory, and then",
 	      "rerun this tool with the correct set of file arguments.",
 	      NULL);
-	err(187, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(185, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5344,17 +5338,17 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || jinfochk == NULL || fnamchk == NULL) {
-	err(188, __func__, "called with NULL arg(s)");
+	err(186, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->extra_count < 0) {
 	warn(__func__, "extra_count %d < 0", infop->extra_count);
     }
     if (author_count <= 0) {
-	err(189, __func__, "author_count %d <= 0", author_count);
+	err(187, __func__, "author_count %d <= 0", author_count);
 	not_reached();
     } else if (author_count > MAX_AUTHORS) {
-	err(190, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
+	err(188, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -5369,7 +5363,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     infop->epoch = strdup(TIMESTAMP_EPOCH);
     if (infop->epoch == NULL) {
-	errp(191, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
+	errp(189, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
 	not_reached();
     }
     dbg(DBG_VVHIGH, "infop->epoch: %s", infop->epoch);
@@ -5380,17 +5374,17 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(192, __func__, "cannot set TZ=UTC");
+	errp(190, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = localtime(&(infop->tstamp));
     if (timeptr == NULL) {
-	errp(193, __func__, "localtime #1 returned NULL");
+	errp(191, __func__, "localtime #1 returned NULL");
 	not_reached();
     }
     if (timeptr->tm_zone == NULL) {
-	err(194, __func__, "timeptr->tm_zone #1 is NULL");
+	err(192, __func__, "timeptr->tm_zone #1 is NULL");
 	not_reached();
     }
 
@@ -5400,7 +5394,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     p = asctime(timeptr);
     if (p == NULL) {
-	errp(195, __func__, "asctime #1 returned NULL");
+	errp(193, __func__, "asctime #1 returned NULL");
 	not_reached();
     }
     asctime_len = strlen(p) - 1; /* -1 to remove trailing newline */
@@ -5408,7 +5402,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     infop->gmtime = (char *)calloc(gmtime_len + 1, 1);
     if (infop->gmtime == NULL) {
-	errp(196, __func__, "calloc of %lu bytes failed", (unsigned long)gmtime_len + 1);
+	errp(194, __func__, "calloc of %lu bytes failed", (unsigned long)gmtime_len + 1);
 	not_reached();
     }
     (void) strncat(infop->gmtime, p, asctime_len);
@@ -5422,20 +5416,20 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(197, __func__, "malloc of %lu bytes failed", (unsigned long)info_path_len + 1);
+	errp(195, __func__, "malloc of %lu bytes failed", (unsigned long)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/.info.json", entry_dir);
     if (ret <= 0) {
-	errp(198, __func__, "snprintf #0 error: %d", ret);
+	errp(196, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(199, __func__, "failed to open for writing: %s", info_path);
+	errp(197, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -5475,7 +5469,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_bool(info_stream, "\t", "test_mode", " : ", test_mode, ",\n") &&
 	fprintf(info_stream, "\t\"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(200, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(198, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5489,7 +5483,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	  json_fprintf_value_string(info_stream, "\t\t{", "remarks", " : ", infop->remarks_md,
 				    ((infop->extra_count > 0) ?  "},\n" : "}\n"));
     if (!ret) {
-	errp(201, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(199, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -5499,7 +5493,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     for (i=0, q=infop->extra_file; i < infop->extra_count && *q != NULL; ++i, ++q) {
         if (json_fprintf_value_string(info_stream, "\t\t{", "extra_file", " : ", *q,
 				     (((i+1) < infop->extra_count) ? "},\n" : "}\n")) != true) {
-	    errp(202, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
+	    errp(200, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
 	    not_reached();
 	}
     }
@@ -5516,7 +5510,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_string(info_stream, "\t", "formed_UTC", " : ", infop->gmtime, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(203, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(201, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5526,7 +5520,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(204, __func__, "fclose error");
+	errp(202, __func__, "fclose error");
 	not_reached();
     }
     /*
@@ -5534,7 +5528,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
      */
     cmd = cmdprintf("% -q -s -F % %", jinfochk, fnamchk, info_path);
     if (cmd == NULL) {
-	err(205, __func__, "failed to cmdprintf: jinfochk %s", info_path);
+	err(203, __func__, "failed to cmdprintf: jinfochk %s", info_path);
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5546,14 +5540,14 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(206, __func__, "fflush(stdout) error code: %d", ret);
+	errp(204, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(207, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(205, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5564,13 +5558,13 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(208, __func__, "error calling system(%s)", cmd);
+	errp(206, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(209, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(207, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(210, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(208, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5621,14 +5615,14 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
      * firewall
      */
     if (infop == NULL || authorp == NULL || entry_dir == NULL || jauthchk == NULL) {
-	err(211, __func__, "called with NULL arg(s)");
+	err(209, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count <= 0) {
-	err(212, __func__, "author_count %d <= 0", author_count);
+	err(210, __func__, "author_count %d <= 0", author_count);
 	not_reached();
     } else if (author_count > MAX_AUTHORS) {
-	err(213, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
+	err(211, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -5640,20 +5634,20 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     author_path = (char *)malloc(author_path_len + 1);
     if (author_path == NULL) {
-	errp(214, __func__, "malloc of %lu bytes failed", (unsigned long)author_path_len + 1);
+	errp(212, __func__, "malloc of %lu bytes failed", (unsigned long)author_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(author_path, author_path_len, "%s/.author.json", entry_dir);
     if (ret <= 0) {
-	errp(215, __func__, "snprintf #0 error: %d", ret);
+	errp(213, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".author.json path: %s", author_path);
     errno = 0;			/* pre-clear errno for errp() */
     author_stream = fopen(author_path, "w");
     if (author_stream == NULL) {
-	errp(216, __func__, "failed to open for writing: %s", author_path);
+	errp(214, __func__, "failed to open for writing: %s", author_path);
 	not_reached();
     }
 
@@ -5672,7 +5666,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_long(author_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
 	fprintf(author_stream, "\t\"authors\" : [\n") > 0;
     if (!ret) {
-	errp(217, __func__, "fprintf error writing leading part of authorship to %s", author_path);
+	errp(215, __func__, "fprintf error writing leading part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5694,7 +5688,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	    json_fprintf_value_long(author_stream, "\t\t\t", "author_number", " : ", authorp[i].author_num, "\n") &&
 	    fprintf(author_stream, "\t\t}%s\n", (((i + 1) < author_count) ? "," : "")) > 0;
 	if (ret < 0) {
-	    errp(218, __func__, "fprintf error writing author info to %s", author_path);
+	    errp(216, __func__, "fprintf error writing author info to %s", author_path);
 	    not_reached();
 	}
     }
@@ -5711,7 +5705,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "formed_UTC", " : ", infop->gmtime, "\n") &&
 	fprintf(author_stream, "}\n") > 0;
     if (!ret) {
-	errp(219, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
+	errp(217, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5721,7 +5715,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(author_stream);
     if (ret < 0) {
-	errp(220, __func__, "fclose error");
+	errp(218, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5733,7 +5727,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
      */
     cmd = cmdprintf("% -q -s %", jauthchk, author_path);
     if (cmd == NULL) {
-	err(221, __func__, "failed to cmdprintf: jauthchk %s", author_path);
+	err(219, __func__, "failed to cmdprintf: jauthchk %s", author_path);
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5745,14 +5739,14 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(222, __func__, "fflush(stdout) error code: %d", ret);
+	errp(220, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(223, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(221, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5763,13 +5757,13 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(224, __func__, "error calling system(%s)", cmd);
+	errp(222, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(225, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(223, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(226, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(224, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5827,7 +5821,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      */
     if (work_dir == NULL || entry_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(227, __func__, "called with NULL arg(s)");
+	err(225, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5843,7 +5837,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(228, __func__, "cannot open .");
+	errp(226, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -5853,7 +5847,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(work_dir);
     if (ret < 0) {
-	errp(229, __func__, "cannot cd %s", work_dir);
+	errp(227, __func__, "cannot cd %s", work_dir);
 	not_reached();
     }
 
@@ -5869,7 +5863,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     basename_tarball_path = base_name(tarball_path);
     cmd = cmdprintf("% --format=v7 -cJf % %", tar, basename_tarball_path, basename_entry_dir);
     if (cmd == NULL) {
-	err(230, __func__, "failed to cmdprintf: tar --format=v7 -cJf tarball_path entry_dir");
+	err(228, __func__, "failed to cmdprintf: tar --format=v7 -cJf tarball_path entry_dir");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5881,14 +5875,14 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(231, __func__, "fflush(stdout) error code: %d", ret);
+	errp(229, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(232, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(230, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5902,13 +5896,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(233, __func__, "error calling system(%s)", cmd);
+	errp(231, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(234, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(232, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(235, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(233, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5918,7 +5912,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(236, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(234, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -5927,7 +5921,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(237, __func__, "The compressed tarball: %s size: %lu > %ld",
+	err(235, __func__, "The compressed tarball: %s size: %lu > %ld",
 		 basename_tarball_path, (unsigned long)buf.st_size, (long)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -5946,13 +5940,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(238, __func__, "cannot fchdir to the previous current directory");
+	errp(236, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(239, __func__, "close of previous current directory failed");
+	errp(237, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -5961,7 +5955,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      */
     cmd = cmdprintf("% -q -F % %/../%", txzchk, fnamchk, entry_dir, basename_tarball_path);
     if (cmd == NULL) {
-	err(240, __func__, "failed to cmdprintf: txzchk -q tarball_path");
+	err(238, __func__, "failed to cmdprintf: txzchk -q tarball_path");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5973,14 +5967,14 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(241, __func__, "fflush(stdout) error code: %d", ret);
+	errp(239, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(242, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(240, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5991,13 +5985,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(243, __func__, "error calling system(%s)", cmd);
+	errp(241, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(244, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(242, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(245, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(243, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
     para("",
@@ -6047,13 +6041,13 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
      * firewall
      */
     if (work_dir == NULL || entry_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(246, __func__, "called with NULL arg(s)");
+	err(244, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     entry_dir_esc = cmdprintf("%", entry_dir);
     if (entry_dir_esc == NULL) {
-	err(247, __func__, "failed to cmdprintf: entry_dir");
+	err(245, __func__, "failed to cmdprintf: entry_dir");
 	not_reached();
     }
 
@@ -6066,14 +6060,14 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    rm -rf %s%s\n", entry_dir[0] == '-' ? "-- " : "", entry_dir_esc);
     if (ret <= 0) {
-	errp(248, __func__, "printf #0 error");
+	errp(246, __func__, "printf #0 error");
 	not_reached();
     }
     free(entry_dir_esc);
 
     work_dir_esc = cmdprintf("%", work_dir);
     if (work_dir_esc == NULL) {
-	err(249, __func__, "failed to cmdprintf: work_dir");
+	err(247, __func__, "failed to cmdprintf: work_dir");
 	not_reached();
     }
 
@@ -6084,7 +6078,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, work_dir[0] == '-' ? "./" : "", work_dir_esc, tarball_path);
     if (ret <= 0) {
-	errp(10, __func__, "printf #2 error");
+	errp(248, __func__, "printf #2 error");
 	not_reached();
     }
     free(work_dir_esc);
@@ -6118,7 +6112,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s/%s\n", work_dir, tarball_path);
 	if (ret <= 0) {
-	    errp(11, __func__, "printf #2 error");
+	    errp(249, __func__, "printf #2 error");
 	    not_reached();
 	}
     }
@@ -6134,7 +6128,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s\n\n", IOCCC_SUBMIT_URL);
 	if (ret < 0) {
-	    errp(12, __func__, "printf #4 error");
+	    errp(10, __func__, "printf #4 error");
 	    not_reached();
 	}
     }

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -88,6 +88,28 @@
  */
 #include "iocccsize.h"
 
+/*
+ * definitions
+ *
+ * XXX: the MKIOCCCENTRY_ANSWERS_VERSION and MKIOCCCENTRY_ANSWERS_EOF have to be
+ * defined in mkiocccentry.c
+ *
+ */
+#define REQUIRED_ARGS (4)	/* number of required arguments on the command line */
+#define ISO_3166_1_CODE_URL0 "https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements"
+#define ISO_3166_1_CODE_URL1 "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
+#define ISO_3166_1_CODE_URL2 "https://www.iso.org/obp/ui/#iso:pub:PUB500001:en"
+#define ISO_3166_1_CODE_URL3 "https://www.iso.org/obp/ui/#search"
+#define ISO_3166_1_CODE_URL4 "https://www.iso.org/glossary-for-iso-3166.html"
+#define TAIL_TITLE_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_+-"	/* [a-z0-9_+-] */
+#define IOCCC_REGISTER_URL "https://register.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
+#define IOCCC_SUBMIT_URL "https://submit.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
+/* XXX: The next two are for the warn_rule_2a_size() function. Do **NOT** change these values! */
+#define RULE_2A_BIG_FILE_WARNING (0)	/* warn that prog.c appears to be too big under Rule 2a */
+#define RULE_2A_IOCCCSIZE_MISMATCH (1)	/* warn that prog.c iocccsize size differs from the file size */
+
+
+
 
 /*
  * usage message
@@ -150,13 +172,13 @@ static void usage(int exitcode, char const *str, char const *program);
 static void free_info(struct info *infop);
 static void free_author_array(struct author *authorp, int author_count);
 static void warn_empty_prog(char const *prog_c);
-static void warn_rule2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size);
+static void warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size);
 static void warn_high_bit(char const *prog_c);
 static void warn_nul_chars(char const *prog_c);
 static void warn_trigraph(char const *prog_c);
 static void warn_wordbuf(char const *prog_c);
 static void warn_ungetc(char const *prog_c);
-static void warn_rule2b_size(struct info *infop, char const *prog_c);
+static void warn_rule_2b_size(struct info *infop, char const *prog_c);
 static RuleCount check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char const *prog_c);
 static void sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp,
 		       char const *ls, char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk);

--- a/txzchk.h
+++ b/txzchk.h
@@ -91,11 +91,6 @@ struct line {
 
 static struct line *lines;
 
-/*
- * txzchk version
- */
-#define TXZCHK_VERSION "0.7 2022-02-12"    /* use format: major.minor YYYY-MM-DD */
-
 
 /*
  * usage message

--- a/version.h
+++ b/version.h
@@ -1,0 +1,65 @@
+/* official IOCCC tools versions */
+#ifndef VERSION_H
+#define VERSION_H
+
+/*
+ * official iocccsize version
+ */
+#define IOCCCSIZE_VERSION "28.7 2022-02-01"	/* use format: major.minor YYYY-MM-DD */
+
+
+/*
+ * official mkiocccentry version
+ */
+#define MKIOCCCENTRY_VERSION "0.36 2022-02-18"	/* use format: major.minor YYYY-MM-DD */
+
+
+/*
+ * Version of info for JSON the .info.json file.
+ *
+ * The following is NOT the version of this mkiocccentry tool!
+ */
+#define INFO_VERSION "1.8 2022-02-13"		/* version of the .info.json file to produce */
+
+
+/*
+ * Version of info for JSON the .author.json file.
+ *
+ * The following is NOT the version of this mkiocccentry tool!
+ */
+#define AUTHOR_VERSION "1.10 2022-02-18"	/* version of the .author.json file to produce */
+
+
+/*
+ * fnamchk version
+ */
+#define FNAMCHK_VERSION "0.2 2022-02-07"	/* use format: major.minor YYYY-MM-DD */
+
+/*
+ * txzchk version
+ */
+#define TXZCHK_VERSION "0.7 2022-02-12"    /* use format: major.minor YYYY-MM-DD */
+
+/*
+ * jinfochk version
+ */
+#define JINFOCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
+
+/*
+ * jauthchk version
+ */
+#define JAUTHCHK_VERSION "0.5 2022-02-19"	/* use format: major.minor YYYY-MM-DD */
+
+
+/*
+ * jstrencode version
+ */
+#define JSTRENCODE_VERSION "0.1 2022-02-14"	/* use format: major.minor YYYY-MM-DD */
+
+
+/*
+ * jstrdecode version
+ */
+#define JSTRDECODE_VERSION "0.1 2022-02-14"	/* use format: major.minor YYYY-MM-DD */
+
+#endif /* VERSION_H */


### PR DESCRIPTION
With the exception of the answers file macros all _VERSION constants are
now in new file version.h and these are all exported into limit_ioccc.sh
(upon running make).

Change format of MKIOCCCENTRY_ANSWERS_VERSION (was
MKIOCCCENTRY_ANSWERS_VER): instead of year it now has IOCCC[0-9][0-9]
(i.e. the contest in question) or IOCCCMOCK (for mock contest) i.e. it
coincides with the #define IOCCC_CONTEST in limit_ioccc.h.

Update Makefile dependencies (due to adding version.h).

Fix handling of winner handle so that if the input is invalid it does
not abort but instead it prompts the user again (after telling them what
the problem is).

The #defines in mkiocccentry.c that are not related to the answers file
have been moved to mkiocccentry.h.

mkiocccentry.c: warn_rule2a_size() -> warn_rule_2a_size() and
warn_rule2b_size() -> warn_rule_2b_size().

Sequence exit codes (make seqcexit).

Additionally (because the git log did not carry over from GitHub on
yesterday's commits) these changes were made (yesterday, 20 February
2022). I'm VERY SORRY for the textbook length but I made many commits
and I believe in thoroughness (I have removed much of the text (which
will show just how thorough I can be!):

        Many updates to the tools

        *   MAX_WINNER_HANDLE -> MAX_HANDLE
        *   num_authors -> author_count
        *   txzchk: Minor rewording message for !exists(tar)
        *   jinfochk and jauthchk: Add formed_timestamp check
        *   jinfochk/jauthchk: Add formed_timestamp_usec test
        *   Add min_timestamp check to jinfochk and jauthchk
        *   Add seqcexit rule to Makefile + run make seqcexit

            Checks for seqcexit tool being installed and if it is it runs it on the
            source files. Now whenever source files are updated one can simply run
            make seqcexit and the job will be done.

        *   Add timestamp_epoch check to jinfochk and jauthchk
        *   Fix test_JSON/good/info.json.sorted

            Outdated mkiocccentry_version caused that test to fail.

        *   Two bug fixes in jinfochk and jauthchk

            Array infinite loop when array is first: although arrays are not handled
            yet this commit should prevent the tools from entering an infinite loop
            when they are in the file ahead of everything else; it only happened if
            the array was first because when extracting the value if it (the array)
            wasn't first the strtok_r() call would be passed in NULL as expected:
            when the array is first it happily continued to call strtok_r(p, ":",
            &savefield); which means that p would once again be the same value until
            the program was terminated.

            Remove trailing whitespace from the value. This fixes the problem where
            a valid value of false (as a boolean) triggered an error since using
            strcmp() on it did not exactly match "false" (or "true"). Only happens
            at the end of the file i.e. when not with a ',' at the end (this because
            of the second argument passed into strtok_r() being ",\0" which does not
            have a newline - which I think was the problem).

        *   Fix bug where asking for IOCCC winner handle fails

            To test the jauthchk (when I get to the arrays part) I have made the
            mkiocccentry-test.sh write five authors to the entry. But this in turn
            revealed a bug: "IOCCC winner handle of author #3 does not start with an
            alpha numeric character." I added the printing of the actual string
            (seems helpful to the user) and it most certainly did start with an
            alphanumerical character: it was "author3-last3". This commit fixes this
            bug as well as (as above) having the maximum number of authors in the
            make test script.

        *   Write number of authors to JSON files

            This will be used to verify that the number of authors is consistent
            with the size of authors array (in .author.json): if the number of
            authors is 2 and the authors array has 3 authors it's an error; if the
            number of authors is 3 and the authors are numbers 0, 1 and 4 (three
            authors but wrong numbers) there is a problem; etc.

            In both write_author() and write_info() (the latter of which did not
            previously take an int author_count) it is now an error if author_count
            <= 0 (it was a warning before but if it is <= 0 it's a sign that there's
            a serious problem because the code verifies that the number of authors
            is within the allowed range which is > 0 && <= MAX_AUTHORS). Also these
            functions now check if author_count > MAX_AUTHORS and if so this is also
            an error (because the code does not allow it).

            What I realised with this commit and adding the tarball path to the
            .author.json (as requested) as well as the winner_handle is that the
            files under test_JSON will fail eventually since the checkers will
            expect to find the number of authors. A test option will be added to
            fix this!

        *   Add new bad JSON test cases

            This is .author.json specific but it has fields that are supposed to be
            in the .info.json and on top of that the (unnamed) array has elements
            that are supposed to be in .info.json. Similar tests can be devised for
            jinfochk (and will be in time).

            Also unnamed arrays should be detected. Currently jinfochk does not
            detect this and neither does jauthchk (the test file is .info.json
            specific: the array has elements in the array that are supposed to
            be in .info.json).

        *   Fix test_JSON/good/info.json.good

            It had the wrong mkiocccentry version so it failed.

        *   Add tarball field to .author.json

            This commit also adds -F /path/to/fnamchk to jauthchk (to verify that
            the tarball field's value in the .author.json file is properly named).
            Note that this tool is not yet used in either of the json checker tools
            (jinfochk and jauthchk).

            Add comment about not free()ing infop->tarball_path.

            Whilst I often used the word 'whilst', I have changed all the uses of
            the word 'whilst' to the word 'while' in the tools I have worked on
            because I think 'while' is more natural than 'whilst' to many people.
            Whilst this goes against my nature having 'while' instead of 'whilst'
            seems a worthwhile thing since it is more natural to most people. :)

        *   mkiocccentry: fix may be uninitialised warning

            Triggered under CentOS:

                mkiocccentry.c: In function 'get_author_info':
                mkiocccentry.c:4690:40: warning: 'j' may be used uninitialized in this function [-Wmaybe-uninitialized]
                    (!isascii(author_set[i].winner_handle[j]) || !isalnum(author_set[i].winner_handle[j]))) {
                                                    ^
            I've initialised both 'i' and 'j' in the function to be 0.

        *   mkiocccentry and txzchk: usage() function clean up

            The usage() function in these tools were passed in the paths to the
            tools the respective program used but these paths are actually just the
            default paths so don't pass in those paths and instead just use them
            directly in the usage() function in each file. The tools that had this
            problem were mkiocccentry and txzchk; the others I already had done this
            (or never had the problem).

    That's all for now! :)