### PR TITLE
Release new version of jinfochk and jauthchk

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -59,7 +59,7 @@ typedef unsigned char bool;
  * backward compatibility
  *
  * Not all compilers support __attribute__ nor do they support __has_builtin.
- * For example, MSVC, TenDRA and Little C Compiler doesn't support __attribute__.
+ * For example, MSVC, TenDRA and Little C Compiler don't support __attribute__.
  * Early gcc does not support __attribute__.
  *
  * Not all compiles have __has_builtin

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -185,7 +185,8 @@ check_author_json_fields_table(void)
 	switch (author_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (author_json_fields[loc].name != NULL) {
-		    err(5, __func__, "found invalid data in author_json_fields table #0");
+		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %lu in author_json_fields table",
+                            author_json_fields[loc].name, (unsigned long)loc);
 		    not_reached();
 		}
 		break;
@@ -199,7 +200,7 @@ check_author_json_fields_table(void)
 		/* these are all the valid types */
 		break;
 	    default:
-		err(6, __func__, "found invalid data in author_json_fields table #1");
+		err(6, __func__, "found invalid data_type in author_json_fields table location %lu", (unsigned long)loc);
 		not_reached();
 		break;
 	}
@@ -772,7 +773,7 @@ add_found_author_json_field(char const *name, char const *val)
     struct json_field *field = NULL; /* iterate through fields list to find the field (or if not found, create a new field) */
     struct json_value *value = NULL; /* the new value */
     struct json_field *field_in_table = NULL;
