### PR TITLE
Various updates, fixes and clean up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,16 @@
 
 Created this CHANGES.md markdown document.
 
-Added -T flag to mkiocccentry to print the IOCCC entry tool set release tag:
+Added -T flag to `mkiocccentry`, `fnamchk`, `txzchk`, `jstrencode` and
+`jstrdecode` to print the IOCCC entry tool set release tag:
+
 
 ```sh
 ./mkiocccentry -T
+./fnamchk -T
+./txzchk -T
+./jstrencode -T
+./jstrdecode -T
 ```
 
 ## Release 0.0
@@ -25,5 +31,3 @@ See these man pages for details
 - iocccsize.1
 - mkiocccentry.1
 - txzchk.1
-- jinfochk.1
-- jauthchk.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,3 +25,5 @@ See these man pages for details
 - iocccsize.1
 - mkiocccentry.1
 - txzchk.1
+- jinfochk.1
+- jauthchk.1

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ iocccsize: iocccsize.c rule_count.o dbg.o Makefile
 dbg_test: dbg.c Makefile
 	${CC} ${CFLAGS} -DDBG_TEST dbg.c -o $@
 
-fnamchk: fnamchk.c dbg.o util.o Makefile
+fnamchk: fnamchk.c fnamchk.h dbg.o util.o Makefile
 	${CC} ${CFLAGS} fnamchk.c dbg.o util.o -o $@
 
 txzchk: txzchk.c txzchk.h rule_count.o dbg.o util.o Makefile
@@ -371,7 +371,7 @@ util.o: util.c dbg.h util.h limit_ioccc.h version.h
 mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h json.h dbg.h \
   limit_ioccc.h version.h iocccsize.h
 iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
-fnamchk.o: fnamchk.c dbg.h util.h limit_ioccc.h version.h
+fnamchk.o: fnamchk.c fnamchk.h dbg.h util.h limit_ioccc.h version.h
 txzchk.o: txzchk.c txzchk.h util.h dbg.h limit_ioccc.h version.h
 jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h json.h limit_ioccc.h \
   version.h

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ MANDIR = /usr/local/share/man/man1
 DESTDIR= /usr/local/bin
 TARGETS= mkiocccentry iocccsize dbg_test limit_ioccc.sh fnamchk txzchk jauthchk jinfochk \
 	jstrencode jstrdecode
-MANPAGES = mkiocccentry.1 txzchk.1 fnamchk.1 iocccsize.1
+MANPAGES = mkiocccentry.1 txzchk.1 fnamchk.1 iocccsize.1 jinfochk.1 jauthchk.1
 TEST_TARGETS= dbg_test
 OBJFILES = dbg.o util.o mkiocccentry.o iocccsize.o fnamchk.o txzchk.o jauthchk.o jinfochk.o \
 	json.o jstrencode.o jstrdecode.o rule_count.o

--- a/dbg.c
+++ b/dbg.c
@@ -756,6 +756,38 @@ warnp_or_errp(int exitcode, const char *name, bool test, const char *fmt, ...)
     return;
 }
 
+/* parse_verbosity	- parse -v option for our tools 
+ *
+ * given:
+ *
+ *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
+ *	arg		- the optarg in the calling tool
+ *
+ * Returns the parsed verbosity.
+ *
+ * Returns DBG_NONE if passed NULL args or empty string.
+ */
+int
+parse_verbosity(char const *program, char const *arg)
+{
+    int verbosity;
+
+    if (program == NULL || arg == NULL || !strlen(arg)) {
+	return DBG_NONE;
+    }
+
+    /*
+     * parse verbosity
+     */
+    errno = 0;		/* pre-clear errno for errp() */
+    verbosity = (int)strtol(arg, NULL, 0);
+    if (errno != 0) {
+	errp(1, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
+	not_reached();
+    }
+
+    return verbosity;
+}
 
 #if defined(DBG_TEST)
 int
@@ -787,12 +819,12 @@ main(int argc, char *argv[])
 	    verbosity_level = (int)strtol(optarg, NULL, 0);
 	    if (errno != 0) {
 		/* exit(1); */
-		err(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno));
+		err(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
 		not_reached();
 	    }
 	    break;
 	case 'e':	/* -e errno - force errno */
-	    /* parse verbosity */
+	    /* parse errno */
 	    errno = 0;
 	    forced_errno = (int)strtol(optarg, NULL, 0);
 	    if (errno != 0) {

--- a/dbg.c
+++ b/dbg.c
@@ -810,7 +810,7 @@ main(int argc, char *argv[])
 	switch (i) {
 	case 'h':	/* -h - print help to stderr and exit 0 */
 	    /* exit(0); */
-	    vfprintf_usage(0, stderr, usage, program, VERSION);
+	    vfprintf_usage(0, stderr, usage, program, VERSION); /*ooo*/
 	    not_reached();
 	    break;
 	case 'v':	/* -v verbosity */
@@ -829,7 +829,7 @@ main(int argc, char *argv[])
 	    forced_errno = (int)strtol(optarg, NULL, 0);
 	    if (errno != 0) {
 		/* exit(2); */
-		err(2, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno));
+		err(2, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
 		not_reached();
 	    }
 	    errno = forced_errno;	/* simulate errno setting */
@@ -837,7 +837,7 @@ main(int argc, char *argv[])
 	default:
 	    vfprintf_usage(DO_NOT_EXIT, stderr, "invalid -flag");
 	    /* exit(3); */
-	    vfprintf_usage(3, stderr, usage, program, VERSION);
+	    vfprintf_usage(3, stderr, usage, program, VERSION); /*ooo*/
 	    not_reached();
 	}
     }
@@ -851,7 +851,7 @@ main(int argc, char *argv[])
     default:
 	vfprintf_usage(DO_NOT_EXIT, stderr, "requires 2 or 3 arguments");
 	/* exit(4); */
-	vfprintf_usage(4, stderr, usage, program, VERSION);
+	vfprintf_usage(4, stderr, usage, program, VERSION); /*ooo*/
 	not_reached();
 	break;
     }
@@ -867,10 +867,10 @@ main(int argc, char *argv[])
      */
     if (errno != 0) {
 	/* exit(5); */
-	errp(5, __func__, "simulated error, foo: %s bar: %s", foo, baz);
+	errp(5, __func__, "simulated error, foo: %s bar: %s", foo, baz); /*ooo*/
     }
     /* exit(6); */
-    err(6, __func__, "simulated error, foo: %s bar: %s", foo, baz);
+    err(6, __func__, "simulated error, foo: %s bar: %s", foo, baz); /*ooo*/
     not_reached();
 }
 #endif /* DBG_TEST */

--- a/dbg.c
+++ b/dbg.c
@@ -756,7 +756,7 @@ warnp_or_errp(int exitcode, const char *name, bool test, const char *fmt, ...)
     return;
 }
 
-/* parse_verbosity	- parse -v option for our tools 
+/* parse_verbosity	- parse -v option for our tools
  *
  * given:
  *

--- a/dbg.h
+++ b/dbg.h
@@ -142,4 +142,6 @@ extern void warn_or_err(int exitcode, const char *name, bool test, const char *f
 extern void warnp_or_errp(int exitcode, const char *name, bool test, const char *fmt, ...) \
  	__attribute__((format(printf, 4, 5)));		/* 4=format 5=params */
 
+extern int parse_verbosity(char const *program, char const *arg);
+
 #endif				/* INCLUDE_DBG_H */

--- a/fnamchk.1
+++ b/fnamchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
-\fBfnamchk [\-h] [\-v level] [\-V] filepath
+\fBfnamchk [\-h] [\-v level] [\-V] [\-T] filepath
 .SH DESCRIPTION
 \fBfnamchk\fP verifies that an IOCCC compressed tarball is properly named.
 .PP
@@ -38,6 +38,9 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
+.PP
+\fB\-T\fP
+Show IOCCC toolset chain release repository tag.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 0 on success; if there's an error the end is not reached.

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -34,64 +34,17 @@
 /*ooo*/ /* exit code out of numerical order - ignore in sequencing */
 /*coo*/ /* exit code change of order - use new value in sequencing */
 
+#define FNAMCHK_C
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 
-
 /*
- * dbg - debug, warning and error reporting facility
+ * Our header file - #includes the header files we need
  */
-#include "dbg.h"
-
-
-/*
- * util - utility functions and definitions
- */
-#include "util.h"
-
-
-/*
- * IOCCC size and rule related limitations
- */
-#include "limit_ioccc.h"
-
-
-/*
- * definitions
- */
-#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
-
-
-/*
- * usage message
- *
- * Use the usage() function to print the these usage_msgX strings.
- */
-static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-T] filepath\n"
-    "\n"
-    "\t-h\t\t\tprint help message and exit 0\n"
-    "\t-v level\t\tset verbosity level: (def level: %d)\n"
-    "\t-V\t\t\tprint version string and exit\n"
-    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
-    "\n"
-    "\tfilepath\t\tpath to an IOCCC compressed tarball\n"
-    "\n"
-    "fnamchk version: %s\n";
-
-
-/*
- * globals
- */
-int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
-
-
-/*
- * forward declarations
- */
-static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
+#include "fnamchk.h"
 
 
 int

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -70,11 +70,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] filepath\n"
+    "usage: %s [-h] [-v level] [-V] [-T] filepath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
     "\n"
     "\tfilepath\t\tpath to an IOCCC compressed tarball\n"
     "\n"
@@ -120,7 +121,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:V")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -142,6 +143,15 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", FNAMCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", FNAMCHK_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -84,12 +84,7 @@ main(int argc, char *argv[])
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/fnamchk.h
+++ b/fnamchk.h
@@ -35,7 +35,7 @@
 #if !defined(INCLUDE_FNAMCHK_H)
 #    define  INCLUDE_FNAMCHK_H
 
-/* 
+/*
  * some of the identifiers below share the name of identifiers in other files so
  * only define/declare the below for fnamchk.c
  */

--- a/fnamchk.h
+++ b/fnamchk.h
@@ -1,0 +1,98 @@
+/* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
+/*
+ * fnamchk - IOCCC compressed tarball filename sanity check tool
+ *
+ * "Because even fprintf has a return value worth paying attention to." :-)
+ *
+ * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and
+ * its documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright, this permission notice and text
+ * this comment, and the disclaimer below appear in all of the following:
+ *
+ *       supporting documentation
+ *       source copies
+ *       source works derived from this source
+ *       binaries derived from this source or from derived source
+ *
+ * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+ * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+ * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * Share and enjoy! :-)
+ */
+
+
+
+
+#if !defined(INCLUDE_FNAMCHK_H)
+#    define  INCLUDE_FNAMCHK_H
+
+/* 
+ * some of the identifiers below share the name of identifiers in other files so
+ * only define/declare the below for fnamchk.c
+ */
+#ifdef FNAMCHK_C
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
+
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+
+/*
+ * IOCCC size and rule related limitations
+ */
+#include "limit_ioccc.h"
+
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the these usage_msgX strings.
+ */
+static const char * const usage_msg =
+    "usage: %s [-h] [-v level] [-V] [-T] filepath\n"
+    "\n"
+    "\t-h\t\t\tprint help message and exit 0\n"
+    "\t-v level\t\tset verbosity level: (def level: %d)\n"
+    "\t-V\t\t\tprint version string and exit\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
+    "\n"
+    "\tfilepath\t\tpath to an IOCCC compressed tarball\n"
+    "\n"
+    "fnamchk version: %s\n";
+
+
+/*
+ * globals
+ */
+int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
+
+
+/*
+ * forward declarations
+ */
+static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
+
+#endif /* FNAMCHK_C */
+#endif /* INCLUDE_FNAMCHK_H */

--- a/iocccsize-test.sh
+++ b/iocccsize-test.sh
@@ -26,7 +26,7 @@ usage()
 	echo "usage: $0 [-h] [-b] [-v lvl] [-V] [-t tool]"
 	echo
 	echo "	-h	    print usage message and exit 2"
-	echo "	-b	    make disclean all (def: makke all)"
+	echo "	-b	    make disclean all (def: make all)"
 	echo "	-v lvl	    set debugging level to lvl (def: no debugging)"
 	echo "	-V	    print tool version and exit 3"
 	echo "	-t tool	    test with tool (def: test with ./iocccsize)"

--- a/jauthchk.1
+++ b/jauthchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jauthchk \- IOCCC tool to validate .author.json file found within an entry directory
 .SH SYNOPSIS
-\fBjauthchk [\-h] [\-v level] [\-V] [\-q] file
+\fBjauthchk [\-h] [\-v level] [\-V] [\-T] [\-q] file
 .SH DESCRIPTION
 \fBjauthchk\fP is primarily used by other tools (not humans).
 As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
@@ -24,6 +24,9 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
+.PP
+\fB\-T\fP
+Show IOCCC toolset chain release repository tag.
 .PP
 \fB\-q\fP
 Quiet mode.

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -35,6 +35,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
+    program_basename = base_name(program);
     while ((i = getopt(argc, argv, "hv:VqsF:tT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
@@ -120,6 +121,16 @@ main(int argc, char **argv)
     }
 
     check_author_json(file, fnamchk);
+
+    if (program_basename != NULL) {
+	free(program_basename);
+	program_basename = NULL;
+    }
+
+    /*
+     * TODO Once the authors array is parsed we have to call
+     * free_author_array()
+     */
 
     /*
      * All Done!!! - Jessica Noll, age 2
@@ -351,7 +362,7 @@ check_author_json(char const *file, char const *fnamchk)
     /* skip past the initial opening brace */
     ++p;
 
-    /* 
+    /*
      * Begin to parse the file, field by field (if it's not a validly formed
      * JSON file an error will occur and the loop will be aborted).
      */
@@ -381,7 +392,7 @@ check_author_json(char const *file, char const *fnamchk)
 	if (*end == '"')
 	    *end = '\0';
 
-	/* 
+	/*
 	 * after removing the spaces and a single '"' at the beginning and end,
 	 * if we find a '"' in the field we know it's erroneous: thus we can
 	 * simply use strcmp() on it. Note that when we get to the array(s) we
@@ -397,7 +408,7 @@ check_author_json(char const *file, char const *fnamchk)
 
 	if (!strcmp(p, "authors")) {
 	    /* TODO: handle the arrays */
-	   
+
 	    /* The below is only done to prevent infinite loop which occurs in
 	     * some cases (e.g. when "authors" is at the top of the file) until
 	     * arrays are handled; when arrays are handled this will be changed.
@@ -424,7 +435,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    while (*end && isspace(*end))
 		*end-- = '\0';
 
-	    /* 
+	    /*
 	     * Depending on the field, remove a single '"' at the beginning and
 	     * end of the value.
 	     */
@@ -437,19 +448,19 @@ check_author_json(char const *file, char const *fnamchk)
 		end = value + strlen(value) - 1;
 		if (*end == '"')
 		    *end = '\0';
-		/* 
+		/*
 		 * after removing the spaces and a single '"' at the beginning and end,
 		 * if we find a '"' in the field we know it's erroneous.
 		 */
 	    }
 	    /* handle regular field */
-	    if (check_common_json_fields("jauthchk", file, fnamchk, p, value)) {
+	    if (check_common_json_fields(program_basename, file, NULL, &author, fnamchk, p, value)) {
 	    } else {
 		/* TODO: after everything else is parsed if we get here it's an
 		 * error as there's invalid fields in the file.
 		 */
 	    }
-	
+
 	    dbg(DBG_MED, "found field '%s' with value '%s'", p, value);
 	}
     } while (true);

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -45,12 +45,7 @@ main(int argc, char **argv)
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -35,7 +35,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqsF:t")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqsF:tT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -57,6 +57,15 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JAUTHCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JAUTHCHK_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -78,6 +78,7 @@ static const char * const usage_msg =
  */
 int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
 char const *program = NULL;		    /* our name */
