### PR TITLE
Bug fixes, enhancements and typos

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -452,6 +452,11 @@ check_author_json(char const *file, char const *fnamchk)
 	    }
 	    /* handle regular field */
 	    if (check_common_json_fields(program_basename, file, &author.common, fnamchk, p, value)) {
+	    } else if (!strcmp(p, "IOCCC_author_version")) {
+		if (strcmp(value, AUTHOR_VERSION)) {
+		    err(219, __func__, "IOCCC_author_version \"%s\" != \"%s\" in file %s", value, AUTHOR_VERSION, file);
+		    not_reached();
+		}
 	    } else {
 		/* TODO: after everything else is parsed if we get here it's an
 		 * error as there's invalid fields in the file.

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -88,7 +88,7 @@ static bool test = false;		    /* true ==> issue warnings instead of errors in s
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 static void sanity_chk(char const *file, char const *fnamchk);
-static void check_author_json(char const *file, char const *fnamchk);
+static int check_author_json(char const *file, char const *fnamchk);
 
 
 #endif /* INCLUDE_JAUTHCHK_H */

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -463,6 +463,11 @@ check_info_json(char const *file, char const *fnamchk)
 	    value_length = strlen(value);
 	    /* handle regular field */
 	    if (check_common_json_fields(program_basename, file, &info.common, fnamchk, p, value)) {
+	    } else if (!strcmp(p, "IOCCC_info_version")) {
+		if (strcmp(value, INFO_VERSION)) {
+		    err(219, __func__, "IOCCC_info_version \"%s\" != \"%s\" in file %s", value, INFO_VERSION, file);
+		    not_reached();
+		}
 	    } else if (!strcmp(p, "title")) {
 		if (value_length == 0) {
 		    err(22, __func__, "title length zero");

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -86,7 +86,6 @@ static bool test = false;		    /* true ==> issue warnings instead of errors in s
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 static void sanity_chk(char const *file, char const *fnamchk);
-static void check_info_json(char const *file, char const *fnamchk);
-
+static int check_info_json(char const *file, char const *fnamchk);
 
 #endif /* INCLUDE_JINFOCHK_H */

--- a/json.c
+++ b/json.c
@@ -1716,12 +1716,7 @@ check_common_json_fields(char const *program, char const *file, struct json_comm
     /*
      * process a given common field
      */
-    if (!strcmp(field, "IOCCC_info_version")) {
-	if (strcmp(value, INFO_VERSION)) {
-	    err(219, __func__, "IOCCC_info_version \"%s\" != \"%s\" in file %s", value, INFO_VERSION, file);
-	    not_reached();
-	}
-    } else if (!strcmp(field, "ioccc_contest")) {
+    if (!strcmp(field, "ioccc_contest")) {
 	if (strcmp(value, IOCCC_CONTEST)) {
 	    err(220, __func__, "ioccc_contest \"%s\" != \"%s\" in file %s", value, IOCCC_CONTEST, file);
 	    not_reached();

--- a/json.h
+++ b/json.h
@@ -60,6 +60,18 @@
 
 #define FORMED_UTC_FMT "%a %b %d %H:%M:%S %Y UTC"   /* format for strptime() of formed_UTC */
 
+struct json_field
+{
+    char *field;
+    char *value;
+
+    size_t count;
+
+    struct json_field *next;
+};
+
+struct json_field *common_json_fields;
+
 /*
  * common json fields
  */
@@ -165,9 +177,11 @@ extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern char const *json_filename(int type);
-extern int check_common_json_fields(char const *program, char const *file, struct json_common *common, char const *fnamchk, char *field, char *value);
+extern int get_common_json_field(char const *program, char const *file, char *field, char *value);
+extern int check_common_json_fields(char const *program, char const *file, char const *fnamchk);
 extern void free_info(struct info *infop);
+extern void free_common_json_fields(void);
 extern void free_author_array(struct author *authorp, int author_count);
-
+extern struct json_field *add_common_json_field(char const *field, char const *value);
 
 #endif /* INCLUDE_JSON_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1222,9 +1222,9 @@ sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const
     jencchk();
 
     /*
-     * obtain version string from iocccsize_version
+     * obtain version string from IOCCCSIZE_VERSION
      */
-    infop->common.iocccsize_ver = iocccsize_version;
+    infop->common.iocccsize_ver = IOCCCSIZE_VERSION;
     return;
 }
 

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -87,6 +87,10 @@
  */
 #include "iocccsize.h"
 
+/*
+ * official versions
+ */
+#include "version.h"
 
 /*
  * definitions

--- a/util.c
+++ b/util.c
@@ -973,11 +973,11 @@ cmdprintf(char const *format, ...)
  *	malloced shell command line, or
  *	NULL ==> error
  *
- * NOTE: This coded is base on an enhancement request by GitHub user @ilyakurdyukov:
+ * NOTE: This code is based on an enhancement request by GitHub user @ilyakurdyukov:
  *
  *		https://github.com/ioccc-src/mkiocccentry/issues/11
  *
- *	 and this function code was writen by him.  Thank you Ilya Kurdyukov!
+ *	 and this function code was written by him.  Thank you Ilya Kurdyukov!
  */
 char *
 vcmdprintf(char const *format, va_list ap)
@@ -1323,7 +1323,7 @@ shell_cmd(char const *name, bool abort, char const *format, ...)
  * given:
  *	name	- name of the calling function
  *	abort	- false ==> return FILE * stream for open pipe to shell, or
- *			    return NULL on falure
+ *			    return NULL on failure
  *		  true ==> return FILE * stream for open pipe to shell, or
  *			   call errp() (and thus exit) if unsuccessful
  *      format	- The format string, any % on this string inserts the next string from the list,


### PR DESCRIPTION
With commit abea8068f4f `mkiocccentry` no longer fails; the problem was with the way the `iocccsize_ver` variable was being assigned after the update to the `IOCCCSIZE_VERSION`. See the commit log for more details on this.

There were two typos in `util.c` as well. 

In a bit I hope to add some more changes though they might be minor too.