### PR TITLE
jinfochk and jauthchk updates

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -714,7 +714,9 @@ get_author_json_field(char const *file, char *name, char *val)
  * check_found_author_json_fields - found_author_json_fields table value check
  *
  * Verify that all the fields in the found_author_json_fields table have
- * values that are valid.
+ * values that are valid and that all fields that are required are in the file
+ * (TODO as of 2 March 2022 this is not actually done because arrays are not yet
+ * parsed: we have to extract all fields first before this test can be added).
  *
  *  given:
  *
@@ -786,7 +788,14 @@ check_found_author_json_fields(char const *file, bool test)
 		 * too: this warning only notes the reason the test will fail.
 		 */
 	    }
-	    /* first we do checks on the field type */
+
+	    /*
+	     * First we do checks on the field type. We only have to check
+	     * numbers and bools: because for strings there's nothing to
+	     * check: we remove the outermost '"'s and then use strcmp() whereas
+	     * for numbers and bools we want to make sure that they're actually
+	     * valid values.
+	     */
 	    switch (author_field->field_type) {
 		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
@@ -813,7 +822,6 @@ check_found_author_json_fields(char const *file, bool test)
 		default:
 		    break;
 	    }
-
 
 	    if (!strcmp(field->name, "IOCCC_author_version")) {
 		if (!test && strcmp(val, AUTHOR_VERSION)) {

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -458,7 +458,7 @@ check_author_json(char const *file, char const *fnamchk)
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p, '{')) {
-	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(23, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_MED, "first character: '%c'", *p);
@@ -527,21 +527,21 @@ check_author_json(char const *file, char const *fnamchk)
 	     * This will come in a future commit.
 	     */
 	    if (!author_field) {
-		err(23, __func__, "authors field not found in author_json_fields table");
+		err(24, __func__, "authors field not found in author_json_fields table");
 		not_reached();
 	    }
 
 	    /* find start of array */
 	    array_start = strtok_r(NULL, ":[{", &saveptr);
 	    if (array_start == NULL) {
-		err(24, __func__, "unable to find beginning of array");
+		err(25, __func__, "unable to find beginning of array");
 		not_reached();
 	    }
 
 	    /* extract the array */
 	    array = strtok_r(NULL, "]", &saveptr);
 	    if (array == NULL) {
-		err(25, __func__, "unable to extract array in file %s", file);
+		err(26, __func__, "unable to extract array in file %s", file);
 		not_reached();
 	    }
 
@@ -549,7 +549,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    errno = 0;
 	    array_dup = strdup(array);
 	    if (array_dup == NULL) {
-		errp(26, __func__, "strdup() on array failed: %s", strerror(errno));
+		errp(27, __func__, "strdup() on array failed: %s", strerror(errno));
 		not_reached();
 	    }
 	    /*
@@ -567,7 +567,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    /* extract the value */
 	    val = strtok_r(NULL, ",", &saveptr);
 	    if (val == NULL) {
-		err(27, __func__, "unable to find value in file %s for field %s", file, p);
+		err(28, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 
@@ -607,7 +607,7 @@ check_author_json(char const *file, char const *fnamchk)
 	     */
 	    val_esc = malloc_json_decode_str(val, NULL, strict);
 	    if (val_esc == NULL) {
-		err(28, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", val, file);
+		err(29, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", val, file);
 		not_reached();
 	    }
 
@@ -702,7 +702,7 @@ get_author_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(29, __func__, "passed NULL arg(s)");
+	err(30, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -752,7 +752,7 @@ check_found_author_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(30, __func__, "passed NULL file");
+	err(31, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -761,7 +761,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(31, __func__, "found NULL or empty field in found_author_json_fields list");
+	    err(32, __func__, "found NULL or empty field in found_author_json_fields list");
 	    not_reached();
 	}
 
@@ -776,7 +776,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * author list is not a author field name.
 	 */
 	if (author_field == NULL) {
-	    err(32, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
+	    err(33, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -883,13 +883,13 @@ add_found_author_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(33, __func__, "passed NULL arg(s)");
+	err(34, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(author_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(34, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
+	err(35, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
 	not_reached();
     }
     /*
@@ -912,7 +912,7 @@ add_found_author_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(35, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(36, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -932,7 +932,7 @@ add_found_author_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(36, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(37, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -437,7 +437,7 @@ check_author_json(char const *file, char const *fnamchk)
      * what comes after the '{' (in parsing); that is to say we proceed in
      * parsing after the first '{' but after the '}' we don't continue.
      */
-    if (check_last_json_char(file, data_dup, strict, &p)) {
+    if (check_last_json_char(file, data_dup, strict, &p, '}')) {
 	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
@@ -446,8 +446,15 @@ check_author_json(char const *file, char const *fnamchk)
     /* remove closing brace (and any whitespace after it) */
     *p = '\0';
 
+    /* check that the new last char is NOT a ',' */
+    if (!check_last_json_char(file, data_dup, strict, &p, ',')) {
+	err(22, __func__, "last char is a ',' in file %s", file);
+	not_reached();
+    }
+
+
     /* verify that the very first character is a '{' */
-    if (check_first_json_char(file, data_dup, strict, &p)) {
+    if (check_first_json_char(file, data_dup, strict, &p, '{')) {
 	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -37,7 +37,7 @@ struct json_field author_json_fields[] =
     { "twitter",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
     { "github",			NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
     { "affiliation",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
-    { "winner_handle",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
+    { "author_handle",		NULL, 0, 5, false, JSON_ARRAY_STRING,	NULL },
     { "author_number",		NULL, 0, 5, false, JSON_ARRAY_NUMBER,	NULL },
     { NULL,			NULL, 0, 0, false, JSON_NULL,		NULL } /* this **MUST** be last */
 };

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -505,7 +505,6 @@ check_author_json(char const *file, char const *fnamchk)
 	author_field = find_json_field_in_table(author_json_fields, p, &loc);
 	common_field = find_json_field_in_table(common_json_fields, p, &loc);
 
-	dbg(DBG_NONE, "p: '%s'", p);
 	/*
 	 * Before we can extract the value we have to determine the field's type
 	 * of value: depending on the type of value we have to handle it
@@ -542,7 +541,6 @@ check_author_json(char const *file, char const *fnamchk)
 		errp(26, __func__, "strdup() on array failed: %s", strerror(errno));
 		not_reached();
 	    }
-	    dbg(DBG_NONE, "array: '%s'", array);
 	    /*
 	     * Update p to go beyond the array.
 	     *

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -446,8 +446,11 @@ check_author_json(char const *file, char const *fnamchk)
     /* remove closing brace (and any whitespace after it) */
     *p = '\0';
 
-    /* check that the new last char is NOT a ',' */
-    if (!check_last_json_char(file, data_dup, strict, &p, ',')) {
+    /*
+     * Check that the new last char is NOT a ','. Don't do strict checking
+     * because we want the end spaces to be trimmed off first.
+     */
+    if (!check_last_json_char(file, data_dup, false, &p, ',')) {
 	err(22, __func__, "last char is a ',' in file %s", file);
 	not_reached();
     }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -616,7 +616,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 * according to the JSON spec.
 		 */
 		array_val_esc = malloc_json_decode_str(array_val, NULL, strict);
-		if (array_dup == NULL) {
+		if (array_val_esc == NULL) {
 		    err(28, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", array_val, file);
 		    not_reached();
 		}

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -472,7 +472,7 @@ check_info_json(char const *file, char const *fnamchk)
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p, '{')) {
-	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(23, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "first character: '%c'", *p);
@@ -538,7 +538,7 @@ check_info_json(char const *file, char const *fnamchk)
 	     * This will come in a future commit.
 	     */
 	    if (!info_field) {
-		err(23, __func__, "manifest field not found in info_json_fields table");
+		err(24, __func__, "manifest field not found in info_json_fields table");
 		not_reached();
 	    }
 
@@ -554,14 +554,14 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* find start of array */
 	    array_start = strtok_r(NULL, ":[{", &saveptr);
 	    if (array_start == NULL) {
-		err(24, __func__, "unable to find beginning of array");
+		err(25, __func__, "unable to find beginning of array");
 		not_reached();
 	    }
 
 	    /* extract the array */
 	    array = strtok_r(NULL, "]", &saveptr);
 	    if (array == NULL) {
-		err(25, __func__, "unable to extract array in file %s", file);
+		err(26, __func__, "unable to extract array in file %s", file);
 		not_reached();
 	    }
 
@@ -569,7 +569,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    errno = 0;
 	    array_dup = strdup(array);
 	    if (array_dup == NULL) {
-		errp(26, __func__, "strdup() on array failed: %s", strerror(errno));
+		errp(27, __func__, "strdup() on array failed: %s", strerror(errno));
 		not_reached();
 	    }
 
@@ -597,7 +597,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		array_val = strtok_r(NULL, ":,", &array_saveptr);
 		if (array_val == NULL) {
-		    err(27, __func__, "array element %s without value", array_field);
+		    err(28, __func__, "array element %s without value", array_field);
 		    not_reached();
 		}
 		/* remove leading spaces from value */
@@ -626,7 +626,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 */
 		array_val_esc = malloc_json_decode_str(array_val, NULL, strict);
 		if (array_val_esc == NULL) {
-		    err(28, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", array_val, file);
+		    err(29, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", array_val, file);
 		    not_reached();
 		}
 		if (get_info_json_field(file, array_field, array_val_esc)) {
@@ -655,7 +655,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* extract the value */
 	    val = strtok_r(NULL, ",\0", &saveptr);
 	    if (val == NULL) {
-		err(29, __func__, "unable to find value in file %s for field '%s'", file, p);
+		err(30, __func__, "unable to find value in file %s for field '%s'", file, p);
 		not_reached();
 	    }
 
@@ -695,7 +695,7 @@ check_info_json(char const *file, char const *fnamchk)
 	     */
 	    val_esc = malloc_json_decode_str(val, NULL, strict);
 	    if (val_esc == NULL) {
-		err(30, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", val, file);
+		err(31, __func__, "malloc_json_decode_str() failed: invalidly formed value '%s' or malloc failure in file %s", val, file);
 		not_reached();
 	    }
 	    /* handle regular field */
@@ -795,7 +795,7 @@ get_info_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(31, __func__, "passed NULL arg(s)");
+	err(32, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -843,13 +843,13 @@ add_found_info_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(32, __func__, "passed NULL arg(s)");
+	err(33, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(33, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	err(34, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
 	not_reached();
     }
     /*
@@ -871,7 +871,7 @@ add_found_info_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(34, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(35, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -891,7 +891,7 @@ add_found_info_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(35, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(36, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 
@@ -947,14 +947,14 @@ add_manifest_file(char const *filename)
     errno = 0;
     file = calloc(1, sizeof *file);
     if (file == NULL) {
-	err(36, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
+	err(37, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
 	not_reached();
     }
 
     errno = 0;
     file->filename = strdup(filename);
     if (file->filename == NULL) {
-	err(37, __func__, "strdup() error on filename %s", filename);
+	err(38, __func__, "strdup() error on filename %s", filename);
 	not_reached();
     }
 
@@ -983,7 +983,7 @@ free_manifest_file(struct manifest_file *file)
      * firewall
      */
     if (file == NULL) {
-	err(38, __func__, "passed NULL file");
+	err(39, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1048,7 +1048,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(39, __func__, "passed NULL file");
+	err(40, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1057,7 +1057,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(40, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(41, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -1072,7 +1072,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(41, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(42, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -1093,7 +1093,7 @@ check_found_info_json_fields(char const *file, bool test)
 		 * manifest has an empty value in a sense so we only do this for
 		 * fields that aren't manifest.
 		 */
-		err(42, __func__, "empty value found for field '%s' in file %s", field->name, file);
+		err(43, __func__, "empty value found for field '%s' in file %s", field->name, file);
 		not_reached();
 	    }
 
@@ -1181,7 +1181,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(43, __func__, "couldn't add info_JSON file '%s'", val);
+		    err(44, __func__, "couldn't add info_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "author_JSON")) {
@@ -1191,7 +1191,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(44, __func__, "couldn't add author_JSON file '%s'", val);
+		    err(45, __func__, "couldn't add author_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "c_src")) {
@@ -1201,7 +1201,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(45, __func__, "couldn't add c_src file '%s'", val);
+		    err(46, __func__, "couldn't add c_src file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "Makefile")) {
@@ -1211,7 +1211,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(46, __func__, "couldn't add Makefile file '%s'", val);
+		    err(47, __func__, "couldn't add Makefile file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "remarks")) {
@@ -1221,7 +1221,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(47, __func__, "couldn't add remarks file '%s'", val);
+		    err(48, __func__, "couldn't add remarks file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "extra_file")) {
@@ -1249,7 +1249,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(48, __func__, "couldn't add extra_file file '%s'", val);
+		    err(49, __func__, "couldn't add extra_file file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "rule_2a_size")) {

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -461,8 +461,11 @@ check_info_json(char const *file, char const *fnamchk)
     /* remove closing brace (and any whitespace after it) */
     *p = '\0';
 
-    /* check that the new last char is NOT a ',' */
-    if (!check_last_json_char(file, data_dup, strict, &p, ',')) {
+    /*
+     * Check that the new last char is NOT a ','. Don't do strict checking
+     * because we want the end spaces to be trimmed off first.
+     */
+    if (!check_last_json_char(file, data_dup, false, &p, ',')) {
 	err(22, __func__, "last char is a ',' in file %s", file);
 	not_reached();
     }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -452,7 +452,7 @@ check_info_json(char const *file, char const *fnamchk)
      * what comes after the '{' (in parsing); that is to say we proceed in
      * parsing after the first '{' but after the '}' we don't continue.
      */
-    if (check_last_json_char(file, data_dup, strict, &p)) {
+    if (check_last_json_char(file, data_dup, strict, &p, '}')) {
 	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
@@ -461,8 +461,14 @@ check_info_json(char const *file, char const *fnamchk)
     /* remove closing brace (and any whitespace after it) */
     *p = '\0';
 
+    /* check that the new last char is NOT a ',' */
+    if (!check_last_json_char(file, data_dup, strict, &p, ',')) {
+	err(22, __func__, "last char is a ',' in file %s", file);
+	not_reached();
+    }
+
     /* verify that the very first character is a '{' */
-    if (check_first_json_char(file, data_dup, strict, &p)) {
+    if (check_first_json_char(file, data_dup, strict, &p, '{')) {
 	err(22, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -483,7 +483,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 	/* get the next field */
 	p = strtok_r(val?NULL:p, ":,", &saveptr);
-	if (p == NULL) {
+	if (p == NULL || *p == '\0') {
 	    break;
 	}
 
@@ -503,6 +503,9 @@ check_info_json(char const *file, char const *fnamchk)
 	/* remove a single '"' if one exists at the end (*end == '"') */
 	if (*end == '"')
 	    *end = '\0';
+
+	if (*p == '\0')
+	    break;
 
 	/*
 	 * After removing the spaces and a single '"' at the beginning and end,
@@ -643,7 +646,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* extract the value */
 	    val = strtok_r(NULL, ",\0", &saveptr);
 	    if (val == NULL) {
-		err(29, __func__, "unable to find value in file %s for field %s", file, p);
+		err(29, __func__, "unable to find value in file %s for field '%s'", file, p);
 		not_reached();
 	    }
 
@@ -935,14 +938,14 @@ add_manifest_file(char const *filename)
     errno = 0;
     file = calloc(1, sizeof *file);
     if (file == NULL) {
-	err(35, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
+	err(36, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
 	not_reached();
     }
 
     errno = 0;
     file->filename = strdup(filename);
     if (file->filename == NULL) {
-	err(36, __func__, "strdup() error on filename %s", filename);
+	err(37, __func__, "strdup() error on filename %s", filename);
 	not_reached();
     }
 
@@ -971,7 +974,7 @@ free_manifest_file(struct manifest_file *file)
      * firewall
      */
     if (file == NULL) {
-	err(37, __func__, "passed NULL file");
+	err(38, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1036,7 +1039,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(36, __func__, "passed NULL file");
+	err(39, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1045,7 +1048,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(37, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(40, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -1060,7 +1063,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(38, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(41, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -1081,7 +1084,7 @@ check_found_info_json_fields(char const *file, bool test)
 		 * manifest has an empty value in a sense so we only do this for
 		 * fields that aren't manifest.
 		 */
-		err(35, __func__, "empty value found for field '%s' in file %s", field->name, file);
+		err(42, __func__, "empty value found for field '%s' in file %s", field->name, file);
 		not_reached();
 	    }
 
@@ -1169,7 +1172,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add info_JSON file '%s'", val);
+		    err(43, __func__, "couldn't add info_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "author_JSON")) {
@@ -1179,7 +1182,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add author_JSON file '%s'", val);
+		    err(44, __func__, "couldn't add author_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "c_src")) {
@@ -1189,7 +1192,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add c_src file '%s'", val);
+		    err(45, __func__, "couldn't add c_src file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "Makefile")) {
@@ -1199,7 +1202,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add Makefile file '%s'", val);
+		    err(46, __func__, "couldn't add Makefile file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "remarks")) {
@@ -1209,7 +1212,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add remarks file '%s'", val);
+		    err(47, __func__, "couldn't add remarks file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "extra_file")) {
@@ -1237,7 +1240,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(35, __func__, "couldn't add extra_file file '%s'", val);
+		    err(48, __func__, "couldn't add extra_file file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "rule_2a_size")) {

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -43,6 +43,14 @@
  */
 #include "limit_ioccc.h"
 
+struct manifest_file {
+    char *filename;	    /* filename of the file */
+    size_t count;	    /* number of times this filename is in the list */
+
+    struct manifest_file *next;	    /* the next in the list */
+};
+
+static struct manifest_file *manifest_files; /* list of files in the manifest: to detect if any filenames are duplicates */
 
 /*
  * usage message
@@ -94,6 +102,9 @@ static int get_info_json_field(char const *file, char *name, char *val);
 static int check_found_info_json_fields(char const *file, bool test);
 static void check_info_json_fields_table(void);
 static void free_found_info_json_fields(void);
+static struct manifest_file *add_manifest_file(char const *filename);
+static void free_manifest_files_list(void);
+static void free_manifest_file(struct manifest_file *file);
 
 
 #endif /* INCLUDE_JINFOCHK_H */

--- a/json.c
+++ b/json.c
@@ -2268,10 +2268,10 @@ new_json_field(char const *name, char const *val)
  * This function returns the newly allocated struct json_value * with the value
  * strdup()d and added to the struct json_field * values list.
  *
- * If the value of the field is already in the field we simply increment the
- * counter of the value.
+ * NOTE: If the value of the field is already in the field we still add the
+ * value.
  *
- * NOTE: This function does not return on error.
+ * This function does not return on error.
  *
  */
 struct json_value *
@@ -2288,16 +2288,7 @@ add_json_value(struct json_field *field, char const *val)
 	not_reached();
     }
 
-    /* try locating the value's value in the field's value list */
-    for (value = field->values; value; value = value->next) {
-	if (!strcmp(value->value, val)) {
-	    value->count++;
-	    return value;
-	}
-    }
-
-    /* if we get here then the value has not been seen yet */
-
+    /* allocate new json_value */
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
@@ -2311,9 +2302,16 @@ add_json_value(struct json_field *field, char const *val)
 	not_reached();
     }
 
-    new_value->count = 1;
-    new_value->next = field->values;
-    field->values = new_value;
+    /* find end of list */
+    for (value = field->values; value != NULL && value->next != NULL; value = value->next)
+	; /* satisfy warnings */
+
+    /* append new value to values list (field->values) */
+    if (!value) {
+	field->values = new_value;
+    } else {
+	value->next = new_value;
+    }
 
     return new_value;
 }

--- a/json.c
+++ b/json.c
@@ -1715,7 +1715,7 @@ json_filename(int type)
 
 
 /*
- * check_first_json_char - check if first char is '{'
+ * check_first_json_char - check if first char is ch
  *
  * given:
  *
@@ -1724,14 +1724,14 @@ json_filename(int type)
  *	strict		- true ==> disallow anything (including whitespace) before the first '{'.
  *	first		- if != NULL set *first to the first character
  *
- *  Returns 0 if first character is '{' and 1 if it is not.
+ *  Returns 0 if first character is ch and 1 if it is not.
  *
  *  Sets *first to the first character (for debugging purposes).
  *
  *  Does not return on NULL.
  */
 int
-check_first_json_char(char const *file, char *data, bool strict, char **first)
+check_first_json_char(char const *file, char *data, bool strict, char **first, char ch)
 {
     /*
      * firewall
@@ -1752,14 +1752,14 @@ check_first_json_char(char const *file, char *data, bool strict, char **first)
 	*first = data;
     }
 
-    if (*data != '{')
+    if (*data != ch)
 	return 1;
     return 0;
 }
 
 
 /*
- * check_last_json_char - check if last char is '}'
+ * check_last_json_char - check if last char is ch 
  *
  * given:
  *
@@ -1767,13 +1767,14 @@ check_first_json_char(char const *file, char *data, bool strict, char **first)
  *	data		- the data read in from the file
  *	strict		- true ==> permit only a single trailing newline ("\n") after the last '}'.
  *	last		- if != NULL set *last to last char
+ *	ch		- the char to check that the last char is
  *
- *  Returns 0 if last character is '}' and 1 if it is not.
+ *  Returns 0 if last character is ch and 1 if it is not.
  *
  *  Does not return on error.
  */
 int
-check_last_json_char(char const *file, char *data, bool strict, char **last)
+check_last_json_char(char const *file, char *data, bool strict, char **last, char ch)
 {
     char *p;
 
@@ -1800,7 +1801,7 @@ check_last_json_char(char const *file, char *data, bool strict, char **last)
     if (last != NULL) {
 	*last = p;
     }
-    if (*p != '}')
+    if (*p != ch)
 	return 1;
 
     return 0;

--- a/json.h
+++ b/json.h
@@ -233,8 +233,8 @@ extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict
 /* jinfochk and jauthchk related */
 extern struct json_field *find_json_field_in_table(struct json_field *table, char const *name, size_t *loc);
 extern char const *json_filename(int type);
-extern int check_first_json_char(char const *file, char *data, bool strict, char **first);
-extern int check_last_json_char(char const *file, char *data, bool strict, char **last);
+extern int check_first_json_char(char const *file, char *data, bool strict, char **first, char ch);
+extern int check_last_json_char(char const *file, char *data, bool strict, char **last, char ch);
 extern struct json_field *add_found_common_json_field(char const *name, char const *val);
 extern void check_common_json_fields_table(void);
 extern int get_common_json_field(char const *program, char const *file, char *name, char *val);

--- a/json.h
+++ b/json.h
@@ -67,8 +67,6 @@ struct json_value
 {
     char *value;
 
-    size_t count;
-
     struct json_value *next;
 };
 

--- a/json.h
+++ b/json.h
@@ -172,7 +172,7 @@ struct author {
     char *twitter;		/* author twitter handle or or empty string ==> not provided */
     char *github;		/* author GitHub username or or empty string ==> not provided */
     char *affiliation;		/* author affiliation or or empty string ==> not provided */
-    char *winner_handle;	/* previous IOCCC winner handle, or empty string ==> not provided */
+    char *author_handle;	/* IOCCC handle (for winning entries) or empty string ==> not provided */
     int author_num;		/* author number */
 
     struct json_common common;	/* fields that are common to this struct author and struct info (below) */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -4317,16 +4317,16 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	    j = 0; /* set j to 0 for when there's more than one author */
 
 	    /*
-	     * request IOCCC winner handle
+	     * request IOCCC author handle
 	     */
-	    author_set[i].winner_handle = NULL;
-	    author_set[i].winner_handle = prompt(need_hints ?
+	    author_set[i].author_handle = NULL;
+	    author_set[i].author_handle = prompt(need_hints ?
 		"Enter author's previous IOCCC winner handle, or press return if none" :
 		"Enter author's previous IOCCC winner handle", &len);
 	    if (len == 0) {
 		dbg(DBG_VHIGH, "IOCCC winner handle not given");
 	    } else {
-		dbg(DBG_VHIGH, "IOCCC winner handle: %s", author_set[i].winner_handle);
+		dbg(DBG_VHIGH, "IOCCC winner handle: %s", author_set[i].author_handle);
 	    }
 
 	    /*
@@ -4348,9 +4348,9 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		/*
 		 * free storage
 		 */
-		if (author_set[i].winner_handle != NULL) {
-		    free(author_set[i].winner_handle);
-		    author_set[i].winner_handle = NULL;
+		if (author_set[i].author_handle != NULL) {
+		    free(author_set[i].author_handle);
+		    author_set[i].author_handle = NULL;
 		}
 		continue;
 	    }
@@ -4359,7 +4359,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	     * IOCCC winner handle, if given, must start with a alphanumeric character
 	     */
 	    if (len > 0 &&
-		(!isascii(author_set[i].winner_handle[0]) || !isalnum(author_set[i].winner_handle[0]))) {
+		(!isascii(author_set[i].author_handle[0]) || !isalnum(author_set[i].author_handle[0]))) {
 		fpara(stderr,
 		      "",
 		      "IOCCC winner handles must start with an alphanumeric character:",
@@ -4367,9 +4367,9 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		      "    A-Z a-z 0-9",
 		      "",
 		      NULL);
-		if (author_set[i].winner_handle != NULL) {
-		    free(author_set[i].winner_handle);
-		    author_set[i].winner_handle = NULL;
+		if (author_set[i].author_handle != NULL) {
+		    free(author_set[i].author_handle);
+		    author_set[i].author_handle = NULL;
 		}
 		continue;
 	    }
@@ -4378,12 +4378,12 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	     * IOCCC winner handle must only use POSIX Fully portable characters: A-Z a-z 0-9 . _ - and the + character
 	     */
 	    for (j=0; j < (int)len; ++j) {
-		if (!isascii(author_set[i].winner_handle[j]) ||
-		    (!isalnum(author_set[i].winner_handle[j]) &&
-		     author_set[i].winner_handle[j] != '.' &&
-		     author_set[i].winner_handle[j] != '_' &&
-		     author_set[i].winner_handle[j] != '-' &&
-		     author_set[i].winner_handle[j] != '+')) {
+		if (!isascii(author_set[i].author_handle[j]) ||
+		    (!isalnum(author_set[i].author_handle[j]) &&
+		     author_set[i].author_handle[j] != '.' &&
+		     author_set[i].author_handle[j] != '_' &&
+		     author_set[i].author_handle[j] != '-' &&
+		     author_set[i].author_handle[j] != '+')) {
 		    fpara(stderr,
 			  "",
 			  "IOCCC winner handles consist of POSIX Fully portable characters and +:",
@@ -4391,19 +4391,19 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 			  "    A-Z a-z 0-9 . _ - +",
 			  "",
 			  NULL);
-		    if (author_set[i].winner_handle != NULL) {
-			free(author_set[i].winner_handle);
-			author_set[i].winner_handle = NULL;
+		    if (author_set[i].author_handle != NULL) {
+			free(author_set[i].author_handle);
+			author_set[i].author_handle = NULL;
 		    }
 		    break;
 		}
 	    }
-	} while (author_set[i].winner_handle == NULL && need_retry);
-	if (author_set[i].winner_handle == NULL) {
+	} while (author_set[i].author_handle == NULL && need_retry);
+	if (author_set[i].author_handle == NULL) {
 	    errp(145, __func__, "retry prompt is disabled");
 	    not_reached();
 	}
-	dbg(DBG_MED, "Author #%d IOCCC winner handle: %s", i, author_set[i].winner_handle);
+	dbg(DBG_MED, "Author #%d IOCCC winner handle: %s", i, author_set[i].author_handle);
 
 	/*
 	 * verify the information for this author
@@ -4422,8 +4422,8 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 						 printf("GitHub username: %s\n", author_set[i].github)) <= 0 ||
 	    ((author_set[i].affiliation[0] == '\0') ? printf("Affiliation not given\n") :
 						      printf("Affiliation: %s\n", author_set[i].affiliation)) <= 0 ||
-	    ((author_set[i].winner_handle[0] == '\0') ? printf("IOCCC winner handle\n\n") :
-						        printf("IOCCC winner handle: %s\n\n", author_set[i].winner_handle)) <= 0) {
+	    ((author_set[i].author_handle[0] == '\0') ? printf("IOCCC winner handle\n\n") :
+						        printf("IOCCC winner handle: %s\n\n", author_set[i].author_handle)) <= 0) {
 	    errp(146, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
@@ -5285,7 +5285,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	    json_fprintf_value_string(author_stream, "\t\t\t", "twitter", " : ", strnull(authorp[i].twitter), ",\n") &&
 	    json_fprintf_value_string(author_stream, "\t\t\t", "github", " : ", strnull(authorp[i].github), ",\n") &&
 	    json_fprintf_value_string(author_stream, "\t\t\t", "affiliation", " : ", strnull(authorp[i].affiliation), ",\n") &&
-	    json_fprintf_value_string(author_stream, "\t\t\t", "winner_handle", " : ", strnull(authorp[i].winner_handle), ",\n") &&
+	    json_fprintf_value_string(author_stream, "\t\t\t", "author_handle", " : ", strnull(authorp[i].author_handle), ",\n") &&
 	    json_fprintf_value_long(author_stream, "\t\t\t", "author_number", " : ", authorp[i].author_num, "\n") &&
 	    fprintf(author_stream, "\t\t}%s\n", (((i + 1) < author_count) ? "," : "")) > 0;
 	if (ret < 0) {

--- a/test_JSON/good/info.json.sorted
+++ b/test_JSON/good/info.json.sorted
@@ -4,7 +4,7 @@
 		{"author_JSON" : ".author.json"},
 		{"c_src" : "prog.c"},
 		{"extra_file" : "extra1"},
-		{"extra_file" : "extra2"}
+		{"extra_file" : "extra2"},
 		{"info_JSON" : ".info.json"},
 		{"remarks" : "remarks.md"}
 	],

--- a/util.c
+++ b/util.c
@@ -2422,7 +2422,7 @@ read_all(FILE *stream, size_t *psize)
  *		  NUL character was found before the final byte, or
  *		  the string is not NUL terminated
  *
- * NOTE: If you are using is_string() to deetct if read_all() read an internal
+ * NOTE: If you are using is_string() to detect if read_all() read an internal
  *	 NUL byte, be sure to check for ONE EXTRA BYTE.  See the read_all()
  *	 comment above for an example.
  */


### PR DESCRIPTION
`winner_handle` -> `author_handle`.

`jinfochk` and `jauthchk` now use `malloc_json_decode_str()` on values.

`jinfochk` also detects duplicate filenames in the manifest.

Typo fixes.

Removed some calls to `dbg()` in `jauthchk.c` that were accidentally committed yesterday.

Possibly some other things I'm forgetting. This very possibly is the last of the day but I'm not sure of that yet.