+char *program_basename = NULL;		    /* our basename */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct author author;		    /* the .author.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' */

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -53,11 +53,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] [-t] file\n"
+"usage: %s [-h] [-v level] [-V] [-T] [-q] [-s] [-F fnamchk] [-t] file\n"
 "\n"
 "\t-h\t\tprint help message and exit 0\n"
 "\t-v level\tset verbosity level: (def level: %d)\n"
 "\t-V\t\tprint version string and exit\n"
+"\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
 "\t-q\t\tquiet mode\n"
 "\t-s\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"

--- a/jinfochk.1
+++ b/jinfochk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jinfochk \- IOCCC tool to validate .info.json file found within an entry directory
 .SH SYNOPSIS
-\fBjinfochk [\-h] [\-v level] [\-V] [\-q] file
+\fBjinfochk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-t] file
 .SH DESCRIPTION
 \fBjinfochk\fP is primarily used by other tools (not humans).
 As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
@@ -24,6 +24,9 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
+.PP
+\fB\-T\fP
+Show IOCCC toolset chain release repository tag.
 .PP
 \fB\-q\fP
 Quiet mode.

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -33,6 +33,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
+    program_basename = base_name(program);
     while ((i = getopt(argc, argv, "hv:VqsF:tT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
@@ -117,6 +118,14 @@ main(int argc, char **argv)
     }
 
     check_info_json(file, fnamchk);
+
+    if (program_basename != NULL) {
+	free(program_basename);
+	program_basename = NULL;
+    }
+
+    /* free any allocated memory in our info struct */
+    free_info(&info);
 
     /*
      * All Done!!! - Jessica Noll, age 2
@@ -453,7 +462,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    }
 	    value_length = strlen(value);
 	    /* handle regular field */
-	    if (check_common_json_fields("jinfochk", file, fnamchk, p, value)) {
+	    if (check_common_json_fields(program_basename, file, &info, NULL, fnamchk, p, value)) {
 	    } else if (!strcmp(p, "title")) {
 		if (value_length == 0) {
 		    err(22, __func__, "title length zero");

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -493,8 +493,6 @@ check_info_json(char const *file, char const *fnamchk)
 				      (unsigned long)value_length, MAX_ABSTRACT_LEN);
 		    not_reached();
 		}
-	    } else if (!strcmp(p, "tarball")) {
-
 	    } else if (!strcmp(p, "rule_2a_size")) {
 	    } else if (!strcmp(p, "rule_2b_size")) {
 	    } else if (!strcmp(p, "empty_override") || !strcmp(p, "rule_2a_override") ||

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -43,12 +43,7 @@ main(int argc, char **argv)
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -33,7 +33,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqsF:t")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqsF:tT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -55,6 +55,15 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JINFOCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JINFOCHK_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -494,7 +494,9 @@ check_info_json(char const *file, char const *fnamchk)
 		    not_reached();
 		}
 	    } else if (!strcmp(p, "rule_2a_size")) {
+		info.rule_2a_size = string_to_long_long(value);
 	    } else if (!strcmp(p, "rule_2b_size")) {
+		info.rule_2b_size = string_to_unsigned_long_long(value);
 	    } else if (!strcmp(p, "empty_override") || !strcmp(p, "rule_2a_override") ||
 	      !strcmp(p, "rule_2a_mismatch") || !strcmp(p, "rule_2b_override") ||
 	      !strcmp(p, "highbit_warning") || !strcmp(p, "nul_warning") ||

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -74,6 +74,7 @@ static const char * const usage_msg =
  */
 int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
 char const *program = NULL;		    /* our name */
+char *program_basename = NULL;		    /* our basename */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct info info;		    /* .info.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' in the file */

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -49,11 +49,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-s] [-F fnamchk] [-t] file\n"
+"usage: %s [-h] [-v level] [-V] [-T] [-q] [-s] [-F fnamchk] [-t] file\n"
 "\n"
 "\t-h\t\t\tprint help message and exit 0\n"
 "\t-v level\t\tset verbosity level: (def level: %d)\n"
 "\t-V\t\t\tprint version string and exit\n"
+"\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
 "\t-q\t\t\tquiet mode\n"
 "\t-s\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"

--- a/json.c
+++ b/json.c
@@ -1662,7 +1662,7 @@ json_filename(int type)
  *				    and author.json and check the value if it is
  *
  * given:
- *	
+ *
  *	name	- which util called this (jinfochk or jauthchk)
  *	file	- the file being parsed (path to)
  *	fnamchk	- path to fnamchk util

--- a/json.h
+++ b/json.h
@@ -65,6 +65,7 @@ struct author {
     char *github;		/* author GitHub username or or empty string ==> not provided */
     char *affiliation;		/* author affiliation or or empty string ==> not provided */
     char *winner_handle;	/* previous IOCCC winner handle, or empty string ==> not provided */
+    char *tarball;		/* tarball path; XXX this is _ONLY allocated in jauthchk_; mkiocccentry uses the copy in struct info! */
     int author_num;		/* author number */
 
     /* jauthchk specific */
@@ -116,7 +117,7 @@ struct info {
     char *remarks_md;		/* remarks.md filename */
     int extra_count;		/* number of extra files */
     char **extra_file;		/* list of extra filenames followed by NULL */
-    char *tarball_path;		/* tarball filename */
+    char *tarball;		/* tarball filename */
     /*
      * time
      */

--- a/json.h
+++ b/json.h
@@ -34,8 +34,8 @@
  */
 
 
-#if !defined(INLUDE_JSON_H)
-#    define  INLUDE_JSON_H
+#if !defined(INCLUDE_JSON_H)
+#    define  INCLUDE_JSON_H
 
 
 #include <time.h>
@@ -143,6 +143,8 @@ extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern char const *json_filename(int type);
-extern int check_common_json_fields(char const *name, char const *file, char const *fnamchk, char *field, char *value);
+extern int check_common_json_fields(char const *program, char const *file, struct info *infop, struct author *authorp, char const *fnamchk, char *field, char *value);
+extern void free_info(struct info *infop);
+extern void free_author_array(struct author *authorp, int author_count);
 
-#endif /* INLUDE_JSON_H */
+#endif /* INCLUDE_JSON_H */

--- a/json.h
+++ b/json.h
@@ -108,7 +108,7 @@ struct info {
     bool found_clean_rule;	/* true ==> Makefile has clean rule */
     bool found_clobber_rule;	/* true ==> Makefile has a clobber rule */
     bool found_try_rule;	/* true ==> Makefile has a try rule */
-    unsigned answers_errors;	/* > 0 ==> flushing or closing answers file failed */
+    unsigned answers_errors;	/* > 0 ==> output errors on answers file */
     /*
      * filenames
      */
@@ -124,7 +124,7 @@ struct info {
     time_t tstamp;		/* seconds since epoch when .info json was formed (see gettimeofday(2)) */
     int usec;			/* microseconds since the tstamp second */
     char *epoch;		/* epoch of tstamp, currently: Thu Jan 1 00:00:00 1970 UTC */
-    char *utctime;		/* UTC converted string for tstamp (see asctime(3)) */
+    char *utctime;		/* UTC converted string for tstamp (see strftime(3)) */
 
     /* jinfochk specific */
     unsigned issues;		/* number of issues found in file (for jinfochk) */

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -84,12 +84,7 @@ main(int argc, char *argv[])
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(2, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -74,7 +74,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:Vtns")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VtnsT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -96,6 +96,15 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", JSTRDECODE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JSTRDECODE_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -66,11 +66,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-t] [-n] [-s] [string ...]\n"
+    "usage: %s [-h] [-v level] [-V] [-T] [-t] [-n] [-s] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-V\t\tprint version string and exit 0\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
     "\t-t\t\tperform jencchk test on code JSON decode/decode functions\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-s\t\tdecode using strict mode (def: not strict)\n"

--- a/jstrencode.c
+++ b/jstrencode.c
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:Vtn")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VtnT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -95,6 +95,15 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", JSTRENCODE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JSTRENCODE_VERSION);
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jstrencode.c
+++ b/jstrencode.c
@@ -84,11 +84,7 @@ main(int argc, char *argv[])
 	     * parse verbosity
 	     */
 	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(2, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno)); /*ooo*/
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -66,11 +66,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-t] [-n] [string ...]\n"
+    "usage: %s [-h] [-v level] [-V] [-T] [-t] [-n] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level: (def level: %d)\n"
     "\t-V\t\tprint version string and exit 0\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
     "\t-t\t\tperform jencchk test on code JSON encode/decode functions\n"
     "\t-n\t\tdo not output newline after encode output\n"
     "\n"

--- a/limit_ioccc.h
+++ b/limit_ioccc.h
@@ -32,7 +32,7 @@
 
 #include <time.h>
 
-/* 
+/*
  * version.h - official version for all the IOCCC tools
  */
 #include "version.h"
@@ -44,8 +44,8 @@
 #define RULE_2A_SIZE ((off_t)(4096))		/* Rule 2a size of prog.c */
 #define RULE_2B_SIZE ((size_t)(2503))		/* Rule 2b size of prog.c */
 #define MAX_TARBALL_LEN ((off_t)(3999971))	/* compressed tarball size limit in bytes */
-/* NOTE: MAX_ENTRY_NUM must be < 10 to the MAX_ENTRY_CHARS power */
 #define MAX_DIR_KSIZE (27651)		/* entry directory size limit in kibibyte (1024 byte) blocks */
+/* NOTE: MAX_ENTRY_NUM must be < 10 to the MAX_ENTRY_CHARS power */
 #define MAX_ENTRY_NUM (9)		/* entry numbers from 0 to MAX_ENTRY_NUM */
 #define MAX_ENTRY_CHARS (1)		/* characters that represent the maximum entry number */
 #define MAX_AUTHORS (5)			/* maximum number of authors of an entry */

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -27,6 +27,9 @@ Show IOCCC toolset chain release repository tag.
 \fB\-V\fP
 Show version and exit.
 .PP
+\fB\-T\fP
+Show IOCCC toolset chain release repository tag.
+.PP
 \fB\-t\fP
 Specify path to tar that accepts the \fB\-J\fP option.
 \fBmkiocccentry\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -285,7 +285,7 @@ main(int argc, char *argv[])
     errno = 0;			/* pre-clear errno for errp() */
     ret = gettimeofday(&tp, NULL);
     if (ret < 0) {
-	errp(3, __func__, "gettimeofday failed");
+	errp(2, __func__, "gettimeofday failed");
 	not_reached();
     }
     info.tstamp = tp.tv_sec;
@@ -299,7 +299,7 @@ main(int argc, char *argv[])
     errno = 0;			/* pre-clear errno for errp() */
     ret = printf("Welcome to mkiocccentry version: %s\n", MKIOCCCENTRY_VERSION);
     if (ret <= 0) {
-	errp(4, __func__, "printf error printing the welcome string");
+	errp(3, __func__, "printf error printing the welcome string");
 	not_reached();
     }
 
@@ -309,7 +309,7 @@ main(int argc, char *argv[])
     errno = 0;			/* pre-clear errno for errp() */
     info.mkiocccentry_ver = strdup(MKIOCCCENTRY_VERSION);
     if (info.mkiocccentry_ver == NULL) {
-	errp(5, __func__, "cannot strdup version: %s", MKIOCCCENTRY_VERSION);
+	errp(4, __func__, "cannot strdup version: %s", MKIOCCCENTRY_VERSION);
 	not_reached();
     }
 
@@ -339,10 +339,10 @@ main(int argc, char *argv[])
 	    errno = 0;
 	    ret = printf("\nTo use the answers file, try:\n\n\t./mkiocccentry -i %s [...]\n\n", answers);
 	    if (ret <= 0) {
-		errp(6, __func__, "printf error telling the user how to use the answers file");
+		errp(5, __func__, "printf error telling the user how to use the answers file");
 		not_reached();
 	    }
-	    err(7, __func__, "won't overwrite answers file");
+	    err(6, __func__, "won't overwrite answers file");
 	    not_reached();
 	}
     }
@@ -352,13 +352,13 @@ main(int argc, char *argv[])
      */
     if (read_answers_flag_used && answers != NULL && strlen(answers) > 0) {
 	if (!is_read(answers)) {
-	    errp(8, __func__, "cannot read answers file");
+	    errp(7, __func__, "cannot read answers file");
 	    not_reached();
 	}
 	errno = 0;
 	answerp = fopen(answers, "r");
 	if (answerp == NULL) {
-	    errp(9, __func__, "cannot open answers file");
+	    errp(8, __func__, "cannot open answers file");
 	    not_reached();
 	}
 	input_stream = answerp;
@@ -386,7 +386,13 @@ main(int argc, char *argv[])
      * create entry directory
      */
     entry_dir = mk_entry_dir(work_dir, info.ioccc_id, info.entry_num, &tarball_path, info.tstamp);
-    info.tarball = tarball_path; /* XXX do **NOT** free this in free_info() ! */
+    errno = 0;
+    info.tarball = strdup(tarball_path);
+    if (info.tarball == NULL) {
+	errp(9, __func__, "strdup() tarball path %s failed", tarball_path);
+	not_reached();
+    }
+
     dbg(DBG_LOW, "formed entry directory: %s", entry_dir);
 
 
@@ -675,8 +681,8 @@ main(int argc, char *argv[])
 	tarball_path = NULL;
     }
     free_info(&info);
