### PR TITLE
Complete all common json fields checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ For more information and examples, try:
 	    man ./jinfochk.1
 
 
+NOTE: This tool is currently unfinished.
+
+
 ##  jauthchk
 
 The official **IOCCC** .author.json sanity checker tool.
@@ -68,4 +71,4 @@ For more information and examples, try:
 	    man ./jauthchk.1
 
 
-
+NOTE: This tool is currently unfinished.

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -497,7 +497,7 @@ check_author_json(char const *file, char const *fnamchk)
 	for (value = field->values; value != NULL; value = value->next) {
 	    char const *v = value->value;
 	    if (!strcmp(field->name, "IOCCC_author_version")) {
-		if (strcmp(v, AUTHOR_VERSION)) {
+		if (!test && strcmp(v, AUTHOR_VERSION)) {
 		    warn(__func__, "IOCCC_author_version \"%s\" != \"%s\" in file %s", v, AUTHOR_VERSION, file);
 		    ++issues;
 		}
@@ -519,7 +519,7 @@ check_author_json(char const *file, char const *fnamchk)
     free_found_author_json_fields();
 
     /* check common json fields which will update the number of issues */
-    issues += check_found_common_json_fields(program_basename, file, fnamchk);
+    issues += check_found_common_json_fields(program_basename, file, fnamchk, test);
 
     /* free the found_common_json_fields list.
      *

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -576,7 +576,10 @@ add_found_author_json_field(char const *name, char const *val)
 		err(24, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
-	    return field; /* already in the list: just return it after adding the new value */
+
+	    field->count++; /* update count */
+
+	    return field; /* already in the list: just return it after incrementing the count and adding the new value */
 	}
     }
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -503,7 +503,7 @@ check_author_json(char const *file, char const *fnamchk)
 		}
 	    } else {
 		/* TODO: after everything else is parsed if we get here it's an
-		 * error as there's invalid fields in the file.
+		 * error as there's an invalid field in the file.
 		 *
 		 * Currently (as of 25 February 2022) this is not done
 		 * because the arrays are not parsed yet.

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -81,7 +81,7 @@ char *program_basename = NULL;			/* our basename */
 static bool quiet = false;			/* true ==> quiet mode */
 struct author author;			/* the .author.json struct */
 static bool strict = false;			/* true ==> disallow anything before/after the '{' and '}' */
-static bool test = false;			/* true ==> issue warnings instead of errors in some cases (N.B.: not yet used) */
+static bool test = false;			/* true ==> some tests are not performed */
 static struct json_field *found_author_json_fields;	/* list of fields specific to .author.json found */
 /*
  * forward declarations

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -89,7 +89,7 @@ static struct json_field *found_author_json_fields;	/* list of fields specific t
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 static void sanity_chk(char const *file, char const *fnamchk);
 static int check_author_json(char const *file, char const *fnamchk);
-static struct json_field *add_found_author_json_field(char const *name, char const *value);
+static struct json_field *add_found_author_json_field(char const *name, char const *val);
 static void free_found_author_json_fields(void);
 
 #endif /* INCLUDE_JAUTHCHK_H */

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -510,7 +510,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    val_length = strlen(v);
 
 	    if (!strcmp(field->name, "IOCCC_info_version")) {
-		if (strcmp(v, INFO_VERSION)) {
+		if (!test && strcmp(v, INFO_VERSION)) {
 		    warn(__func__, "IOCCC_info_version \"%s\" != \"%s\" in file %s", v, INFO_VERSION, file);
 		    ++issues;
 		}
@@ -579,7 +579,7 @@ check_info_json(char const *file, char const *fnamchk)
      */
     free_found_info_json_fields();
 
-    issues += check_found_common_json_fields(program_basename, file, fnamchk);
+    issues += check_found_common_json_fields(program_basename, file, fnamchk, test);
 
     /* free the found_common_json_fields list.
      *

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -563,7 +563,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    }
 	    else {
 		/* TODO: after everything else is parsed if we get here it's an
-		 * error as there's invalid fields in the file.
+		 * error as there's an invalid field in the file.
 		 *
 		 * Currently (as of 25 February 2022) this is not done
 		 * because the arrays are not parsed yet.
@@ -624,7 +624,7 @@ add_found_info_json_field(char const *name, char const *val)
     for (field = found_info_json_fields; field; field = field->next) {
 	if (field->name && !strcmp(field->name, name)) {
 	    /*
-	     * we found a field already in the list, add the value (even if this
+	     * we found a field already in the list: add the value (even if this
 	     * value was already in the list as this might need to be reported).
 	     */
 	    value = add_json_value(field, val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -636,7 +636,10 @@ add_found_info_json_field(char const *name, char const *val)
 		err(24, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
-	    return field; /* already in the list: just return it after adding the new value */
+
+	    field->count++; /* update count */
+
+	    return field; /* already in the list: just return it after incrementing the count and adding the new value */
 	}
     }
 

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -88,7 +88,7 @@ static struct json_field *found_info_json_fields; /* list of fields specific to 
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 static void sanity_chk(char const *file, char const *fnamchk);
 static int check_info_json(char const *file, char const *fnamchk);
-static struct json_field *add_found_info_json_field(char const *name, char const *value);
+static struct json_field *add_found_info_json_field(char const *name, char const *val);
 static void free_found_info_json_fields(void);
 
 #endif /* INCLUDE_JINFOCHK_H */

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -79,8 +79,9 @@ char *program_basename = NULL;		    /* our basename */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct info info;		    /* .info.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' in the file */
-static bool test = false;		    /* true ==> issue warnings instead of errors in some cases (N.B.: not yet used) */
+static bool test = false;		    /* true ==> some tests are not performed */
 static struct json_field *found_info_json_fields; /* list of fields specific to .info.json that have been found */
+extern struct json_field info_json_fields[];
 
 /*
  * forward declarations

--- a/json.c
+++ b/json.c
@@ -1674,10 +1674,10 @@ json_filename(int type)
  *
  * given:
  *
- *	name	- which util called this (jinfochk or jauthchk)
+ *	program	- which util called this (jinfochk or jauthchk)
  *	file	- the file being parsed (path to)
- *	field	- the field name
- *	value	- the value of the field
+ *	name	- the field name
+ *	val	- the value of the field
  *
  * returns:
  *	1 ==> if the field is common to both files
@@ -1686,14 +1686,14 @@ json_filename(int type)
  * NOTE: Does not return on error (NULL pointers).
  */
 int
-get_common_json_field(char const *program, char const *file, char *field, char *value)
+get_common_json_field(char const *program, char const *file, char *name, char *val)
 {
     int ret = 1;	/* return value: 1 ==> known field, 0 ==> not a common field */
 
     /*
      * firewall
      */
-    if (program == NULL || file == NULL || field == NULL || value == NULL) {
+    if (program == NULL || file == NULL || name == NULL || val == NULL) {
 	err(218, __func__, "passed NULL arg(s)");
 	not_reached();
     }
@@ -1701,13 +1701,13 @@ get_common_json_field(char const *program, char const *file, char *field, char *
     /*
      * process a given common field
      */
-    if (!strcmp(field, "ioccc_contest") || !strcmp(field, "ioccc_year") ||
-	!strcmp(field, "mkiocccentry_version") || !strcmp(field, "iocccsize_version") ||
-	!strcmp(field, "IOCCC_contest_id") || !strcmp(field, "min_timestamp") ||
-	!strcmp(field, "timestamp_epoch") || !strcmp(field, "formed_timestamp_usec") ||
-	!strcmp(field, "entry_num") || !strcmp(field, "formed_UTC") ||
-	!strcmp(field, "formed_timestamp") || !strcmp(field, "tarball")) {
-	    add_common_json_field(field, value);
+    if (!strcmp(name, "ioccc_contest") || !strcmp(name, "ioccc_year") ||
+	!strcmp(name, "mkiocccentry_version") || !strcmp(name, "iocccsize_version") ||
+	!strcmp(name, "IOCCC_contest_id") || !strcmp(name, "min_timestamp") ||
+	!strcmp(name, "timestamp_epoch") || !strcmp(name, "formed_timestamp_usec") ||
+	!strcmp(name, "entry_num") || !strcmp(name, "formed_UTC") ||
+	!strcmp(name, "formed_timestamp") || !strcmp(name, "tarball")) {
+	    add_found_common_json_field(name, val);
     } else {
 	ret = 0;
     }
@@ -1720,7 +1720,7 @@ get_common_json_field(char const *program, char const *file, char *field, char *
  *
  * given:
  *
- *	name	- which util called this (jinfochk or jauthchk)
+ *	program	- which util called this (jinfochk or jauthchk)
  *	file	- the file being parsed (path to)
  *	fnamchk	- path to fnamchk util
  *
@@ -1761,66 +1761,66 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * process a given common field
 	 */
 	for (value = field->values; value != NULL; value = value->next) {
-	    char *v = value->value;
+	    char *val = value->value;
 
 	    if (!strcmp(field->name, "ioccc_contest")) {
-		if (strcmp(v, IOCCC_CONTEST)) {
-		    warn(__func__, "ioccc_contest \"%s\" != \"%s\" in file %s", v, IOCCC_CONTEST, file);
+		if (strcmp(val, IOCCC_CONTEST)) {
+		    warn(__func__, "ioccc_contest \"%s\" != \"%s\" in file %s", val, IOCCC_CONTEST, file);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "ioccc_year")) {
-		year = string_to_int(v);
+		year = string_to_int(val);
 		if (year != IOCCC_YEAR) {
 		    warn(__func__, "ioccc_year %d != IOCCC_YEAR %d", year, IOCCC_YEAR);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "mkiocccentry_version")) {
-		if (strcmp(v, MKIOCCCENTRY_VERSION)) {
-		    warn(__func__, "mkiocccentry_version \"%s\" != MKIOCCCENTRY_VERSION \"%s\"", v, MKIOCCCENTRY_VERSION);
+		if (strcmp(val, MKIOCCCENTRY_VERSION)) {
+		    warn(__func__, "mkiocccentry_version \"%s\" != MKIOCCCENTRY_VERSION \"%s\"", val, MKIOCCCENTRY_VERSION);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "iocccsize_version")) {
-		if (strcmp(v, IOCCCSIZE_VERSION)) {
-		    warn(__func__, "iocccsize_version \"%s\" != IOCCCSIZE_VERSION \"%s\"", v, IOCCCSIZE_VERSION);
+		if (strcmp(val, IOCCCSIZE_VERSION)) {
+		    warn(__func__, "iocccsize_version \"%s\" != IOCCCSIZE_VERSION \"%s\"", val, IOCCCSIZE_VERSION);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "IOCCC_contest_id")) {
-		if (!valid_contest_id(v)) {
-		    warn(__func__, "IOCCC_contest_id \"%s\" is invalid", v);
+		if (!valid_contest_id(val)) {
+		    warn(__func__, "IOCCC_contest_id \"%s\" is invalid", val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "min_timestamp")) {
-		ts = string_to_long(v);
+		ts = string_to_long(val);
 		if (ts != MIN_TIMESTAMP) {
 		    warn(__func__, "min_timestamp '%ld' != MIN_TIMESTAMP '%ld'", ts, MIN_TIMESTAMP);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "timestamp_epoch")) {
-		if (strcmp(v, TIMESTAMP_EPOCH)) {
-		    warn(__func__, "timestamp_epoch \"%s\" != TIMESTAMP_EPOCH \"%s\"", v, TIMESTAMP_EPOCH);
+		if (strcmp(val, TIMESTAMP_EPOCH)) {
+		    warn(__func__, "timestamp_epoch \"%s\" != TIMESTAMP_EPOCH \"%s\"", val, TIMESTAMP_EPOCH);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_timestamp_usec")) {
 		errno = 0;
-		ts = string_to_long(v);
+		ts = string_to_long(val);
 		if (ts < 0 || ts > 999999) {
 		    warnp(__func__, "formed_timestamp_usec '%ld' out of range of >= 0 && <= 999999", ts);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "entry_num")) {
-		entry_num = string_to_int(v);
+		entry_num = string_to_int(val);
 		if (!(entry_num >= 0 && entry_num <= MAX_ENTRY_NUM)) {
 		    warn(__func__, "entry number %d out of range", entry_num);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_UTC")) {
-		p = strptime(v, FORMED_UTC_FMT, &tm);
+		p = strptime(val, FORMED_UTC_FMT, &tm);
 		if (p == NULL) {
-		    warn(__func__, "formed_UTC \"%s\" does not match FORMED_UTC_FMT \"%s\"", v, FORMED_UTC_FMT);
+		    warn(__func__, "formed_UTC \"%s\" does not match FORMED_UTC_FMT \"%s\"", val, FORMED_UTC_FMT);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_timestamp")) {
-		ts = string_to_long(v);
+		ts = string_to_long(val);
 		if (ts < MIN_TIMESTAMP) {
 		    warn(__func__, "formed_timestamp '%ld' < MIN_TIMESTAMP '%ld'", ts, MIN_TIMESTAMP);
 		    ++issues;
@@ -1830,10 +1830,10 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		/*
 		 * execute the fnamchk command
 		 */
-		exit_code = shell_cmd(__func__, true, "% % >/dev/null", fnamchk, v);
+		exit_code = shell_cmd(__func__, true, "% % >/dev/null", fnamchk, val);
 		if (exit_code != 0) {
 		    warn(__func__, "%s: %s %s > /dev/null: failed with exit code: %d",
-					program, fnamchk, v, WEXITSTATUS(exit_code));
+					program, fnamchk, val, WEXITSTATUS(exit_code));
 		    ++issues;
 		}
 
@@ -1847,13 +1847,13 @@ check_found_common_json_fields(char const *program, char const *file, char const
     return issues;
 }
 
-/* add_common_json_field   - add a common json field to found_common_json_fields list
+/* add_found_common_json_field   - add a common json field to found_common_json_fields list
  *
  *
  * given:
  *
  *	name	    - name of the field
- *	value	    - value of the field
+ *	val	    - value of the field
  *
  * Allocates a struct json_field * and add it to the json_common_fields list.
  * This will be used for reporting errors after parsing the file as well as
@@ -1865,14 +1865,14 @@ check_found_common_json_fields(char const *program, char const *file, char const
  *
  */
 struct json_field *
-add_common_json_field(char const *name, char const *value)
+add_found_common_json_field(char const *name, char const *val)
 {
     struct json_field *f; /* newly allocated field */
 
     /*
      * firewall
      */
-    if (name == NULL || value == NULL) {
+    if (name == NULL || val == NULL) {
 	err(220, __func__, "passed NULL arg(s)");
 	not_reached();
     }
@@ -1880,42 +1880,26 @@ add_common_json_field(char const *name, char const *value)
     for (f = found_common_json_fields; f != NULL; f = f->next) {
 	if (f->name && !strcmp(f->name, name)) {
 	    f->count++;
-	    if (add_json_value(f, value) == NULL) {
-		err(221, __func__, "couldn't add value '%s' to field '%s'", value, f->name);
+	    if (add_json_value(f, val) == NULL) {
+		err(221, __func__, "couldn't add value '%s' to field '%s'", val, f->name);
 		not_reached();
 	    }
 	    return f;
 	}
     }
 
+    f = new_json_field(name, val);
     if (f == NULL) {
-	/* if we did NOT find it in the list, we have to allocate a new struct */
-	errno = 0;
-	f = calloc(1, sizeof *f);
-	if (f == NULL) {
-	    errp(222, __func__, "unable to calloc struct json_field * for field '%s' with value '%s'", name, value);
-	    not_reached();
-	}
-	/* now that we have a struct json_field * we can strdup() the field name */
-	errno = 0;
-	f->name = strdup(name);
-	if (f->name == NULL) {
-	    errp(223, __func__, "unable to strdup field '%s'", name);
-	    not_reached();
-	}
-    }
-
-    /* now let's add a new value to the field's list of values */
-    if (add_json_value(f, value) == NULL) {
-	/* we should never get here but just in case */
-	err(224, __func__, "error adding value '%s' to field '%s'", value, name);
+	/* this should NEVER be reached but we check just to be sure */
+	err(222, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
+
     /* add field to found_common_json_fields list */
     f->next = found_common_json_fields;
     found_common_json_fields = f;
 
-    dbg(DBG_VHIGH, "added field '%s' value '%s' to found_common_json_fields", f->name, value);
+    dbg(DBG_VHIGH, "added field '%s' value '%s' to found_common_json_fields", f->name, val);
     return f;
 }
 
@@ -1924,7 +1908,7 @@ add_common_json_field(char const *name, char const *value)
  * given:
  *
  *	name	    - the field name
- *	value	    - the field's value
+ *	val	    - the field's value
  *
  * Returns the newly allocated struct json_field *.
  *
@@ -1934,35 +1918,34 @@ add_common_json_field(char const *name, char const *value)
  *
  */
 struct json_field *
-new_json_field(char const *name, char const *value)
+new_json_field(char const *name, char const *val)
 {
     struct json_field *field; /* the new field */
 
     /*
      * firewall
      */
-    if (name == NULL || value == NULL) {
-	err(225, __func__, "passed NULL arg(s)");
+    if (name == NULL || val == NULL) {
+	err(223, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	err(226, __func__, "error allocating new struct json_field * for field '%s' and value '%s'", name, value);
+	err(224, __func__, "error allocating new struct json_field * for field '%s' and value '%s'", name, val);
 	not_reached();
     }
-
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	err(227, __func__, "unable to strdup() field name '%s'", name);
+	err(225, __func__, "unable to strdup() field name '%s'", name);
 	not_reached();
     }
 
-    if (add_json_value(field, value) == NULL) {
-	err(228, __func__, "error adding value '%s' to field '%s'", value, name);
+    if (add_json_value(field, val) == NULL) {
+	err(226, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
     return field;
@@ -1981,24 +1964,23 @@ new_json_field(char const *name, char const *value)
 void
 free_json_field(struct json_field *field)
 {
-    struct json_value *value, *next_value; /* to free the values of the field */
-
     /*
      * firewall
      */
     if (field == NULL) {
-	err(229, __func__, "passed NULL field");
+	err(227, __func__, "passed NULL field");
 	not_reached();
     }
-    for (value = field->values; value != NULL; value = next_value) {
-	next_value = value->next;
 
-	if (value->value != NULL) {
-	    free(value->value);
-	    value->value = NULL;
-	}
-	value = NULL;
+    /* free the field's values list */
+    free_json_field_values(field);
+    field->values = NULL; /* redundant but for safety */
+
+    if (field->name) {
+	free(field->name);
+	field->name = NULL;
     }
+
     free(field);
     field = NULL;
 }
@@ -2008,7 +1990,7 @@ free_json_field(struct json_field *field)
  * given:
  *
  *	field		- the field to add to
- *	str		- the value to add
+ *	val		- the value to add
  *
  * This function returns the newly allocated struct json_value * with the value
  * strdup()d and added to the struct json_field * values list.
@@ -2017,7 +1999,7 @@ free_json_field(struct json_field *field)
  *
  */
 struct json_value *
-add_json_value(struct json_field *field, char const *str)
+add_json_value(struct json_field *field, char const *val)
 {
     struct json_value *new_value = NULL;    /* the newly allocated value */
     struct json_value *value = NULL;	    /* the current list of values in field */
@@ -2025,21 +2007,21 @@ add_json_value(struct json_field *field, char const *str)
     /*
      * firewall
      */
-    if (field == NULL || str == NULL) {
-	err(230, __func__, "passed NULL arg(s)");
+    if (field == NULL || val == NULL) {
+	err(228, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(231, __func__, "error allocating new value '%s' for field '%s'", str, field->name);
+	errp(229, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     errno = 0;
-    new_value->value = strdup(str);
+    new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(232, __func__, "error strdup()ing value '%s' for field '%s'", str, field->name);
+	errp(230, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     /* find end of list */
@@ -2054,6 +2036,41 @@ add_json_value(struct json_field *field, char const *str)
     }
     return new_value;
 }
+
+/* free_json_field_values	- free a field's values list
+ *
+ * given:
+ *
+ *	field			- field to free the values list
+ *
+ * Returns void.
+ *
+ * NOTE: This function does not return on error (NULL field passed in).
+ */
+void
+free_json_field_values(struct json_field *field)
+{
+    struct json_value *value, *next_value; /* to free the values of the field */
+
+    /*
+     * firewall
+     */
+    if (field == NULL) {
+	err(231, __func__, "passed NULL field");
+	not_reached();
+    }
+
+    /* free each value */
+    for (value = field->values; value != NULL; value = next_value) {
+	next_value = value->next;
+
+	if (value->value != NULL) {
+	    free(value->value);
+	    value->value = NULL;
+	}
+	value = NULL;
+    }
+}
 /* free_found_common_json_fields  - free the common json fields list
  *
  * This function returns void.
@@ -2063,6 +2080,7 @@ free_found_common_json_fields(void)
 {
     struct json_field *field, *next_field;
 
+
     for (field = found_common_json_fields; field != NULL; field = next_field) {
 	next_field = field->next;
 
@@ -2070,9 +2088,9 @@ free_found_common_json_fields(void)
 	    free(field->name);
 	    field->name = NULL;
 	}
-	if (field->value) {
-	    free(field->value);
-	    field->value = NULL;
+	if (field->values) {
+	    free_json_field_values(field);
+	    field->values = NULL; /* redundant but for safety anyway */
 	}
 	free(field);
 	field = NULL;
@@ -2098,7 +2116,7 @@ free_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(233, __func__, "called with NULL arg(s)");
+	err(232, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2189,11 +2207,11 @@ free_author_array(struct author *author_set, int author_count)
      * firewall
      */
     if (author_set == NULL) {
-	err(234, __func__, "called with NULL arg(s)");
+	err(233, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count < 0) {
-	err(235, __func__, "author_count: %d < 0", author_count);
+	err(234, __func__, "author_count: %d < 0", author_count);
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -1593,7 +1593,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
      * firewall
      */
     if (table == NULL || name == NULL) {
-	err(35, __func__, "passed NULL arg(s)");
+	err(214, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1673,10 +1673,10 @@ check_first_json_char(char const *file, char *data, bool strict, char **first)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(214, __func__, "passed NULL or zero length data");
+	err(215, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || first == NULL) {
-	err(215, __func__, "passed NULL arg(s)");
+	err(216, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1716,10 +1716,10 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(216, __func__, "passed NULL or zero length data");
+	err(217, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || last == NULL) {
-	err(217, __func__, "passed NULL arg(s)");
+	err(218, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1769,13 +1769,13 @@ add_found_common_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(218, __func__, "passed NULL arg(s)");
+	err(219, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(common_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(35, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
+	err(220, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
 	not_reached();
     }
     /*
@@ -1788,7 +1788,7 @@ add_found_common_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    field->count++;
 	    if (add_json_value(field, val) == NULL) {
-		err(219, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
+		err(221, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 	    return field;
@@ -1798,7 +1798,7 @@ add_found_common_json_field(char const *name, char const *val)
     field = new_json_field(name, val);
     if (field == NULL) {
 	/* this should NEVER be reached but we check just to be sure */
-	err(220, __func__, "new_json_field() returned NULL pointer");
+	err(222, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
 
@@ -1839,7 +1839,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
      * firewall
      */
     if (program == NULL || file == NULL || name == NULL || val == NULL) {
-	err(221, __func__, "passed NULL arg(s)");
+	err(223, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1890,7 +1890,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * firewall
      */
     if (program == NULL || file == NULL || fnamchk == NULL) {
-	err(222, __func__, "passed NULL arg(s)");
+	err(224, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1908,7 +1908,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(35, __func__, "found NULL or empty field in found_common_json_fields list");
+	    err(225, __func__, "found NULL or empty field in found_common_json_fields list");
 	    not_reached();
 	}
 
@@ -1923,7 +1923,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * common list is not a common field name.
 	 */
 	if (common_field == NULL) {
-	    err(36, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
+	    err(226, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -2060,26 +2060,26 @@ new_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(223, __func__, "passed NULL arg(s)");
+	err(227, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	err(224, __func__, "error allocating new struct json_field * for field '%s' and value '%s'", name, val);
+	err(228, __func__, "error allocating new struct json_field * for field '%s' and value '%s'", name, val);
 	not_reached();
     }
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	errp(225, __func__, "unable to strdup() field name '%s'", name);
+	errp(229, __func__, "unable to strdup() field name '%s'", name);
 	not_reached();
     }
 
     if (add_json_value(field, val) == NULL) {
-	err(226, __func__, "error adding value '%s' to field '%s'", val, name);
+	err(230, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
 
@@ -2111,20 +2111,20 @@ add_json_value(struct json_field *field, char const *val)
      * firewall
      */
     if (field == NULL || val == NULL) {
-	err(227, __func__, "passed NULL arg(s)");
+	err(231, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(228, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
+	errp(232, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(229, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
+	errp(233, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     /* find end of list */
@@ -2160,7 +2160,7 @@ free_json_field_values(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(230, __func__, "passed NULL field");
+	err(234, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2222,7 +2222,7 @@ free_json_field(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(231, __func__, "passed NULL field");
+	err(235, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2256,7 +2256,7 @@ free_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(232, __func__, "called with NULL arg(s)");
+	err(236, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2347,11 +2347,11 @@ free_author_array(struct author *author_set, int author_count)
      * firewall
      */
     if (author_set == NULL) {
-	err(233, __func__, "called with NULL arg(s)");
+	err(237, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count < 0) {
-	err(234, __func__, "author_count: %d < 0", author_count);
+	err(238, __func__, "author_count: %d < 0", author_count);
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -1685,40 +1685,40 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
 struct json_field *
 add_found_common_json_field(char const *name, char const *val)
 {
-    struct json_field *f; /* newly allocated field */
+    struct json_field *field; /* newly allocated field */
 
     /*
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(220, __func__, "passed NULL arg(s)");
+	err(218, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
-    for (f = found_common_json_fields; f != NULL; f = f->next) {
-	if (f->name && !strcmp(f->name, name)) {
-	    f->count++;
-	    if (add_json_value(f, val) == NULL) {
-		err(221, __func__, "couldn't add value '%s' to field '%s'", val, f->name);
+    for (field = found_common_json_fields; field != NULL; field = field->next) {
+	if (field->name && !strcmp(field->name, name)) {
+	    field->count++;
+	    if (add_json_value(field, val) == NULL) {
+		err(219, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
-	    return f;
+	    return field;
 	}
     }
 
-    f = new_json_field(name, val);
-    if (f == NULL) {
+    field = new_json_field(name, val);
+    if (field == NULL) {
 	/* this should NEVER be reached but we check just to be sure */
-	err(222, __func__, "new_json_field() returned NULL pointer");
+	err(220, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
 
     /* add field to found_common_json_fields list */
-    f->next = found_common_json_fields;
-    found_common_json_fields = f;
+    field->next = found_common_json_fields;
+    found_common_json_fields = field;
 
-    dbg(DBG_VHIGH, "added field '%s' value '%s' to found_common_json_fields", f->name, val);
-    return f;
+    dbg(DBG_VHIGH, "added field '%s' value '%s' to found_common_json_fields", field->name, val);
+    return field;
 }
 
 /*
@@ -1748,7 +1748,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
      * firewall
      */
     if (program == NULL || file == NULL || name == NULL || val == NULL) {
-	err(218, __func__, "passed NULL arg(s)");
+	err(221, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1801,7 +1801,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * firewall
      */
     if (program == NULL || file == NULL || fnamchk == NULL) {
-	err(219, __func__, "passed NULL arg(s)");
+	err(222, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1913,7 +1913,8 @@ check_found_common_json_fields(char const *program, char const *file, char const
  *
  * NOTE: This function does not return on NULL and it does not check any list:
  * as long as no NULL pointers are encountered it will return a newly allocated
- * struct json_field *.
+ * struct json_field *. This means that it is the caller's responsibility to
+ * check if the field is already in the list.
  *
  */
 struct json_field *
@@ -1939,7 +1940,7 @@ new_json_field(char const *name, char const *val)
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	err(225, __func__, "unable to strdup() field name '%s'", name);
+	errp(225, __func__, "unable to strdup() field name '%s'", name);
 	not_reached();
     }
 
@@ -1947,6 +1948,9 @@ new_json_field(char const *name, char const *val)
 	err(226, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
+
+    field->count = 1;
+
     return field;
 }
 
@@ -1973,20 +1977,20 @@ add_json_value(struct json_field *field, char const *val)
      * firewall
      */
     if (field == NULL || val == NULL) {
-	err(228, __func__, "passed NULL arg(s)");
+	err(227, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(229, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
+	errp(228, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(230, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
+	errp(229, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
 	not_reached();
     }
     /* find end of list */
@@ -2022,7 +2026,7 @@ free_json_field_values(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(231, __func__, "passed NULL field");
+	err(230, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2084,7 +2088,7 @@ free_json_field(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(227, __func__, "passed NULL field");
+	err(231, __func__, "passed NULL field");
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -1872,7 +1872,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
  * NOTE: Does not return on error (NULL pointers).
  */
 int
-check_found_common_json_fields(char const *program, char const *file, char const *fnamchk)
+check_found_common_json_fields(char const *program, char const *file, char const *fnamchk, bool test)
 {
     int year = 0;	/* ioccc_year: IOCCC year as an integer */
     int entry_num = -1;	/* entry_num: entry number as an integer */
@@ -1952,12 +1952,12 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "mkiocccentry_version")) {
-		if (strcmp(val, MKIOCCCENTRY_VERSION)) {
+		if (!test && strcmp(val, MKIOCCCENTRY_VERSION)) {
 		    warn(__func__, "mkiocccentry_version \"%s\" != MKIOCCCENTRY_VERSION \"%s\"", val, MKIOCCCENTRY_VERSION);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "iocccsize_version")) {
-		if (strcmp(val, IOCCCSIZE_VERSION)) {
+		if (!test && strcmp(val, IOCCCSIZE_VERSION)) {
 		    warn(__func__, "iocccsize_version \"%s\" != IOCCCSIZE_VERSION \"%s\"", val, IOCCCSIZE_VERSION);
 		    ++issues;
 		}

--- a/json.c
+++ b/json.c
@@ -1576,8 +1576,8 @@ struct json_field common_json_fields[] =
  *
  * XXX The table MUST end with NULL!
  *
- * NOTE: If index != NULL and the name is not found in the table then in the
- * calling function index will be the number of entries in the table. To get the
+ * NOTE: If loc != NULL and the name is not found in the table then in the
+ * calling function loc will be the number of entries in the table. To get the
  * number of entries in the table pass in an empty name ("") as there will never
  * be an empty name in any of the tables.
  *
@@ -1604,10 +1604,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
     for (i = 0; table[i].name != NULL; ++i) {
 	if (!strcmp(table[i].name, name)) {
 	    field = &table[i];
-	    if (loc != NULL) {
-		*loc = i;
-	    }
-	    return field;
+	    break;
 	}
     }
 
@@ -1615,7 +1612,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
 	*loc = i;
     }
 
-    return NULL;
+    return field;
 }
 /*
  * json_filename    - return ".info.json", ".author.json" or "null" depending on type

--- a/json.c
+++ b/json.c
@@ -2064,14 +2064,14 @@ new_json_field(char const *name, char const *val)
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	err(228, __func__, "error allocating new struct json_field * for field '%s' and value '%s'", name, val);
+	errp(228, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
 	not_reached();
     }
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	errp(229, __func__, "unable to strdup() field name '%s'", name);
+	errp(229, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
 	not_reached();
     }
 
@@ -2115,13 +2115,13 @@ add_json_value(struct json_field *field, char const *val)
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(232, __func__, "error allocating new value '%s' for field '%s'", val, field->name);
+	errp(232, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(233, __func__, "error strdup()ing value '%s' for field '%s'", val, field->name);
+	errp(233, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     /* find end of list */

--- a/json.h
+++ b/json.h
@@ -61,7 +61,7 @@
 #define FORMED_UTC_FMT "%a %b %d %H:%M:%S %Y UTC"   /* format for strptime() of formed_UTC */
 
 /*
- * JSON values: a linked list of all values for the same field
+ * JSON value: a linked list of all values of the same json_field (below)
  */
 struct json_value
 {
@@ -70,6 +70,10 @@ struct json_value
     struct json_value *next;
 };
 
+/*
+ * JSON field: a JSON field consists of the name and all the values (if more
+ * than one field of the same name is found in the file).
+ */
 struct json_field
 {
     char *name;
@@ -80,10 +84,21 @@ struct json_field
     struct json_field *next;
 };
 
+/*
+ * linked list of the common json fields found in the .info.json and
+ * .author.json files.
+ *
+ * A common json field is a field that is supposed to be in both .info.json and
+ * .author.json.
+ */
 struct json_field *found_common_json_fields;
 
 /*
- * common json fields
+ * common json fields - for use in mkiocccentry.
+ *
+ * NOTE: We don't use the json_field or json_value fields because this struct is
+ * for mkiocccentry which is in control of what's written whereas for jinfochk
+ * and jauthchk we don't have control of what's in the file.
  */
 struct json_common
 {
@@ -180,18 +195,18 @@ extern bool json_putc(uint8_t const c, FILE *stream);
 extern char *malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict);
 extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict);
 /* jinfochk and jauthchk related */
+extern char const *json_filename(int type);
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
-extern char const *json_filename(int type);
 extern struct json_field *add_found_common_json_field(char const *name, char const *val);
 extern int get_common_json_field(char const *program, char const *file, char *name, char *val);
 extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk);
-extern struct json_value *add_json_value(struct json_field *field, char const *val);
 extern struct json_field *new_json_field(char const *name, char const *val);
+extern struct json_value *add_json_value(struct json_field *field, char const *val);
 /* free() functions */
+extern void free_json_field_values(struct json_field *field);
 extern void free_found_common_json_fields(void);
 extern void free_json_field(struct json_field *field);
-extern void free_json_field_values(struct json_field *field);
 /* these free() functions are also used in mkiocccentry.c */
 extern void free_info(struct info *infop);
 extern void free_author_array(struct author *authorp, int author_count);

--- a/json.h
+++ b/json.h
@@ -74,7 +74,6 @@ struct json_field
 {
     char *name;
     struct json_value *values;
-    char *value;
 
     size_t count;
 
@@ -184,15 +183,15 @@ extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern char const *json_filename(int type);
-extern struct json_field *add_common_json_field(char const *field, char const *value);
-extern int get_common_json_field(char const *program, char const *file, char *field, char *value);
+extern struct json_field *add_found_common_json_field(char const *name, char const *val);
+extern int get_common_json_field(char const *program, char const *file, char *name, char *val);
 extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk);
-extern struct json_value *add_json_value(struct json_field *field, char const *str);
-extern struct json_field *new_json_field(char const *name, char const *value);
+extern struct json_value *add_json_value(struct json_field *field, char const *val);
+extern struct json_field *new_json_field(char const *name, char const *val);
 /* free() functions */
 extern void free_found_common_json_fields(void);
 extern void free_json_field(struct json_field *field);
-extern void free_json_values(struct json_value *value);
+extern void free_json_field_values(struct json_field *field);
 /* these free() functions are also used in mkiocccentry.c */
 extern void free_info(struct info *infop);
 extern void free_author_array(struct author *authorp, int author_count);

--- a/json.h
+++ b/json.h
@@ -76,13 +76,27 @@ struct json_value
  */
 struct json_field
 {
-    char *name;
-    struct json_value *values;
+    char *name;			/* field name */
+    struct json_value *values;	/* linked list of values */
 
-    size_t count;
+    /*
+     * Number of times this field has been seen in the list, how many are
+     * actually allowed and whether the field has been found: This is for the
+     * tables that say tell many times a field has been seen, how many times it
+     * is allowed and whether or not it's been seen (it is true that this could
+     * simply be count > 0 but this is to be more clear, however slight).
+     *
+     * In other words this is done as part of the checks after the field:value
+     * pairs have been extracted.
+     */
+    size_t count;		/* how many of this field in the list (or how many values) */
+    size_t max_count;		/* how many of this field is allowed */
+    bool found;			/* if this field was found */
 
-    struct json_field *next;
+    struct json_field *next;	/* the next in the whatever list (XXX don't add to more than one list!) */
 };
+
+extern struct json_field common_json_fields[];
 
 /*
  * linked list of the common json fields found in the .info.json and
@@ -195,6 +209,7 @@ extern bool json_putc(uint8_t const c, FILE *stream);
 extern char *malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict);
 extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict);
 /* jinfochk and jauthchk related */
+extern struct json_field *find_json_field_in_table(struct json_field *table, char const *name, size_t *loc);
 extern char const *json_filename(int type);
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);

--- a/json.h
+++ b/json.h
@@ -215,7 +215,7 @@ extern int check_first_json_char(char const *file, char *data, bool strict, char
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern struct json_field *add_found_common_json_field(char const *name, char const *val);
 extern int get_common_json_field(char const *program, char const *file, char *name, char *val);
-extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk);
+extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk, bool test);
 extern struct json_field *new_json_field(char const *name, char const *val);
 extern struct json_value *add_json_value(struct json_field *field, char const *val);
 /* free() functions */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -314,9 +314,10 @@ main(int argc, char *argv[])
     /* if the user requested to ignore warnings, ignore this once and warn them :) */
     if (ignore_warnings) {
 	para("",
-	     "WARNING: You've chosen to ignore all warnings (except this warning! :) )!",
-	     "If this was unintentional run this program again without the -W option.",
-	     "Note that The Judges will NOT ignore warnings!",
+	     "WARNING: You've chosen to ignore all warnings. While we will not show",
+	     "you any additional warnings, you should note that The Judges will NOT",
+	     "ignore warnings! If this was unintentional, run the program again",
+	     "without specifying -W. We cannot stress the importance of this enough!",
 	     NULL);
     }
 
@@ -5260,6 +5261,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "ioccc_contest", " : ", IOCCC_CONTEST, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "ioccc_year", " : ", (long)IOCCC_YEAR, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "mkiocccentry_version", " : ", infop->common.mkiocccentry_ver, ",\n") &&
+	json_fprintf_value_string(author_stream, "\t", "iocccsize_version", " : ", infop->common.iocccsize_ver, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "IOCCC_contest_id", " : ", infop->common.ioccc_id, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "tarball", " : ", infop->common.tarball, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "entry_num", " : ", (long)infop->common.entry_num, ",\n") &&

--- a/test_JSON/good/info.json.sorted
+++ b/test_JSON/good/info.json.sorted
@@ -36,7 +36,7 @@
 	"rule_2b_size" : 0,
 	"tarball" : "entry.12345678-1234-4321-abcd-1234567890ab-0.1645212226.txz",
 	"test_mode" : false,
-	"timestamp_epoch" : "Thu Jan  1 00:00:00 1970 UTC",
+	"timestamp_epoch" : "Thu Jan 01 00:00:00 1970 UTC",
 	"title" : "title-for-entry0",
 	"trigraph_warning" : false,
 	"ungetc_warning" : false,

--- a/util.c
+++ b/util.c
@@ -2292,15 +2292,20 @@ long long string_to_long_long(char const *str)
 	not_reached();
     }
 
+    if (strlen(str) > LLONG_MAX_BASE10_DIGITS) {
+	err(158, __func__, "string '%s' too long", str);
+	not_reached();
+    }
+
     errno = 0;
     num = strtoll(str, NULL, 10);
 
     if (errno != 0) {
-	errp(158, __func__, "error converting string \"%s\" to long long int: %s", str, strerror(errno));
+	errp(159, __func__, "error converting string \"%s\" to long long int: %s", str, strerror(errno));
 	not_reached();
     }
     else if (num <= LLONG_MIN || num >= LLONG_MAX) {
-	err(159, __func__, "number %s out of range for long long int (must be > %lld && < %lld)", str, LLONG_MIN, LLONG_MAX);
+	err(160, __func__, "number %s out of range for long long int (must be > %lld && < %lld)", str, LLONG_MIN, LLONG_MAX);
 	not_reached();
     }
     return num;
@@ -2326,7 +2331,7 @@ int string_to_int(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(160, __func__, "passed NULL arg");
+	err(161, __func__, "passed NULL arg");
 	not_reached();
     }
 
@@ -2334,11 +2339,11 @@ int string_to_int(char const *str)
     num = (int)strtoll(str, NULL, 10);
 
     if (errno != 0) {
-	errp(161, __func__, "error converting string \"%s\" to int: %s", str, strerror(errno));
+	errp(162, __func__, "error converting string \"%s\" to int: %s", str, strerror(errno));
 	not_reached();
     }
     else if (num < INT_MIN || num > INT_MAX) {
-	err(162, __func__, "number %s out of range for int (must be >= %d && <= %d)", str, INT_MIN, INT_MAX);
+	err(163, __func__, "number %s out of range for int (must be >= %d && <= %d)", str, INT_MIN, INT_MAX);
 	not_reached();
     }
     return (int)num;
@@ -2364,17 +2369,17 @@ unsigned long string_to_unsigned_long(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(163, __func__, "passed NULL arg");
+	err(164, __func__, "passed NULL arg");
 	not_reached();
     }
 
     errno = 0;
     num = strtoul(str, NULL, 10);
     if (errno != 0) {
-	errp(164, __func__, "strtoul(%s): %s", str, strerror(errno));
+	errp(165, __func__, "strtoul(%s): %s", str, strerror(errno));
 	not_reached();
     } else if (num >= ULONG_MAX) {
-	err(165, __func__, "strtoul(%s): too big", str);
+	err(166, __func__, "strtoul(%s): too big", str);
 	not_reached();
     }
 
@@ -2401,17 +2406,17 @@ unsigned long long string_to_unsigned_long_long(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(166, __func__, "passed NULL arg");
+	err(167, __func__, "passed NULL arg");
 	not_reached();
     }
 
     errno = 0;
     num = strtoul(str, NULL, 10);
     if (errno != 0) {
-	errp(167, __func__, "strtoul(%s): %s", str, strerror(errno));
+	errp(168, __func__, "strtoul(%s): %s", str, strerror(errno));
 	not_reached();
     } else if (num >= ULLONG_MAX) {
-	err(168, __func__, "strtoul(%s): too big", str);
+	err(169, __func__, "strtoul(%s): too big", str);
 	not_reached();
     }
 

--- a/util.h
+++ b/util.h
@@ -66,6 +66,10 @@ struct location {
 #define READ_ALL_CHUNK (65536)	/* grow this read_all by this amount when needed */
 #define TAIL_TITLE_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_+-"	/* [a-z0-9_+-] */
 
+
+#define LLONG_MAX_BASE10_DIGITS (19)
+
+
 /*
  * paths to utilities the IOCCC tools use (including our own tools fnamchk,
  * txzchk, jinfochk, jauthchk, etc.)

--- a/version.h
+++ b/version.h
@@ -109,12 +109,12 @@
 /*
  * official jinfochk version
  */
-#define JINFOCHK_VERSION "0.7 2022-02-25"	/* format: major.minor YYYY-MM-DD */
+#define JINFOCHK_VERSION "0.8 2022-02-26"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jauthchk version
  */
-#define JAUTHCHK_VERSION "0.7 2022-02-25"	/* format: major.minor YYYY-MM-DD */
+#define JAUTHCHK_VERSION "0.8 2022-02-26"	/* format: major.minor YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
The first commit cleans up commits 8c7c56f6 and a99522d5 (the former of which fixed some issues in the latter) and also makes more consistent names of variables and parameters.

Fix memory leaks. This includes referencing struct json_field's char *value instead of 'struct json_value *values' (which is what's used).  'value' has now been removed. 

In functions the parameter for the field name is now called 'name' and the parameter for the value is now called 'val'. In the functions (most of them - the ones that directly act on a struct json_field * and/or struct json_value *) the struct json_field * is called 'field' and the struct json_value * is called 'value'. Any 'char *' for the value is called 'val' (just like in the parameter). In the check_(info|author)_json() functions the variable names are 'p' (for field) and 'value' (for field's value - i.e. the part after the ':' in the name:value pairs); and the struct json_field * is called 'field' and the struct json_value * is called 'field_value'. Similarly in the check_(info|author)_json() functions the 'char *value' is now 'char *val' and the 'struct json_value *field_value' is now 'struct json_value *value'. However the field name is still a 'char *p' as it's not only used for names.

Now all the functions that refer to the found_ lists that did not have found_ before the list name with the exception of get_common_json_field(); this is because at this point the field is not found and it's only checking if the current value of 'p' is one of the common fields.