### PR TITLE
jinfochk and jauthchk: additional checks added

### DIFF
--- a/fnamchk.1
+++ b/fnamchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
-\fBfnamchk [\-h] [\-v level] [\-V] [\-T] filepath
+\fBfnamchk [\-h] [\-v level] [\-V] [\-T] [\-t|\-u] filepath
 .SH DESCRIPTION
 \fBfnamchk\fP verifies that an IOCCC compressed tarball is properly named.
 .PP
@@ -41,9 +41,18 @@ Show version and exit.
 .PP
 \fB\-T\fP
 Show IOCCC toolset chain release repository tag.
+.PP
+\fB\-t\fP
+If the filename does not start with the test mode filename format, issue an error.
+In other words the filename has to start with \fB"entry.test-"\fP or it's an error.
+.PP
+\fB\-u\fP
+If the filename does not start with the normal filename format, issue an error.
+In other words if the filename starts with \fB"entry.test-"\fP it is an error.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 0 on success; if there's an error the end is not reached.
+If there's an error the error message is printed; else the output will be the name of the required directory in the tarball.
 .SH FILES
 \fIfnamchk.c\fP
 .RS
@@ -65,7 +74,7 @@ Run the program on the tarball \fIentry.test.0.1644094311.txz\fP:
 
 .RS
 \fB
- ./fnamchk entry.test.0.1644094311.txz\fP
+ ./fnamchk entry.test-0.1644094311.txz\fP
 .fi
 .RE
 .PP
@@ -77,3 +86,23 @@ Run the program on the tarball \fItest.tar\fP, which will fail:
  ./fnamchk test.tar
 .fi
 .RE
+.PP
+.nf
+Run the program on the tarball \fIentry.test.0.1644094311.txz\fP with the option \fI\-u\fP which will fail:
+
+.RS
+\fB
+ ./fnamchk -u entry.test-0.1644094311.txz\fP
+.fi
+.RE
+.PP
+.nf
+Run the program on the tarball \fIentry.test.0.1644094311.txz\fP with the option \fI\-t\fP which will pass:
+
+.RS
+\fB
+ ./fnamchk -t entry.test-0.1644094311.txz\fP
+.fi
+.RE
+.PP
+The above will print \fBtest\-0\fP.

--- a/fnamchk.h
+++ b/fnamchk.h
@@ -64,16 +64,20 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-T] filepath\n"
+    "usage: %s [-h] [-v level] [-V] [-T] [-t|-u] filepath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-V\t\t\tprint version string and exit\n"
     "\t-T\t\t\tshow IOCCC toolset chain release repository tag\n"
+    "\t-t\t\t\tfilename must match test entry filename\n"
+    "\t-u\t\t\tfilename must match real entry filename\n"
     "\n"
+    "\t\tNOTE: -t and -u cannot be used together.\n\n"
     "\tfilepath\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "fnamchk version: %s\n";
+
 
 
 /*

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -183,8 +183,9 @@ static void
 check_author_json_fields_table(void)
 {
     size_t loc;
+    size_t max = sizeof(author_json_fields)/sizeof(author_json_fields[0]);
 
-    for (loc = 0; author_json_fields[loc].name != NULL; ++loc) {
+    for (loc = 0; loc < max - 1 && author_json_fields[loc].name != NULL; ++loc) {
 	switch (author_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (author_json_fields[loc].name != NULL) {
@@ -208,6 +209,12 @@ check_author_json_fields_table(void)
 		break;
 	}
     }
+
+    if (max - 1 != loc) {
+	err(7, __func__, "found embedded NULL element in author_json_fields table");
+	not_reached();
+    }
+
 }
 
 
@@ -230,7 +237,7 @@ sanity_chk(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(7, __func__, "called with NULL arg(s)");
+	err(8, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -246,7 +253,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [options] <file>"
 	      "",
 	      NULL);
-	err(8, __func__, "file does not exist: %s", file);
+	err(9, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
@@ -259,7 +266,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [...] <file>",
 	      "",
 	      NULL);
-	err(9, __func__, "file is not a file: %s", file);
+	err(10, __func__, "file is not a file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -272,7 +279,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [...] <file>"
 	      "",
 	      NULL);
-	err(10, __func__, "file is not readable: %s", file);
+	err(11, __func__, "file is not readable: %s", file);
 	not_reached();
     }
 
@@ -294,7 +301,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(11, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(12, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -311,7 +318,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(12, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(13, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -328,7 +335,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(13, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(14, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -377,22 +384,22 @@ check_author_json(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(14, __func__, "passed NULL arg(s)");
+	err(15, __func__, "passed NULL arg(s)");
 	not_reached();
     }
     stream = fopen(file, "r");
     if (stream == NULL) {
-	err(15, __func__, "couldn't open %s", file);
+	err(16, __func__, "couldn't open %s", file);
 	not_reached();
     }
 
     /* read in the file */
     data = read_all(stream, &length);
     if (data == NULL) {
-	err(16, __func__, "error while reading data in %s", file);
+	err(17, __func__, "error while reading data in %s", file);
 	not_reached();
     } else if (length == 0) {
-	err(17, __func__, "zero length data in file %s", file);
+	err(18, __func__, "zero length data in file %s", file);
 	not_reached();
     }
     dbg(DBG_MED, "%s read length: %lu", file, (unsigned long)length);