-
     memset(&info, 0, sizeof(info));
+
     if (author_set != NULL) {
 	free_author_array(author_set, author_count);
 	free(author_set);
@@ -743,156 +749,6 @@ usage(int exitcode, char const *str, char const *program)
 }
 
 
-/*
- * free_info - free info and related sub-elements
- *
- * given:
- *      infop   - pointer to info structure to free
- *
- * This function does not return.
- */
-static void
-free_info(struct info *infop)
-{
-    int i;
-
-    /*
-     * firewall
-     */
-    if (infop == NULL) {
-	err(12, __func__, "called with NULL arg(s)");
-	not_reached();
-    }
-
-    /*
-     * free version values
-     */
-    if (infop->mkiocccentry_ver != NULL) {
-	free(infop->mkiocccentry_ver);
-	infop->mkiocccentry_ver = NULL;
-    }
-
-    /*
-     * free entry values
-     */
-    if (infop->ioccc_id != NULL) {
-	free(infop->ioccc_id);
-	infop->ioccc_id = NULL;
-    }
-    if (infop->title != NULL) {
-	free(infop->title);
-	infop->title = NULL;
-    }
-    if (infop->abstract != NULL) {
-	free(infop->abstract);
-	infop->abstract = NULL;
-    }
-
-    /*
-     * free filenames
-     */
-    if (infop->prog_c != NULL) {
-	free(infop->prog_c);
-	infop->prog_c = NULL;
-    }
-    if (infop->Makefile != NULL) {
-	free(infop->Makefile);
-	infop->Makefile = NULL;
-    }
-    if (infop->remarks_md != NULL) {
-	free(infop->remarks_md);
-	infop->remarks_md = NULL;
-    }
-    if (infop->extra_file != NULL) {
-	for (i = 0; i < infop->extra_count; ++i) {
-	    if (infop->extra_file[i] != NULL) {
-		free(infop->extra_file[i]);
-		infop->extra_file[i] = NULL;
-	    }
-	}
-	free(infop->extra_file);
-	infop->extra_file = NULL;
-    }
-
-    /* Do NOT free(infop->tarball_path)! This is because it shares the memory
-     * with tarball_path in main() which is free()d there!
-     */
-
-    /*
-     * free time values
-     */
-    if (infop->epoch != NULL) {
-	free(infop->epoch);
-	infop->epoch = NULL;
-    }
-    if (infop->utctime != NULL) {
-	free(infop->utctime);
-	infop->utctime = NULL;
-    }
-    return;
-}
-
-
-/*
- * free_author_array - free storage related to a struct author
- *
- * given:
- *      author_set      - pointer to a struct author array
- *      author_count    - length of author array
- */
-static void
-free_author_array(struct author *author_set, int author_count)
-{
-    int i;
-
-    /*
-     * firewall
-     */
-    if (author_set == NULL) {
-	err(13, __func__, "called with NULL arg(s)");
-	not_reached();
-    }
-    if (author_count < 0) {
-	err(14, __func__, "author_count: %d < 0", author_count);
-	not_reached();
-    }
-
-    /*
-     * free elements of each array member
-     */
-    for (i = 0; i < author_count; ++i) {
-	if (author_set[i].name != NULL) {
-	    free(author_set[i].name);
-	    author_set[i].name = NULL;
-	}
-	if (author_set[i].location_code != NULL) {
-	    free(author_set[i].location_code);
-	    author_set[i].location_code = NULL;
-	}
-	if (author_set[i].email != NULL) {
-	    free(author_set[i].email);
-	    author_set[i].email = NULL;
-	}
-	if (author_set[i].url != NULL) {
-	    free(author_set[i].url);
-	    author_set[i].url = NULL;
-	}
-	if (author_set[i].twitter != NULL) {
-	    free(author_set[i].twitter);
-	    author_set[i].twitter = NULL;
-	}
-	if (author_set[i].github != NULL) {
-	    free(author_set[i].github);
-	    author_set[i].github = NULL;
-	}
-	if (author_set[i].affiliation != NULL) {
-	    free(author_set[i].affiliation);
-	    author_set[i].affiliation = NULL;
-	}
-    }
-    return;
-}
-
 
 /*
  * sanity_chk - perform basic sanity checks
@@ -922,7 +778,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
      */
     if (infop == NULL || work_dir == NULL || tar == NULL || cp == NULL || ls == NULL ||
 	txzchk == NULL || fnamchk == NULL || jinfochk == NULL || jauthchk == NULL) {
-	err(15, __func__, "called with NULL arg(s)");
+	err(12, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -944,7 +800,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(16, __func__, "tar does not exist: %s", tar);
+	err(13, __func__, "tar does not exist: %s", tar);
 	not_reached();
     }
     if (!is_file(tar)) {
@@ -961,7 +817,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(17, __func__, "tar is not a file: %s", tar);
+	err(14, __func__, "tar is not a file: %s", tar);
 	not_reached();
     }
     if (!is_exec(tar)) {
@@ -978,7 +834,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(18, __func__, "tar is not an executable program: %s", tar);
+	err(15, __func__, "tar is not an executable program: %s", tar);
 	not_reached();
     }
 
@@ -1000,7 +856,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(19, __func__, "cp does not exist: %s", cp);
+	err(16, __func__, "cp does not exist: %s", cp);
 	not_reached();
     }
     if (!is_file(cp)) {
@@ -1017,7 +873,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(20, __func__, "cp is not a file: %s", cp);
+	err(17, __func__, "cp is not a file: %s", cp);
 	not_reached();
     }
     if (!is_exec(cp)) {
@@ -1034,7 +890,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(21, __func__, "cp is not an executable program: %s", cp);
+	err(18, __func__, "cp is not an executable program: %s", cp);
 	not_reached();
     }
 
@@ -1056,7 +912,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(22, __func__, "ls does not exist: %s", ls);
+	err(19, __func__, "ls does not exist: %s", ls);
 	not_reached();
     }
     if (!is_file(ls)) {
@@ -1073,7 +929,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(23, __func__, "ls is not a file: %s", ls);
+	err(20, __func__, "ls is not a file: %s", ls);
 	not_reached();
     }
     if (!is_exec(ls)) {
@@ -1090,7 +946,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(24, __func__, "ls is not an executable program: %s", ls);
+	err(21, __func__, "ls is not an executable program: %s", ls);
 	not_reached();
     }
 
@@ -1112,7 +968,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(25, __func__, "txzchk does not exist: %s", txzchk);
+	err(22, __func__, "txzchk does not exist: %s", txzchk);
 	not_reached();
     }
     if (!is_file(txzchk)) {
@@ -1129,7 +985,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(26, __func__, "txzchk is not a file: %s", txzchk);
+	err(23, __func__, "txzchk is not a file: %s", txzchk);
 	not_reached();
     }
     if (!is_exec(txzchk)) {
@@ -1146,7 +1002,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(27, __func__, "txzchk is not an executable program: %s", txzchk);
+	err(24, __func__, "txzchk is not an executable program: %s", txzchk);
 	not_reached();
     }
 
@@ -1168,7 +1024,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(28, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(25, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -1185,7 +1041,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(29, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(26, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -1202,7 +1058,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(30, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(27, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -1224,7 +1080,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(31, __func__, "jinfochk does not exist: %s", jinfochk);
+	err(28, __func__, "jinfochk does not exist: %s", jinfochk);
 	not_reached();
     }
     if (!is_file(jinfochk)) {
@@ -1241,7 +1097,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(32, __func__, "jinfochk is not a file: %s", jinfochk);
+	err(29, __func__, "jinfochk is not a file: %s", jinfochk);
 	not_reached();
     }
     if (!is_exec(jinfochk)) {
@@ -1258,7 +1114,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(33, __func__, "jinfochk is not an executable program: %s", jinfochk);
+	err(30, __func__, "jinfochk is not an executable program: %s", jinfochk);
 	not_reached();
     }
 
@@ -1280,7 +1136,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(34, __func__, "jauthchk does not exist: %s", jauthchk);
+	err(31, __func__, "jauthchk does not exist: %s", jauthchk);
 	not_reached();
     }
     if (!is_file(jauthchk)) {
@@ -1297,7 +1153,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(35, __func__, "jauthchk is not a file: %s", jauthchk);
+	err(32, __func__, "jauthchk is not a file: %s", jauthchk);
 	not_reached();
     }
     if (!is_exec(jauthchk)) {
@@ -1314,7 +1170,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(36, __func__, "jauthchk is not an executable program: %s", jauthchk);
+	err(33, __func__, "jauthchk is not an executable program: %s", jauthchk);
 	not_reached();
     }
 
@@ -1329,7 +1185,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "You should either create work_dir, or use a different work_dir directory path on the command line.",
 	      "",
 	      NULL);
-	err(37, __func__, "work_dir does not exist: %s", work_dir);
+	err(34, __func__, "work_dir does not exist: %s", work_dir);
 	not_reached();
     }
     if (!is_dir(work_dir)) {
@@ -1341,7 +1197,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "work_dir directory path on the command line.",
 	      "",
 	      NULL);
-	err(38, __func__, "work_dir is not a directory: %s", work_dir);
+	err(35, __func__, "work_dir is not a directory: %s", work_dir);
 	not_reached();
     }
     if (!is_write(work_dir)) {
@@ -1353,7 +1209,7 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
 	      "create a new writable directory, or use a different work_dir directory path on the command line.",
 	      "",
 	      NULL);
-	err(39, __func__, "work_dir is not a writable directory: %s", work_dir);
+	err(36, __func__, "work_dir is not a writable directory: %s", work_dir);
 	not_reached();
     }
 