-    size_t loc = 0; /* location in info_json_fields table */
+    size_t loc = 0; /* location in author_json_fields table */
 
     /*
      * firewall

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -740,7 +740,7 @@ add_found_author_json_field(char const *name, char const *val)
 
     field_in_table = find_json_field_in_table(author_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(220, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
+	err(27, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
 	not_reached();
     }
     /*
@@ -763,7 +763,7 @@ add_found_author_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(27, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(28, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -783,7 +783,7 @@ add_found_author_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(28, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(29, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
     }
 
     /* add to the list */

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -566,7 +566,7 @@ get_author_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(223, __func__, "passed NULL arg(s)");
+	err(22, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -612,7 +612,7 @@ check_found_author_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(224, __func__, "passed NULL file");
+	err(23, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -621,7 +621,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(225, __func__, "found NULL or empty field in found_author_json_fields list");
+	    err(24, __func__, "found NULL or empty field in found_author_json_fields list");
 	    not_reached();
 	}
 
@@ -636,7 +636,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * author list is not a author field name.
 	 */
 	if (author_field == NULL) {
-	    err(226, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
+	    err(25, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -732,7 +732,7 @@ add_found_author_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(23, __func__, "passed NULL arg(s)");
+	err(26, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -748,7 +748,7 @@ add_found_author_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(24, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(27, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -768,7 +768,7 @@ add_found_author_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(25, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(28, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
     }
 
     /* add to the list */

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -16,18 +16,44 @@
  */
 #include "jauthchk.h"
 
+/*
+ * .author.json fields table used to determine if a name belongs in the file,
+ * whether it's been added to the found_author_json_fields list, how many times
+ * it's been seen and how many are allowed.
+ *
+ * XXX: As of 27 February 2022 all fields are in the table but because arrays
+ * are not yet parsed not all of these values will be dealt with: that is they
+ * won't be in the found_author_json list. Additionally the way array elements
+ * are defined might very well change.
+ */
+struct json_field author_json_fields[] =
+{
+    { "IOCCC_author_version",	NULL, 0, 1, false, JSON_STRING,		NULL },
+    { "authors",		NULL, 0, 1, false, JSON_ARRAY,		NULL },
+    { "name",			NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "location_code",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "email",			NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "url",			NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "twitter",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "github",			NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "affiliation",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "winner_handle",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "author_number",		NULL, 0, 5, false, JSON_ARRAY_NUMBER,	NULL },
+    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL } /* this **MUST** be last */
+};
+
 
 int
 main(int argc, char **argv)
 {
-    extern char *optarg;	/* option argument */
-    extern int optind;		/* argv index of the next arg */
-    char *file;		/* file argument to check */
-    int ret;			/* libc return code */
-    int i;
-    int issues;
+    extern char *optarg;		/* option argument */
+    extern int optind;			/* argv index of the next arg */
+    char *file;				/* file argument to check */
+    int ret;				/* libc return code */
+    int i;				/* return value of getopt() */
+    int issues;				/* issues found */
     char *fnamchk = FNAMCHK_PATH_0;	/* path to fnamchk executable */
-    bool fnamchk_flag_used = false; /* true ==> -F fnamchk used */
+    bool fnamchk_flag_used = false;	/* true ==> -F fnamchk used */
 
 
     /*
@@ -295,8 +321,9 @@ check_author_json(char const *file, char const *fnamchk)
     char *end = NULL;	/* temporary use: end of strings (p, field) for removing spaces */
     char *val = NULL;	/* current field's value being parsed */
     char *savefield = NULL; /* for strtok_r() usage */
-    struct json_field *field = NULL; /* for fields list */
-    struct json_value *value = NULL; /* for fields list's value */
+    struct json_field *author_field; /* temporary use to determine type of value if .author.json field */
+    struct json_field *common_field; /* temporary use to determine type of value if common field */
+    size_t loc = 0;
 
     /*
      * firewall
@@ -377,11 +404,13 @@ check_author_json(char const *file, char const *fnamchk)
 	/* we have to skip skip leading whitespace */
 	while (*p && isspace(*p))
 	    ++p;
+
 	/* get the next field */
 	p = strtok_r(val?NULL:p, ":", &savefield);
 	if (p == NULL) {
 	    break;
 	}
+
 	/* skip leading whitespace on the field */
 	while (*p && isspace(*p))
 	    ++p;
@@ -399,18 +428,22 @@ check_author_json(char const *file, char const *fnamchk)
 	if (*end == '"')
 	    *end = '\0';
 
-	/*
-	 * after removing the spaces and a single '"' at the beginning and end,
-	 * if we find a '"' in the field we know it's erroneous: thus we can
-	 * simply use strcmp() on it. Note that when we get to the array(s) we
-	 * have to handle it specially but this step still has to be done.
-	 */
 
-	/* Before we can extract the value we have to determine if the field is
-	 * supposed to be an array or not: if it's an array we have to handle it
-	 * differently as there's more to parse. If it's not an array we just
-	 * check the name, retrieve the value and then test if it's a valid
-	 * value.
+	/*
+	 * After removing the spaces and a single '"' at the beginning and end,
+	 * if we find a '"' in the field (name) we know it's erroneous: thus we
+	 * can simply use strcmp() on it.
+	 *
+	 * Now we see if we can find the field in the info_json_fields table or
+	 * the common_json_fields table.
+	 */
+	author_field = find_json_field_in_table(author_json_fields, p, &loc);
+	common_field = find_json_field_in_table(common_json_fields, p, &loc);
+
+	/*
+	 * Before we can extract the value we have to determine the field's type
+	 * of value: depending on the type of value we have to handle it
+	 * differently; the above function calls will help us do that.
 	 */
 
 	if (!strcmp(p, "authors")) {
@@ -443,37 +476,35 @@ check_author_json(char const *file, char const *fnamchk)
 		*end-- = '\0';
 
 	    /*
-	     * Depending on the field, remove a single '"' at the beginning and
-	     * end of the value.
+	     * If the field type is a string we have to remove a single '"' and
+	     * from the beginning and end of the value.
 	     */
-	    if (strcmp(p, "ioccc_year") && strcmp(p, "entry_num")) {
-		/* remove a single '"' at the beginning of the value */
-		if (*val == '"')
-		    ++val;
+	    if ((common_field && (common_field->field_type == JSON_STRING || common_field->field_type == JSON_ARRAY_STRING)) ||
+		(author_field && (author_field->field_type == JSON_STRING || author_field->field_type == JSON_ARRAY_STRING))) {
+		    /* remove a single '"' at the beginning of the value */
+		    if (*val == '"')
+			++val;
 
-		/* also remove a trailing '"' at the end of the value. */
-		end = val + strlen(val) - 1;
-		if (*end == '"')
-		    *end = '\0';
-		/*
-		 * after removing the spaces and a single '"' at the beginning and end,
-		 * if we find a '"' in the field we know it's erroneous.
-		 */
+		    /* also remove a trailing '"' at the end of the value. */
+		    end = val + strlen(val) - 1;
+		    if (*end == '"')
+			*end = '\0';
+
+		    /*
+		     * after removing the spaces and a single '"' at the beginning and end,
+		     * if we find a '"' in the field we know it's erroneous.
+		     */
 	    }
+
 	    /* handle regular field */
 	    if (get_common_json_field(program_basename, file, p, val)) {
+	    } else if (get_author_json_field(file, p, val)) {
 	    } else {
-		field = add_found_author_json_field(p, val);
-		if (field == NULL) {
-		    /*
-		     * if this is NULL there's a serious problem as the other
-		     * functions should have aborted already
-		     */
-		    err(22, __func__, "couldn't add field '%s' with value '%s' to list", p, val);
-		    not_reached();
-		}
+		/*
+		 * invalid field: currently we cannot report this as an issue
+		 * since arrays are not handled yet.
+		 */
 	    }
-	    dbg(DBG_MED, "found field '%s' with value '%s'", p, val);
 	}
     } while (true);
 
@@ -485,32 +516,8 @@ check_author_json(char const *file, char const *fnamchk)
     free(data_dup);
     data_dup = NULL;
 
-
-    /*
-     * now iterate through the found_author_json_fields list, reporting any issues
-     *
-     * XXX Note that fields that aren't expected to be in the file would also be
-     * added to the list but this will be dealt with at a later time.
-     */
-    for (field = found_author_json_fields; field != NULL; field = field->next) {
-	dbg(DBG_VHIGH, "checking field '%s' in file %s", field->name, file);
-	for (value = field->values; value != NULL; value = value->next) {
-	    char const *v = value->value;
-	    if (!strcmp(field->name, "IOCCC_author_version")) {
-		if (!test && strcmp(v, AUTHOR_VERSION)) {
-		    warn(__func__, "IOCCC_author_version \"%s\" != \"%s\" in file %s", v, AUTHOR_VERSION, file);
-		    ++issues;
-		}
-	    } else {
-		/* TODO: after everything else is parsed if we get here it's an
-		 * error as there's an invalid field in the file.
-		 *
-		 * Currently (as of 25 February 2022) this is not done
-		 * because the arrays are not parsed yet.
-		 */
-	    }
-	}
-    }
+    /* check the found_author_json_fields list for issues */
+    issues += check_found_author_json_fields(file, test);
 
     /* now free the found_author_json_fields list.
      *
@@ -518,7 +525,7 @@ check_author_json(char const *file, char const *fnamchk)
      */
     free_found_author_json_fields();
 
-    /* check common json fields which will update the number of issues */
+    /* check found_common_json_fields list, updating the number of issues found */
     issues += check_found_common_json_fields(program_basename, file, fnamchk, test);
 
     /* free the found_common_json_fields list.
@@ -528,6 +535,174 @@ check_author_json(char const *file, char const *fnamchk)
     free_found_common_json_fields();
 
     /* if issues != 0 there will be a non-zero return status of jauthchk */
+    return issues;
+}
+
+/*
+ * get_author_json_field	-	    check if name is a .info.json field
+ *				    and if it is add it to the found_author_json
+ *				    list.
+ *
+ * given:
+ *
+ *	file	- the file being parsed (path to)
+ *	name	- the field name
+ *	val	- the value of the field
+ *
+ * returns:
+ *	1 ==> if the name is a .info.json field
+ *	0 ==> if it's not one of the .info.json fields
+ *
+ * NOTE: Does not return on error (NULL pointers).
+ */
+int
+get_author_json_field(char const *file, char *name, char *val)
+{
+    int ret = 1;	/* return value: 1 ==> known field, 0 ==> not a common field */
+    struct json_field *field = NULL; /* the field in the author_json_fields table if found */
+    size_t loc = 0; /* location in the author_json_fields table */
+
+    /*
+     * firewall
+     */
+    if (file == NULL || name == NULL || val == NULL) {
+	err(223, __func__, "passed NULL arg(s)");
+	not_reached();
+    }
+
+    /*
+     * check if the name is an expected common field
+     */
+    field = find_json_field_in_table(author_json_fields, name, &loc);
+    if (field != NULL) {
+	dbg(DBG_MED, "found field '%s' with value '%s'", field->name, val);
+	add_found_author_json_field(field->name, val);
+    } else {
+	ret = 0;
+    }
+    return ret;
+}
+
+/*
+ * check_found_author_json_fields - check that all the fields in the
+ *				    found_author_json_fields table have valid
+ *				    values
+ *
+ *  given:
+ *
+ *	    file	- .author.json file we're checking
+ *	    test	- if test mode: ignore some checks
+ *
+ *
+ * returns:
+ *	>0 ==> the number of issues found
+ *	0 ==> if no issues were found
+ */
+int
+check_found_author_json_fields(char const *file, bool test)
+{
+    struct json_field *field; /* current field in found_author_json_fields list */
+    struct json_value *value; /* current value in current field's values list */
+    struct json_field *author_field = NULL; /* element in the author_json_fields table */
+    size_t loc = 0;	/* location in the author_json_fields table */
+    int issues = 0;
+    size_t val_length = 0;  /* current value length */
+
+    /*
+     * firewall
+     */
+    if (file == NULL) {
+	err(224, __func__, "passed NULL file");
+	not_reached();
+    }
+
+    for (field = found_author_json_fields; field != NULL; field = field->next) {
+	/*
+	 * first make sure the name != NULL and strlen() > 0
+	 */
+	if (field->name == NULL || !strlen(field->name)) {
+	    err(225, __func__, "found NULL or empty field in found_author_json_fields list");
+	    not_reached();
+	}
+
+	/* now make sure it's allowed to be in this table. */
+	loc = 0;
+	author_field = find_json_field_in_table(author_json_fields, field->name, &loc);
+
+	/*
+	 * If the field is not allowed in the list then it suggests there is a
+	 * problem in the code because only author fields should be added to the
+	 * list in the first place. Thus it's an error if a field that's in the
+	 * author list is not a author field name.
+	 */
+	if (author_field == NULL) {
+	    err(226, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
+	    not_reached();
+	}
+
+	dbg(DBG_VHIGH, "checking field '%s' in file %s", field->name, file);
+	/* make sure the field is not over the limit allowed */
+	if (author_field->max_count > 0 && author_field->count > author_field->max_count) {
+	    warn(__func__, "field '%s' found %lu times but is only allowed %lu times", author_field->name,
+		    (unsigned long)author_field->count, (unsigned long)author_field->max_count);
+	    ++issues;
+	}
+
+	for (value = field->values; value != NULL; value = value->next) {
+	    char *val = value->value;
+	    val_length = strlen(val);
+
+	    if (!val_length) {
+		warn(__func__, "empty value found for field '%s' in file %s", field->name, file);
+		/* don't increase issues because the below checks will do that
+		 * too: this warning only notes the reason the test will fail.
+		 */
+	    }
+	    /* first we do checks on the field type */
+	    switch (author_field->field_type) {
+		case JSON_BOOL:
+		    if (strcmp(val, "false") && strcmp(val, "true")) {
+			warn(__func__, "bool field '%s' has invalid value '%s' in file %s", author_field->name, val, file);
+			++issues;
+			continue;
+		    } else {
+			dbg(DBG_VHIGH, "%s is a bool", val);
+		    }
+		    break;
+		case JSON_ARRAY_BOOL:
+		    break; /* arrays are not handled yet */
+		case JSON_NUMBER:
+		    if (!is_number(val)) {
+			warn(__func__, "number field '%s' has non-number value '%s' in file %s", author_field->name, val, file);
+			++issues;
+			continue;
+		    } else {
+			dbg(DBG_VHIGH, "%s is a number", val);
+		    }
+		    break;
+		case JSON_ARRAY_NUMBER:
+		    break; /* arrays are not handled yet */
+		default:
+		    break;
+	    }
+
+
+	    if (!strcmp(field->name, "IOCCC_author_version")) {
+		if (!test && strcmp(val, AUTHOR_VERSION)) {
+		    warn(__func__, "IOCCC_author_version \"%s\" != \"%s\" in file %s", val, AUTHOR_VERSION, file);
+		    ++issues;
+		}
+	    } else {
+		/* TODO: after everything else is parsed if we get here it's an
+		 * error as there's an invalid field in the file.
+		 *
+		 * Currently (as of 27 February 2022) this is not done
+		 * because the arrays are not parsed yet.
+		 */
+	    }
+	}
+    }
+
     return issues;
 }
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -434,7 +434,7 @@ check_author_json(char const *file, char const *fnamchk)
 	 * if we find a '"' in the field (name) we know it's erroneous: thus we
 	 * can simply use strcmp() on it.
 	 *
-	 * Now we see if we can find the field in the info_json_fields table or
+	 * Now we see if we can find the field in the author_json_fields table or
 	 * the common_json_fields table.
 	 */
 	author_field = find_json_field_in_table(author_json_fields, p, &loc);
@@ -727,6 +727,8 @@ add_found_author_json_field(char const *name, char const *val)
 {
     struct json_field *field = NULL; /* iterate through fields list to find the field (or if not found, create a new field) */
     struct json_value *value = NULL; /* the new value */
+    struct json_field *field_in_table = NULL;
+    size_t loc = 0; /* location in info_json_fields table */
 
     /*
      * firewall
@@ -735,6 +737,19 @@ add_found_author_json_field(char const *name, char const *val)
 	err(26, __func__, "passed NULL arg(s)");
 	not_reached();
     }
+
+    field_in_table = find_json_field_in_table(author_json_fields, name, &loc);
+    if (field_in_table == NULL) {
+	err(220, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
+	not_reached();
+    }
+    /*
+     * Set in table that it's found and increment the number of times it's been
+     * seen.
+     */
+    author_json_fields[loc].count++;
+    author_json_fields[loc].found = true;
+
 
     for (field = found_author_json_fields; field; field = field->next) {
 	if (field->name && !strcmp(field->name, name)) {

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -93,6 +93,7 @@ static int check_author_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_author_json_field(char const *name, char const *val);
 static int get_author_json_field(char const *file, char *name, char *val);
 static int check_found_author_json_fields(char const *file, bool test);
+static void check_author_json_fields_table(void);
 static void free_found_author_json_fields(void);
 
 #endif /* INCLUDE_JAUTHCHK_H */

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -83,6 +83,7 @@ struct author author;			/* the .author.json struct */
 static bool strict = false;			/* true ==> disallow anything before/after the '{' and '}' */
 static bool test = false;			/* true ==> some tests are not performed */
 static struct json_field *found_author_json_fields;	/* list of fields specific to .author.json found */
+extern struct json_field author_json_fields[];
 /*
  * forward declarations
  */
@@ -90,6 +91,8 @@ static void usage(int exitcode, char const *name, char const *str) __attribute__
 static void sanity_chk(char const *file, char const *fnamchk);
 static int check_author_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_author_json_field(char const *name, char const *val);
+static int get_author_json_field(char const *file, char *name, char *val);
+static int check_found_author_json_fields(char const *file, bool test);
 static void free_found_author_json_fields(void);
 
 #endif /* INCLUDE_JAUTHCHK_H */

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -198,7 +198,8 @@ check_info_json_fields_table(void)
 	switch (info_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (info_json_fields[loc].name != NULL) {
-		    err(5, __func__, "found invalid data in info_json_fields table #0");
+		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %lu in info_json_fields table",
+			    info_json_fields[loc].name, (unsigned long)loc);
 		    not_reached();
 		}
 		break;
@@ -212,7 +213,7 @@ check_info_json_fields_table(void)
 		/* these are all the valid types */
 		break;
 	    default:
-		err(6, __func__, "found invalid data in info_json_fields table #1");
+		err(6, __func__, "found invalid data_type in info_json_fields table location %lu", (unsigned long)loc);
 		not_reached();
 		break;
 	}

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -57,7 +57,8 @@ struct json_field info_json_fields[] =
     { "Makefile",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
     { "remarks",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
     { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL } /* this **MUST** be last */
+    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL }, /* this **MUST** be last */
+    { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	NULL },
 };
 
 int
@@ -179,6 +180,44 @@ main(int argc, char **argv)
     exit(issues != 0); /*ooo*/
 }
 
+/* check_info_json_fields_table	    - perform some sanity checks on the
+ *				      info_json_fields table
+ *
+ * This function checks if JSON_NULL is used on any field other than the NULL
+ * field. It also makes sure that each field_type is valid. More tests might be
+ * devised later on but this is a good start (27 Feb 2022).
+ *
+ * This function does not return on error.
+ */
+static void
+check_info_json_fields_table(void)
+{
+    size_t loc;
+
+    for (loc = 0; info_json_fields[loc].name != NULL; ++loc) {
+	switch (info_json_fields[loc].field_type) {
+	    case JSON_NULL:
+		if (info_json_fields[loc].name != NULL) {
+		    err(5, __func__, "found invalid data in info_json_fields table #0");
+		    not_reached();
+		}
+		break;
+	    case JSON_NUMBER:
+	    case JSON_BOOL:
+	    case JSON_STRING:
+	    case JSON_ARRAY:
+	    case JSON_ARRAY_NUMBER:
+	    case JSON_ARRAY_BOOL:
+	    case JSON_ARRAY_STRING:
+		/* these are all the valid types */
+		break;
+	    default:
+		err(6, __func__, "found invalid data in info_json_fields table #1");
+		not_reached();
+		break;
+	}
+    }
+}
 
 /*
  * sanity_chk - perform basic sanity checks
@@ -199,7 +238,7 @@ sanity_chk(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(5, __func__, "called with NULL arg(s)");
+	err(7, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -215,7 +254,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [options] <file>"
 	      "",
 	      NULL);
-	err(6, __func__, "file does not exist: %s", file);
+	err(8, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
@@ -228,7 +267,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>",
 	      "",
 	      NULL);
-	err(7, __func__, "file is not a file: %s", file);
+	err(9, __func__, "file is not a file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -241,7 +280,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>"
 	      "",
 	      NULL);
-	err(8, __func__, "file is not readable: %s", file);
+	err(10, __func__, "file is not readable: %s", file);
 	not_reached();
     }
 
@@ -263,7 +302,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(9, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(11, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -280,7 +319,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(10, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(12, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -297,10 +336,15 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(11, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(13, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
+    /* check the common_json_fields table */
+    check_common_json_fields_table();
+
+    /* check our info_json_fields table */
+    check_info_json_fields_table();
 
     return;
 }
@@ -341,23 +385,23 @@ check_info_json(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(12, __func__, "passed NULL arg(s)");
+	err(14, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     stream = fopen(file, "r");
     if (stream == NULL) {
-	err(13, __func__, "couldn't open %s", file);
+	err(15, __func__, "couldn't open %s", file);
 	not_reached();
     }
 
     /* read in the file */
     data = read_all(stream, &length);
     if (data == NULL) {
-	err(14, __func__, "error while reading data in %s", file);
+	err(16, __func__, "error while reading data in %s", file);
 	not_reached();
     } else if (length == 0) {
-	err(15, __func__, "zero length data in file %s", file);
+	err(17, __func__, "zero length data in file %s", file);
 	not_reached();
     }
     dbg(DBG_HIGH, "%s read length: %lu", file, (unsigned long)length);
@@ -373,14 +417,14 @@ check_info_json(char const *file, char const *fnamchk)
     errno = 0;			/* pre-clear errno for errp() */
     p = (char *)memchr(data, 0, (size_t)length);
     if (p != NULL) {
-	errp(16, __func__, "found NUL before EOF: %s", file);
+	errp(18, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }
 
     errno = 0;
     data_dup = strdup(data);
     if (data_dup == NULL) {
-	errp(17, __func__, "unable to strdup file %s contents", file);
+	errp(19, __func__, "unable to strdup file %s contents", file);
 	not_reached();
     }
 
@@ -391,7 +435,7 @@ check_info_json(char const *file, char const *fnamchk)
      * parsing after the first '{' but after the '}' we don't continue.
      */
     if (check_last_json_char(file, data_dup, strict, &p)) {
-	err(18, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	err(20, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "last character: '%c'", *p);
@@ -401,7 +445,7 @@ check_info_json(char const *file, char const *fnamchk)
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p)) {
-	err(19, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(21, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "first character: '%c'", *p);
@@ -463,14 +507,14 @@ check_info_json(char const *file, char const *fnamchk)
 	     */
 	    val = strtok_r(NULL, ",\0", &savefield);
 	    if (val == NULL) {
-		err(20, __func__, "unable to find value in file %s for field %s", file, p);
+		err(22, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 	} else {
 	    /* extract the value */
 	    val = strtok_r(NULL, ",\0", &savefield);
 	    if (val == NULL) {
-		err(21, __func__, "unable to find value in file %s for field %s", file, p);
+		err(23, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 
@@ -578,7 +622,7 @@ get_info_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(22, __func__, "passed NULL arg(s)");
+	err(24, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -625,13 +669,13 @@ add_found_info_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(23, __func__, "passed NULL arg(s)");
+	err(25, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(24, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	err(26, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
 	not_reached();
     }
     /*
@@ -653,7 +697,7 @@ add_found_info_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(25, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(27, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -673,7 +717,7 @@ add_found_info_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(26, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(28, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 
@@ -717,7 +761,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(27, __func__, "passed NULL file");
+	err(29, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -726,7 +770,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(28, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(30, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -741,7 +785,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(29, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(31, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -783,7 +783,7 @@ check_found_info_json_fields(char const *file, bool test)
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "title")) {
-		if (val == 0) {
+		if (val_length == 0) {
 		    warn(__func__, "title length zero");
 		    ++issues;
 		} else if (val_length > MAX_TITLE_LEN) {

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -578,7 +578,7 @@ get_info_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(223, __func__, "passed NULL arg(s)");
+	err(22, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -703,7 +703,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(224, __func__, "passed NULL file");
+	err(26, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -712,7 +712,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(225, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(27, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -727,7 +727,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(226, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(28, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -17,6 +17,48 @@
  */
 #include "jinfochk.h"
 
+/*
+ * .info.json fields table used to determine if a name belongs in the file,
+ * whether it's been added to the found_info_json_fields list, how many times
+ * it's been seen and how many are allowed.
+ *
+ * XXX: As of 27 February 2022 all fields are in the table but because arrays
+ * are not yet parsed not all of these values will be dealt with: that is they
+ * won't be in the found_info_json list. Additionally the way array elements are
+ * defined might very well change.
+ */
+struct json_field info_json_fields[] =
+{
+    { "IOCCC_info_version",	NULL, 0, 1, false, JSON_STRING,		NULL },
+    { "title",			NULL, 0, 1, false, JSON_STRING,		NULL },
+    { "abstract",		NULL, 0, 1, false, JSON_STRING,		NULL },
+    { "rule_2a_size",		NULL, 0, 1, false, JSON_NUMBER,		NULL },
+    { "rule_2b_size",		NULL, 0, 1, false, JSON_NUMBER,		NULL },
+    { "empty_override",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "rule_2a_override",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "rule_2a_mismatch",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "rule_2b_override",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "highbit_warning",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "nul_warning",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "trigraph_warning",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "wordbuf_warning",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "ungetc_warning",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "Makefile_override",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "first_rule_is_all",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "found_all_rule",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "found_clean_rule",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "found_clobber_rule",	NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "found_try_rule",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "test_mode",		NULL, 0, 1, false, JSON_BOOL,		NULL },
+    { "manifest",		NULL, 0, 1, false, JSON_ARRAY,		NULL },
+    { "info_JSON",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
+    { "author_JSON",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
+    { "c_src",			NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
+    { "Makefile",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
+    { "remarks",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
+    { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	NULL },
+    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL } /* this **MUST** be last */
+};
 
 int
 main(int argc, char **argv)
@@ -291,10 +333,9 @@ check_info_json(char const *file, char const *fnamchk)
     char *end = NULL;	/* temporary use: end of strings (p, field) for removing spaces */
     char *val = NULL;	/* current field's value being parsed */
     char *savefield = NULL; /* for strtok_r() usage */
-    size_t val_length;    /* length of current val */
-    size_t span;
-    struct json_field *field; /* for found_info_json_fields list */
-    struct json_value *value; /* for found_info_json_fields list's value */
+    struct json_field *info_field; /* temporary use to determine type of value if .info.json field */
+    struct json_field *common_field; /* temporary use to determine type of value if common field */
+    size_t loc = 0;
 
     /*
      * firewall
@@ -376,6 +417,7 @@ check_info_json(char const *file, char const *fnamchk)
 	/* we have to skip leading whitespace */
 	while (*p && isspace(*p))
 	    ++p;
+
 	/* get the next field */
 	p = strtok_r(val?NULL:p, ":", &savefield);
 	if (p == NULL) {
@@ -399,20 +441,18 @@ check_info_json(char const *file, char const *fnamchk)
 	if (*end == '"')
 	    *end = '\0';
 
-
 	/*
-	 * after removing the spaces and a single '"' at the beginning and end,
-	 * if we find a '"' in the field we know it's erroneous: thus we can
-	 * simply use strcmp() on it. Note that when we get to the array(s) we
-	 * have to handle it specially but this step still has to be done.
+	 * After removing the spaces and a single '"' at the beginning and end,
+	 * if we find a '"' in the field (name) we know it's erroneous: thus we
+	 * can simply use strcmp() on it.
 	 */
+	info_field = find_json_field_in_table(info_json_fields, p, &loc);
+	common_field = find_json_field_in_table(common_json_fields, p, &loc);
 
 	/*
-	 * Before we can extract the value we have to determine if the field is
-	 * supposed to be an array or not: if it's an array we have to handle it
-	 * differently as there's more to parse. If it's not an array we just
-	 * check the name, retrieve the value and then test if it's a valid
-	 * value.
+	 * Before we can extract the value we have to determine the field's type
+	 * of value: depending on the type of value we have to handle it
+	 * differently; the above function calls will help us do that.
 	 */
 	if (!strcmp(p, "manifest")) {
 	    /* TODO: handle the array */
@@ -445,16 +485,11 @@ check_info_json(char const *file, char const *fnamchk)
 		*end-- = '\0';
 
 	    /*
-	     * Depending on the field, remove a single '"' at the beginning and
-	     * end of the value.
+	     * If the field type is a string we have to remove a single '"' and
+	     * from the beginning and end of the value.
 	     */
-	    if (strcmp(p, "ioccc_year") && strcmp(p, "entry_num") && strcmp(p, "rule_2a_size") &&
-		strcmp(p, "rule_2b_size") && strcmp(p, "empty_override") && strcmp(p, "rule_2a_override") &&
-		strcmp(p, "rule_2a_mismatch") && strcmp(p, "rule_2b_override") && strcmp(p, "highbit_warning") &&
-		strcmp(p, "nul_warning") && strcmp(p, "trigraph_warning") && strcmp(p, "wordbuf_warning") &&
-		strcmp(p, "ungetc_warning") && strcmp(p, "Makefile_override") && strcmp(p, "first_rule_is_all") &&
-		strcmp(p, "found_all_rule") && strcmp(p, "found_clean_rule") && strcmp(p, "found_clobber_rule") &&
-		strcmp(p, "found_try_rule") && strcmp(p, "test_mode")) {
+	    if ((common_field && (common_field->field_type == JSON_STRING || common_field->field_type == JSON_ARRAY_STRING)) ||
+		(info_field && (info_field->field_type == JSON_STRING || info_field->field_type == JSON_ARRAY_STRING))) {
 		    /* remove a single '"' at the beginning of the value */
 		    if (*val == '"')
 			++val;
@@ -469,22 +504,16 @@ check_info_json(char const *file, char const *fnamchk)
 		     * if we find a '"' in the field we know it's erroneous.
 		     */
 	    }
-	    val_length = strlen(val);
+
 	    /* handle regular field */
 	    if (get_common_json_field(program_basename, file, p, val)) {
-		dbg(DBG_HIGH, "found common field '%s' value '%s'", p, val);
+	    } else if (get_info_json_field(file, p, val)) {
 	    } else {
-		field = add_found_info_json_field(p, val);
-		if (field == NULL) {
-		    /*
-		     * if this is NULL there's a serious problem as the other
-		     * functions should have aborted already
-		     */
-		    err(22, __func__, "couldn't add field '%s' with value '%s' to list", p, val);
-		    not_reached();
-		}
-		dbg(DBG_HIGH, "found field '%s' with value '%s'", p, val);
-	    } /* uncommon value: value specific to .info.json */
+		/*
+		 * invalid field: currently we cannot report this as an issue
+		 * since arrays are not handled yet.
+		 */
+	    }
 	}
     } while (true); /* end do while */
 
@@ -499,79 +528,8 @@ check_info_json(char const *file, char const *fnamchk)
 
     /*
      * now iterate through the found_info_json_fields list, reporting any issues
-     *
-     * XXX Note that fields that aren't expected to be in the file would also be
-     * added to the list but this will be dealt with at a later time.
      */
-    for (field = found_info_json_fields; field != NULL; field = field->next) {
-	dbg(DBG_VHIGH, "checking field '%s' in file %s", field->name, file);
-	for (value = field->values; value != NULL; value = value->next) {
-	    char const *v = value->value;
-	    val_length = strlen(v);
-
-	    if (!strcmp(field->name, "IOCCC_info_version")) {
-		if (!test && strcmp(v, INFO_VERSION)) {
-		    warn(__func__, "IOCCC_info_version \"%s\" != \"%s\" in file %s", v, INFO_VERSION, file);
-		    ++issues;
-		}
-	    } else if (!strcmp(field->name, "title")) {
-		if (val == 0) {
-		    warn(__func__, "title length zero");
-		    ++issues;
-		} else if (val_length > MAX_TITLE_LEN) {
-		    warn(__func__, "title length %lu > max %d",
-				      (unsigned long)val_length, MAX_TITLE_LEN);
-		    ++issues;
-		}
-
-		/* check for valid chars only */
-		if (!isascii(v[0]) || (!islower(v[0]) && !isdigit(v[0]))) {
-		    warn(__func__, "first char of title '%c' invalid", v[0]);
-		    ++issues;
-		} else {
-		    span = strspn(v, TAIL_TITLE_CHARS);
-		    if (span != val_length) {
-			warn(__func__, "invalid chars found in title \"%s\"", v);
-			++issues;
-		    }
-		}
-	    } else if (!strcmp(field->name, "abstract")) {
-		if (val_length == 0) {
-		    warn(__func__, "abstract value zero length");
-		    ++issues;
-		} else if (val_length > MAX_ABSTRACT_LEN) {
-		    warn(__func__, "abstract length %lu > max %d",
-				      (unsigned long)val_length, MAX_ABSTRACT_LEN);
-		    ++issues;
-		}
-	    } else if (!strcmp(field->name, "rule_2a_size")) {
-		info.rule_2a_size = string_to_long_long(v);
-	    } else if (!strcmp(field->name, "rule_2b_size")) {
-		info.rule_2b_size = string_to_unsigned_long_long(v);
-	    } else if (!strcmp(field->name, "empty_override") || !strcmp(field->name, "rule_2a_override") ||
-	      !strcmp(field->name, "rule_2a_mismatch") || !strcmp(field->name, "rule_2b_override") ||
-	      !strcmp(field->name, "highbit_warning") || !strcmp(field->name, "nul_warning") ||
-	      !strcmp(field->name, "trigraph_warning") || !strcmp(field->name, "wordbuf_warning") ||
-	      !strcmp(field->name, "ungetc_warning") || !strcmp(field->name, "Makefile_override") ||
-	      !strcmp(field->name, "first_rule_is_all") || !strcmp(field->name, "found_all_rule") ||
-	      !strcmp(field->name, "found_clean_rule") || !strcmp(field->name, "found_clobber_rule") ||
-	      !strcmp(field->name, "found_try_rule") || !strcmp(field->name, "test_mode")) {
-		if (strcmp(v, "false") && strcmp(v, "true")) {
-		    warn(__func__, "found non-boolean value '%s' for boolean '%s' in file %s", v,  field->name, file);
-		    ++issues;
-		}
-	    }
-	    else {
-		/* TODO: after everything else is parsed if we get here it's an
-		 * error as there's an invalid field in the file.
-		 *
-		 * Currently (as of 25 February 2022) this is not done
-		 * because the arrays are not parsed yet.
-		 */
-
-	    }
-	}
-    }
+    issues += check_found_info_json_fields(file, test);
 
     /* now free the found_info_json_fields list.
      *
@@ -579,6 +537,7 @@ check_info_json(char const *file, char const *fnamchk)
      */
     free_found_info_json_fields();
 
+    /* check the found_common_json_fields list */
     issues += check_found_common_json_fields(program_basename, file, fnamchk, test);
 
     /* free the found_common_json_fields list.
@@ -590,6 +549,53 @@ check_info_json(char const *file, char const *fnamchk)
     /* if issues != 0 there will be a non-zero return status of jinfochk */
     return issues;
 }
+
+/*
+ * get_info_json_field	-	    check if name is a .info.json field
+ *				    and if it is add it to the found_info_json
+ *				    list.
+ *
+ * given:
+ *
+ *	file	- the file being parsed (path to)
+ *	name	- the field name
+ *	val	- the value of the field
+ *
+ * returns:
+ *	1 ==> if the name is a .info.json field
+ *	0 ==> if it's not one of the .info.json fields
+ *
+ * NOTE: Does not return on error (NULL pointers).
+ */
+int
+get_info_json_field(char const *file, char *name, char *val)
+{
+    int ret = 1;	/* return value: 1 ==> known field, 0 ==> not a common field */
+    struct json_field *field = NULL; /* the field in the info_json_fields table if found */
+    size_t loc = 0; /* location in the info_json_fields table */
+
+    /*
+     * firewall
+     */
+    if (file == NULL || name == NULL || val == NULL) {
+	err(223, __func__, "passed NULL arg(s)");
+	not_reached();
+    }
+
+    /*
+     * check if the name is an expected common field
+     */
+    field = find_json_field_in_table(info_json_fields, name, &loc);
+    if (field != NULL) {
+	dbg(DBG_HIGH, "found field '%s' with value '%s'", name, val);
+	add_found_info_json_field(name, val);
+    } else {
+	ret = 0;
+    }
+    return ret;
+}
+
+
 
 /* add_found_info_json_field	- add a field:value pair to the
  *				  found_info_json_fields list
@@ -666,6 +672,164 @@ add_found_info_json_field(char const *name, char const *val)
 
     return field;
 }
+
+/*
+ * check_found_info_json_fields - check that all the fields in the
+ *				    found_info_json_fields table have valid
+ *				    values
+ *
+ *  given:
+ *
+ *	    file	- .info.json file we're checking
+ *	    test	- if test mode: ignore some checks
+ *
+ *
+ * returns:
+ *	>0 ==> the number of issues found
+ *	0 ==> if no issues were found
+ */
+int
+check_found_info_json_fields(char const *file, bool test)
+{
+    struct json_field *field; /* current field in found_info_json_fields list */
+    struct json_value *value; /* current value in current field's values list */
+    struct json_field *info_field = NULL; /* element in the info_json_fields table */
+    size_t loc = 0;	/* location in the info_json_fields table */
+    size_t val_length = 0;
+    int issues = 0;
+    size_t span;
+
+    /*
+     * firewall
+     */
+    if (file == NULL) {
+	err(224, __func__, "passed NULL file");
+	not_reached();
+    }
+
+    for (field = found_info_json_fields; field != NULL; field = field->next) {
+	/*
+	 * first make sure the name != NULL and strlen() > 0
+	 */
+	if (field->name == NULL || !strlen(field->name)) {
+	    err(225, __func__, "found NULL or empty field in found_info_json_fields list");
+	    not_reached();
+	}
+
+	/* now make sure it's allowed to be in this table. */
+	loc = 0;
+	info_field = find_json_field_in_table(info_json_fields, field->name, &loc);
+
+	/*
+	 * If the field is not allowed in the list then it suggests there is a
+	 * problem in the code because only info fields should be added to the
+	 * list in the first place. Thus it's an error if a field that's in the
+	 * info list is not a info field name.
+	 */
+	if (info_field == NULL) {
+	    err(226, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    not_reached();
+	}
+
+	dbg(DBG_VHIGH, "checking field '%s' in file %s", field->name, file);
+	/* make sure the field is not over the limit allowed */
+	if (info_field->max_count > 0 && info_field->count > info_field->max_count) {
+	    warn(__func__, "field '%s' found %lu times but is only allowed %lu times", info_field->name,
+		    (unsigned long)info_field->count, (unsigned long)info_field->max_count);
+	    ++issues;
+	}
+
+	for (value = field->values; value != NULL; value = value->next) {
+	    char *val = value->value;
+	    val_length = strlen(val);
+
+	    if (!val_length) {
+		warn(__func__, "empty value found for field '%s' in file %s", field->name, file);
+		/* don't increase issues because the below checks will do that
+		 * too: this warning only notes the reason the test will fail.
+		 */
+	    }
+	    /* first we do checks on the field type */
+	    switch (info_field->field_type) {
+		case JSON_BOOL:
+		    if (strcmp(val, "false") && strcmp(val, "true")) {
+			warn(__func__, "bool field '%s' has invalid value '%s' in file %s", info_field->name, val, file);
+			++issues;
+			continue;
+		    } else {
+			dbg(DBG_VHIGH, "%s is a bool", val);
+		    }
+		    break;
+		case JSON_ARRAY_BOOL:
+		    break; /* arrays are not handled yet */
+		case JSON_NUMBER:
+		    if (!is_number(val)) {
+			warn(__func__, "number field '%s' has non-number value '%s' in file %s", info_field->name, val, file);
+			++issues;
+			continue;
+		    } else {
+			dbg(DBG_VHIGH, "%s is a number", val);
+		    }
+		    break;
+		case JSON_ARRAY_NUMBER:
+		    break; /* arrays are not handled yet */
+		default:
+		    break;
+	    }
+
+	    if (!strcmp(field->name, "IOCCC_info_version")) {
+		if (!test && strcmp(val, INFO_VERSION)) {
+		    warn(__func__, "IOCCC_info_version \"%s\" != \"%s\" in file %s", val, INFO_VERSION, file);
+		    ++issues;
+		}
+	    } else if (!strcmp(field->name, "title")) {
+		if (val == 0) {
+		    warn(__func__, "title length zero");
+		    ++issues;
+		} else if (val_length > MAX_TITLE_LEN) {
+		    warn(__func__, "title length %lu > max %d",
+				      (unsigned long)val_length, MAX_TITLE_LEN);
+		    ++issues;
+		}
+
+		/* check for valid chars only */
+		if (!isascii(*val) || (!islower(*val) && !isdigit(*val))) {
+		    warn(__func__, "first char of title '%c' invalid", *val);
+		    ++issues;
+		} else {
+		    span = strspn(val, TAIL_TITLE_CHARS);
+		    if (span != val_length) {
+			warn(__func__, "invalid chars found in title \"%s\"", val);
+			++issues;
+		    }
+		}
+	    } else if (!strcmp(field->name, "abstract")) {
+		if (val_length == 0) {
+		    warn(__func__, "abstract value zero length");
+		    ++issues;
+		} else if (val_length > MAX_ABSTRACT_LEN) {
+		    warn(__func__, "abstract length %lu > max %d",
+				      (unsigned long)val_length, MAX_ABSTRACT_LEN);
+		    ++issues;
+		}
+	    } else if (!strcmp(field->name, "rule_2a_size")) {
+		info.rule_2a_size = string_to_long_long(val);
+	    } else if (!strcmp(field->name, "rule_2b_size")) {
+		info.rule_2b_size = string_to_unsigned_long_long(val);
+	    } else {
+		/* TODO: after everything else is parsed if we get here it's an
+		 * error as there's an invalid field in the file.
+		 *
+		 * Currently (as of 27 February 2022) this is not done
+		 * because the arrays are not parsed yet.
+		 */
+	    }
+	}
+    }
+
+    return issues;
+}
+
 
 /* free_found_info_json_fields  - free the infos json fields list
  *

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -631,7 +631,7 @@ add_found_info_json_field(char const *name, char const *val)
 
     field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(220, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	err(24, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
 	not_reached();
     }
     /*
@@ -653,7 +653,7 @@ add_found_info_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(24, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(25, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -673,7 +673,7 @@ add_found_info_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(25, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(26, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 
@@ -717,7 +717,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(26, __func__, "passed NULL file");
+	err(27, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -726,7 +726,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(27, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(28, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -741,7 +741,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(28, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(29, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -812,10 +812,47 @@ check_found_info_json_fields(char const *file, bool test)
 				      (unsigned long)val_length, MAX_ABSTRACT_LEN);
 		    ++issues;
 		}
+	    /*
+	     * The next checks for boolean names could be cleaned up: for now
+	     * we use strcmp() on each and every name but perhaps a table for
+	     * booleans should be formed for easier assignment.
+	     */
 	    } else if (!strcmp(field->name, "rule_2a_size")) {
 		info.rule_2a_size = string_to_long_long(val);
 	    } else if (!strcmp(field->name, "rule_2b_size")) {
 		info.rule_2b_size = string_to_unsigned_long_long(val);
+	    } else if (!strcmp(field->name, "empty_override")) {
+		info.empty_override = string_to_bool(val);
+	    } else if (!strcmp(field->name, "rule_2a_override")) {
+		info.rule_2a_override = string_to_bool(val);
+	    } else if (!strcmp(field->name, "rule_2a_mismatch")) {
+		info.rule_2a_mismatch = string_to_bool(val);
+	    } else if (!strcmp(field->name, "rule_2b_override")) {
+		info.rule_2b_override = string_to_bool(val);
+	    } else if (!strcmp(field->name, "highbit_warning")) {
+		info.highbit_warning = string_to_bool(val);
+	    } else if (!strcmp(field->name, "nul_warning")) {
+		info.nul_warning = string_to_bool(val);
+	    } else if (!strcmp(field->name, "trigraph_warning")) {
+		info.trigraph_warning = string_to_bool(val);
+	    } else if (!strcmp(field->name, "wordbuf_warning")) {
+		info.wordbuf_warning = string_to_bool(val);
+	    } else if (!strcmp(field->name, "ungetc_warning")) {
+		info.ungetc_warning = string_to_bool(val);
+	    } else if (!strcmp(field->name, "Makefile_override")) {
+		info.Makefile_override = string_to_bool(val);
+	    } else if (!strcmp(field->name, "first_rule_is_all")) {
+		info.first_rule_is_all = string_to_bool(val);
+	    } else if (!strcmp(field->name, "found_all_rule")) {
+		info.found_all_rule = string_to_bool(val);
+	    } else if (!strcmp(field->name, "found_clean_rule")) {
+		info.found_clean_rule = string_to_bool(val);
+	    } else if (!strcmp(field->name, "found_clobber_rule")) {
+		info.found_clobber_rule = string_to_bool(val);
+	    } else if (!strcmp(field->name, "found_try_rule")) {
+		info.found_try_rule = string_to_bool(val);
+	    } else if (!strcmp(field->name, "test_mode")) {
+		info.test_mode = string_to_bool(val);
 	    } else {
 		/* TODO: after everything else is parsed if we get here it's an
 		 * error as there's an invalid field in the file.
@@ -825,6 +862,30 @@ check_found_info_json_fields(char const *file, bool test)
 		 */
 	    }
 	}
+    }
+
+    /*
+     * Now we have to do some additional sanity tests like bool mismatches etc.
+     *
+     * XXX More tests need to be added here!
+     */
+
+    /*
+     * If Makefile override is set to true and there's no problems found with
+     * the Makefile there's a mismatch: check and report if this is the case.
+     */
+    if (info.Makefile_override && info.first_rule_is_all && info.found_all_rule &&
+	    info.found_clean_rule && info.found_clobber_rule && info.found_try_rule) {
+	warn(__func__, "Makefile_override == true but all expected Makefile rules found and 'all:' is first");
+	++issues;
+    }
+    /*
+     * If info.found_all_rule == false and info.first_rule_is_all == true
+     * there's a mismatch: check this and report if this is the case.
+     */
+    if (!info.found_all_rule && info.first_rule_is_all) {
+	warn(__func__, "'all:' rule not found but first_rule_is_all == true");
+	++issues;
     }
 
     return issues;

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -618,6 +618,8 @@ add_found_info_json_field(char const *name, char const *val)
 {
     struct json_field *field = NULL; /* iterate through fields list to find the field (or if not found, create a new field) */
     struct json_value *value = NULL; /* the new value */
+    struct json_field *field_in_table = NULL;
+    size_t loc = 0; /* location in info_json_fields table */
 
     /*
      * firewall
@@ -626,6 +628,18 @@ add_found_info_json_field(char const *name, char const *val)
 	err(23, __func__, "passed NULL arg(s)");
 	not_reached();
     }
+
+    field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
+    if (field_in_table == NULL) {
+	err(220, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	not_reached();
+    }
+    /*
+     * Set in table that it's found and increment the number of times it's been
+     * seen.
+     */
+    info_json_fields[loc].count++;
+    info_json_fields[loc].found = true;
 
     for (field = found_info_json_fields; field; field = field->next) {
 	if (field->name && !strcmp(field->name, name)) {

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -783,7 +783,7 @@ check_found_info_json_fields(char const *file, bool test)
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "title")) {
-		if (val_length == 0) {
+		if (!val_length) {
 		    warn(__func__, "title length zero");
 		    ++issues;
 		} else if (val_length > MAX_TITLE_LEN) {
@@ -804,7 +804,7 @@ check_found_info_json_fields(char const *file, bool test)
 		    }
 		}
 	    } else if (!strcmp(field->name, "abstract")) {
-		if (val_length == 0) {
+		if (!val_length) {
 		    warn(__func__, "abstract value zero length");
 		    ++issues;
 		} else if (val_length > MAX_ABSTRACT_LEN) {

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -90,6 +90,8 @@ static void usage(int exitcode, char const *name, char const *str) __attribute__
 static void sanity_chk(char const *file, char const *fnamchk);
 static int check_info_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_info_json_field(char const *name, char const *val);
+static int get_info_json_field(char const *file, char *name, char *val);
+static int check_found_info_json_fields(char const *file, bool test);
 static void free_found_info_json_fields(void);
 
 #endif /* INCLUDE_JINFOCHK_H */

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -92,6 +92,7 @@ static int check_info_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_info_json_field(char const *name, char const *val);
 static int get_info_json_field(char const *file, char *name, char *val);
 static int check_found_info_json_fields(char const *file, bool test);
+static void check_info_json_fields_table(void);
 static void free_found_info_json_fields(void);
 
 #endif /* INCLUDE_JINFOCHK_H */

--- a/json.c
+++ b/json.c
@@ -1618,6 +1618,46 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
     return field;
 }
 
+/* check_common_json_fields_table	    - perform some sanity checks on the
+ *					      common_json_fields table
+ *
+ * This function checks if JSON_NULL is used on any field other than the NULL
+ * field. It also makes sure that each field_type is valid. More tests might be
+ * devised later on but this is a good start (27 Feb 2022).
+ *
+ * This function does not return on error.
+ */
+void
+check_common_json_fields_table(void)
+{
+    size_t loc;
+
+    for (loc = 0; common_json_fields[loc].name != NULL; ++loc) {
+	switch (common_json_fields[loc].field_type) {
+	    case JSON_NULL:
+		if (common_json_fields[loc].name != NULL) {
+		    err(215, __func__, "found invalid data in common_json_fields table #0");
+		    not_reached();
+		}
+		break;
+	    case JSON_NUMBER:
+	    case JSON_BOOL:
+	    case JSON_STRING:
+	    case JSON_ARRAY:
+	    case JSON_ARRAY_NUMBER:
+	    case JSON_ARRAY_BOOL:
+	    case JSON_ARRAY_STRING:
+		/* these are all the valid types */
+		break;
+	    default:
+		err(216, __func__, "found invalid data in common_json_fields table #1");
+		not_reached();
+		break;
+	}
+    }
+}
+
+
 /*
  * json_filename    - return ".info.json", ".author.json" or "null" depending on type
  *
@@ -1674,10 +1714,10 @@ check_first_json_char(char const *file, char *data, bool strict, char **first)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(215, __func__, "passed NULL or zero length data");
+	err(217, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || first == NULL) {
-	err(216, __func__, "passed NULL arg(s)");
+	err(218, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1717,10 +1757,10 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(217, __func__, "passed NULL or zero length data");
+	err(219, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || last == NULL) {
-	err(218, __func__, "passed NULL arg(s)");
+	err(220, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1770,13 +1810,13 @@ add_found_common_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(219, __func__, "passed NULL arg(s)");
+	err(221, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(common_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(220, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
+	err(222, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
 	not_reached();
     }
     /*
@@ -1789,7 +1829,7 @@ add_found_common_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    field->count++;
 	    if (add_json_value(field, val) == NULL) {
-		err(221, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
+		err(223, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 	    return field;
@@ -1799,7 +1839,7 @@ add_found_common_json_field(char const *name, char const *val)
     field = new_json_field(name, val);
     if (field == NULL) {
 	/* this should NEVER be reached but we check just to be sure */
-	err(222, __func__, "new_json_field() returned NULL pointer");
+	err(224, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
 
@@ -1840,7 +1880,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
      * firewall
      */
     if (program == NULL || file == NULL || name == NULL || val == NULL) {
-	err(223, __func__, "passed NULL arg(s)");
+	err(225, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1895,7 +1935,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * firewall
      */
     if (program == NULL || file == NULL || fnamchk == NULL) {
-	err(224, __func__, "passed NULL arg(s)");
+	err(226, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1913,7 +1953,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(225, __func__, "found NULL or empty field in found_common_json_fields list");
+	    err(227, __func__, "found NULL or empty field in found_common_json_fields list");
 	    not_reached();
 	}
 
@@ -1928,7 +1968,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * common list is not a common field name.
 	 */
 	if (common_field == NULL) {
-	    err(226, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
+	    err(228, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -2101,26 +2141,26 @@ new_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(227, __func__, "passed NULL arg(s)");
+	err(229, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	errp(228, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
+	errp(230, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
 	not_reached();
     }
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	errp(229, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
+	errp(231, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
 	not_reached();
     }
 
     if (add_json_value(field, val) == NULL) {
-	err(230, __func__, "error adding value '%s' to field '%s'", val, name);
+	err(232, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
 
@@ -2152,20 +2192,20 @@ add_json_value(struct json_field *field, char const *val)
      * firewall
      */
     if (field == NULL || val == NULL) {
-	err(231, __func__, "passed NULL arg(s)");
+	err(233, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(232, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(234, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(233, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(235, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     /* find end of list */
@@ -2201,7 +2241,7 @@ free_json_field_values(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(234, __func__, "passed NULL field");
+	err(236, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2263,7 +2303,7 @@ free_json_field(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(235, __func__, "passed NULL field");
+	err(237, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2297,7 +2337,7 @@ free_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(236, __func__, "called with NULL arg(s)");
+	err(238, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2388,11 +2428,11 @@ free_author_array(struct author *author_set, int author_count)
      * firewall
      */
     if (author_set == NULL) {
-	err(237, __func__, "called with NULL arg(s)");
+	err(239, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count < 0) {
-	err(238, __func__, "author_count: %d < 0", author_count);
+	err(240, __func__, "author_count: %d < 0", author_count);
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -1879,6 +1879,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 {
     int year = 0;	/* ioccc_year: IOCCC year as an integer */
     int entry_num = -1;	/* entry_num: entry number as an integer */
+    int author_count = 0; /* author count */
     long ts = 0;	/* formed_timestamp_usec: microseconds as an integer */
     struct tm tm;	/* formed_timestamp: formatted as a time structure */
     int exit_code = 0;	/* tarball: exit code from fnamchk command */
@@ -2023,6 +2024,12 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		entry_num = string_to_int(val);
 		if (!(entry_num >= 0 && entry_num <= MAX_ENTRY_NUM)) {
 		    warn(__func__, "entry number %d out of range", entry_num);
+		    ++issues;
+		}
+	    } else if (!strcmp(field->name, "author_count")) {
+		author_count = string_to_int(val);
+		if (!(author_count > 0 && author_count <= MAX_AUTHORS)) {
+		    warn(__func__, "author count %d out of range of > 1 && <= %d", author_count, MAX_AUTHORS);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_UTC")) {

--- a/json.c
+++ b/json.c
@@ -1483,7 +1483,7 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 /*
  * malloc_json_decode_str - return a JSON decoding of a string
  *
- * This is an simplified interface for malloc_json_decode().
+ * This is a simplified interface for malloc_json_decode().
  *
  * given:
  *	str	a string to decode
@@ -1636,7 +1636,8 @@ check_common_json_fields_table(void)
 	switch (common_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (common_json_fields[loc].name != NULL) {
-		    err(215, __func__, "found invalid data in common_json_fields table #0");
+		    err(215, __func__, "found JSON_NULL element with non NULL name '%s' location %lu in common_json_fields table",
+                            common_json_fields[loc].name, (unsigned long)loc);
 		    not_reached();
 		}
 		break;
@@ -1650,7 +1651,7 @@ check_common_json_fields_table(void)
 		/* these are all the valid types */
 		break;
 	    default:
-		err(216, __func__, "found invalid data in common_json_fields table #1");
+		err(216, __func__, "found invalid data_type in common_json_fields table location %lu", (unsigned long)loc);
 		not_reached();
 		break;
 	}

--- a/json.c
+++ b/json.c
@@ -2091,7 +2091,6 @@ check_found_common_json_fields(char const *program, char const *file, char const
  * as long as no NULL pointers are encountered it will return a newly allocated
  * struct json_field *. This means that it is the caller's responsibility to
  * check if the field is already in the list.
- *
  */
 struct json_field *
 new_json_field(char const *name, char const *val)

--- a/json.h
+++ b/json.h
@@ -203,6 +203,7 @@ struct info {
     bool found_clean_rule;	/* true ==> Makefile has clean rule */
     bool found_clobber_rule;	/* true ==> Makefile has a clobber rule */
     bool found_try_rule;	/* true ==> Makefile has a try rule */
+    bool test_mode;		/* true ==> contest ID is test */
     /*
      * filenames
      */

--- a/json.h
+++ b/json.h
@@ -70,6 +70,15 @@ struct json_value
     struct json_value *next;
 };
 
+#define JSON_NUMBER	    (0)	    /* json field is supposed to be a number */
+#define JSON_BOOL	    (1)	    /* json field is supposed to be a boolean */
+#define JSON_STRING	    (2)	    /* json field is supposed to be a string */
+#define JSON_ARRAY	    (3)	    /* json field is supposed to be an array */
+#define JSON_ARRAY_NUMBER   (5)	    /* json field is supposed to be a number in an array */
+#define JSON_ARRAY_BOOL	    (6)	    /* json field is supposed to be a number in an array (NB: not used) */
+#define JSON_ARRAY_STRING   (7)	    /* json field is supposed to be a string in an array */
+#define JSON_NULL	    (-1)    /* json field is NULL (not null): used internally to mark end of the tables */
+
 /*
  * JSON field: a JSON field consists of the name and all the values (if more
  * than one field of the same name is found in the file).
@@ -80,6 +89,9 @@ struct json_field
     struct json_value *values;	/* linked list of values */
 
     /*
+     * the below are for the tables: common_json_fields, info_json_fields and
+     * author_json_fields:
+     *
      * Number of times this field has been seen in the list, how many are
      * actually allowed and whether the field has been found: This is for the
      * tables that say tell many times a field has been seen, how many times it
@@ -88,10 +100,18 @@ struct json_field
      *
      * In other words this is done as part of the checks after the field:value
      * pairs have been extracted.
+     *
+     * NOTE: A max_count == 0 means that there's no limit.
      */
     size_t count;		/* how many of this field in the list (or how many values) */
     size_t max_count;		/* how many of this field is allowed */
     bool found;			/* if this field was found */
+
+    /*
+     * Data type: one of JSON_NUMBER, JSON_BOOL, JSON_STRING or
+     * JSON_ARRAY_ equivalents.
+     */
+    int field_type;
 
     struct json_field *next;	/* the next in the whatever list (XXX don't add to more than one list!) */
 };

--- a/json.h
+++ b/json.h
@@ -235,6 +235,7 @@ extern char const *json_filename(int type);
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
 extern struct json_field *add_found_common_json_field(char const *name, char const *val);
+extern void check_common_json_fields_table(void);
 extern int get_common_json_field(char const *program, char const *file, char *name, char *val);
 extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk, bool test);
 extern struct json_field *new_json_field(char const *name, char const *val);

--- a/limit_ioccc.h
+++ b/limit_ioccc.h
@@ -59,7 +59,7 @@
 #define MAX_AFFILIATION_LEN (48)	/* max affiliation name length */
 #define MAX_TITLE_LEN (32)		/* maximum length of a title */
 #define MAX_ABSTRACT_LEN (64)		/* maximum length of an abstract */
-#define MAX_HANDLE (32)			/* maximum IOCCC winner handle */
+#define MAX_HANDLE (32)			/* maximum length of IOCCC winner handle */
 #define MAX_BASENAME_LEN ((size_t)(99))	/* tar --format=v7 limits filenames to 99 characters */
 #define UUID_LEN (36)			/* characters in a UUID string - as per RFC4122 */
 #define UUID_VERSION (4)		/* version 4 - random UUID */
@@ -68,7 +68,7 @@
 #define MAX_TIMESTAMP_LEN (48)		/* 28 + 20 more padding for locate */
 
 /*
- * Be careful to change this value as it will invalidate all IOCCC timestamps < this value
+ * Be careful not to change this value as it will invalidate all IOCCC timestamps < this value
  */
 #define MIN_TIMESTAMP ((time_t)1643987926)
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -122,7 +122,6 @@ main(int argc, char *argv[])
     char *jinfochk = JINFOCHK_PATH_0;		/* path to jinfochk executable */
     char const *answers = NULL;			/* path to the answers file (recording input given on stdin) */
     FILE *answerp = NULL;			/* file pointer to the answers file */
-    bool test_mode = false;			/* true ==> contest ID is test */
     char *entry_dir = NULL;			/* entry directory from which to form a compressed tarball */
     char *tarball_path = NULL;			/* path of the compressed tarball to form */
     int extra_count = 0;			/* number of extra files */
@@ -366,7 +365,7 @@ main(int argc, char *argv[])
     /*
      * obtain the IOCCC contest ID
      */
-    info.common.ioccc_id = get_contest_id(&test_mode, &read_answers_flag_used);
+    info.common.ioccc_id = get_contest_id(&info.test_mode, &read_answers_flag_used);
     dbg(DBG_MED, "IOCCC contest ID: %s", info.common.ioccc_id);
 
     /*
@@ -533,7 +532,7 @@ main(int argc, char *argv[])
      * write the .info.json file
      */
     para("", "Forming the .info.json file ...", NULL);
-    write_info(&info, entry_dir, test_mode, jinfochk, fnamchk, author_count);
+    write_info(&info, entry_dir, info.test_mode, jinfochk, fnamchk, author_count);
     para("... completed the .info.json file.", "", NULL);
 
     /*
@@ -672,7 +671,7 @@ main(int argc, char *argv[])
     /*
      * remind user various things e.g., to upload (unless in test mode)
      */
-    remind_user(work_dir, entry_dir, tar, tarball_path, test_mode);
+    remind_user(work_dir, entry_dir, tar, tarball_path, info.test_mode);
 
     /*
      * free storage

--- a/util.c
+++ b/util.c
@@ -2586,7 +2586,7 @@ string_to_bool(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(35, __func__, "passed NULL string");
+	err(171, __func__, "passed NULL string");
 	not_reached();
     }
     if (*str == '1' || !strcmp(str, "true")) {

--- a/util.c
+++ b/util.c
@@ -1995,7 +1995,7 @@ find_utils(bool tar_flag_used, char **tar, bool cp_flag_used, char **cp, bool ls
 
 
 /*
- * round_to_multiple - round to a multiple
+ * round_to_multiple - round up to a multiple
  *
  * given:
  *
@@ -2011,7 +2011,7 @@ find_utils(bool tar_flag_used, char **tar, bool cp_flag_used, char **cp, bool ls
  *
  *  Examples:
  *
- *	0 rounds 0
+ *	0 rounds to 0
  *	1 rounds to 1024
  *	1023 rounds to 1024
  *	1024 rounds to 1024
@@ -2182,7 +2182,7 @@ read_all(FILE *stream, size_t *psize)
 	    } else if (ferror(stream)) {
 		warnp(__func__, "I/O error detected while reading stream at: %lu bytes", (unsigned long)used);
 	    } else {
-		warnp(__func__, "fread returned 0 although the EOF nor ERROR flag were not set: assuming EOF anyway");
+		warnp(__func__, "fread returned 0 although neither the EOF nor ERROR flag were set: assuming EOF anyway");
 	    }
 
 	    /*
@@ -2523,4 +2523,48 @@ parse_verbosity(char const *program, char const *arg)
     }
 
     return verbosity;
+}
+
+/* is_number	    - if the string str is a number
+ *
+ * given:
+ *
+ *	str	    - string to check
+ *
+ * For our purposes a number is defined as: a string that starts with either a
+ * '-' or '+' and beyond that no other characters but [0-9] (any count).
+ *
+ * returns:
+ *
+ *	true	==> str is a number
+ *	false	==> str is not a number
+ *
+ * NOTE: This function does not return on error (str == NULL). An empty string
+ * is considered not a number.
+ */
+bool
+is_number(char const *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	err(35, __func__, "passed NULL string");
+	not_reached();
+    }
+
+    switch (*str) {
+	case '-':
+	case '+':
+	    str++;
+	    break;
+	default:
+	    break;
+    }
+
+    if (!strlen(str)) {
+	return false;
+    }
+
+    return strspn(str, "0123456789") == strlen(str);
 }

--- a/util.c
+++ b/util.c
@@ -2575,7 +2575,7 @@ is_number(char const *str)
  *
  *	str		- string to convert to bool
  *
- * Returns true if *str == '1' or string is "true"; else it returns false.
+ * Returns true if !strcmp(str, "true").
  *
  * This function does not return on NULL str. If strlen(str) == 0 return false.
  */
@@ -2589,7 +2589,7 @@ string_to_bool(char const *str)
 	err(171, __func__, "passed NULL string");
 	not_reached();
     }
-    if (*str == '1' || !strcmp(str, "true")) {
+    if (!strcmp(str, "true")) {
 	return true;
     }
 

--- a/util.c
+++ b/util.c
@@ -2549,7 +2549,7 @@ is_number(char const *str)
      * firewall
      */
     if (str == NULL) {
-	err(35, __func__, "passed NULL string");
+	err(170, __func__, "passed NULL string");
 	not_reached();
     }
 

--- a/util.c
+++ b/util.c
@@ -2589,9 +2589,6 @@ string_to_bool(char const *str)
 	err(171, __func__, "passed NULL string");
 	not_reached();
     }
-    if (!strcmp(str, "true")) {
-	return true;
-    }
 
-    return false;
+    return !strcmp(str, "true");
 }

--- a/util.c
+++ b/util.c
@@ -2568,3 +2568,30 @@ is_number(char const *str)
 
     return strspn(str, "0123456789") == strlen(str);
 }
+
+/* string_to_bool	- convert string to a bool
+ *
+ * given:
+ *
+ *	str		- string to convert to bool
+ *
+ * Returns true if *str == '1' or string is "true"; else it returns false.
+ *
+ * This function does not return on NULL str. If strlen(str) == 0 return false.
+ */
+bool
+string_to_bool(char const *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	err(35, __func__, "passed NULL string");
+	not_reached();
+    }
+    if (*str == '1' || !strcmp(str, "true")) {
+	return true;
+    }
+
+    return false;
+}

--- a/util.h
+++ b/util.h
@@ -138,5 +138,6 @@ extern unsigned long long string_to_unsigned_long_long(char const *str);
 extern bool valid_contest_id(char *str);
 extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_number(char const *str);
+extern bool string_to_bool(char const *str);
 
 #endif				/* INCLUDE_UTIL_H */

--- a/util.h
+++ b/util.h
@@ -65,8 +65,7 @@ struct location {
 #define INITIAL_BUF_SIZE (8192)	/* initial size of buffer allocated by read_all */
 #define READ_ALL_CHUNK (65536)	/* grow this read_all by this amount when needed */
 #define TAIL_TITLE_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_+-"	/* [a-z0-9_+-] */
-
-
+/* for string to int functions */
 #define LLONG_MAX_BASE10_DIGITS (19)
 
 
@@ -138,6 +137,6 @@ extern unsigned long string_to_unsigned_long(char const *str);
 extern unsigned long long string_to_unsigned_long_long(char const *str);
 extern bool valid_contest_id(char *str);
 extern int parse_verbosity(char const *program, char const *arg);
-
+extern bool is_number(char const *str);
 
 #endif				/* INCLUDE_UTIL_H */

--- a/version.h
+++ b/version.h
@@ -109,12 +109,12 @@
 /*
  * official jinfochk version
  */
-#define JINFOCHK_VERSION "0.8 2022-02-26"	/* format: major.minor YYYY-MM-DD */
+#define JINFOCHK_VERSION "0.9 2022-02-27"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jauthchk version
  */
-#define JAUTHCHK_VERSION "0.8 2022-02-26"	/* format: major.minor YYYY-MM-DD */
+#define JAUTHCHK_VERSION "0.9 2022-02-27"	/* format: major.minor YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
New version for these tools: 0.9 2022-02-27.

The `struct json_field` now has an `int field_type` which can be one of:
`JSON_NUMBER`, `JSON_BOOL`, `JSON_STRING`, `JSON_ARRAY`, `JSON_ARRAY_NUMBER`, `JSON_ARRAY_BOOL` or `JSON_ARRAY_STRING`. `JSON_NULL` also exists: this is only as an end of list marker. Note that the array versions are not
handled yet because arrays are not handled yet and the JSON_ARRAY_
macros might be changed but I needed to distinguish that they're part of
an array. The `JSON_STRING` and `JSON_ARRAY_STRING` are used to decide
whether or not to remove '"'s from the values (they're always removed
from the field names). It used to be done via a bunch of `strcmp() != 0`
results i.e. by a long list of names.

Added list for both .info.json and .author.json. All the fields in the
file are added but because the arrays are not handled the array fields
will not be added to the list (this also means that anything not in the
list will not be added; however in the future - once arrays are dealt
with - these will be reported as an issue but this cannot happen yet as
it would make the tools fail).

Clean up the adding fields to lists and checking fields lists. This is
via the new functions:

```c
    /*
     * get_info_json_field  -           check if name is a .info.json field
     *                                  and if it is add it to the found_info_json
     *                                  list.
     *
     * given:
     *
     *      file    - the file being parsed (path to)
     *      name    - the field name
     *      val     - the value of the field
     *
     * returns:
     *      1 ==> if the name is a .info.json field
     *      0 ==> if it's not one of the .info.json fields
     *
     * NOTE: Does not return on error (NULL pointers).
     */
```
and

```c
    /*
     * check_found_info_json_fields - check that all the fields in the
     *                                  found_info_json_fields table have valid
     *                                  values
     *
     *  given:
     *
     *          file        - .info.json file we're checking
     *          test        - if test mode: ignore some checks
     *
     *
     * returns:
     *      >0 ==> the number of issues found
     *      0 ==> if no issues were found
     */
```

... as well as the author equivalents. The functions for the common
fields version have also been cleaned up some.

New function in util.c:

```c
    /* is_number        - if the string str is a number
     *
     * given:
     *
     *      str         - string to check
     *
     * For our purposes a number is defined as: a string that starts with either a
     * '-' or '+' and beyond that no other characters but [0-9] (any count).
     *
     * returns:
     *
     *      true    ==> str is a number
     *      false   ==> str is not a number
     *
     * NOTE: This function does not return on error (str == NULL). An empty string
     * is considered not a number.
     */
```
... which is used in the json check functions specific to json field
type. Maybe this should be done in other places as well.

In test mode don't complain about different `INFO_VERSION` (in jinfochk)
and `AUTHOR_VERSION` (in jauthchk).

Typo fixes and comments updates.

Some additional sanity checks have been added. One that comes to mind is
we warn about empty values (this does not count as an issue because the
checks below will trigger that - this is only to show why it would
happen).

The `find_json_field_in_table()` function no longer can erroneously find a
field with an empty name and you can now get the number of elements via
passing an empty string or a NULL pointer (if empty it's set to NULL).

There might be other changes I've forgotten.