@@ -406,14 +413,14 @@ check_author_json(char const *file, char const *fnamchk)
 
     /* scan for embedded NUL bytes (before EOF) */
     if (!is_string(data, length+1)) {
-	err(18, __func__, "found NUL before EOF: %s", file);
+	err(19, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }
 
     errno = 0;
     data_dup = strdup(data);
     if (data_dup == NULL) {
-	errp(19, __func__, "unable to strdup file contents");
+	errp(20, __func__, "unable to strdup file contents");
 	not_reached();
     }
 
@@ -424,7 +431,7 @@ check_author_json(char const *file, char const *fnamchk)
      * parsing after the first '{' but after the '}' we don't continue.
      */
     if (check_last_json_char(file, data_dup, strict, &p)) {
-	err(20, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_MED, "last character: '%c'", *p);
@@ -434,7 +441,7 @@ check_author_json(char const *file, char const *fnamchk)
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p)) {
-	err(21, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_MED, "first character: '%c'", *p);
@@ -501,14 +508,14 @@ check_author_json(char const *file, char const *fnamchk)
 	     */
 	    val = strtok_r(NULL, ",\0", &savefield);
 	    if (val == NULL) {
-		err(22, __func__, "unable to find value in file %s for field %s", file, p);
+		err(23, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 	} else {
 	    /* extract the value */
 	    val = strtok_r(NULL, ",", &savefield);
 	    if (val == NULL) {
-		err(23, __func__, "unable to find value in file %s for field %s", file, p);
+		err(24, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 
@@ -614,7 +621,7 @@ get_author_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(24, __func__, "passed NULL arg(s)");
+	err(25, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -662,7 +669,7 @@ check_found_author_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(25, __func__, "passed NULL file");
+	err(26, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -671,7 +678,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(26, __func__, "found NULL or empty field in found_author_json_fields list");
+	    err(27, __func__, "found NULL or empty field in found_author_json_fields list");
 	    not_reached();
 	}
 
@@ -686,7 +693,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * author list is not a author field name.
 	 */
 	if (author_field == NULL) {
-	    err(27, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
+	    err(28, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -787,13 +794,13 @@ add_found_author_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(28, __func__, "passed NULL arg(s)");
+	err(29, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(author_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(29, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
+	err(30, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
 	not_reached();
     }
     /*
@@ -816,7 +823,7 @@ add_found_author_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(30, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(31, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -836,7 +843,7 @@ add_found_author_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(31, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(32, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
     }
 
     /* add to the list */

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -282,9 +282,9 @@ sanity_chk(char const *file, char const *fnamchk)
     if (!exists(fnamchk)) {
 	fpara(stderr,
 	      "",
-	      "We cannot find a fnamchk tool.",
+	      "We cannot find fnamchk.",
 	      "",
-	      "A fnamchk program performs a sanity check on the compressed tarball.",
+	      "A fnamchk program performs a sanity check on the compressed tarball filename.",
 	      "Perhaps you need to use:",
 	      "",
 	      "    jauthchk -F /path/to/fnamchk ...",
@@ -365,7 +365,7 @@ check_author_json(char const *file, char const *fnamchk)
     char *data;		/* .author.json contents */
     char *data_dup;	/* contents of file strdup()d */
     size_t length;	/* length of input buffer */
-    char *p = NULL;	/* temporary use: check for NUL bytes and field extraction */
+    char *p = NULL;	/* for field extraction */
     char *end = NULL;	/* temporary use: end of strings (p, field) for removing spaces */
     char *val = NULL;	/* current field's value being parsed */
     char *savefield = NULL; /* for strtok_r() usage */
@@ -405,7 +405,7 @@ check_author_json(char const *file, char const *fnamchk)
     }
 
     /* scan for embedded NUL bytes (before EOF) */
-    if (is_string(data, length+1) == false) {
+    if (!is_string(data, length+1)) {
 	err(18, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -56,8 +56,7 @@ struct json_field info_json_fields[] =
     { "Makefile",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
     { "remarks",		NULL, 0, 1, false, JSON_ARRAY_STRING,	NULL },
     { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL }, /* this **MUST** be last */
-    { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	NULL },
+    { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL } /* this **MUST** be last */
 };
 
 
@@ -188,7 +187,7 @@ main(int argc, char **argv)
  * field. It also makes sure that each field_type is valid.  These sanitu checks
  * are performed with the info_json_fields table.
  *
- * NPTE: More tests might be devised later on but this is a good start (27 Feb 2022).
+ * NOTE: More tests might be devised later on but this is a good start (27 Feb 2022).
  *
  * This function does not return on error.
  */
@@ -196,8 +195,9 @@ static void
 check_info_json_fields_table(void)
 {
     size_t loc;
+    size_t max = sizeof(info_json_fields)/sizeof(info_json_fields[0]);
 
-    for (loc = 0; info_json_fields[loc].name != NULL; ++loc) {
+    for (loc = 0; loc < max - 1 && info_json_fields[loc].name != NULL; ++loc) {
 	switch (info_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (info_json_fields[loc].name != NULL) {
@@ -221,6 +221,12 @@ check_info_json_fields_table(void)
 		break;
 	}
     }
+
+    if (max - 1 != loc) {
+	err(7, __func__, "found embedded NULL element in info_json_fields table");
+	not_reached();
+    }
+
 }
 
 /*
@@ -242,7 +248,7 @@ sanity_chk(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(7, __func__, "called with NULL arg(s)");
+	err(8, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -258,7 +264,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [options] <file>"
 	      "",
 	      NULL);
-	err(8, __func__, "file does not exist: %s", file);
+	err(9, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
@@ -271,7 +277,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>",
 	      "",
 	      NULL);
-	err(9, __func__, "file is not a file: %s", file);
+	err(10, __func__, "file is not a file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -284,7 +290,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>"
 	      "",
 	      NULL);
-	err(10, __func__, "file is not readable: %s", file);
+	err(11, __func__, "file is not readable: %s", file);
 	not_reached();
     }
 
@@ -306,7 +312,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(11, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(12, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -323,7 +329,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(12, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(13, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -340,7 +346,7 @@ sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(13, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(14, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -389,23 +395,23 @@ check_info_json(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(14, __func__, "passed NULL arg(s)");
+	err(15, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     stream = fopen(file, "r");
     if (stream == NULL) {
-	err(15, __func__, "couldn't open %s", file);
+	err(16, __func__, "couldn't open %s", file);
 	not_reached();
     }
 
     /* read in the file */
     data = read_all(stream, &length);
     if (data == NULL) {
-	err(16, __func__, "error while reading data in %s", file);
+	err(17, __func__, "error while reading data in %s", file);
 	not_reached();
     } else if (length == 0) {
-	err(17, __func__, "zero length data in file %s", file);
+	err(18, __func__, "zero length data in file %s", file);
 	not_reached();
     }
     dbg(DBG_HIGH, "%s read length: %lu", file, (unsigned long)length);
@@ -419,14 +425,14 @@ check_info_json(char const *file, char const *fnamchk)
 
     /* scan for embedded NUL bytes (before EOF) */
     if (!is_string(data, length+1)) {
-	err(18, __func__, "found NUL before EOF: %s", file);
+	err(19, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }
 
     errno = 0;
     data_dup = strdup(data);
     if (data_dup == NULL) {
-	errp(19, __func__, "unable to strdup file %s contents", file);
+	errp(20, __func__, "unable to strdup file %s contents", file);
 	not_reached();
     }
 
@@ -437,7 +443,7 @@ check_info_json(char const *file, char const *fnamchk)
      * parsing after the first '{' but after the '}' we don't continue.
      */
     if (check_last_json_char(file, data_dup, strict, &p)) {
-	err(20, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "last character: '%c'", *p);
@@ -447,7 +453,7 @@ check_info_json(char const *file, char const *fnamchk)
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p)) {
-	err(21, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "first character: '%c'", *p);
@@ -509,14 +515,14 @@ check_info_json(char const *file, char const *fnamchk)
 	     */
 	    val = strtok_r(NULL, ",\0", &savefield);
 	    if (val == NULL) {
-		err(22, __func__, "unable to find value in file %s for field %s", file, p);
+		err(23, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 	} else {
 	    /* extract the value */
 	    val = strtok_r(NULL, ",\0", &savefield);
 	    if (val == NULL) {
-		err(23, __func__, "unable to find value in file %s for field %s", file, p);
+		err(24, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 
@@ -626,7 +632,7 @@ get_info_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(24, __func__, "passed NULL arg(s)");
+	err(25, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -674,13 +680,13 @@ add_found_info_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(25, __func__, "passed NULL arg(s)");
+	err(26, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(26, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	err(27, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
 	not_reached();
     }
     /*
@@ -702,7 +708,7 @@ add_found_info_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(27, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(28, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -722,7 +728,7 @@ add_found_info_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(28, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(29, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 
@@ -768,7 +774,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(29, __func__, "passed NULL file");
+	err(30, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -777,7 +783,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(30, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(31, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -792,7 +798,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(31, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(32, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 

--- a/json.c
+++ b/json.c
@@ -2147,7 +2147,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      */
     for (loc = 0; common_json_fields[loc].name != NULL; ++loc) {
 	if (!common_json_fields[loc].found) {
-	    warn(__func__, "field '%s' not found in common_json_fields list", common_json_fields[loc].name);
+	    warn(__func__, "field '%s' not found in found_common_json_fields list", common_json_fields[loc].name);
 	    ++issues;
 	}
     }

--- a/json.c
+++ b/json.c
@@ -1640,8 +1640,9 @@ void
 check_common_json_fields_table(void)
 {
     size_t loc;
+    size_t max = sizeof(common_json_fields)/sizeof(common_json_fields[0]);
 
-    for (loc = 0; common_json_fields[loc].name != NULL; ++loc) {
+    for (loc = 0; loc < max-1 && common_json_fields[loc].name != NULL; ++loc) {
 	switch (common_json_fields[loc].field_type) {
 	    case JSON_NULL:
 		if (common_json_fields[loc].name != NULL) {
@@ -1664,6 +1665,10 @@ check_common_json_fields_table(void)
 		not_reached();
 		break;
 	}
+    }
+    if (max - 1 != loc) {
+	err(217, __func__, "found embedded NULL element in common_json_fields table");
+	not_reached();
     }
 }
 
@@ -1726,10 +1731,10 @@ check_first_json_char(char const *file, char *data, bool strict, char **first)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(217, __func__, "passed NULL or zero length data");
+	err(218, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || first == NULL) {
-	err(218, __func__, "passed NULL arg(s)");
+	err(219, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1770,10 +1775,10 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(219, __func__, "passed NULL or zero length data");
+	err(220, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || last == NULL) {
-	err(220, __func__, "passed NULL arg(s)");
+	err(221, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1826,13 +1831,13 @@ add_found_common_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(221, __func__, "passed NULL arg(s)");
+	err(222, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(common_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(222, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
+	err(223, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
 	not_reached();
     }
     /*
@@ -1845,7 +1850,7 @@ add_found_common_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    field->count++;
 	    if (add_json_value(field, val) == NULL) {
-		err(223, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
+		err(224, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 	    return field;
@@ -1855,7 +1860,7 @@ add_found_common_json_field(char const *name, char const *val)
     field = new_json_field(name, val);
     if (field == NULL) {
 	/* this should NEVER be reached but we check just to be sure */
-	err(224, __func__, "new_json_field() returned NULL pointer");
+	err(225, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
 
@@ -1899,7 +1904,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
      * firewall
      */
     if (program == NULL || file == NULL || name == NULL || val == NULL) {
-	err(225, __func__, "passed NULL arg(s)");
+	err(226, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1958,7 +1963,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * firewall
      */
     if (program == NULL || file == NULL || fnamchk == NULL) {
-	err(226, __func__, "passed NULL arg(s)");
+	err(227, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1976,7 +1981,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(227, __func__, "found NULL or empty field in found_common_json_fields list");
+	    err(228, __func__, "found NULL or empty field in found_common_json_fields list");
 	    not_reached();
 	}
 
@@ -1991,7 +1996,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * common list is not a common field name.
 	 */
 	if (common_field == NULL) {
-	    err(228, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
+	    err(229, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -2216,26 +2221,26 @@ new_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(229, __func__, "passed NULL arg(s)");
+	err(230, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	errp(230, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
+	errp(231, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
 	not_reached();
     }
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	errp(231, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
+	errp(232, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
 	not_reached();
     }
 
     if (add_json_value(field, val) == NULL) {
-	err(232, __func__, "error adding value '%s' to field '%s'", val, name);
+	err(233, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
 
@@ -2269,20 +2274,20 @@ add_json_value(struct json_field *field, char const *val)
      * firewall
      */
     if (field == NULL || val == NULL) {
-	err(233, __func__, "passed NULL arg(s)");
+	err(234, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(234, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(235, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(235, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(236, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     /* find end of list */
@@ -2319,7 +2324,7 @@ free_json_field_values(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(236, __func__, "passed NULL field");
+	err(237, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2385,7 +2390,7 @@ free_json_field(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(237, __func__, "passed NULL field");
+	err(238, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2420,7 +2425,7 @@ free_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(238, __func__, "called with NULL arg(s)");
+	err(239, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2512,11 +2517,11 @@ free_author_array(struct author *author_set, int author_count)
      * firewall
      */
     if (author_set == NULL) {
-	err(239, __func__, "called with NULL arg(s)");
+	err(240, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count < 0) {
-	err(240, __func__, "author_count: %d < 0", author_count);
+	err(241, __func__, "author_count: %d < 0", author_count);
 	not_reached();
     }
 

--- a/json.h
+++ b/json.h
@@ -147,6 +147,7 @@ struct json_common
     char *ioccc_id;		/* IOCCC contest ID */
     int entry_num;		/* IOCCC entry number */
     char *tarball;		/* tarball filename */
+    bool test_mode;		/* true ==> test mode entered */
 
     /*
      * time

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -365,7 +365,7 @@ main(int argc, char *argv[])
     /*
      * obtain the IOCCC contest ID
      */
-    info.common.ioccc_id = get_contest_id(&info.test_mode, &read_answers_flag_used);
+    info.common.ioccc_id = get_contest_id(&info.common.test_mode, &read_answers_flag_used);
     dbg(DBG_MED, "IOCCC contest ID: %s", info.common.ioccc_id);
 
     /*
@@ -532,7 +532,7 @@ main(int argc, char *argv[])
      * write the .info.json file
      */
     para("", "Forming the .info.json file ...", NULL);
-    write_info(&info, entry_dir, info.test_mode, jinfochk, fnamchk, author_count);
+    write_info(&info, entry_dir, jinfochk, fnamchk, author_count);
     para("... completed the .info.json file.", "", NULL);
 
     /*
@@ -671,7 +671,7 @@ main(int argc, char *argv[])
     /*
      * remind user various things e.g., to upload (unless in test mode)
      */
-    remind_user(work_dir, entry_dir, tar, tarball_path, info.test_mode);
+    remind_user(work_dir, entry_dir, tar, tarball_path, info.common.test_mode);
 
     /*
      * free storage
@@ -2259,7 +2259,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     if (infop->rule_2a_size < 0) {
 	err(89, __func__, "file_size error: %ld on prog_c: %s", (long)infop->rule_2a_size, prog_c);
 	not_reached();
-    } else if (infop->rule_2a_size == 0) {
+    } else if (infop->rule_2a_size == 0 || infop->rule_2b_size == 0) {
 	warn_empty_prog(prog_c);
 	infop->empty_override = true;
 	infop->rule_2a_override = false;
@@ -4947,7 +4947,6 @@ json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char c
  * given:
  *      infop           - pointer to info structure
  *      entry_dir       - path to entry directory
- *      test_mode       - true ==> test mode, do not upload
  *      jinfochk	- path to jinfochk tool
  *      fnamchk		- path to fnamchk tool
  *      author_count	- number of authors
@@ -4958,7 +4957,7 @@ json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char c
  * This function does not return on error.
  */
 static void
-write_info(struct info *infop, char const *entry_dir, bool test_mode, char const *jinfochk, char const *fnamchk, int author_count)
+write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char const *fnamchk, int author_count)
 {
     struct tm *timeptr;		/* localtime return */
     char *info_path;		/* path to .info.json file */
@@ -5105,7 +5104,7 @@ write_info(struct info *infop, char const *entry_dir, bool test_mode, char const
 	json_fprintf_value_bool(info_stream, "\t", "found_clean_rule", " : ", infop->found_clean_rule, ",\n") &&
 	json_fprintf_value_bool(info_stream, "\t", "found_clobber_rule", " : ", infop->found_clobber_rule, ",\n") &&
 	json_fprintf_value_bool(info_stream, "\t", "found_try_rule", " : ", infop->found_try_rule, ",\n") &&
-	json_fprintf_value_bool(info_stream, "\t", "test_mode", " : ", test_mode, ",\n") &&
+	json_fprintf_value_bool(info_stream, "\t", "test_mode", " : ", infop->common.test_mode, ",\n") &&
 	fprintf(info_stream, "\t\"manifest\" : [\n") > 0;
     if (!ret) {
 	errp(167, __func__, "fprintf error writing leading part of info to %s", info_path);
@@ -5265,6 +5264,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "tarball", " : ", infop->common.tarball, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "entry_num", " : ", (long)infop->common.entry_num, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
+	json_fprintf_value_bool(author_stream, "\t", "test_mode", " : ", infop->common.test_mode, ",\n") &&
 	fprintf(author_stream, "\t\"authors\" : [\n") > 0;
     if (!ret) {
 	errp(179, __func__, "fprintf error writing leading part of authorship to %s", author_path);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -205,7 +205,7 @@ static bool json_fprintf_value_long(FILE *stream, char const *lead, char const *
 				    char const *tail);
 static bool json_fprintf_value_bool(FILE *stream, char const *lead, char const *name, char const *middle, bool value,
 				    char const *tail);
-static void write_info(struct info *infop, char const *entry_dir, bool test_mode, char const *jinfochk, char const *fnamchk, int author_count);
+static void write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char const *fnamchk, int author_count);
 static void write_author(struct info *infop, int author_count, struct author *authorp, char const *entry_dir, char const *jauthchk);
 static void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk);

--- a/version.h
+++ b/version.h
@@ -77,7 +77,7 @@
 /*
  * official mkiocccentry version
  */
-#define MKIOCCCENTRY_VERSION "0.37 2022-02-23"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "0.38 2022-02-28"	/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -99,7 +99,7 @@
 /*
  * official fnamchk version
  */
-#define FNAMCHK_VERSION "0.3 2022-02-23"	/* format: major.minor YYYY-MM-DD */
+#define FNAMCHK_VERSION "0.4 2022-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official txzchk version
@@ -109,12 +109,12 @@
 /*
  * official jinfochk version
  */
-#define JINFOCHK_VERSION "0.9 2022-02-27"	/* format: major.minor YYYY-MM-DD */
+#define JINFOCHK_VERSION "0.10 2022-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jauthchk version
  */
-#define JAUTHCHK_VERSION "0.9 2022-02-27"	/* format: major.minor YYYY-MM-DD */
+#define JAUTHCHK_VERSION "0.10 2022-02-28"	/* format: major.minor YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Add empty_override and rule 2a/2b size mismatches: If empty_override ==
true and either the rule 2a or 2b size != 0 then it's an issue; if false
and either rule 2a or 2b size == 0 it's an issue. This has also been
added to mkiocccentry: if either size is 0 then warn about empty prog.c.

The 'test_mode' field is now common to both .info.json and .author.json
and we verify test_mode consistency with fnamchk: that is to say that if
test_mode == true the tarball filename must start with "entry.test-"; if
false it must be a UUID. This is done by adding two options to fnamchk:
-u: if filename is a test mode filename then it's an error; -t: if
filename is a UUID filename it is an error.

I've bumped the version of fnamchk, jinfochk, jauthchk and mkiocccentry
for the above changes.