@@ -1403,7 +1259,7 @@ prompt(char const *str, size_t *lenp)
      * firewall
      */
     if (str == NULL) {
-	err(40, __func__, "called with NULL arg(s)");
+	err(37, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1415,13 +1271,13 @@ prompt(char const *str, size_t *lenp)
     ret = fputs(str, stdout);
     if (ret == EOF) {
 	if (ferror(stdout)) {
-	    errp(41, __func__, "error printing prompt string");
+	    errp(38, __func__, "error printing prompt string");
 	    not_reached();
 	} else if (feof(stdout)) {
-	    err(42, __func__, "EOF while printing prompt string");
+	    err(39, __func__, "EOF while printing prompt string");
 	    not_reached();
 	} else {
-	    errp(43, __func__, "unexpected fputs error printing prompt string");
+	    errp(40, __func__, "unexpected fputs error printing prompt string");
 	    not_reached();
 	}
     }
@@ -1430,13 +1286,13 @@ prompt(char const *str, size_t *lenp)
     ret = fputs(": ", stdout);
     if (ret == EOF) {
 	if (ferror(stdout)) {
-	    errp(44, __func__, "error printing :<space>");
+	    errp(41, __func__, "error printing :<space>");
 	    not_reached();
 	} else if (feof(stdout)) {
-	    err(45, __func__, "EOF while writing :<space>");
+	    err(42, __func__, "EOF while writing :<space>");
 	    not_reached();
 	} else {
-	    errp(46, __func__, "unexpected fputs error printing :<space>");
+	    errp(43, __func__, "unexpected fputs error printing :<space>");
 	    not_reached();
 	}
     }
@@ -1445,13 +1301,13 @@ prompt(char const *str, size_t *lenp)
     ret = fflush(stdout);
     if (ret == EOF) {
 	if (ferror(stdout)) {
-	    errp(47, __func__, "error flushing prompt to stdout");
+	    errp(44, __func__, "error flushing prompt to stdout");
 	    not_reached();
 	} else if (feof(stdout)) {
-	    err(48, __func__, "EOF while flushing prompt to stdout");
+	    err(45, __func__, "EOF while flushing prompt to stdout");
 	    not_reached();
 	} else {
-	    errp(49, __func__, "unexpected fflush error while flushing prompt to stdout");
+	    errp(46, __func__, "unexpected fflush error while flushing prompt to stdout");
 	    not_reached();
 	}
     }
@@ -1461,7 +1317,7 @@ prompt(char const *str, size_t *lenp)
      */
     buf = readline_dup(&linep, true, &len, input_stream);
     if (buf == NULL) {
-	err(50, __func__, "EOF while reading prompt input");
+	err(47, __func__, "EOF while reading prompt input");
 	not_reached();
     }
     dbg(DBG_VHIGH, "received a %lu byte response", (unsigned long)len);
@@ -1521,7 +1377,7 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
      * firewall
      */
     if (testp == NULL) {
-	err(51, __func__, "called with NULL arg(s)");
+	err(48, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1572,7 +1428,7 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
 	}
 	if (*read_answers_flag_used && !seen_answers_header) {
 	    dbg(DBG_HIGH, "the IOCCC contest ID as entered is: %s", malloc_ret);
-	    err(52, __func__, "didn't find the correct answers file header");
+	    err(49, __func__, "didn't find the correct answers file header");
 	    not_reached();
 	}
 
@@ -1665,7 +1521,7 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
      * report on the result of the contest ID validation
      */
     if (ret != 8) {
-	errp(53, __func__, "retry prompt is disabled");
+	errp(50, __func__, "retry prompt is disabled");
 	not_reached();
     }
     dbg(DBG_MED, "IOCCC contest ID is a UUID: %s", malloc_ret);
@@ -1706,7 +1562,7 @@ get_entry_num(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(54, __func__, "called with NULL arg(s)");
+	err(51, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1722,7 +1578,7 @@ get_entry_num(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = printf("\nYou are allowed to submit up to %d entries to a given IOCCC.\n", MAX_ENTRY_NUM + 1);
 	    if (ret <= 0) {
-		errp(55, __func__, "printf error printing number of entries allowed");
+		errp(52, __func__, "printf error printing number of entries allowed");
 		not_reached();
 	    }
 	    para("",
@@ -1766,7 +1622,7 @@ get_entry_num(struct info *infop)
      * report on the result of the entry number validation
      */
     if (entry_num < 0 || entry_num > MAX_ENTRY_NUM) {
-	err(56, __func__, "retry prompt is disabled");
+	err(53, __func__, "retry prompt is disabled");
 	not_reached();
     }
     dbg(DBG_MED, "IOCCC entry number is valid: %d", entry_num);
@@ -1808,11 +1664,11 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
      * firewall
      */
     if (work_dir == NULL || ioccc_id == NULL || tarball_path == NULL) {
-	err(57, __func__, "called with NULL arg(s)");
+	err(54, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (entry_num < 0 || entry_num > MAX_ENTRY_NUM) {
-	err(58, __func__, "entry number: %d must >= 0 and <= %d", entry_num, MAX_ENTRY_NUM);
+	err(55, __func__, "entry number: %d must >= 0 and <= %d", entry_num, MAX_ENTRY_NUM);
 	not_reached();
     }
 
@@ -1826,13 +1682,13 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     entry_dir = (char *)malloc(entry_dir_len + 1);
     if (entry_dir == NULL) {
-	errp(59, __func__, "malloc #0 of %lu bytes failed", (unsigned long)(entry_dir_len + 1));
+	errp(56, __func__, "malloc #0 of %lu bytes failed", (unsigned long)(entry_dir_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(entry_dir, entry_dir_len + 1, "%s/%s-%d", work_dir, ioccc_id, entry_num);
     if (ret <= 0) {
-	errp(60, __func__, "snprintf to form entry directory failed");
+	errp(57, __func__, "snprintf to form entry directory failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "entry directory path: %s", entry_dir);
@@ -1851,7 +1707,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
 	      "You need to move that directory, or remove it, or use a different work_dir.",
 	      "",
 	      NULL);
-	err(61, __func__, "entry directory exists: %s", entry_dir);
+	err(58, __func__, "entry directory exists: %s", entry_dir);
 	not_reached();
     }
     dbg(DBG_HIGH, "entry directory path: %s", entry_dir);
@@ -1862,7 +1718,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     ret = mkdir(entry_dir, 0755);
     if (ret < 0) {
-	errp(62, __func__, "cannot mkdir %s with mode 0755", entry_dir);
+	errp(59, __func__, "cannot mkdir %s with mode 0755", entry_dir);
 	not_reached();
     }
 
@@ -1875,13 +1731,13 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     *tarball_path = (char *)malloc(tarball_len + 1);
     if (*tarball_path == NULL) {
-	errp(63, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(tarball_len + 1));
+	errp(60, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(tarball_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(*tarball_path, tarball_len + 1, "entry.%s-%d.%ld.txz", ioccc_id, entry_num, (long)tstamp);
     if (ret <= 0) {
-	errp(64, __func__, "snprintf to form compressed tarball path failed");
+	errp(61, __func__, "snprintf to form compressed tarball path failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "compressed tarball path: %s", *tarball_path);
@@ -1911,7 +1767,7 @@ warn_empty_prog(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(65, __func__, "called with NULL arg(s)");
+	err(62, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1934,7 +1790,7 @@ warn_empty_prog(char const *prog_c)
 	  NULL);
 	    yorn = yes_or_no("Are you sure you want to submit an empty prog.c file? [yn]");
 	    if (!yorn) {
-		err(66, __func__, "please fix your prog.c file: %s", prog_c);
+		err(63, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that their empty prog.c: %s is OK", prog_c);
@@ -1964,7 +1820,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(67, __func__, "called with NULL arg(s)");
+	err(64, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1989,7 +1845,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
 	      NULL);
 	    yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	    if (!yorn) {
-		err(68, __func__, "please fix your prog.c file: %s", prog_c);
+		err(65, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that their prog.c %s size: %ld > Rule 2a max size: %ld is OK", prog_c,
@@ -2011,7 +1867,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
 	    }
 	    yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	    if (!yorn) {
-		err(69, __func__, "please fix your prog.c file: %s", prog_c);
+		err(66, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that prog.c %s size: %ld != rule_count function size: %ld is OK", prog_c,
@@ -2022,7 +1878,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
      * invalid mode
      */
     } else {
-	err(70, __func__, "invalid mode used: %d", mode);
+	err(67, __func__, "invalid mode used: %d", mode);
 	not_reached();
     }
     return;
@@ -2046,7 +1902,7 @@ warn_high_bit(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(71, __func__, "called with NULL arg(s)");
+	err(68, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2062,7 +1918,7 @@ warn_high_bit(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(72, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(69, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having non-ASCII and/or character(s) with high bit is OK", prog_c);
@@ -2088,7 +1944,7 @@ warn_nul_chars(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(73, __func__, "called with NULL arg(s)");
+	err(70, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2104,7 +1960,7 @@ warn_nul_chars(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(74, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(71, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having NUL character(s) is OK", prog_c);
@@ -2131,7 +1987,7 @@ warn_trigraph(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(75, __func__, "called with NULL arg(s)");
+	err(72, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2147,7 +2003,7 @@ warn_trigraph(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(76, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(73, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having unknown or invalid trigraph(s) is OK", prog_c);
@@ -2173,7 +2029,7 @@ warn_wordbuf(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(77, __func__, "called with NULL arg(s)");
+	err(74, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2190,7 +2046,7 @@ warn_wordbuf(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(78, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(75, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s triggered a word buffer overflow is OK", prog_c);
@@ -2217,7 +2073,7 @@ warn_ungetc(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(79, __func__, "called with NULL arg(s)");
+	err(76, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2234,7 +2090,7 @@ warn_ungetc(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(80, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(77, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s triggered an ungetc warning OK", prog_c);
@@ -2260,7 +2116,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(81, __func__, "called with NULL arg(s)");
+	err(78, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2272,7 +2128,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
 	ret = fprintf(stderr, "\nWARNING: The prog.c %s size: %lu > Rule 2b maximum: %lu\n", prog_c,
 		      (unsigned long)infop->rule_2b_size, (unsigned long)RULE_2B_SIZE);
 	if (ret <= 0) {
-	    errp(82, __func__, "printf error printing prog.c size > Rule 2b maximum");
+	    errp(79, __func__, "printf error printing prog.c size > Rule 2b maximum");
 	    not_reached();
 	}
 
@@ -2284,7 +2140,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
 	      NULL);
 	yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	if (!yorn) {
-	    err(83, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(80, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that their prog.c %s size: %lu > Rule 2B max size: %lu is OK", prog_c,
@@ -2324,17 +2180,17 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || prog_c == NULL) {
-	err(84, __func__, "called with NULL arg(s)");
+	err(81, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     entry_dir_len = strlen(entry_dir);
     if (entry_dir_len <= 0) {
-	err(85, __func__, "entry_dir arg is an empty string");
+	err(82, __func__, "entry_dir arg is an empty string");
 	not_reached();
     }
     prog_c_len = strlen(prog_c);
     if (prog_c_len <= 0) {
-	err(86, __func__, "prog_c arg is an empty string");
+	err(83, __func__, "prog_c arg is an empty string");
 	not_reached();
     }
 
@@ -2347,7 +2203,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(87, __func__, "prog.c does not exist: %s", prog_c);
+	err(84, __func__, "prog.c does not exist: %s", prog_c);
 	not_reached();
     }
     if (!is_file(prog_c)) {
@@ -2356,7 +2212,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "The prog.c path, while it exists, is not a file.",
 	      "",
 	      NULL);
-	err(88, __func__, "prog.c is not a file: %s", prog_c);
+	err(85, __func__, "prog.c is not a file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -2365,7 +2221,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "The prog.c, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(89, __func__, "prog.c is not a readable file: %s", prog_c);
+	err(86, __func__, "prog.c is not a readable file: %s", prog_c);
 	not_reached();
     }
 
@@ -2379,7 +2235,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     prog_stream = fopen(prog_c, "r");
     if (prog_stream == NULL) {
-	errp(90, __func__, "failed to fopen: %s", prog_c);
+	errp(87, __func__, "failed to fopen: %s", prog_c);
 	not_reached();
     }
     size = rule_count(prog_stream);
@@ -2388,7 +2244,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(prog_stream);
     if (ret != 0) {
-	errp(91, __func__, "failed to fclose: %s", prog_c);
+	errp(88, __func__, "failed to fclose: %s", prog_c);
 	not_reached();
     }
 
@@ -2398,7 +2254,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     infop->rule_2a_size = file_size(prog_c);
     dbg(DBG_MED, "Rule 2a size: %ld", (long)infop->rule_2a_size);
     if (infop->rule_2a_size < 0) {
-	err(92, __func__, "file_size error: %ld on prog_c: %s", (long)infop->rule_2a_size, prog_c);
+	err(89, __func__, "file_size error: %ld on prog_c: %s", (long)infop->rule_2a_size, prog_c);
 	not_reached();
     } else if (infop->rule_2a_size == 0) {
 	warn_empty_prog(prog_c);
@@ -2493,7 +2349,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% -- % %/prog.c", cp, prog_c, entry_dir);
     if (cmd == NULL) {
-	err(93, __func__, "failed to cmdprintf: cp prog_c entry_dir/prog.c");
+	err(90, __func__, "failed to cmdprintf: cp prog_c entry_dir/prog.c");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -2505,14 +2361,14 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(94, __func__, "fflush(stdout) #2: error code: %d", ret);
+	errp(91, __func__, "fflush(stdout) #2: error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(95, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(92, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -2522,13 +2378,13 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(96, __func__, "error calling system(%s)", cmd);
+	errp(93, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(97, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(94, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(98, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(95, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -2538,7 +2394,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     infop->prog_c = strdup("prog.c");
     if (infop->prog_c == NULL) {
-	errp(99, __func__, "malloc #2 of %lu bytes failed", (unsigned long)(LITLEN("prog.c") + 1));
+	errp(96, __func__, "malloc #2 of %lu bytes failed", (unsigned long)(LITLEN("prog.c") + 1));
 	not_reached();
     }
 
@@ -2587,7 +2443,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(100, __func__, "called with NULL arg(s)");
+	err(97, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2597,7 +2453,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     stream = fopen(Makefile, "r");
     if (stream == NULL) {
-	errp(101, __func__, "cannot open Makefile: %s", Makefile);
+	errp(98, __func__, "cannot open Makefile: %s", Makefile);
 	not_reached();
     }
 
@@ -2733,7 +2589,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(stream);
     if (ret < 0) {
-	errp(102, __func__, "fclose error");
+	errp(99, __func__, "fclose error");
 	not_reached();
     }
 
@@ -2778,7 +2634,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(103, __func__, "called with NULL arg(s)");
+	err(100, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (need_confirm && !ignore_warnings) {
@@ -2857,7 +2713,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
 	 */
 	yorn = yes_or_no("Do you still want to submit this Makefile in the hopes that it is OK? [yn]");
 	if (!yorn) {
-	    err(104, __func__, "Use a different Makefile or modify this file: %s", Makefile);
+	    err(101, __func__, "Use a different Makefile or modify this file: %s", Makefile);
 	    not_reached();
 	}
     }
@@ -2891,7 +2747,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || Makefile == NULL) {
-	err(105, __func__, "called with NULL arg(s)");
+	err(102, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2904,7 +2760,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(106, __func__, "Makefile does not exist: %s", Makefile);
+	err(103, __func__, "Makefile does not exist: %s", Makefile);
 	not_reached();
     }
     if (!is_file(Makefile)) {
@@ -2913,7 +2769,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	       "The Makefile path, while it exists, is not a file.",
 	       "",
 	       NULL);
-	err(107, __func__, "Makefile is not a file: %s", Makefile);
+	err(104, __func__, "Makefile is not a file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -2922,15 +2778,15 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	      "The Makefile, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(108, __func__, "Makefile is not readable file: %s", Makefile);
+	err(105, __func__, "Makefile is not readable file: %s", Makefile);
 	not_reached();
     }
     filesize = file_size(Makefile);
     if (filesize < 0) {
-	err(109, __func__, "file_size error: %ld on Makefile  %s", (long)filesize, Makefile);
+	err(106, __func__, "file_size error: %ld on Makefile  %s", (long)filesize, Makefile);
 	not_reached();
     } else if (filesize == 0) {
-	err(110, __func__, "Makefile cannot be empty: %s", Makefile);
+	err(107, __func__, "Makefile cannot be empty: %s", Makefile);
 	not_reached();
     }
 
@@ -2950,7 +2806,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% -- % %/Makefile", cp, Makefile, entry_dir);
     if (cmd == NULL) {
-	err(111, __func__, "failed to cmdprintf: cp Makefile entry_dir/Makefile");
+	err(108, __func__, "failed to cmdprintf: cp Makefile entry_dir/Makefile");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -2962,14 +2818,14 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(112, __func__, "fflush(stdout) error code: %d", ret);
+	errp(109, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(113, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(110, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -2979,13 +2835,13 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(114, __func__, "error calling system(%s)", cmd);
+	errp(111, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(115, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(112, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(116, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(113, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -2995,7 +2851,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     errno = 0;			/* pre-clear errno for errp() */
     infop->Makefile = strdup("Makefile");
     if (infop->Makefile == NULL) {
-	errp(117, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(LITLEN("Makefile") + 1));
+	errp(114, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(LITLEN("Makefile") + 1));
 	not_reached();
     }
 
@@ -3037,7 +2893,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || remarks_md == NULL) {
-	err(118, __func__, "called with NULL arg(s)");
+	err(115, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3050,7 +2906,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	       "We cannot find the remarks.md file.",
 	       "",
 	       NULL);
-	err(119, __func__, "remarks.md does not exist: %s", remarks_md);
+	err(116, __func__, "remarks.md does not exist: %s", remarks_md);
 	not_reached();
     }
     if (!is_file(remarks_md)) {
@@ -3058,7 +2914,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	      "The remarks.md path, while it exists, is not a file.",
 	      "",
 	      NULL);
-	err(120, __func__, "remarks_md is not a file: %s", remarks_md);
+	err(117, __func__, "remarks_md is not a file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -3067,15 +2923,15 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	      "The remarks.md, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(121, __func__, "remarks_md is not readable file: %s", remarks_md);
+	err(118, __func__, "remarks_md is not readable file: %s", remarks_md);
 	not_reached();
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(122, __func__, "file_size error: %ld on remarks_md %s", (long)filesize, remarks_md);
+	err(119, __func__, "file_size error: %ld on remarks_md %s", (long)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
-	err(123, __func__, "remarks.md cannot be empty: %s", remarks_md);
+	err(120, __func__, "remarks.md cannot be empty: %s", remarks_md);
 	not_reached();
     }
 
@@ -3085,7 +2941,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% -- % %/remarks.md", cp, remarks_md, entry_dir);
     if (cmd == NULL) {
-	err(124, __func__, "failed to cmdprintf: cp remarks.md entry_dir/remarks.md");
+	err(121, __func__, "failed to cmdprintf: cp remarks.md entry_dir/remarks.md");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -3097,14 +2953,14 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(125, __func__, "fflush(stdout) error code: %d", ret);
+	errp(122, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(126, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(123, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -3114,13 +2970,13 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(128, __func__, "error calling system(%s)", cmd);
+	errp(124, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(129, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(125, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(130, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(126, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -3130,7 +2986,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     errno = 0;			/* pre-clear errno for errp() */
     infop->remarks_md = strdup("remarks.md");
     if (infop->remarks_md == NULL) {
-	errp(131, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(LITLEN("remarks.md") + 1));
+	errp(128, __func__, "malloc #1 of %lu bytes failed", (unsigned long)(LITLEN("remarks.md") + 1));
 	not_reached();
     }
 
@@ -3178,11 +3034,11 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || args == NULL) {
-	err(132, __func__, "called with NULL arg(s)");
+	err(129, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (count < 0) {
-	err(133, __func__, "count :%d < 0", count);
+	err(130, __func__, "count :%d < 0", count);
 	not_reached();
     }
 
@@ -3198,7 +3054,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
     /* + 1 for trailing NULL */
     infop->extra_file = (char **)calloc((size_t)(count + 1), sizeof(char *));
     if (infop->extra_file == NULL) {
-	errp(134, __func__, "calloc #0 of %d char * pointers failed", count + 1);
+	errp(131, __func__, "calloc #0 of %d char * pointers failed", count + 1);
 	not_reached();
     }
 
@@ -3218,7 +3074,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "We cannot find an extra data file.",
 		  "",
 		  NULL);
-	    err(135, __func__, "extra[%i] does not exist: %s", i, args[i]);
+	    err(132, __func__, "extra[%i] does not exist: %s", i, args[i]);
 	    not_reached();
 	}
 	if (!is_file(args[i])) {
@@ -3227,7 +3083,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		   "The file, while it exists, is not a regular file.",
 		   "",
 		   NULL);
-	    err(136, __func__, "extra[%i] is not a file: %s", i, args[i]);
+	    err(133, __func__, "extra[%i] is not a file: %s", i, args[i]);
 	    not_reached();
 	}
 	if (!is_read(args[i])) {
@@ -3236,7 +3092,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "The file, while it is a file, is not readable.",
 		  "",
 		  NULL);
-	    err(137, __func__, "extra[%i] is not readable file: %s", i, args[i]);
+	    err(134, __func__, "extra[%i] is not readable file: %s", i, args[i]);
 	    not_reached();
 	}
 
@@ -3247,7 +3103,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	dbg(DBG_VHIGH, "basename(%s): %s", args[i], base);
 	base_len = strlen(base);
 	if (base_len == 0) {
-	    err(138, __func__, "basename of extra data file: %s has a length of 0", args[i]);
+	    err(135, __func__, "basename of extra data file: %s has a length of 0", args[i]);
 	    not_reached();
 	} else if (base_len > MAX_BASENAME_LEN) {
 	    fpara(stderr,
@@ -3255,7 +3111,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "The basename of an extra file is too long.",
 		  "",
 		  NULL);
-	    err(139, __func__, "basename of extra data file: %s is %lu characters an is > the limit: %lu",
+	    err(136, __func__, "basename of extra data file: %s is %lu characters an is > the limit: %lu",
 			       args[i], (unsigned long)base_len, (unsigned long)MAX_BASENAME_LEN);
 	    not_reached();
 	}
@@ -3269,7 +3125,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "The first character is the basename of an extra file must be alphanumeric:",
 		  "",
 		  NULL);
-	    err(140, __func__, "basename of extra data file: %s start with in invalid character: %s", args[i], base);
+	    err(137, __func__, "basename of extra data file: %s start with in invalid character: %s", args[i], base);
 	    not_reached();
 	}
 
@@ -3290,7 +3146,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		      "    A-Z a-z 0-9 . _ - +",
 		      "",
 		      NULL);
-		err(141, __func__, "basename of %s character %lu is NOT a POSIX Fully portable character nor +",
+		err(138, __func__, "basename of %s character %lu is NOT a POSIX Fully portable character nor +",
 				   args[i], (unsigned long)j);
 		not_reached();
 	    }
@@ -3304,12 +3160,12 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	errno = 0;		/* pre-clear errno for errp() */
 	dest = (char *)malloc(dest_len + 1);
 	if (dest == NULL) {
-	    errp(142, __func__, "malloc #0 of %lu bytes failed", (unsigned long)(dest_len + 1));
+	    errp(139, __func__, "malloc #0 of %lu bytes failed", (unsigned long)(dest_len + 1));
 	    not_reached();
 	}
 	ret = snprintf(dest, dest_len, "%s/%s", entry_dir, base);
 	if (ret <= 0) {
-	    errp(143, __func__, "snprintf #0 error: %d", ret);
+	    errp(140, __func__, "snprintf #0 error: %d", ret);
 	    not_reached();
 	}
 	dbg(DBG_VHIGH, "destination path: %s", dest);
@@ -3323,7 +3179,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "extra data files cannot overwrite other files.",
 		  "",
 		  NULL);
-	    err(144, __func__, "for extra file: %s destination already exists: %s", args[i], dest);
+	    err(141, __func__, "for extra file: %s destination already exists: %s", args[i], dest);
 	    not_reached();
 	}
 
@@ -3332,7 +3188,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	 */
 	cmd = cmdprintf("% -- % %", cp, args[i], dest);
 	if (cmd == NULL) {
-	    err(145, __func__, "failed to cmdprintf: cp extra_file[%d]: %s dest: %s", i, args[i], dest);
+	    err(142, __func__, "failed to cmdprintf: cp extra_file[%d]: %s dest: %s", i, args[i], dest);
 	    not_reached();
 	}
 	dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -3344,14 +3200,14 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fflush(stdout);
 	if (ret < 0) {
-	    errp(146, __func__, "fflush(stdout) error code: %d", ret);
+	    errp(143, __func__, "fflush(stdout) error code: %d", ret);
 	    not_reached();
 	}
 	clearerr(stderr);		/* pre-clear ferror() status */
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = fflush(stderr);
 	if (ret < 0) {
-	    errp(147, __func__, "fflush(stderr) #1: error code: %d", ret);
+	    errp(144, __func__, "fflush(stderr) #1: error code: %d", ret);
 	    not_reached();
 	}
 
@@ -3361,13 +3217,13 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	errno = 0;		/* pre-clear errno for errp() */
 	exit_code = system(cmd);
 	if (exit_code < 0) {
-	    errp(148, __func__, "error calling system(%s)", cmd);
+	    errp(145, __func__, "error calling system(%s)", cmd);
 	    not_reached();
 	} else if (exit_code == 127) {
-	    errp(149, __func__, "execution of the shell failed for system(%s)", cmd);
+	    errp(146, __func__, "execution of the shell failed for system(%s)", cmd);
 	    not_reached();
 	} else if (exit_code != 0) {
-	    err(150, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	    err(147, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	    not_reached();
 	}
 
@@ -3408,7 +3264,7 @@ lookup_location_name(char const *upper_code)
      * firewall
      */
     if (upper_code == NULL) {
-	err(151, __func__, "called with NULL arg(s)");
+	err(148, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3449,7 +3305,7 @@ yes_or_no(char const *question)
      * firewall
      */
     if (question == NULL) {
-	err(152, __func__, "called with NULL arg(s)");
+	err(149, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3519,7 +3375,7 @@ yes_or_no(char const *question)
 
     } while (response == NULL && need_retry);
     if (response == NULL) {
-	errp(153, __func__, "retry prompt is disabled");
+	errp(150, __func__, "retry prompt is disabled");
 	not_reached();
     }
 
@@ -3564,7 +3420,7 @@ get_title(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(154, __func__, "called with NULL arg(s)");
+	err(151, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3710,7 +3566,7 @@ get_title(struct info *infop)
      * check the result of the title validation
      */
     if (title == NULL) {
-	errp(155, __func__, "retry prompt is disabled");
+	errp(152, __func__, "retry prompt is disabled");
 	not_reached();
     }
 
@@ -3746,7 +3602,7 @@ get_abstract(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(156, __func__, "called with NULL arg(s)");
+	err(153, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3826,7 +3682,7 @@ get_abstract(struct info *infop)
      * check the result of the abstract validation
      */
     if (abstract == NULL) {
-	errp(157, __func__, "retry prompt is disabled");
+	errp(154, __func__, "retry prompt is disabled");
 	not_reached();
     }
 
@@ -3869,7 +3725,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
      * firewall
      */
     if (infop == NULL || ioccc_id == NULL || author_set_p == NULL) {
-	err(158, __func__, "called with NULL arg(s)");
+	err(155, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3917,7 +3773,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
     } while ((author_count < 1 || author_count > MAX_AUTHORS) && need_retry);
 
     if (author_count < 1 || author_count > MAX_AUTHORS) {
-	errp(159, __func__, "retry prompt is disabled");
+	errp(156, __func__, "retry prompt is disabled");
 	not_reached();
     }
 
@@ -3929,7 +3785,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
     errno = 0;			/* pre-clear errno for errp() */
     author_set = (struct author *) malloc(sizeof(struct author) * (size_t)author_count);
     if (author_set == NULL) {
-	errp(160, __func__, "malloc a struct author array of length: %d failed", author_count);
+	errp(157, __func__, "malloc a struct author array of length: %d failed", author_count);
 	not_reached();
     }
 
@@ -4066,7 +3922,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].name == NULL && need_retry);
 	if (author_set[i].name == NULL) {
-	    errp(161, __func__, "retry prompt is disabled");
+	    errp(158, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d Name %s", i, author_set[i].name);
@@ -4233,7 +4089,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	} while ((author_set[i].location_code == NULL || author_set[i].location_name == NULL || !yorn) &&
 		 need_retry);
 	if (author_set[i].location_code == NULL || author_set[i].location_name == NULL || !yorn) {
-	    errp(162, __func__, "retry prompt is disabled");
+	    errp(159, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d location/country: %s (%s)", i, author_set[i].location_code, author_set[i].location_name);
@@ -4309,7 +4165,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].email == NULL && need_retry);
 	if (author_set[i].email == NULL) {
-	    errp(163, __func__, "retry prompt is disabled");
+	    errp(160, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d Email: %s", i, author_set[i].email);
@@ -4397,7 +4253,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].url == NULL && need_retry);
 	if (author_set[i].url == NULL) {
-	    errp(164, __func__, "retry prompt is disabled");
+	    errp(161, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d URL: %s", i, author_set[i].url);
@@ -4474,7 +4330,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].twitter == NULL && need_retry);
 	if (author_set[i].twitter == NULL) {
-	    errp(165, __func__, "retry prompt is disabled");
+	    errp(162, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d twitter: %s", i, author_set[i].twitter);
@@ -4553,7 +4409,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].github == NULL && need_retry);
 	if (author_set[i].github == NULL) {
-	    errp(166, __func__, "retry prompt is disabled");
+	    errp(163, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d GitHub: %s", i, author_set[i].github);
@@ -4603,7 +4459,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].affiliation == NULL && need_retry);
 	if (author_set[i].affiliation == NULL) {
-	    errp(167, __func__, "retry prompt is disabled");
+	    errp(164, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d affiliation: %s", i, author_set[i].affiliation);
@@ -4698,7 +4554,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    }
 	} while (author_set[i].winner_handle == NULL && need_retry);
 	if (author_set[i].winner_handle == NULL) {
-	    errp(168, __func__, "retry prompt is disabled");
+	    errp(165, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
 	dbg(DBG_MED, "Author #%d IOCCC winner handle: %s", i, author_set[i].winner_handle);
@@ -4722,7 +4578,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 						      printf("Affiliation: %s\n", author_set[i].affiliation)) <= 0 ||
 	    ((author_set[i].winner_handle[0] == '\0') ? printf("IOCCC winner handle\n\n") :
 						        printf("IOCCC winner handle: %s\n\n", author_set[i].winner_handle)) <= 0) {
-	    errp(169, __func__, "error while printing author #%d information\n", i);
+	    errp(166, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -4775,7 +4631,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      * firewall
      */
     if (entry_dir == NULL || ls == NULL) {
-	err(170, __func__, "called with NULL arg(s)");
+	err(167, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4797,7 +4653,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("cd -- % && % -lak .", entry_dir, ls);
     if (cmd == NULL) {
-	err(171, __func__, "failed to cmdprintf: cd entry_dir && ls -lak .");
+	err(168, __func__, "failed to cmdprintf: cd entry_dir && ls -lak .");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -4809,7 +4665,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(172, __func__, "fflush(stdout) error code: %d", ret);
+	errp(169, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
@@ -4817,7 +4673,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(173, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(170, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -4827,13 +4683,13 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(174, __func__, "error calling system(%s)", cmd);
+	errp(171, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(175, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(172, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(176, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(173, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -4845,14 +4701,14 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(177, __func__, "fflush(stdout) #0: error code: %d", ret);
+	errp(174, __func__, "fflush(stdout) #0: error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(178, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(175, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -4862,7 +4718,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     errno = 0;			/* pre-clear errno for errp() */
     ls_stream = popen(cmd, "r");
     if (ls_stream == NULL) {
-	errp(179, __func__, "popen for reading failed for: %s", cmd);
+	errp(176, __func__, "popen for reading failed for: %s", cmd);
 	not_reached();
     }
 
@@ -4878,7 +4734,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     dbg(DBG_HIGH, "reading 1st line from popen(%s, r)", cmd);
     readline_len = readline(&linep, ls_stream);
     if (readline_len < 0) {
-	err(180, __func__, "EOF while reading 1st line from ls: %s", ls);
+	err(177, __func__, "EOF while reading 1st line from ls: %s", ls);
 	not_reached();
     } else {
 	dbg(DBG_HIGH, "ls 1st line read length: %ld buffer: %s", (long)readline_len, linep);
@@ -4889,11 +4745,11 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      */
     ret = sscanf(linep, "total %d%c", &kdirsize, &guard);
     if (ret != 1) {
-	err(181, __func__, "failed to parse block line from ls: %s", linep);
+	err(178, __func__, "failed to parse block line from ls: %s", linep);
 	not_reached();
     }
     if (kdirsize <= 0) {
-	err(182, __func__, "ls k block value: %d <= 0", kdirsize);
+	err(179, __func__, "ls k block value: %d <= 0", kdirsize);
 	not_reached();
     }
     if (kdirsize > MAX_DIR_KSIZE) {
@@ -4906,10 +4762,10 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	ret = fprintf(stderr, "The entry directory %s is %d kibibyte (1024 byte blocks) in length.\n"
 			      "It must be <= %d kibibyte (1024 byte blocks).\n\n", entry_dir, kdirsize, MAX_DIR_KSIZE);
 	if (ret <= 0) {
-	    errp(183, __func__, "fprintf error while printing entry directory kibibyte sizes");
+	    errp(180, __func__, "fprintf error while printing entry directory kibibyte sizes");
 	    not_reached();
 	}
-	err(184, __func__, "The entry directory is too large: %s", entry_dir);
+	err(181, __func__, "The entry directory is too large: %s", entry_dir);
 	not_reached();
     }
     dbg(DBG_LOW, "entry directory %s size in kibibyte (1024 byte blocks): %d", entry_dir, kdirsize);
@@ -4934,7 +4790,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	      "We suggest you remove the existing entry directory, and then",
 	      "rerun this tool with the correct set of file arguments.",
 	      NULL);
-	err(185, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(182, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5340,17 +5196,17 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || jinfochk == NULL || fnamchk == NULL) {
-	err(186, __func__, "called with NULL arg(s)");
+	err(183, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->extra_count < 0) {
 	warn(__func__, "extra_count %d < 0", infop->extra_count);
     }
     if (author_count <= 0) {
-	err(187, __func__, "author_count %d <= 0", author_count);
+	err(184, __func__, "author_count %d <= 0", author_count);
 	not_reached();
     } else if (author_count > MAX_AUTHORS) {
-	err(188, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
+	err(185, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -5365,7 +5221,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     infop->epoch = strdup(TIMESTAMP_EPOCH);
     if (infop->epoch == NULL) {
-	errp(189, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
+	errp(186, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
 	not_reached();
     }
     dbg(DBG_VVHIGH, "infop->epoch: %s", infop->epoch);
@@ -5376,13 +5232,13 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(190, __func__, "cannot set TZ=UTC");
+	errp(187, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = gmtime(&(infop->tstamp));
     if (timeptr == NULL) {
-	errp(191, __func__, "localtime #1 returned NULL");
+	errp(188, __func__, "localtime #1 returned NULL");
 	not_reached();
     }
 
@@ -5393,7 +5249,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     infop->utctime = (char *)calloc(utctime_len + 1, 1); /* + 1 for paranoia padding */
     if (infop->utctime == NULL) {
-	errp(192, __func__, "calloc of %lu bytes failed", (unsigned long)utctime_len + 1);
+	errp(189, __func__, "calloc of %lu bytes failed", (unsigned long)utctime_len + 1);
 	not_reached();
     }
 
@@ -5408,7 +5264,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     strftime_ret = strftime(infop->utctime, utctime_len, "%a %b %d %H:%M:%S %Y UTC", timeptr);
     if (strftime_ret == 0) {
-	errp(193, __func__, "strftime returned 0");
+	errp(190, __func__, "strftime returned 0");
 	not_reached();
     }
     dbg(DBG_VHIGH, "infop->utctime: %s", infop->utctime);
@@ -5420,20 +5276,20 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(194, __func__, "malloc of %lu bytes failed", (unsigned long)info_path_len + 1);
+	errp(191, __func__, "malloc of %lu bytes failed", (unsigned long)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/.info.json", entry_dir);
     if (ret <= 0) {
-	errp(195, __func__, "snprintf #0 error: %d", ret);
+	errp(192, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(196, __func__, "failed to open for writing: %s", info_path);
+	errp(193, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -5473,7 +5329,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_bool(info_stream, "\t", "test_mode", " : ", test_mode, ",\n") &&
 	fprintf(info_stream, "\t\"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(197, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(194, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5487,7 +5343,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	  json_fprintf_value_string(info_stream, "\t\t{", "remarks", " : ", infop->remarks_md,
 				    ((infop->extra_count > 0) ?  "},\n" : "}\n"));
     if (!ret) {
-	errp(198, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(195, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -5497,7 +5353,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     for (i=0, q=infop->extra_file; i < infop->extra_count && *q != NULL; ++i, ++q) {
         if (json_fprintf_value_string(info_stream, "\t\t{", "extra_file", " : ", *q,
 				     (((i+1) < infop->extra_count) ? "},\n" : "}\n")) != true) {
-	    errp(199, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
+	    errp(196, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
 	    not_reached();
 	}
     }
@@ -5514,7 +5370,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_string(info_stream, "\t", "formed_UTC", " : ", infop->utctime, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(200, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(197, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5524,7 +5380,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(201, __func__, "fclose error");
+	errp(198, __func__, "fclose error");
 	not_reached();
     }
     /*
@@ -5532,7 +5388,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
      */
     cmd = cmdprintf("% -q -s -F % %", jinfochk, fnamchk, info_path);
     if (cmd == NULL) {
-	err(202, __func__, "failed to cmdprintf: jinfochk %s", info_path);
+	err(199, __func__, "failed to cmdprintf: jinfochk %s", info_path);
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5544,14 +5400,14 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(203, __func__, "fflush(stdout) error code: %d", ret);
+	errp(200, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(204, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(201, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5562,13 +5418,13 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(205, __func__, "error calling system(%s)", cmd);
+	errp(202, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(206, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(203, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(207, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(204, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5619,14 +5475,14 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
      * firewall
      */
     if (infop == NULL || authorp == NULL || entry_dir == NULL || jauthchk == NULL) {
-	err(208, __func__, "called with NULL arg(s)");
+	err(205, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count <= 0) {
-	err(209, __func__, "author_count %d <= 0", author_count);
+	err(206, __func__, "author_count %d <= 0", author_count);
 	not_reached();
     } else if (author_count > MAX_AUTHORS) {
-	err(210, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
+	err(207, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -5638,20 +5494,20 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     author_path = (char *)malloc(author_path_len + 1);
     if (author_path == NULL) {
-	errp(211, __func__, "malloc of %lu bytes failed", (unsigned long)author_path_len + 1);
+	errp(208, __func__, "malloc of %lu bytes failed", (unsigned long)author_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(author_path, author_path_len, "%s/.author.json", entry_dir);
     if (ret <= 0) {
-	errp(212, __func__, "snprintf #0 error: %d", ret);
+	errp(209, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".author.json path: %s", author_path);
     errno = 0;			/* pre-clear errno for errp() */
     author_stream = fopen(author_path, "w");
     if (author_stream == NULL) {
-	errp(213, __func__, "failed to open for writing: %s", author_path);
+	errp(210, __func__, "failed to open for writing: %s", author_path);
 	not_reached();
     }
 
@@ -5670,7 +5526,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_long(author_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
 	fprintf(author_stream, "\t\"authors\" : [\n") > 0;
     if (!ret) {
-	errp(214, __func__, "fprintf error writing leading part of authorship to %s", author_path);
+	errp(211, __func__, "fprintf error writing leading part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5692,7 +5548,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	    json_fprintf_value_long(author_stream, "\t\t\t", "author_number", " : ", authorp[i].author_num, "\n") &&
 	    fprintf(author_stream, "\t\t}%s\n", (((i + 1) < author_count) ? "," : "")) > 0;
 	if (ret < 0) {
-	    errp(215, __func__, "fprintf error writing author info to %s", author_path);
+	    errp(212, __func__, "fprintf error writing author info to %s", author_path);
 	    not_reached();
 	}
     }
@@ -5709,7 +5565,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "formed_UTC", " : ", infop->utctime, "\n") &&
 	fprintf(author_stream, "}\n") > 0;
     if (!ret) {
-	errp(216, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
+	errp(213, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5719,7 +5575,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(author_stream);
     if (ret < 0) {
-	errp(217, __func__, "fclose error");
+	errp(214, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5731,7 +5587,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
      */
     cmd = cmdprintf("% -q -s %", jauthchk, author_path);
     if (cmd == NULL) {
-	err(218, __func__, "failed to cmdprintf: jauthchk %s", author_path);
+	err(215, __func__, "failed to cmdprintf: jauthchk %s", author_path);
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5743,14 +5599,14 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(219, __func__, "fflush(stdout) error code: %d", ret);
+	errp(216, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(220, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(217, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5761,13 +5617,13 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(221, __func__, "error calling system(%s)", cmd);
+	errp(218, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(222, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(219, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(223, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(220, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5825,7 +5681,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      */
     if (work_dir == NULL || entry_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(224, __func__, "called with NULL arg(s)");
+	err(221, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5841,7 +5697,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(225, __func__, "cannot open .");
+	errp(222, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -5851,7 +5707,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(work_dir);
     if (ret < 0) {
-	errp(226, __func__, "cannot cd %s", work_dir);
+	errp(223, __func__, "cannot cd %s", work_dir);
 	not_reached();
     }
 
@@ -5867,7 +5723,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     basename_tarball_path = base_name(tarball_path);
     cmd = cmdprintf("% --format=v7 -cJf % %", tar, basename_tarball_path, basename_entry_dir);
     if (cmd == NULL) {
-	err(227, __func__, "failed to cmdprintf: tar --format=v7 -cJf tarball_path entry_dir");
+	err(224, __func__, "failed to cmdprintf: tar --format=v7 -cJf tarball_path entry_dir");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5879,14 +5735,14 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(228, __func__, "fflush(stdout) error code: %d", ret);
+	errp(225, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(229, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(226, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5900,13 +5756,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(230, __func__, "error calling system(%s)", cmd);
+	errp(227, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(231, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(228, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(232, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(229, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
 
@@ -5916,7 +5772,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(233, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(230, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -5925,7 +5781,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(234, __func__, "The compressed tarball: %s size: %lu > %ld",
+	err(231, __func__, "The compressed tarball: %s size: %lu > %ld",
 		 basename_tarball_path, (unsigned long)buf.st_size, (long)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -5944,13 +5800,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(235, __func__, "cannot fchdir to the previous current directory");
+	errp(232, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(236, __func__, "close of previous current directory failed");
+	errp(233, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -5959,7 +5815,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      */
     cmd = cmdprintf("% -q -F % %/../%", txzchk, fnamchk, entry_dir, basename_tarball_path);
     if (cmd == NULL) {
-	err(237, __func__, "failed to cmdprintf: txzchk -q tarball_path");
+	err(234, __func__, "failed to cmdprintf: txzchk -q tarball_path");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -5971,14 +5827,14 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;		/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(238, __func__, "fflush(stdout) error code: %d", ret);
+	errp(235, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     clearerr(stderr);		/* pre-clear ferror() status */
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(239, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(236, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -5989,13 +5845,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(240, __func__, "error calling system(%s)", cmd);
+	errp(237, __func__, "error calling system(%s)", cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(241, __func__, "execution of the shell failed for system(%s)", cmd);
+	errp(238, __func__, "execution of the shell failed for system(%s)", cmd);
 	not_reached();
     } else if (exit_code != 0) {
-	err(242, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	err(239, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	not_reached();
     }
     para("",
@@ -6045,13 +5901,13 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
      * firewall
      */
     if (work_dir == NULL || entry_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(243, __func__, "called with NULL arg(s)");
+	err(240, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     entry_dir_esc = cmdprintf("%", entry_dir);
     if (entry_dir_esc == NULL) {
-	err(244, __func__, "failed to cmdprintf: entry_dir");
+	err(241, __func__, "failed to cmdprintf: entry_dir");
 	not_reached();
     }
 
@@ -6064,14 +5920,14 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    rm -rf %s%s\n", entry_dir[0] == '-' ? "-- " : "", entry_dir_esc);
     if (ret <= 0) {
-	errp(245, __func__, "printf #0 error");
+	errp(242, __func__, "printf #0 error");
 	not_reached();
     }
     free(entry_dir_esc);
 
     work_dir_esc = cmdprintf("%", work_dir);
     if (work_dir_esc == NULL) {
-	err(246, __func__, "failed to cmdprintf: work_dir");
+	err(243, __func__, "failed to cmdprintf: work_dir");
 	not_reached();
     }
 
@@ -6082,7 +5938,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, work_dir[0] == '-' ? "./" : "", work_dir_esc, tarball_path);
     if (ret <= 0) {
-	errp(247, __func__, "printf #2 error");
+	errp(244, __func__, "printf #2 error");
 	not_reached();
     }
     free(work_dir_esc);
@@ -6116,7 +5972,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s/%s\n", work_dir, tarball_path);
 	if (ret <= 0) {
-	    errp(248, __func__, "printf #2 error");
+	    errp(245, __func__, "printf #2 error");
 	    not_reached();
 	}
     }
@@ -6132,7 +5988,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s\n\n", IOCCC_SUBMIT_URL);
 	if (ret < 0) {
-	    errp(249, __func__, "printf #4 error");
+	    errp(246, __func__, "printf #4 error");
 	    not_reached();
 	}
     }

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -391,7 +391,7 @@ main(int argc, char *argv[])
      * create entry directory
      */
     entry_dir = mk_entry_dir(work_dir, info.ioccc_id, info.entry_num, &tarball_path, info.tstamp);
-    info.tarball_path = tarball_path; /* note: do NOT free this in free_info() ! */
+    info.tarball = tarball_path; /* XXX do **NOT** free this in free_info() ! */
     dbg(DBG_LOW, "formed entry directory: %s", entry_dir);
 
 
@@ -3661,7 +3661,7 @@ get_title(struct info *infop)
 	 */
 	if (!isascii(title[0]) || (!islower(title[0]) && !isdigit(title[0]))) {
 	    /*
-	     * reject long title
+	     * reject title whose first char is not [a-z0-9]
 	     */
 	    fpara(stderr,
 		  "",
@@ -5457,7 +5457,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_long(info_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "title", " : ", infop->title, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "abstract", " : ", infop->abstract, ",\n") &&
-	json_fprintf_value_string(info_stream, "\t", "tarball", " : ", infop->tarball_path, ",\n") &&
+	json_fprintf_value_string(info_stream, "\t", "tarball", " : ", infop->tarball, ",\n") &&
 	json_fprintf_value_long(info_stream, "\t", "rule_2a_size", " : ", (long)infop->rule_2a_size, ",\n") &&
 	json_fprintf_value_long(info_stream, "\t", "rule_2b_size", " : ", (long)infop->rule_2b_size, ",\n") &&
 	json_fprintf_value_bool(info_stream, "\t", "empty_override", " : ", infop->empty_override, ",\n") &&
@@ -5670,7 +5670,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_long(author_stream, "\t", "ioccc_year", " : ", (long)IOCCC_YEAR, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "mkiocccentry_version", " : ", infop->mkiocccentry_ver, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "IOCCC_contest_id", " : ", infop->ioccc_id, ",\n") &&
-	json_fprintf_value_string(author_stream, "\t", "tarball", " : ", infop->tarball_path, ",\n") &&
+	json_fprintf_value_string(author_stream, "\t", "tarball", " : ", infop->tarball, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "entry_num", " : ", (long)infop->entry_num, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
 	fprintf(author_stream, "\t\"authors\" : [\n") > 0;

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -96,7 +96,7 @@
  *
  * The following is NOT the version of this mkiocccentry tool!
  *
- * XXX These MUST be here and **NOT** in version.h!
+ * XXX These MUST be here and **NOT** in version.h or mkiocccentry.h!
  */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS-IOCCCMOCK-1.0"
 /* Answers file EOF marker */
@@ -5333,7 +5333,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
     char *info_path;		/* path to .info.json file */
     size_t info_path_len;	/* length of path to .info.json */
     FILE *info_stream;		/* open write stream to the .info.json file */
-    size_t strftime_ret;	/* length of asctime() string without the trailing newline */
+    size_t strftime_ret;	/* length of strftime() string without the trailing newline */
     size_t utctime_len;		/* length of utctime string (utctime() + " UTC") */
     int ret;			/* libc function return */
     char **q;			/* extra filename array pointer */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -162,12 +162,7 @@ main(int argc, char *argv[])
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(2, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno));
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -168,8 +168,6 @@ static FILE *input_stream = NULL;
  * forward declarations
  */
 static void usage(int exitcode, char const *str, char const *program);
-static void free_info(struct info *infop);
-static void free_author_array(struct author *authorp, int author_count);
 static void warn_empty_prog(char const *prog_c);
 static void warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size);
 static void warn_high_bit(char const *prog_c);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -120,7 +120,7 @@ static const char * const usage_msg0 =
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
-    "\t-T\t\t\tShow IOCCC toolset chain release repository tag\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
     "\t-W\t\t\tignore all warnings (this does NOT mean the judges will! :) )\n";
 
 static const char * const usage_msg1 =

--- a/txzchk.1
+++ b/txzchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
+\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-T] [\-t tar] [\-F fnamchk] [\-f] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked indirectly through \fBmkiocccentry(1)\fP.
 .PP
@@ -26,6 +26,9 @@ This does not include warnings, errors or the output of the \fBtar\fP command.
 \fB\-V\fP
 Show version and exit.
 .PP
+\fB\-T\fP
+Show IOCCC toolset chain release repository tag.
+.PP
 \fB\-t\fP
 Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 \fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
@@ -34,7 +37,7 @@ Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
 .PP
-\fB\-T\fP
+\fB\-f\fP
 Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
 .SH EXIT STATUS
 .PP

--- a/txzchk.c
+++ b/txzchk.c
@@ -113,7 +113,7 @@ main(int argc, char **argv)
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = printf("Welcome to txzchk version: %s\n", TXZCHK_VERSION);
 	if (ret <= 0) {
-	    errp(2, __func__, "printf error printing the welcome string");
+	    errp(1, __func__, "printf error printing the welcome string");
 	    not_reached();
 	}
     }
@@ -184,7 +184,7 @@ show_txz_info(char const *txzpath)
      * firewall
      */
     if (txzpath == NULL) {
-	err(3, __func__, "passed NULL arg");
+	err(2, __func__, "passed NULL arg");
 	not_reached();
     }
     if (verbosity_level >= DBG_MED) {
@@ -274,7 +274,7 @@ sanity_chk(char const *tar, char const *fnamchk)
      * firewall
      */
     if ((tar == NULL && !text_file_flag_used) || fnamchk == NULL || txzpath == NULL) {
-	err(4, __func__, "called with NULL arg(s)");
+	err(3, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -297,7 +297,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 		  "    https://www.gnu.org/software/tar/",
 		  "",
 		  NULL);
-	    err(5, __func__, "tar does not exist: %s", tar);
+	    err(4, __func__, "tar does not exist: %s", tar);
 	    not_reached();
 	}
 	if (!is_file(tar)) {
@@ -314,7 +314,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 		  "    https://www.gnu.org/software/tar/",
 		  "",
 		  NULL);
-	    err(6, __func__, "tar is not a file: %s", tar);
+	    err(5, __func__, "tar is not a file: %s", tar);
 	    not_reached();
 	}
 	if (!is_exec(tar)) {
@@ -331,7 +331,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 		  "    https://www.gnu.org/software/tar/",
 		  "",
 		  NULL);
-	    err(7, __func__, "tar is not an executable program: %s", tar);
+	    err(6, __func__, "tar is not an executable program: %s", tar);
 	    not_reached();
 	}
     }
@@ -349,7 +349,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(8, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(7, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -361,7 +361,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(9, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(8, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -373,7 +373,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(10, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(9, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -390,7 +390,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "    txzchk [options] <txzpath>"
 	      "",
 	      NULL);
-	err(11, __func__, "txzpath does not exist: %s", txzpath);
+	err(10, __func__, "txzpath does not exist: %s", txzpath);
 	not_reached();
     }
     if (!is_file(txzpath)) {
@@ -403,7 +403,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "    txzchk [...] <txzpath>",
 	      "",
 	      NULL);
-	err(12, __func__, "txzpath is not a file: %s", txzpath);
+	err(11, __func__, "txzpath is not a file: %s", txzpath);
 	not_reached();
     }
     if (!is_read(txzpath)) {
@@ -416,7 +416,7 @@ sanity_chk(char const *tar, char const *fnamchk)
 	      "    txzchk [...] <txzpath>"
 	      "",
 	      NULL);
-	err(13, __func__, "txzpath is not readable: %s", txzpath);
+	err(12, __func__, "txzpath is not readable: %s", txzpath);
 	not_reached();
     }
 
@@ -447,7 +447,7 @@ check_file(char const *txzpath, char *p, char const *dir_name, struct file *file
      * firewall
      */
     if (txzpath == NULL || p == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
-	err(14, __func__, "passed NULL arg(s)");
+	err(13, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -510,7 +510,7 @@ check_empty_file(char const *txzpath, off_t size, struct file *file)
      */
 
     if (txzpath == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
-	err(15, __func__, "called with NULL arg(s)");
+	err(14, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -563,7 +563,7 @@ check_all_files(char const *dir_name)
 
     /* report total file size */
     if (txz_info.file_sizes < 0) {
-	err(16, __func__, "%s: total size of all files < 0!", txzpath);
+	err(15, __func__, "%s: total size of all files < 0!", txzpath);
 	not_reached();
     } else if (txz_info.file_sizes == 0) {
 	warn("txzchk", "%s: total size of all files == 0", txzpath);
@@ -571,7 +571,7 @@ check_all_files(char const *dir_name)
     }
     txz_info.rounded_file_size = round_to_multiple(txz_info.file_sizes, 1024);
     if (txz_info.rounded_file_size < 0) {
-	err(17, __func__, "%s: total size of all files rounded up to multiple of 1024 < 0!", txzpath);
+	err(16, __func__, "%s: total size of all files rounded up to multiple of 1024 < 0!", txzpath);
 	not_reached();
     } else if (txz_info.rounded_file_size > MAX_DIR_KSIZE) {
 	warn("txzchk", "%s: total size of files %lld rounded up to multiple of 1024 %lld > %d", txzpath, (long long) txz_info.file_sizes,
@@ -681,7 +681,7 @@ check_directories(struct file *file, char const *dir_name, char const *txzpath)
      * firewall
      */
     if (txzpath == NULL || file == NULL || file->filename == NULL) {
-	err(18, __func__, "passed NULL arg(s)");
+	err(17, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -800,7 +800,7 @@ parse_linux_line(char *p, char *linep, char *line_dup, char const *dir_name, cha
      */
 
     if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || saveptr == NULL) {
-	err(19, __func__, "called with NULL arg(s)");
+	err(18, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -904,7 +904,7 @@ parse_bsd_line(char *p, char *linep, char *line_dup, char const *dir_name, char 
      */
 
     if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || saveptr == NULL) {
-	err(20, __func__, "called with NULL arg(s)");
+	err(19, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1009,7 +1009,7 @@ parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpat
      */
 
     if (linep == NULL || line_dup == NULL || txzpath == NULL || dir_count == NULL) {
-	err(21, __func__, "called with NULL arg(s)");
+	err(20, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     /*
@@ -1089,7 +1089,7 @@ check_tarball(char const *tar, char const *fnamchk)
      * firewall
      */
     if ((!text_file_flag_used && tar == NULL) || fnamchk == NULL || txzpath == NULL) {
-	err(22, __func__, "called with NULL arg(s)");
+	err(21, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1104,7 +1104,7 @@ check_tarball(char const *tar, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     cmd = cmdprintf("% %", fnamchk, txzpath);
     if (cmd == NULL) {
-	err(23, __func__, "failed to cmdprintf: fnamchk txzpath");
+	err(22, __func__, "failed to cmdprintf: fnamchk txzpath");
 	not_reached();
     }
     dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -1116,7 +1116,7 @@ check_tarball(char const *tar, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	errp(24, __func__, "fflush(stdout) error code: %d", ret);
+	errp(23, __func__, "fflush(stdout) error code: %d", ret);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
@@ -1124,7 +1124,7 @@ check_tarball(char const *tar, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	errp(25, __func__, "fflush(stderr) #1: error code: %d", ret);
+	errp(24, __func__, "fflush(stderr) #1: error code: %d", ret);
 	not_reached();
     }
 
@@ -1134,10 +1134,10 @@ check_tarball(char const *tar, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	errp(26, "txzchk", "%s: error calling system(%s)", txzpath, cmd);
+	errp(25, "txzchk", "%s: error calling system(%s)", txzpath, cmd);
 	not_reached();
     } else if (exit_code == 127) {
-	errp(27, "txzchk", "%s: execution of the shell failed for system(%s)", txzpath, cmd);
+	errp(26, "txzchk", "%s: execution of the shell failed for system(%s)", txzpath, cmd);
 	not_reached();
     } else if (exit_code != 0) {
 	warn("txzchk", "%s: %s failed with exit code: %d", txzpath, cmd, WEXITSTATUS(exit_code));
@@ -1164,7 +1164,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	fnamchk_stream = popen(cmd, "r");
 	if (fnamchk_stream == NULL) {
-	    errp(28, __func__, "popen for reading failed for: %s", cmd);
+	    errp(27, __func__, "popen for reading failed for: %s", cmd);
 	    not_reached();
 	}
 
@@ -1190,7 +1190,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	fnamchk_stream = NULL;
 
 	if (dir_name == NULL || !strlen(dir_name)) {
-	    err(29, __func__, "txzchk: %s: unexpected NULL pointer from %s", txzpath, cmd);
+	    err(28, __func__, "txzchk: %s: unexpected NULL pointer from %s", txzpath, cmd);
 	    not_reached();
 	}
     }
@@ -1199,7 +1199,7 @@ check_tarball(char const *tar, char const *fnamchk)
     txz_info.size = file_size(txzpath);
     /* report size (if too big) */
     if (txz_info.size < 0) {
-	err(30, __func__, "%s: impossible error: sanity_chk() found tarball but file_size() did not", txzpath);
+	err(29, __func__, "%s: impossible error: sanity_chk() found tarball but file_size() did not", txzpath);
 	not_reached();
     }
     else if (txz_info.size > MAX_TARBALL_LEN) {
@@ -1209,7 +1209,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(31, __func__, "%s: The compressed tarball size %lld > %ld",
+	err(30, __func__, "%s: The compressed tarball size %lld > %ld",
 		 txzpath, (long long)txz_info.size, (long)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -1232,7 +1232,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	input_stream = fopen(txzpath, "r");
 	errno = 0;
 	if (input_stream == NULL) {
-	    errp(32, __func__, "fopen of %s failed", txzpath);
+	    errp(31, __func__, "fopen of %s failed", txzpath);
 	    not_reached();
 	}
 	errno = 0;
@@ -1246,7 +1246,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	cmd = cmdprintf("% -tJvf %", tar, txzpath);
 	if (cmd == NULL) {
-	    err(33, __func__, "failed to cmdprintf: tar -tJvf txzpath");
+	    err(32, __func__, "failed to cmdprintf: tar -tJvf txzpath");
 	    not_reached();
 	}
 	dbg(DBG_HIGH, "about to perform: system(%s)", cmd);
@@ -1258,7 +1258,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = fflush(stdout);
 	if (ret < 0) {
-	    errp(34, __func__, "fflush(stdout) error code: %d", ret);
+	    errp(33, __func__, "fflush(stdout) error code: %d", ret);
 	    not_reached();
 	}
 	errno = 0;			/* pre-clear errno for errp() */
@@ -1266,7 +1266,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = fflush(stderr);
 	if (ret < 0) {
-	    errp(35, __func__, "fflush(stderr) #1: error code: %d", ret);
+	    errp(34, __func__, "fflush(stderr) #1: error code: %d", ret);
 	    not_reached();
 	}
 
@@ -1276,13 +1276,13 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	exit_code = system(cmd);
 	if (exit_code < 0) {
-	    errp(36, __func__, "error calling system(%s)", cmd);
+	    errp(35, __func__, "error calling system(%s)", cmd);
 	    not_reached();
 	} else if (exit_code == 127) {
-	    errp(37, __func__, "execution of the shell failed for system(%s)", cmd);
+	    errp(36, __func__, "execution of the shell failed for system(%s)", cmd);
 	    not_reached();
 	} else if (exit_code != 0) {
-	    err(38, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
+	    err(37, __func__, "%s failed with exit code: %d", cmd, WEXITSTATUS(exit_code));
 	    not_reached();
 	}
 
@@ -1294,14 +1294,14 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = fflush(stdout);
 	if (ret < 0) {
-	    errp(39, __func__, "fflush(stdout) #0: error code: %d", ret);
+	    errp(38, __func__, "fflush(stdout) #0: error code: %d", ret);
 	    not_reached();
 	}
 	clearerr(stderr);		/* pre-clear ferror() status */
 	errno = 0;			/* pre-clear errno for errp() */
 	ret = fflush(stderr);
 	if (ret < 0) {
-	    errp(40, __func__, "fflush(stderr) #1: error code: %d", ret);
+	    errp(39, __func__, "fflush(stderr) #1: error code: %d", ret);
 	    not_reached();
 	}
 
@@ -1311,7 +1311,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;			/* pre-clear errno for errp() */
 	input_stream = popen(cmd, "r");
 	if (input_stream == NULL) {
-	    errp(41, __func__, "popen for reading failed for: %s", cmd);
+	    errp(40, __func__, "popen for reading failed for: %s", cmd);
 	    not_reached();
 	}
     }
@@ -1428,7 +1428,7 @@ has_special_bits(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(42, __func__, "called with NULL arg(s)");
+	err(41, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1459,21 +1459,21 @@ add_line(char const *str, int line_num)
      * firewall
      */
     if (str == NULL) {
-	err(43, __func__, "passed NULL arg");
+	err(42, __func__, "passed NULL arg");
 	not_reached();
     }
 
     errno = 0;
     line = calloc(1, sizeof *line);
     if (line == NULL) {
-	err(44, __func__, "unable to allocate struct line *");
+	err(43, __func__, "unable to allocate struct line *");
 	not_reached();
     }
 
     errno = 0;
     line->line = strdup(str);
     if (line->line == NULL) {
-	err(45, __func__, "unable to strdup string '%s' for lines list", str);
+	err(44, __func__, "unable to strdup string '%s' for lines list", str);
 	not_reached();
     }
     line->line_num = line_num;
@@ -1508,7 +1508,7 @@ parse_all_lines(char const *dir_name, char const *txzpath)
      * firewall
      */
     if (txzpath == NULL) {
-	err(46, __func__, "passed NULL arg");
+	err(45, __func__, "passed NULL arg");
 	not_reached();
     }
 
@@ -1519,7 +1519,7 @@ parse_all_lines(char const *dir_name, char const *txzpath)
 	}
 	line_dup = strdup(line->line);
 	if (line_dup == NULL) {
-	    err(47, __func__, "%s: duplicating %s failed", txzpath, line->line);
+	    err(46, __func__, "%s: duplicating %s failed", txzpath, line->line);
 	    not_reached();
 	}
 
@@ -1582,27 +1582,27 @@ alloc_file(char const *p)
      * firewall
      */
     if (p == NULL) {
-	err(48, __func__, "passed NULL path");
+	err(47, __func__, "passed NULL path");
 	not_reached();
     }
     errno = 0;
     file = calloc(1, sizeof *file);
     if (file == NULL) {
-	err(49, __func__, "%s: unable to allocate a struct file *", txzpath);
+	err(48, __func__, "%s: unable to allocate a struct file *", txzpath);
 	not_reached();
     }
 
     errno = 0;
     file->filename = strdup(p);
     if (!file->filename) {
-	err(50, __func__, "%s: unable to strdup filename %s", txzpath, p);
+	err(49, __func__, "%s: unable to strdup filename %s", txzpath, p);
 	not_reached();
     }
 
     errno = 0;
     file->basename = strdup(base_name(p)?base_name(p):"");
     if (!file->basename || !strlen(file->basename)) {
-	err(51, __func__, "%s: unable to strdup basename of filename %s", txzpath, p);
+	err(50, __func__, "%s: unable to strdup basename of filename %s", txzpath, p);
 	not_reached();
     }
 
@@ -1632,7 +1632,7 @@ add_file_to_list(struct file *file)
      * firewall
      */
     if (file == NULL || !file->filename || !file->basename) {
-	err(52, __func__, "called with NULL pointer(s)");
+	err(51, __func__, "called with NULL pointer(s)");
 	not_reached();
     }
 

--- a/txzchk.c
+++ b/txzchk.c
@@ -128,7 +128,7 @@ main(int argc, char **argv)
      * On some systems where /usr/bin != /bin, the distribution made the mistake of
      * moving historic critical applications, look to see if the alternate path works instead.
      *
-     * If -T was used we don't actually need tar(1) so we test for that
+     * If -f was used we don't actually need tar(1) so we test for that
      * specifically.
      */
 
@@ -1063,7 +1063,7 @@ parse_line(char *linep, char *line_dup, char const *dir_name, char const *txzpat
  *
  * given:
  *
- *	tar		- path to executable tar program (if -T was not
+ *	tar		- path to executable tar program (if -f was not
  *			  specified)
  *	fnamchk		- path to fnamchk tool
  *
@@ -1076,7 +1076,7 @@ check_tarball(char const *tar, char const *fnamchk)
 {
     unsigned line_num = 0; /* line number of tar output */
     char *cmd = NULL;	/* fnamchk and tar -tJvf */
-    FILE *input_stream = NULL; /* pipe for tar output (or if -T specified read as a text file) */
+    FILE *input_stream = NULL; /* pipe for tar output (or if -f specified read as a text file) */
     FILE *fnamchk_stream = NULL; /* pipe for fnamchk output */
     char *linep = NULL;		/* allocated line read from tar (or text file) */
     char *dir_name = NULL;	/* line read from fnamchk (directory name) */
@@ -1197,7 +1197,7 @@ check_tarball(char const *tar, char const *fnamchk)
 
     /* determine size of tarball */
     txz_info.size = file_size(txzpath);
-    /* report size (if too big) */
+    /* report size if too big or !quiet */
     if (txz_info.size < 0) {
 	err(29, __func__, "%s: impossible error: sanity_chk() found tarball but file_size() did not", txzpath);
 	not_reached();
@@ -1223,7 +1223,7 @@ check_tarball(char const *tar, char const *fnamchk)
     dbg(DBG_MED, "txzchk: %s size in bytes: %lld", txzpath, (long long)txz_info.size);
 
     /*
-     * free cmd for tar (if -T wasn't specified) command
+     * free cmd for tar (if -f wasn't specified) command
      */
     free(cmd);
     cmd = NULL;
@@ -1241,7 +1241,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	    warnp(__func__, "setvbuf failed for %s", txzpath);
 	}
     }
-    else { /* if -T not specified we have to do more to set up input stream */
+    else { /* if -f not specified we have to do more to set up input stream */
 
 	errno = 0;			/* pre-clear errno for errp() */
 	cmd = cmdprintf("% -tJvf %", tar, txzpath);
@@ -1306,7 +1306,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 
 	/*
-	 * If we get here -T was not specified so open pipe to tar command.
+	 * If we get here -f was not specified so open pipe to tar command.
 	 */
 	errno = 0;			/* pre-clear errno for errp() */
 	input_stream = popen(cmd, "r");
@@ -1374,7 +1374,7 @@ check_tarball(char const *tar, char const *fnamchk)
 
     } while (readline_len >= 0);
     /*
-     * free cmd (it'll be NULL if -T was specified but this is safe)
+     * free cmd (it'll be NULL if -f was specified but this is safe)
      */
     free(cmd);
     cmd = NULL;

--- a/txzchk.c
+++ b/txzchk.c
@@ -59,12 +59,7 @@ main(int argc, char **argv)
 	    /*
 	     * parse verbosity
 	     */
-	    errno = 0;		/* pre-clear errno for errp() */
-	    verbosity_level = (int)strtol(optarg, NULL, 0);
-	    if (errno != 0) {
-		errp(1, __func__, "cannot parse -v arg: %s error: %s", optarg, strerror(errno));
-		not_reached();
-	    }
+	    verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */

--- a/txzchk.c
+++ b/txzchk.c
@@ -49,7 +49,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VqF:t:T")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqF:t:fT")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(0, "-h help mode", program);
@@ -86,8 +86,17 @@ main(int argc, char **argv)
 	case 'q':
 	    quiet = true;
 	    break;
-	case 'T':
+	case 'f':
 	    text_file_flag_used = true; /* don't rely on tar: just read file as if it was a text file */
+	    break;
+	case 'T':		/* -T (IOCCC toolset chain release repository tag) */
+	    errno = 0;		/* pre-clear errno for warnp() */
+	    ret = printf("%s\n", IOCCC_TOOLSET_RELEASE);
+	    if (ret <= 0) {
+		warnp(__func__, "printf error printing IOCCC toolset release repository tag");
+	    }
+	    exit(0); /*ooo*/
+	    not_reached();
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/

--- a/txzchk.h
+++ b/txzchk.h
@@ -98,16 +98,17 @@ static struct line *lines;
  * Use the usage() function to print the usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] [-T] txzpath\n"
+    "usage: %s [-h] [-v level] [-V] [-t tar] [-F fnamchk] [-f] txzpath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
+    "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
     "\n"
     "\t-t /path/to/tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
     "\t-F /path/to/fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
     "\t\t\t\tfilename (def: %s)\n\n"
-    "\t-T\t\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
+    "\t-f\t\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
     "\ttxzpath\t\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "txzchk version: %s\n";

--- a/txzchk.h
+++ b/txzchk.h
@@ -17,7 +17,7 @@
 #if !defined(INCLUDE_TXZCHK_H)
 #    define  INCLUDE_TXZCHK_H
 
-/* 
+/*
  * some of the identifiers below share the name of identifiers in other files so
  * only define/declare the below for txzchk.c
  */

--- a/util.c
+++ b/util.c
@@ -1897,6 +1897,76 @@ int string_to_int(char const *str)
     return (int)num;
 }
 
+/* string_to_unsigned_long - string to unsigned long with error checks
+ *
+ * given:
+ *
+ *	str	- the string to convert to unsigned long
+ *
+ * Returns str as an unsigned long.
+ *
+ * Does not return on error.
+ */
+unsigned long string_to_unsigned_long(char const *str)
+{
+    unsigned long num = 0;
+
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	err(151, __func__, "passed NULL arg");
+	not_reached();
+    }
+
+    errno = 0;
+    num = strtoul(str, NULL, 10);
+    if (errno != 0) {
+	err(152, __func__, "strtoul(%s): %s", str, strerror(errno));
+	not_reached();
+    } else if (num >= ULONG_MAX) {
+	err(153, __func__, "strtoul(%s): too big", str);
+	not_reached();
+    }
+
+    return num;
+}
+
+/* string_to_unsigned_long_long - string to unsigned long long with error checks
+ *
+ * given:
+ *
+ *	str	- the string to convert to unsigned long long
+ *
+ * Returns str as an unsigned long long.
+ *
+ * Does not return on error.
+ */
+unsigned long long string_to_unsigned_long_long(char const *str)
+{
+    unsigned long long num;
+
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	err(154, __func__, "passed NULL arg");
+	not_reached();
+    }
+
+    errno = 0;
+    num = strtoul(str, NULL, 10);
+    if (errno != 0) {
+	err(155, __func__, "strtoul(%s): %s", str, strerror(errno));
+	not_reached();
+    } else if (num >= ULLONG_MAX) {
+	err(156, __func__, "strtoul(%s): too big", str);
+	not_reached();
+    }
+
+    return num;
+
+}
 /* valid_contest_id	    -	validate string as a contest ID
  *
  * given:

--- a/util.h
+++ b/util.h
@@ -118,6 +118,8 @@ extern char const * strnull(char const * const str);
 extern long string_to_long(char const *str);
 extern long long string_to_long_long(char const *str);
 extern int string_to_int(char const *str);
+extern unsigned long string_to_unsigned_long(char const *str);
+extern unsigned long long string_to_unsigned_long_long(char const *str);
 extern bool valid_contest_id(char *str);
 
 #endif				/* INCLUDE_UTIL_H */

--- a/version.h
+++ b/version.h
@@ -97,34 +97,34 @@
 
 
 /*
- * fnamchk version
+ * official fnamchk version
  */
 #define FNAMCHK_VERSION "0.2 2022-02-07"	/* format: major.minor YYYY-MM-DD */
 
 /*
- * txzchk version
+ * official txzchk version
  */
 #define TXZCHK_VERSION "0.7 2022-02-12"		/* format: major.minor YYYY-MM-DD */
 
 /*
- * jinfochk version
+ * official jinfochk version
  */
 #define JINFOCHK_VERSION "0.5 2022-02-19"	/* format: major.minor YYYY-MM-DD */
 
 /*
- * jauthchk version
+ * official jauthchk version
  */
 #define JAUTHCHK_VERSION "0.5 2022-02-19"	/* format: major.minor YYYY-MM-DD */
 
 
 /*
- * jstrencode version
+ * official jstrencode version
  */
 #define JSTRENCODE_VERSION "0.1 2022-02-14"	/* format: major.minor YYYY-MM-DD */
 
 
 /*
- * jstrdecode version
+ * official jstrdecode version
  */
 #define JSTRDECODE_VERSION "0.1 2022-02-14"	/* format: major.minor YYYY-MM-DD */
 


### PR DESCRIPTION
I've not added any additional tests to the `jinfochk` and `jauthchk` tools but I think these updates are better to have. I think that I will probably get the tarball check added today but I'm not sure that if I do when it will be.

The `check_common_json_fields()` function has had its definition updated so that each tool can keep a log of problems to report at the end if quiet mode is not set. Note that this function does not yet add anything to the structs and some of it will very possibly change but this will take a bit more thought and time.

There were some typo fixes as well. I also actually thought of an additional test for `jinfochk` but I'll note that on that issue - in a few minutes I should expect (though I have to open the file again to make sure I am saying it right).