### PR TITLE
Minor updates and fixes

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -451,7 +451,7 @@ check_author_json(char const *file, char const *fnamchk)
 		 */
 	    }
 	    /* handle regular field */
-	    if (check_common_json_fields(program_basename, file, NULL, &author, fnamchk, p, value)) {
+	    if (check_common_json_fields(program_basename, file, &author.common, fnamchk, p, value)) {
 	    } else {
 		/* TODO: after everything else is parsed if we get here it's an
 		 * error as there's invalid fields in the file.

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -462,7 +462,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    }
 	    value_length = strlen(value);
 	    /* handle regular field */
-	    if (check_common_json_fields(program_basename, file, &info, NULL, fnamchk, p, value)) {
+	    if (check_common_json_fields(program_basename, file, &info.common, fnamchk, p, value)) {
 	    } else if (!strcmp(p, "title")) {
 		if (value_length == 0) {
 		    err(22, __func__, "title length zero");

--- a/json.c
+++ b/json.c
@@ -1673,6 +1673,8 @@ json_filename(int type)
  *
  *	name	- which util called this (jinfochk or jauthchk)
  *	file	- the file being parsed (path to)
+ *	common	- pointer to struct json_common (in either a struct info or
+ *		  struct author)
  *	fnamchk	- path to fnamchk util
  *	field	- the field name
  *	value	- the value of the field
@@ -1683,8 +1685,8 @@ json_filename(int type)
  *
  * Does not return on error (NULL pointers).
  */
-int check_common_json_fields(char const *program, char const *file, struct info *infop,
-	struct author *authorp, char const *fnamchk, char *field, char *value)
+int check_common_json_fields(char const *program, char const *file, struct json_common *common,
+	char const *fnamchk, char *field, char *value)
 {
     int ret = 1;
     int year = 0;
@@ -1697,8 +1699,7 @@ int check_common_json_fields(char const *program, char const *file, struct info 
     /*
      * firewall
      */
-    if (program == NULL || file == NULL || fnamchk == NULL || field == NULL || value == NULL ||
-	(!strcmp(program, "jinfochk") && infop == NULL) || (!strcmp(program, "jauthchk") && authorp == NULL)) {
+    if (program == NULL || file == NULL || fnamchk == NULL || field == NULL || value == NULL || common == NULL) {
 	err(218, __func__, "passed NULL arg(s)");
 	not_reached();
     }

--- a/json.c
+++ b/json.c
@@ -1848,17 +1848,17 @@ free_info(struct info *infop)
     /*
      * free version values
      */
-    if (infop->mkiocccentry_ver != NULL) {
-	free(infop->mkiocccentry_ver);
-	infop->mkiocccentry_ver = NULL;
+    if (infop->common.mkiocccentry_ver != NULL) {
+	free(infop->common.mkiocccentry_ver);
+	infop->common.mkiocccentry_ver = NULL;
     }
 
     /*
      * free entry values
      */
-    if (infop->ioccc_id != NULL) {
-	free(infop->ioccc_id);
-	infop->ioccc_id = NULL;
+    if (infop->common.ioccc_id != NULL) {
+	free(infop->common.ioccc_id);
+	infop->common.ioccc_id = NULL;
     }
     if (infop->title != NULL) {
 	free(infop->title);
@@ -1895,21 +1895,21 @@ free_info(struct info *infop)
 	infop->extra_file = NULL;
     }
 
-    if (infop->tarball != NULL) {
-	free(infop->tarball);
-	infop->tarball = NULL;
+    if (infop->common.tarball != NULL) {
+	free(infop->common.tarball);
+	infop->common.tarball = NULL;
     }
 
     /*
      * free time values
      */
-    if (infop->epoch != NULL) {
-	free(infop->epoch);
-	infop->epoch = NULL;
+    if (infop->common.epoch != NULL) {
+	free(infop->common.epoch);
+	infop->common.epoch = NULL;
     }
-    if (infop->utctime != NULL) {
-	free(infop->utctime);
-	infop->utctime = NULL;
+    if (infop->common.utctime != NULL) {
+	free(infop->common.utctime);
+	infop->common.utctime = NULL;
     }
     memset(infop, 0, sizeof *infop);
 

--- a/json.c
+++ b/json.c
@@ -1651,17 +1651,19 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
 char const *
 json_filename(int type)
 {
+    char const *name = INVALID_JSON_FILENAME; /* "null" */
+
     switch (type) {
 	case INFO_JSON:
-	    return ".info.json";
+	    return INFO_JSON_FILENAME; /* ".info.json" */
 	    break; /* in case the return is ever removed */
 	case AUTHOR_JSON:
-	    return ".author.json";
+	    return AUTHOR_JSON_FILENAME; /* ".author.json" */
 	    break; /* in case the return is ever removed */
 	default:
-	    return "null";
 	    break; /* in case the return is ever removed */
     }
+    return name;
 }
 
 

--- a/json.h
+++ b/json.h
@@ -158,7 +158,7 @@ extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern char const *json_filename(int type);
-extern int check_common_json_fields(char const *program, char const *file, struct info *infop, struct author *authorp, char const *fnamchk, char *field, char *value);
+extern int check_common_json_fields(char const *program, char const *file, struct json_common *common, char const *fnamchk, char *field, char *value);
 extern void free_info(struct info *infop);
 extern void free_author_array(struct author *authorp, int author_count);
 

--- a/json.h
+++ b/json.h
@@ -49,9 +49,16 @@
 #define MAX_BYTE (0xff)		    /* maximum byte value */
 #define BYTE_VALUES (MAX_BYTE+1)    /* number of different combinations of bytes */
 
+/*
+ * the next five are for the json_filename() function
+ */
 #define INFO_JSON	(0)	    /* file is assumed to be a .info.json file */
 #define AUTHOR_JSON	(1)	    /* file is assumed to be a .author.json file */
-#define FORMED_UTC_FMT "%a %b %d %H:%M:%S %Y UTC"
+#define INFO_JSON_FILENAME ".info.json"
+#define AUTHOR_JSON_FILENAME ".author.json"
+#define INVALID_JSON_FILENAME "null"
+
+#define FORMED_UTC_FMT "%a %b %d %H:%M:%S %Y UTC"   /* format for strptime() of formed_UTC */
 
 /*
  * common json fields

--- a/json.h
+++ b/json.h
@@ -52,6 +52,33 @@
 #define INFO_JSON	(0)	    /* file is assumed to be a .info.json file */
 #define AUTHOR_JSON	(1)	    /* file is assumed to be a .author.json file */
 #define FORMED_UTC_FMT "%a %b %d %H:%M:%S %Y UTC"
+
+/*
+ * common json fields
+ */
+struct json_common
+{
+    /*
+     * version
+     */
+    char *mkiocccentry_ver;	/* mkiocccentry version (MKIOCCCENTRY_VERSION) */
+    char const *iocccsize_ver;	/* iocccsize version (compiled in, same as iocccsize -V) */
+    /*
+     * entry
+     */
+    char *ioccc_id;		/* IOCCC contest ID */
+    int entry_num;		/* IOCCC entry number */
+    char *tarball;		/* tarball filename */
+
+    /*
+     * time
+     */
+    time_t tstamp;		/* seconds since epoch when .info json was formed (see gettimeofday(2)) */
+    int usec;			/* microseconds since the tstamp second */
+    char *epoch;		/* epoch of tstamp, currently: Thu Jan 1 00:00:00 1970 UTC */
+    char *utctime;		/* UTC converted string for tstamp (see strftime(3)) */
+};
+
 /*
  * author info
  */
@@ -65,13 +92,12 @@ struct author {
     char *github;		/* author GitHub username or or empty string ==> not provided */
     char *affiliation;		/* author affiliation or or empty string ==> not provided */
     char *winner_handle;	/* previous IOCCC winner handle, or empty string ==> not provided */
-    char *tarball;		/* tarball path; XXX this is _ONLY allocated in jauthchk_; mkiocccentry uses the copy in struct info! */
     int author_num;		/* author number */
 
+    struct json_common common;	/* fields that are common to this struct author and struct info (below) */
     /* jauthchk specific */
     unsigned issues;		/* number of issues found in file (for jauthchk) */
 };
-
 
 /*
  * info for JSON
@@ -80,15 +106,8 @@ struct author {
  */
 struct info {
     /*
-     * version
-     */
-    char *mkiocccentry_ver;	/* mkiocccentry version (MKIOCCCENTRY_VERSION) */
-    char const *iocccsize_ver;	/* iocccsize version (compiled in, same as iocccsize -V) */
-    /*
      * entry
      */
-    char *ioccc_id;		/* IOCCC contest ID */
-    int entry_num;		/* IOCCC entry number */
     char *title;		/* entry title */
     char *abstract;		/* entry abstract */
     off_t rule_2a_size;		/* Rule 2a size of prog.c */
@@ -108,7 +127,6 @@ struct info {
     bool found_clean_rule;	/* true ==> Makefile has clean rule */
     bool found_clobber_rule;	/* true ==> Makefile has a clobber rule */
     bool found_try_rule;	/* true ==> Makefile has a try rule */
-    unsigned answers_errors;	/* > 0 ==> output errors on answers file */
     /*
      * filenames
      */
@@ -117,14 +135,11 @@ struct info {
     char *remarks_md;		/* remarks.md filename */
     int extra_count;		/* number of extra files */
     char **extra_file;		/* list of extra filenames followed by NULL */
-    char *tarball;		/* tarball filename */
     /*
      * time
      */
-    time_t tstamp;		/* seconds since epoch when .info json was formed (see gettimeofday(2)) */
-    int usec;			/* microseconds since the tstamp second */
-    char *epoch;		/* epoch of tstamp, currently: Thu Jan 1 00:00:00 1970 UTC */
-    char *utctime;		/* UTC converted string for tstamp (see strftime(3)) */
+
+    struct json_common common;	/* fields that are common to this struct info and struct author (above) */
 
     /* jinfochk specific */
     unsigned issues;		/* number of issues found in file (for jinfochk) */

--- a/mkiocccentry-test.sh
+++ b/mkiocccentry-test.sh
@@ -103,7 +103,7 @@ answers >>answers.txt
 yes | ./mkiocccentry -i answers.txt -- "${work_dir}" "${src_dir}"/{prog.c,Makefile,remarks.md,extra1,extra2}
 status=$?
 if [[ ${status} -ne 0 ]]; then
-    echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
+    echo "$0: FATAL: mkiocccentry non-zero exit code: $status" 1>&2
     exit "${status}"
 fi
 
@@ -113,7 +113,7 @@ find "${work_dir_esc}" -mindepth 1 -depth -delete
 yes | ./mkiocccentry -W -i answers.txt -- "${work_dir}" "${src_dir}"/{empty.c,Makefile,remarks.md,extra1,extra2}
 status=$?
 if [[ ${status} -ne 0 ]]; then
-    echo "$0: FATAL: /mkiocccentry non-zero exit code: $status" 1>&2
+    echo "$0: FATAL: mkiocccentry non-zero exit code: $status" 1>&2
     exit "${status}"
 fi
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -412,6 +412,7 @@ main(int argc, char *argv[])
         ret = fprintf(answerp, "%s\n", MKIOCCCENTRY_ANSWERS_VERSION);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing header to the answers file");
+	    ++answers_errors;
 	}
     }
 
@@ -423,11 +424,13 @@ main(int argc, char *argv[])
         ret = fprintf(answerp, "%s\n", info.common.ioccc_id);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing IOCCC contest id to the answers file");
+	    ++answers_errors;
 	}
 	errno = 0;			/* pre-clear errno for warnp() */
 	ret = fprintf(answerp, "%d\n", info.common.entry_num);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing entry number to the answers file");
+	    ++answers_errors;
 	}
     }
 
@@ -469,6 +472,7 @@ main(int argc, char *argv[])
 	ret = fprintf(answerp, "%s\n", info.title);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing title to the answers file");
+	    ++answers_errors;
 	}
     }
 
@@ -482,6 +486,7 @@ main(int argc, char *argv[])
 	ret = fprintf(answerp, "%s\n", info.abstract);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing abstract to the answers file");
+	    ++answers_errors;
 	}
     }
 
@@ -499,7 +504,7 @@ main(int argc, char *argv[])
         ret = fprintf(answerp, "%d\n", author_count);
 	if (ret <= 0) {
 	    warnp(__func__, "fprintf error printing IOCCC author count to the answers file");
-	    answers_errors++;
+	    ++answers_errors;
 	}
 
 	/*
@@ -518,7 +523,7 @@ main(int argc, char *argv[])
 		author_set[i].affiliation);
 	    if (ret <= 0) {
 		warnp(__func__, "fprintf error printing author info the answers file");
-		answers_errors++;
+		++answers_errors;
 	    }
 	}
     }
@@ -538,8 +543,9 @@ main(int argc, char *argv[])
     para("... completed .author.json file.", "", NULL);
 
     /*
-     * finalize the answers file, writing final answers (if writing answers) and
-     * then closing the stream.
+     * finalize the answers file: either write the final answers (if writing
+     * answers) or read the answers EOF marker and then finally closing the
+     * stream.
      */
     if (answerp != NULL) {
 	if (read_answers_flag_used) {
@@ -561,14 +567,14 @@ main(int argc, char *argv[])
 	    ret = fprintf(answerp, "%s\n", MKIOCCCENTRY_ANSWERS_EOF);
 	    if (ret <= 0) {
 	        warnp(__func__, "fprintf error writing ANSWERS_EOF marker to the answers file");
-		answers_errors++;
+		++answers_errors;
 	    }
 	}
 	if (answers != NULL) {
 	    ret = fclose(answerp);
 	    if (ret != 0) {
 	        warnp(__func__, "error in fclose to the answers file");
-	        answers_errors++;
+		++answers_errors;
 	    }
 	}
 	answerp = NULL;

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -158,9 +158,10 @@ static const char * const usage_msg4 =
 int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
 static bool need_confirm = true;	/* true ==> ask for confirmations */
 static bool need_hints = true;		/* true ==> show hints */
-static bool need_retry = true;
+static bool need_retry = true;		/* true ==> re-prompt for input on error */
 static bool ignore_warnings = false;	/* true ==> ignore all warnings (this does NOT mean the judges will! :) */
-static FILE *input_stream = NULL;
+static FILE *input_stream = NULL;	/* input file: stdin or answers file  */
+static unsigned answers_errors;		/* > 0 ==> output errors on answers file */
 
 
 /*


### PR DESCRIPTION
Move common JSON fields to json_common struct

That is to say that the fields that are written to .info.json and
.author.json are now in a common struct which is in both struct info and
struct author. Please do note that in mkiocccentry.c these still share
memory (or rather the info struct is used): previously in the functions
that refer to author and info structs it referenced e.g. info.ioccc_id
or infop->ioccc_id and the memory was only allocated in the info struct.
Now it's just info.common.ioccc_id or infop->common.ioccc_id instead.
This change is primarily for jinfochk and jauthchk in a future commit.