### PR TITLE
Add sanity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ TARGETS= mkiocccentry iocccsize dbg_test limit_ioccc.sh fnamchk txzchk jauthchk 
 MANPAGES = mkiocccentry.1 txzchk.1 fnamchk.1 iocccsize.1 jinfochk.1 jauthchk.1
 TEST_TARGETS= dbg_test
 OBJFILES = dbg.o util.o mkiocccentry.o iocccsize.o fnamchk.o txzchk.o jauthchk.o jinfochk.o \
-	json.o jstrencode.o jstrdecode.o rule_count.o location.o utf8_posix_map.o
+	json.o jstrencode.o jstrdecode.o rule_count.o location.o utf8_posix_map.o sanity.o
 SRCFILES = $(patsubst %.o,%.c,$(OBJFILES))
 H_FILES = dbg.h jauthchk.h jinfochk.h json.h jstrdecode.h jstrencode.h limit_ioccc.h \
 	mkiocccentry.h txzchk.h util.h location.h utf8_posix_map.h
@@ -146,10 +146,13 @@ all: ${TARGETS} ${TEST_TARGETS}
 rule_count.o: rule_count.c Makefile
 	${CC} ${CFLAGS} -DMKIOCCCENTRY_USE rule_count.c -c
 
+sanity.o: sanity.c sanity.h location.h utf8_posix_map.h Makefile
+	${CC} ${CFLAGS} sanity.c -c
+
 mkiocccentry: mkiocccentry.c mkiocccentry.h rule_count.o dbg.o util.o json.o location.o \
-	utf8_posix_map.o Makefile
+	utf8_posix_map.o sanity.o Makefile
 	${CC} ${CFLAGS} mkiocccentry.c rule_count.o dbg.o util.o json.o location.o \
-		utf8_posix_map.o -o $@
+		utf8_posix_map.o sanity.o -o $@
 
 iocccsize: iocccsize.c rule_count.o dbg.o Makefile
 	${CC} ${CFLAGS} -DMKIOCCCENTRY_USE iocccsize.c rule_count.o dbg.o -o $@
@@ -160,14 +163,14 @@ dbg_test: dbg.c Makefile
 fnamchk: fnamchk.c fnamchk.h dbg.o util.o Makefile
 	${CC} ${CFLAGS} fnamchk.c dbg.o util.o -o $@
 
-txzchk: txzchk.c txzchk.h rule_count.o dbg.o util.o Makefile
-	${CC} ${CFLAGS} txzchk.c rule_count.o dbg.o util.o -o $@
+txzchk: txzchk.c txzchk.h rule_count.o dbg.o util.o location.o json.o utf8_posix_map.o sanity.o Makefile
+	${CC} ${CFLAGS} txzchk.c rule_count.o dbg.o util.o location.o json.o utf8_posix_map.o sanity.o -o $@
 
-jauthchk: jauthchk.c jauthchk.h json.h rule_count.o json.o dbg.o util.o Makefile
-	${CC} ${CFLAGS} jauthchk.c rule_count.o json.o dbg.o util.o -o $@
+jauthchk: jauthchk.c jauthchk.h json.h rule_count.o json.o dbg.o util.o sanity.o location.o utf8_posix_map.o Makefile
+	${CC} ${CFLAGS} jauthchk.c rule_count.o json.o dbg.o util.o sanity.o location.o utf8_posix_map.o -o $@
 
-jinfochk: jinfochk.c jinfochk.h rule_count.o json.o dbg.o util.o Makefile
-	${CC} ${CFLAGS} jinfochk.c rule_count.o json.o dbg.o util.o -o $@
+jinfochk: jinfochk.c jinfochk.h rule_count.o json.o dbg.o util.o sanity.o location.o utf8_posix_map.o Makefile
+	${CC} ${CFLAGS} jinfochk.c rule_count.o json.o dbg.o util.o sanity.o location.o utf8_posix_map.o -o $@
 
 jstrencode: jstrencode.c jstrencode.h dbg.o json.o util.o Makefile
 	${CC} ${CFLAGS} jstrencode.c dbg.o json.o util.o -o $@
@@ -371,19 +374,23 @@ depend:
 dbg.o: dbg.c dbg.h
 util.o: util.c dbg.h util.h limit_ioccc.h version.h
 mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h json.h dbg.h \
-  location.h limit_ioccc.h version.h iocccsize.h
+  location.h utf8_posix_map.h sanity.h limit_ioccc.h version.h \
+  iocccsize.h
 iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
 fnamchk.o: fnamchk.c fnamchk.h dbg.h util.h limit_ioccc.h version.h
-txzchk.o: txzchk.c txzchk.h util.h dbg.h limit_ioccc.h version.h
+txzchk.o: txzchk.c txzchk.h util.h dbg.h sanity.h location.h \
+  utf8_posix_map.h json.h limit_ioccc.h version.h
 jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h json.h limit_ioccc.h \
   version.h
-jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h json.h limit_ioccc.h \
-  version.h
+jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h json.h sanity.h location.h \
+  utf8_posix_map.h limit_ioccc.h version.h
 json.o: json.c dbg.h util.h limit_ioccc.h version.h json.h
 jstrencode.o: jstrencode.c jstrencode.h dbg.h util.h json.h limit_ioccc.h \
   version.h
 jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h json.h limit_ioccc.h \
   version.h
 rule_count.o: rule_count.c iocccsize_err.h iocccsize.h
-location.o: location.c location.h
-utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h
+location.o: location.c location.h util.h dbg.h
+utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dbg.h
+sanity.o: sanity.c sanity.h util.h dbg.h location.h utf8_posix_map.h \
+  json.h

--- a/dbg.c
+++ b/dbg.c
@@ -652,7 +652,7 @@ warn_or_err(int exitcode, const char *name, bool test, const char *fmt, ...)
     if (test == true) {
 
 	/*
-	 * issue a wanring as the calling function
+	 * issue a warning as the calling function
 	 */
 	warn(name, fmt, ap);
 
@@ -729,7 +729,7 @@ warnp_or_errp(int exitcode, const char *name, bool test, const char *fmt, ...)
     if (test == true) {
 
 	/*
-	 * issue a wanring as the calling function
+	 * issue a warning as the calling function
 	 */
 	warnp(name, fmt, ap);
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -16,32 +16,6 @@
  */
 #include "jauthchk.h"
 
-/*
- * .author.json fields table used to determine if a name belongs in the file,
- * whether it's been added to the found_author_json_fields list, how many times
- * it's been seen and how many are allowed.
- *
- * XXX: As of 4 March 2022 all fields are in the table but because arrays
- * are not yet parsed not all of these values will be dealt with: that is they
- * won't be checked.
- */
-struct json_field author_json_fields[] =
-{
-    { "IOCCC_author_version",	NULL, 0, 1, false, JSON_STRING,		false, 	NULL },
-    { "authors",		NULL, 0, 1, false, JSON_ARRAY,		false, 	NULL },
-    { "name",			NULL, 0, 5, false, JSON_ARRAY_STRING,	false,  NULL },
-    { "location_code",		NULL, 0, 5, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "email",			NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "url",			NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "twitter",		NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "github",			NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "affiliation",		NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "author_handle",		NULL, 0, 5, false, JSON_ARRAY_STRING,	true,	NULL },
-    { "author_number",		NULL, 0, 5, false, JSON_ARRAY_NUMBER,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_NULL,		false,	NULL } /* this **MUST** be last */
-};
-
-
 int
 main(int argc, char **argv)
 {
@@ -166,58 +140,6 @@ main(int argc, char **argv)
     exit(issues != 0 && !test); /*ooo*/
 }
 
-
-/*
- * check_author_json_fields_table - perform author_json_fields table sanity checks
- *
- * This function checks if JSON_NULL is used on any field other than the NULL
- * field. It also makes sure that each field_type is valid.  Additionally it
- * makes sure that there are no NULL elements before the final element.
- *
- * The checks are performed on the author_json_fields table.
- *
- * NOTE: More tests might be devised later on but this is a good start (28 Feb
- * 2022).
- *
- * This function does not return on error.
- */
-static void
-check_author_json_fields_table(void)
-{
-    size_t loc;
-    size_t max = sizeof(author_json_fields)/sizeof(author_json_fields[0]);
-
-    for (loc = 0; loc < max - 1 && author_json_fields[loc].name != NULL; ++loc) {
-	switch (author_json_fields[loc].field_type) {
-	    case JSON_NULL:
-		if (author_json_fields[loc].name != NULL) {
-		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in author_json_fields table",
-                            author_json_fields[loc].name, (uintmax_t)loc);
-		    not_reached();
-		}
-		break;
-	    case JSON_NUMBER:
-	    case JSON_BOOL:
-	    case JSON_STRING:
-	    case JSON_ARRAY:
-	    case JSON_ARRAY_NUMBER:
-	    case JSON_ARRAY_BOOL:
-	    case JSON_ARRAY_STRING:
-		/* these are all the valid types */
-		break;
-	    default:
-		err(6, __func__, "found invalid data_type in author_json_fields table location %ju", (uintmax_t)loc);
-		not_reached();
-		break;
-	}
-    }
-
-    if (max - 1 != loc) {
-	err(7, __func__, "found embedded NULL element in author_json_fields table");
-	not_reached();
-    }
-
-}
 
 
 /*

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -161,7 +161,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(8, __func__, "called with NULL arg(s)");
+	err(5, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -177,7 +177,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [options] <file>"
 	      "",
 	      NULL);
-	err(9, __func__, "file does not exist: %s", file);
+	err(6, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
@@ -190,7 +190,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [...] <file>",
 	      "",
 	      NULL);
-	err(10, __func__, "file is not a file: %s", file);
+	err(7, __func__, "file is not a file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -203,7 +203,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jauthchk [...] <file>"
 	      "",
 	      NULL);
-	err(11, __func__, "file is not readable: %s", file);
+	err(8, __func__, "file is not readable: %s", file);
 	not_reached();
     }
 
@@ -225,7 +225,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(12, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(9, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -242,7 +242,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(13, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(10, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -259,7 +259,7 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(14, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(11, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -313,22 +313,22 @@ check_author_json(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(15, __func__, "passed NULL arg(s)");
+	err(12, __func__, "passed NULL arg(s)");
 	not_reached();
     }
     stream = fopen(file, "r");
     if (stream == NULL) {
-	err(16, __func__, "couldn't open %s", file);
+	err(13, __func__, "couldn't open %s", file);
 	not_reached();
     }
 
     /* read in the file */
     data = read_all(stream, &length);
     if (data == NULL) {
-	err(17, __func__, "error while reading data in %s", file);
+	err(14, __func__, "error while reading data in %s", file);
 	not_reached();
     } else if (length == 0) {
-	err(18, __func__, "zero length data in file %s", file);
+	err(15, __func__, "zero length data in file %s", file);
 	not_reached();
     }
     dbg(DBG_MED, "%s read length: %ju", file, (uintmax_t)length);
@@ -342,14 +342,14 @@ check_author_json(char const *file, char const *fnamchk)
 
     /* scan for embedded NUL bytes (before EOF) */
     if (!is_string(data, length+1)) {
-	err(19, __func__, "found NUL before EOF: %s", file);
+	err(16, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }
 
     errno = 0;
     data_dup = strdup(data);
     if (data_dup == NULL) {
-	errp(20, __func__, "unable to strdup file contents");
+	errp(17, __func__, "unable to strdup file contents");
 	not_reached();
     }
 
@@ -360,7 +360,7 @@ check_author_json(char const *file, char const *fnamchk)
      * parsing after the first '{' but after the '}' we don't continue.
      */
     if (check_last_json_char(file, data_dup, strict, &p, '}')) {
-	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	err(18, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_MED, "last character: '%c'", *p);
@@ -373,14 +373,14 @@ check_author_json(char const *file, char const *fnamchk)
      * because we want the end spaces to be trimmed off first.
      */
     if (!check_last_json_char(file, data_dup, false, &p, ',')) {
-	err(22, __func__, "last char is a ',' in file %s", file);
+	err(19, __func__, "last char is a ',' in file %s", file);
 	not_reached();
     }
 
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p, '{')) {
-	err(23, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(20, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_MED, "first character: '%c'", *p);
@@ -470,7 +470,7 @@ check_author_json(char const *file, char const *fnamchk)
 	 * which is an error regardless of test mode.
 	 */
 	if (author_field == NULL && common_field == NULL) {
-	    err(24, __func__, "invalid field '%s'", p);
+	    err(21, __func__, "invalid field '%s'", p);
 	    not_reached();
 	}
 
@@ -479,14 +479,14 @@ check_author_json(char const *file, char const *fnamchk)
 	     * This will come in a future commit.
 	     */
 	    if (!author_field) {
-		err(25, __func__, "authors field not found in author_json_fields table");
+		err(22, __func__, "authors field not found in author_json_fields table");
 		not_reached();
 	    }
 
 	    /* find start of array */
 	    array_start = strtok_r(NULL, ":[{", &saveptr);
 	    if (array_start == NULL) {
-		err(26, __func__, "unable to find beginning of array");
+		err(23, __func__, "unable to find beginning of array");
 		not_reached();
 	    }
 
@@ -497,12 +497,12 @@ check_author_json(char const *file, char const *fnamchk)
 	    /* extract the array */
 	    array = strtok_r(NULL, "]", &saveptr);
 	    if (array == NULL) {
-		err(27, __func__, "unable to extract array in file %s", file);
+		err(24, __func__, "unable to extract array in file %s", file);
 		not_reached();
 	    }
 
 	    if (!*array) {
-		err(28, __func__, "empty array in file %s", file);
+		err(25, __func__, "empty array in file %s", file);
 		not_reached();
 	    }
 
@@ -510,7 +510,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    errno = 0;
 	    array_dup = strdup(array);
 	    if (array_dup == NULL) {
-		errp(29, __func__, "strdup() on array failed: %s", strerror(errno));
+		errp(26, __func__, "strdup() on array failed: %s", strerror(errno));
 		not_reached();
 	    }
 	    /* Update p to go beyond the array. */
@@ -519,7 +519,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    /* extract the value */
 	    val = strtok_r(NULL, ",", &saveptr);
 	    if (val == NULL) {
-		err(30, __func__, "unable to find value in file %s for field %s", file, p);
+		err(27, __func__, "unable to find value in file %s for field %s", file, p);
 		not_reached();
 	    }
 
@@ -639,7 +639,7 @@ check_author_json(char const *file, char const *fnamchk)
 	     */
 	    val_esc = malloc_json_decode_str(val, NULL, strict);
 	    if (val_esc == NULL) {
-		err(31, __func__, "malloc_json_decode(): invalidly formed field '%s' value '%s' or malloc failure in file %s",
+		err(28, __func__, "malloc_json_decode(): invalidly formed field '%s' value '%s' or malloc failure in file %s",
 			p, val, file);
 		not_reached();
 	    }
@@ -741,7 +741,7 @@ get_author_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(32, __func__, "passed NULL arg(s)");
+	err(29, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -791,7 +791,7 @@ check_found_author_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(33, __func__, "passed NULL file");
+	err(30, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -800,7 +800,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(34, __func__, "found NULL or empty field in found_author_json_fields list");
+	    err(31, __func__, "found NULL or empty field in found_author_json_fields list");
 	    not_reached();
 	}
 
@@ -815,7 +815,7 @@ check_found_author_json_fields(char const *file, bool test)
 	 * author list is not a author field name.
 	 */
 	if (author_field == NULL) {
-	    err(35, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
+	    err(32, __func__, "illegal field name '%s' in found_author_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -919,13 +919,13 @@ add_found_author_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(36, __func__, "passed NULL arg(s)");
+	err(33, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(author_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(37, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
+	err(34, __func__, "called add_found_author_json_field() on field '%s' not specific to .author.json", name);
 	not_reached();
     }
     /*
@@ -948,7 +948,7 @@ add_found_author_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(38, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(35, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -968,7 +968,7 @@ add_found_author_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(39, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(36, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -940,7 +940,7 @@ add_found_author_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    /*
 	     * we found a field already in the list, add the value (even if this
-	     * value was already in the list as this might need to be reported).
+	     * value was already in the list as this is needed in some cases).
 	     */
 	    value = add_json_value(field, val);
 	    if (value == NULL) {

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -75,15 +75,16 @@ static const char * const usage_msg =
 /*
  * globals
  */
-int verbosity_level = DBG_DEFAULT;		/* debug level set by -v */
-char const *program = NULL;			/* our name */
-char *program_basename = NULL;			/* our basename */
+int verbosity_level;		/* debug level set by -v */
+static char const *program = NULL;			/* our name */
+static char *program_basename = NULL;			/* our basename */
 static bool quiet = false;			/* true ==> quiet mode */
 struct author author;			/* the .author.json struct */
 static bool strict = false;			/* true ==> disallow anything before/after the '{' and '}' */
 static bool test = false;			/* true ==> some tests are not performed */
 static struct json_field *found_author_json_fields;	/* list of fields specific to .author.json found */
 extern struct json_field author_json_fields[];
+extern size_t SIZEOF_AUTHOR_JSON_FIELDS_TABLE;	/* number of elements in the author_json_fields table */
 
 /*
  * forward declarations
@@ -94,7 +95,6 @@ static int check_author_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_author_json_field(char const *name, char const *val);
 static int get_author_json_field(char const *file, char *name, char *val);
 static int check_found_author_json_fields(char const *file, bool test);
-static void check_author_json_fields_table(void);
 static void free_found_author_json_fields(void);
 
 

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -599,6 +599,9 @@ check_info_json(char const *file, char const *fnamchk)
 		while (*array_val && isspace(*array_val))
 		    ++array_val;
 
+		if (!*array_val)
+		    break;
+
 		/*
 		 * remove any spaces at the end of the value (prior to the
 		 * closing '}'

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -155,7 +155,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(8, __func__, "called with NULL arg(s)");
+	err(5, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -171,7 +171,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [options] <file>"
 	      "",
 	      NULL);
-	err(9, __func__, "file does not exist: %s", file);
+	err(6, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
@@ -184,7 +184,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>",
 	      "",
 	      NULL);
-	err(10, __func__, "file is not a file: %s", file);
+	err(7, __func__, "file is not a file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -197,7 +197,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>"
 	      "",
 	      NULL);
-	err(11, __func__, "file is not readable: %s", file);
+	err(8, __func__, "file is not readable: %s", file);
 	not_reached();
     }
 
@@ -219,7 +219,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(12, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(9, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -236,7 +236,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(13, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(10, __func__, "fnamchk is not a file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -253,7 +253,7 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(14, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(11, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -308,23 +308,23 @@ check_info_json(char const *file, char const *fnamchk)
      * firewall
      */
     if (file == NULL || fnamchk == NULL) {
-	err(15, __func__, "passed NULL arg(s)");
+	err(12, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     stream = fopen(file, "r");
     if (stream == NULL) {
-	err(16, __func__, "couldn't open %s", file);
+	err(13, __func__, "couldn't open %s", file);
 	not_reached();
     }
 
     /* read in the file */
     data = read_all(stream, &length);
     if (data == NULL) {
-	err(17, __func__, "error while reading data in %s", file);
+	err(14, __func__, "error while reading data in %s", file);
 	not_reached();
     } else if (length == 0) {
-	err(18, __func__, "zero length data in file %s", file);
+	err(15, __func__, "zero length data in file %s", file);
 	not_reached();
     }
     dbg(DBG_HIGH, "%s read length: %ju", file, (uintmax_t)length);
@@ -338,14 +338,14 @@ check_info_json(char const *file, char const *fnamchk)
 
     /* scan for embedded NUL bytes (before EOF) */
     if (!is_string(data, length+1)) {
-	err(19, __func__, "found NUL before EOF: %s", file);
+	err(16, __func__, "found NUL before EOF: %s", file);
 	not_reached();
     }
 
     errno = 0;
     data_dup = strdup(data);
     if (data_dup == NULL) {
-	errp(20, __func__, "unable to strdup file %s contents", file);
+	errp(17, __func__, "unable to strdup file %s contents", file);
 	not_reached();
     }
 
@@ -356,7 +356,7 @@ check_info_json(char const *file, char const *fnamchk)
      * parsing after the first '{' but after the '}' we don't continue.
      */
     if (check_last_json_char(file, data_dup, strict, &p, '}')) {
-	err(21, __func__, "last character in file %s not a '}': '%c'", file, *p);
+	err(18, __func__, "last character in file %s not a '}': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "last character: '%c'", *p);
@@ -369,13 +369,13 @@ check_info_json(char const *file, char const *fnamchk)
      * because we want the end spaces to be trimmed off first.
      */
     if (!check_last_json_char(file, data_dup, false, &p, ',')) {
-	err(22, __func__, "last char is a ',' in file %s", file);
+	err(19, __func__, "last char is a ',' in file %s", file);
 	not_reached();
     }
 
     /* verify that the very first character is a '{' */
     if (check_first_json_char(file, data_dup, strict, &p, '{')) {
-	err(23, __func__, "first character in file %s not a '{': '%c'", file, *p);
+	err(20, __func__, "first character in file %s not a '{': '%c'", file, *p);
 	not_reached();
     }
     dbg(DBG_HIGH, "first character: '%c'", *p);
@@ -461,7 +461,7 @@ check_info_json(char const *file, char const *fnamchk)
 	 * which is an error regardless of test mode.
 	 */
 	if (info_field == NULL && common_field == NULL) {
-	    err(24, __func__, "invalid field '%s'", p);
+	    err(21, __func__, "invalid field '%s'", p);
 	    not_reached();
 	}
 
@@ -473,7 +473,7 @@ check_info_json(char const *file, char const *fnamchk)
 	     * This will come in a future commit.
 	     */
 	    if (!info_field) {
-		err(25, __func__, "manifest field not found in info_json_fields table");
+		err(22, __func__, "manifest field not found in info_json_fields table");
 		not_reached();
 	    }
 
@@ -489,7 +489,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* find start of array */
 	    array_start = strtok_r(NULL, ":[{", &saveptr);
 	    if (array_start == NULL) {
-		err(26, __func__, "unable to find beginning of array");
+		err(23, __func__, "unable to find beginning of array");
 		not_reached();
 	    }
 
@@ -500,12 +500,12 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* extract the array */
 	    array = strtok_r(NULL, "]", &saveptr);
 	    if (array == NULL) {
-		err(27, __func__, "unable to extract array in file %s", file);
+		err(24, __func__, "unable to extract array in file %s", file);
 		not_reached();
 	    }
 
 	    if (!*array) {
-		err(28, __func__, "empty array in file %s", file);
+		err(25, __func__, "empty array in file %s", file);
 		not_reached();
 	    }
 
@@ -513,7 +513,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    errno = 0;
 	    array_dup = strdup(array);
 	    if (array_dup == NULL) {
-		errp(29, __func__, "strdup() on array failed: %s", strerror(errno));
+		errp(26, __func__, "strdup() on array failed: %s", strerror(errno));
 		not_reached();
 	    }
 
@@ -584,7 +584,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 * error regardless of test mode.
 		 */
 		if (array_info_field == NULL) {
-		    err(30, __func__, "invalid field '%s' in manifest array", array_field);
+		    err(27, __func__, "invalid field '%s' in manifest array", array_field);
 		    not_reached();
 		}
 
@@ -592,7 +592,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		array_val = strtok_r(NULL, ":,", &array_saveptr);
 		if (array_val == NULL) {
-		    err(31, __func__, "array element %s without value", array_field);
+		    err(28, __func__, "array element %s without value", array_field);
 		    not_reached();
 		}
 		/* remove leading spaces from value */
@@ -701,7 +701,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 */
 		array_val_esc = malloc_json_decode_str(array_val, NULL, strict);
 		if (array_val_esc == NULL) {
-		    err(32, __func__, "malloc_json_decode(): invalidly formed field '%s' value '%s' or malloc failure in file %s",
+		    err(29, __func__, "malloc_json_decode(): invalidly formed field '%s' value '%s' or malloc failure in file %s",
 			    array_field, array_val, file);
 		    not_reached();
 		}
@@ -735,7 +735,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    /* extract the value */
 	    val = strtok_r(NULL, ",\0", &saveptr);
 	    if (val == NULL) {
-		err(33, __func__, "unable to find value in file %s for field '%s'", file, p);
+		err(30, __func__, "unable to find value in file %s for field '%s'", file, p);
 		not_reached();
 	    }
 
@@ -857,7 +857,7 @@ check_info_json(char const *file, char const *fnamchk)
 	     */
 	    val_esc = malloc_json_decode_str(val, NULL, strict);
 	    if (val_esc == NULL) {
-		err(34, __func__, "malloc_json_decode_str(): invalidly formed field '%s' value '%s' or malloc failure in file %s", p, val, file);
+		err(31, __func__, "malloc_json_decode_str(): invalidly formed field '%s' value '%s' or malloc failure in file %s", p, val, file);
 		not_reached();
 	    }
 	    
@@ -966,7 +966,7 @@ get_info_json_field(char const *file, char *name, char *val)
      * firewall
      */
     if (file == NULL || name == NULL || val == NULL) {
-	err(35, __func__, "passed NULL arg(s)");
+	err(32, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1014,13 +1014,13 @@ add_found_info_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(36, __func__, "passed NULL arg(s)");
+	err(33, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(info_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(37, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
+	err(34, __func__, "called add_found_info_json_field() on field '%s' not specific to .info.json", name);
 	not_reached();
     }
     /*
@@ -1042,7 +1042,7 @@ add_found_info_json_field(char const *name, char const *val)
 		 * this shouldn't happen as if add_json_value() gets an error
 		 * it'll abort but just to be safe we check here too
 		 */
-		err(38, __func__, "error adding json value '%s' to field '%s'", val, field->name);
+		err(35, __func__, "error adding json value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 
@@ -1062,7 +1062,7 @@ add_found_info_json_field(char const *name, char const *val)
 	 * we should never get here because if new_json_field gets NULL it
 	 * aborts the program.
 	 */
-	err(39, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
+	err(36, __func__, "error creating new struct json_field * for field '%s' value '%s'", name, val);
 	not_reached();
     }
 
@@ -1118,14 +1118,14 @@ add_manifest_file(char const *filename)
     errno = 0;
     file = calloc(1, sizeof *file);
     if (file == NULL) {
-	err(40, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
+	err(37, __func__, "calloc() error allocating struct manifest_file * for filename %s", filename);
 	not_reached();
     }
 
     errno = 0;
     file->filename = strdup(filename);
     if (file->filename == NULL) {
-	err(41, __func__, "strdup() error on filename %s", filename);
+	err(38, __func__, "strdup() error on filename %s", filename);
 	not_reached();
     }
 
@@ -1154,7 +1154,7 @@ free_manifest_file(struct manifest_file *file)
      * firewall
      */
     if (file == NULL) {
-	err(42, __func__, "passed NULL file");
+	err(39, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1219,7 +1219,7 @@ check_found_info_json_fields(char const *file, bool test)
      * firewall
      */
     if (file == NULL) {
-	err(43, __func__, "passed NULL file");
+	err(40, __func__, "passed NULL file");
 	not_reached();
     }
 
@@ -1228,7 +1228,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(44, __func__, "found NULL or empty field in found_info_json_fields list");
+	    err(41, __func__, "found NULL or empty field in found_info_json_fields list");
 	    not_reached();
 	}
 
@@ -1243,7 +1243,7 @@ check_found_info_json_fields(char const *file, bool test)
 	 * info list is not a info field name.
 	 */
 	if (info_field == NULL) {
-	    err(45, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
+	    err(42, __func__, "illegal field name '%s' in found_info_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -1264,7 +1264,7 @@ check_found_info_json_fields(char const *file, bool test)
 		 * manifest has an empty value in a sense so we only do this for
 		 * fields that aren't manifest.
 		 */
-		err(46, __func__, "empty value found for field '%s' in file %s", field->name, file);
+		err(43, __func__, "empty value found for field '%s' in file %s", field->name, file);
 		not_reached();
 	    }
 
@@ -1352,7 +1352,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(47, __func__, "couldn't add info_JSON file '%s'", val);
+		    err(44, __func__, "couldn't add info_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "author_JSON")) {
@@ -1362,7 +1362,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(48, __func__, "couldn't add author_JSON file '%s'", val);
+		    err(45, __func__, "couldn't add author_JSON file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "c_src")) {
@@ -1372,7 +1372,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(49, __func__, "couldn't add c_src file '%s'", val);
+		    err(46, __func__, "couldn't add c_src file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "Makefile")) {
@@ -1382,7 +1382,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(50, __func__, "couldn't add Makefile file '%s'", val);
+		    err(47, __func__, "couldn't add Makefile file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "remarks")) {
@@ -1392,7 +1392,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(51, __func__, "couldn't add remarks file '%s'", val);
+		    err(48, __func__, "couldn't add remarks file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "extra_file")) {
@@ -1420,7 +1420,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(52, __func__, "couldn't add extra_file file '%s'", val);
+		    err(49, __func__, "couldn't add extra_file file '%s'", val);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "rule_2a_size")) {

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -17,45 +17,6 @@
  */
 #include "jinfochk.h"
 
-/*
- * .info.json fields table used to determine if a name belongs in the file,
- * whether it's been added to the found_info_json_fields list, how many times
- * it's been seen and how many are allowed.
- *
- */
-struct json_field info_json_fields[] =
-{
-    { "IOCCC_info_version",	NULL, 0, 1, false, JSON_STRING,		false, NULL },
-    { "title",			NULL, 0, 1, false, JSON_STRING,		false, NULL },
-    { "abstract",		NULL, 0, 1, false, JSON_STRING,		false, NULL },
-    { "rule_2a_size",		NULL, 0, 1, false, JSON_NUMBER,		false, NULL },
-    { "rule_2b_size",		NULL, 0, 1, false, JSON_NUMBER,		false, NULL },
-    { "empty_override",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2a_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2a_mismatch",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2b_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "highbit_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "nul_warning",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "trigraph_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "wordbuf_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "ungetc_warning",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "Makefile_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "first_rule_is_all",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_all_rule",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_clean_rule",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_clobber_rule",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_try_rule",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "manifest",		NULL, 0, 1, false, JSON_ARRAY,		false, NULL },
-    { "info_JSON",		NULL, 0, 1, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "author_JSON",		NULL, 0, 1, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "c_src",			NULL, 0, 1, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "Makefile",		NULL, 0, 1, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "remarks",		NULL, 0, 1, false, JSON_ARRAY_STRING,	false,	NULL },
-    { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_STRING,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_NULL,		false,	NULL } /* this **MUST** be last */
-};
-
-
 int
 main(int argc, char **argv)
 {
@@ -175,63 +136,10 @@ main(int argc, char **argv)
     exit(issues != 0 && !test); /*ooo*/
 }
 
-
-/*
- * check_info_json_fields_table	 - sanity check info_json_fields table
- *
- * This function checks if JSON_NULL is used on any field other than the NULL
- * field. It also makes sure that each field_type is valid. Additionally it
- * makes sure that there are no NULL elements before the final element.
- *
- * These sanity checks are performed on the info_json_fields table.
- *
- * NOTE: More tests might be devised later on but this is a good start (28 Feb
- * 2022).
- *
- * This function does not return on error.
- */
-static void
-check_info_json_fields_table(void)
-{
-    size_t loc;
-    size_t max = sizeof(info_json_fields)/sizeof(info_json_fields[0]);
-
-    for (loc = 0; loc < max - 1 && info_json_fields[loc].name != NULL; ++loc) {
-	switch (info_json_fields[loc].field_type) {
-	    case JSON_NULL:
-		if (info_json_fields[loc].name != NULL) {
-		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in info_json_fields table",
-			    info_json_fields[loc].name, (uintmax_t)loc);
-		    not_reached();
-		}
-		break;
-	    case JSON_NUMBER:
-	    case JSON_BOOL:
-	    case JSON_STRING:
-	    case JSON_ARRAY:
-	    case JSON_ARRAY_NUMBER:
-	    case JSON_ARRAY_BOOL:
-	    case JSON_ARRAY_STRING:
-		/* these are all the valid types */
-		break;
-	    default:
-		err(6, __func__, "found invalid data_type in info_json_fields table location %ju", (uintmax_t)loc);
-		not_reached();
-		break;
-	}
-    }
-
-    if (max - 1 != loc) {
-	err(7, __func__, "found embedded NULL element in info_json_fields table");
-	not_reached();
-    }
-
-}
-
 /*
  * jinfochk_sanity_chk - perform basic sanity checks
  *
- * We perform basic sanity checks on paths.
+ * We perform basic sanity checks on paths and tables.
  *
  * given:
  *
@@ -349,11 +257,8 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	not_reached();
     }
 
-    /* check the common_json_fields table */
-    check_common_json_fields_table();
 
-    /* check our info_json_fields table */
-    check_info_json_fields_table();
+    ioccc_sanity_chk();
 
     return;
 }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1037,7 +1037,7 @@ add_found_info_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    /*
 	     * we found a field already in the list: add the value (even if this
-	     * value was already in the list as this might need to be reported).
+	     * value was already in the list as this is needed in some cases).
 	     */
 	    value = add_json_value(field, val);
 	    if (value == NULL) {
@@ -1519,7 +1519,7 @@ check_found_info_json_fields(char const *file, bool test)
      * so I can see everything.
      */
     for (loc = 0; !test && info_json_fields[loc].name != NULL; ++loc) {
-	if (!info_json_fields[loc].found) {
+	if (!info_json_fields[loc].found && info_json_fields[loc].max_count > 0) {
 	    warn(__func__, "field '%s' not found in found_info_json_fields list", info_json_fields[loc].name);
 	    ++issues;
 	}

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -39,6 +39,11 @@
 #include "json.h"
 
 /*
+ * sanity
+ */
+#include "sanity.h"
+
+/*
  * IOCCC size and rule related limitations
  */
 #include "limit_ioccc.h"
@@ -81,9 +86,9 @@ static const char * const usage_msg =
 /*
  * globals
  */
-int verbosity_level = DBG_DEFAULT;	    /* debug level set by -v */
-char const *program = NULL;		    /* our name */
-char *program_basename = NULL;		    /* our basename */
+int verbosity_level;	    /* debug level set by -v */
+static char const *program = NULL;		    /* our name */
+static char *program_basename = NULL;		    /* our basename */
 static bool quiet = false;		    /* true ==> quiet mode */
 static struct info info;		    /* .info.json struct */
 static bool strict = false;		    /* true ==> disallow anything before/after the '{' and '}' in the file */
@@ -91,6 +96,7 @@ static bool test = false;		    /* true ==> some tests are not performed */
 static struct json_field *found_info_json_fields; /* list of fields specific to .info.json that have been found */
 extern struct json_field info_json_fields[];
 
+extern size_t SIZEOF_INFO_JSON_FIELDS_TABLE;
 /*
  * forward declarations
  */
@@ -100,7 +106,6 @@ static int check_info_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_info_json_field(char const *name, char const *val);
 static int get_info_json_field(char const *file, char *name, char *val);
 static int check_found_info_json_fields(char const *file, bool test);
-static void check_info_json_fields_table(void);
 static void free_found_info_json_fields(void);
 static struct manifest_file *add_manifest_file(char const *filename);
 static void free_manifest_files_list(void);

--- a/json.c
+++ b/json.c
@@ -1770,7 +1770,7 @@ check_common_json_fields_table(void)
 	not_reached();
     }
     if (common_json_fields[i].name != NULL) {
-	err(334, __func__, "no final NULL element found in common_json_fields table");
+	err(218, __func__, "no final NULL element found in common_json_fields table");
 	not_reached();
     }
 }
@@ -1797,7 +1797,7 @@ check_info_json_fields_table(void)
 	switch (info_json_fields[i].field_type) {
 	    case JSON_NULL:
 		if (info_json_fields[i].name != NULL) {
-		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in info_json_fields table",
+		    err(219, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in info_json_fields table",
 			    info_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
@@ -1812,19 +1812,19 @@ check_info_json_fields_table(void)
 		/* these are all the valid types */
 		break;
 	    default:
-		err(6, __func__, "found invalid data_type in info_json_fields table location %ju", (uintmax_t)i);
+		err(220, __func__, "found invalid data_type in info_json_fields table location %ju", (uintmax_t)i);
 		not_reached();
 		break;
 	}
     }
 
     if (max - 1 != i) {
-	err(7, __func__, "found embedded NULL element in info_json_fields table");
+	err(221, __func__, "found embedded NULL element in info_json_fields table");
 	not_reached();
     }
 
     if (info_json_fields[i].name != NULL) {
-	err(334, __func__, "no final NULL element found in info_json_fields table");
+	err(222, __func__, "no final NULL element found in info_json_fields table");
 	not_reached();
     }
 
@@ -1852,7 +1852,7 @@ check_author_json_fields_table(void)
 	switch (author_json_fields[i].field_type) {
 	    case JSON_NULL:
 		if (author_json_fields[i].name != NULL) {
-		    err(5, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in author_json_fields table",
+		    err(223, __func__, "found JSON_NULL element with non NULL name '%s' location %ju in author_json_fields table",
                             author_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
@@ -1867,18 +1867,18 @@ check_author_json_fields_table(void)
 		/* these are all the valid types */
 		break;
 	    default:
-		err(6, __func__, "found invalid data_type in author_json_fields table location %ju", (uintmax_t)i);
+		err(224, __func__, "found invalid data_type in author_json_fields table location %ju", (uintmax_t)i);
 		not_reached();
 		break;
 	}
     }
 
     if (max - 1 != i) {
-	err(7, __func__, "found embedded NULL element in author_json_fields table");
+	err(225, __func__, "found embedded NULL element in author_json_fields table");
 	not_reached();
     }
     if (author_json_fields[i].name != NULL) {
-	err(334, __func__, "no final NULL element found in author_json_fields table");
+	err(226, __func__, "no final NULL element found in author_json_fields table");
 	not_reached();
     }
 }
@@ -1944,10 +1944,10 @@ check_first_json_char(char const *file, char *data, bool strict, char **first, c
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(218, __func__, "passed NULL or zero length data");
+	err(227, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || first == NULL) {
-	err(219, __func__, "passed NULL arg(s)");
+	err(228, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -1989,10 +1989,10 @@ check_last_json_char(char const *file, char *data, bool strict, char **last, cha
      * firewall
      */
     if (data == NULL || strlen(data) == 0) {
-	err(220, __func__, "passed NULL or zero length data");
+	err(229, __func__, "passed NULL or zero length data");
 	not_reached();
     } else if (file == NULL || last == NULL) {
-	err(221, __func__, "passed NULL arg(s)");
+	err(230, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -2045,13 +2045,13 @@ add_found_common_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(222, __func__, "passed NULL arg(s)");
+	err(231, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     field_in_table = find_json_field_in_table(common_json_fields, name, &loc);
     if (field_in_table == NULL) {
-	err(223, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
+	err(232, __func__, "called add_found_common_json_field() on uncommon field '%s'", name);
 	not_reached();
     }
     /*
@@ -2064,7 +2064,7 @@ add_found_common_json_field(char const *name, char const *val)
 	if (field->name && !strcmp(field->name, name)) {
 	    field->count++;
 	    if (add_json_value(field, val) == NULL) {
-		err(224, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
+		err(233, __func__, "couldn't add value '%s' to field '%s'", val, field->name);
 		not_reached();
 	    }
 	    return field;
@@ -2074,7 +2074,7 @@ add_found_common_json_field(char const *name, char const *val)
     field = new_json_field(name, val);
     if (field == NULL) {
 	/* this should NEVER be reached but we check just to be sure */
-	err(225, __func__, "new_json_field() returned NULL pointer");
+	err(234, __func__, "new_json_field() returned NULL pointer");
 	not_reached();
     }
 
@@ -2118,7 +2118,7 @@ get_common_json_field(char const *program, char const *file, char *name, char *v
      * firewall
      */
     if (program == NULL || file == NULL || name == NULL || val == NULL) {
-	err(226, __func__, "passed NULL arg(s)");
+	err(235, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -2178,7 +2178,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * firewall
      */
     if (program == NULL || file == NULL || fnamchk == NULL) {
-	err(227, __func__, "passed NULL arg(s)");
+	err(236, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -2196,7 +2196,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * first make sure the name != NULL and strlen() > 0
 	 */
 	if (field->name == NULL || !strlen(field->name)) {
-	    err(228, __func__, "found NULL or empty field in found_common_json_fields list");
+	    err(237, __func__, "found NULL or empty field in found_common_json_fields list");
 	    not_reached();
 	}
 
@@ -2211,7 +2211,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * common list is not a common field name.
 	 */
 	if (common_field == NULL) {
-	    err(229, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
+	    err(238, __func__, "illegal field name '%s' in found_common_json_fields list", field->name);
 	    not_reached();
 	}
 
@@ -2449,26 +2449,26 @@ new_json_field(char const *name, char const *val)
      * firewall
      */
     if (name == NULL || val == NULL) {
-	err(230, __func__, "passed NULL arg(s)");
+	err(239, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     errno = 0;
     field = calloc(1, sizeof *field);
     if (field == NULL) {
-	errp(231, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
+	errp(240, __func__, "error allocating new struct json_field * for field '%s' and value '%s': %s", name, val, strerror(errno));
 	not_reached();
     }
 
     errno = 0;
     field->name = strdup(name);
     if (field->name == NULL) {
-	errp(232, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
+	errp(241, __func__, "unable to strdup() field name '%s': %s", name, strerror(errno));
 	not_reached();
     }
 
     if (add_json_value(field, val) == NULL) {
-	err(233, __func__, "error adding value '%s' to field '%s'", val, name);
+	err(242, __func__, "error adding value '%s' to field '%s'", val, name);
 	not_reached();
     }
 
@@ -2505,7 +2505,7 @@ add_json_value(struct json_field *field, char const *val)
      * firewall
      */
     if (field == NULL || val == NULL) {
-	err(234, __func__, "passed NULL arg(s)");
+	err(243, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -2513,13 +2513,13 @@ add_json_value(struct json_field *field, char const *val)
     errno = 0;
     new_value = calloc(1, sizeof *new_value);
     if (new_value == NULL) {
-	errp(235, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(244, __func__, "error allocating new value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
     errno = 0;
     new_value->value = strdup(val);
     if (new_value->value == NULL) {
-	errp(236, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
+	errp(245, __func__, "error strdup()ing value '%s' for field '%s': %s", val, field->name, strerror(errno));
 	not_reached();
     }
 
@@ -2558,7 +2558,7 @@ free_json_field_values(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(237, __func__, "passed NULL field");
+	err(246, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2624,7 +2624,7 @@ free_json_field(struct json_field *field)
      * firewall
      */
     if (field == NULL) {
-	err(238, __func__, "passed NULL field");
+	err(247, __func__, "passed NULL field");
 	not_reached();
     }
 
@@ -2659,7 +2659,7 @@ free_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(239, __func__, "called with NULL arg(s)");
+	err(248, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2751,11 +2751,11 @@ free_author_array(struct author *author_set, int author_count)
      * firewall
      */
     if (author_set == NULL) {
-	err(240, __func__, "called with NULL arg(s)");
+	err(249, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count < 0) {
-	err(241, __func__, "author_count: %d < 0", author_count);
+	err(10, __func__, "author_count: %d < 0", author_count);
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -2374,7 +2374,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * so I can see everything.
      */
     for (loc = 0; !test && common_json_fields[loc].name != NULL; ++loc) {
-	if (!common_json_fields[loc].found) {
+	if (!common_json_fields[loc].found && common_json_fields[loc].max_count > 0) {
 	    warn(__func__, "field '%s' not found in found_common_json_fields list", common_json_fields[loc].name);
 	    ++issues;
 	}

--- a/json.h
+++ b/json.h
@@ -127,6 +127,7 @@ struct json_field
 };
 
 extern struct json_field common_json_fields[];
+extern size_t SIZEOF_COMMON_JSON_FIELDS_TABLE;
 
 /*
  * linked list of the common json fields found in the .info.json and
@@ -240,13 +241,18 @@ extern void jencchk(void);
 extern bool json_putc(uint8_t const c, FILE *stream);
 extern char *malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict);
 extern char *malloc_json_decode_str(char const *str, size_t *retlen, bool strict);
+
 /* jinfochk and jauthchk related */
 extern struct json_field *find_json_field_in_table(struct json_field *table, char const *name, size_t *loc);
 extern char const *json_filename(int type);
+/* checks on the JSON fields tables */
+extern void check_json_fields_tables(void);
+extern void check_common_json_fields_table(void);
+extern void check_author_json_fields_table(void);
+extern void check_info_json_fields_table(void);
 extern int check_first_json_char(char const *file, char *data, bool strict, char **first, char ch);
 extern int check_last_json_char(char const *file, char *data, bool strict, char **last, char ch);
 extern struct json_field *add_found_common_json_field(char const *name, char const *val);
-extern void check_common_json_fields_table(void);
 extern int get_common_json_field(char const *program, char const *file, char *name, char *val);
 extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk, bool test);
 extern struct json_field *new_json_field(char const *name, char const *val);

--- a/json.h
+++ b/json.h
@@ -101,7 +101,8 @@ struct json_field
      * In other words this is done as part of the checks after the field:value
      * pairs have been extracted.
      *
-     * NOTE: A max_count == 0 means that there's no limit.
+     * NOTE: A max_count == 0 means that there's no limit and that it's not
+     * required.
      */
     size_t count;		/* how many of this field in the list (or how many values) */
     size_t max_count;		/* how many of this field is allowed */

--- a/location.c
+++ b/location.c
@@ -465,7 +465,7 @@ check_location_table(void)
 	not_reached();
     }
     if (loc[i].code != NULL || loc[i].name != NULL) {
-	err(334, __func__, "no final NULL element found in location table");
+	err(10, __func__, "no final NULL element found in location table");
 	not_reached();
     }
 }

--- a/location.c
+++ b/location.c
@@ -38,6 +38,8 @@
 
 /*
  * location
+ *
+ * #includes the header files we need.
  */
 #include "location.h"
 
@@ -437,3 +439,35 @@ struct location loc[] = {
     {"ZZ", "User-assigned code ZZ"},	/* User-assigned code */
     {NULL, NULL}		/* MUST BE LAST */
 };
+
+size_t SIZEOF_LOCATION_TABLE = sizeof(loc)/sizeof(loc[0]);
+/* check_location_table	    - make sure that there are no embedded NULL elements
+ *			      in the location table and that the last element is
+ *			      NULL
+ *
+ * This function verifies that the only NULL element in the table is the very
+ * last element: if it's not there or there's another NULL element it's a
+ * problem that has to be fixed.
+ *
+ */
+void
+check_location_table(void)
+{
+    size_t max = SIZEOF_LOCATION_TABLE;
+
+    size_t i;
+
+    for (i = 0; i < max - 1 && loc[i].code != NULL; )
+	++i;
+
+    if (max - 1 != i) {
+	err(333, __func__, "found embedded NULL element in location table");
+	not_reached();
+    }
+    if (loc[i].code != NULL || loc[i].name != NULL) {
+	err(334, __func__, "no final NULL element found in location table");
+	not_reached();
+    }
+}
+
+

--- a/location.h
+++ b/location.h
@@ -33,6 +33,16 @@
 #if !defined(INCLUDE_LOCATION_H)
 #    define  INCLUDE_LOCATION_H
 
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
 
 /*
  * location/country codes
@@ -46,6 +56,6 @@ struct location {
  * global variables
  */
 extern struct location loc[];		/* location/country codes */
-
+extern size_t SIZEOF_LOCATION_TABLE;
 
 #endif				/* INCLUDE_LOCATION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -756,7 +756,8 @@ usage(int exitcode, char const *str, char const *program)
 /*
  * mkiocccentry_sanity_chk - perform basic sanity checks
  *
- * We perform basic sanity checks on paths and the IOCCC contest ID.
+ * We perform basic sanity checks on paths and the IOCCC contest ID as well as
+ * the IOCCC toolkit tables.
  *
  * given:
  *
@@ -1225,6 +1226,10 @@ mkiocccentry_sanity_chk(struct info *infop, char const *work_dir, char const *ta
      * obtain version string from IOCCCSIZE_VERSION
      */
     infop->common.iocccsize_ver = IOCCCSIZE_VERSION;
+
+    /* we also check that all the tables across the IOCCC toolkit are sane */
+    ioccc_sanity_chk();
+
     return;
 }
 

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -83,6 +83,16 @@
 #include "location.h"
 
 /*
+ * UTF-8 -> POSIX map
+ */
+#include "utf8_posix_map.h"
+
+/*
+ * IOCCC tables sanity checkers
+ */
+#include "sanity.h"
+
+/*
  * IOCCC size and rule related limitations
  */
 #include "limit_ioccc.h"

--- a/sanity.c
+++ b/sanity.c
@@ -1,0 +1,62 @@
+/*
+ * sanity: the IOCCC source code sanity checker
+ *
+ * Each IOCCC tool in the mkiocccentry repo should run the sanity_chk()
+ * function to verify that certain things are in a sane state. This should be
+ * done via each tool's sanity checker function e.g. txzchk_sanity_chk() for
+ * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
+ *
+ * "Because sometimes we're all a little insane, some of us are a lot insane and
+ * code is often very insane." :-)
+ *
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+
+
+/*
+ * sanity - our header file
+ *
+ * #includes everything we need
+ *
+ */
+#include "sanity.h"
+
+/*
+ * ioccc_sanity_chks	-   run sanity checks on specific data that's
+ *			    used in several of the IOCCC tools
+ *
+ * This function does not return if things are not sane.
+ */
+void
+ioccc_sanity_chk(void)
+{
+    /*
+     * Check that the UTF-8 POSIX map is sane: that there are no embedded NULL
+     * elements and that the final element is in fact NULL.
+     */
+    dbg(DBG_MED, "Running sanity checks on UTF-8 POSIX map ...");
+    check_utf8_posix_map();
+    dbg(DBG_MED, "... all OK.");
+
+    /*
+     * Check that the location table is sane: that there are no embedded NULL
+     * elements and that the final element is in fact NULL.
+     */
+    dbg(DBG_MED, "Running sanity checks on location table ...");
+    check_location_table();
+    dbg(DBG_MED, "... all OK.");
+
+    /*
+     * Check that the JSON fields tables are sane: that there are no
+     * embedded NULL elements, that the only JSON_NULL type is the final
+     * element, that the other elements have valid field types and that the
+     * final element is in fact NULL.
+     *
+     * NOTE: The below function calls dbg() for each table it checks so we don't
+     * duplicate that message here.
+     */
+    check_json_fields_tables();
+}

--- a/sanity.h
+++ b/sanity.h
@@ -1,0 +1,54 @@
+/*
+ * sanity: the IOCCC source code sanity checker
+ *
+ * Each IOCCC tool in the mkiocccentry repo should run the sanity_chk()
+ * function to verify that certain things are in a sane state. This should be
+ * done via each tool's sanity checker function e.g. txzchk_sanity_chk() for
+ * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
+ *
+ * "Because sometimes we're all a little insane, some of us are a lot insane and
+ * code is often very insane." :-)
+ *
+ */
+
+
+#if !defined(INCLUDE_SANITY_H)
+#    define  INCLUDE_SANITY_H
+
+
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
+/*
+ * location table
+ */
+#include "location.h"
+
+/*
+ * UTF-8 -> POSIX map
+ */
+#include "utf8_posix_map.h"
+
+/*
+ * JSON specific tables
+ */
+#include "json.h"
+
+/*
+ * function prototypes
+ */
+extern void ioccc_sanity_chk(); /* all *_sanity_chk() functions should call this */
+
+extern void check_utf8_posix_map(void);
+extern void check_location_table(void);
+extern void check_common_json_fields_table(void);
+
+
+#endif /* INCLUDE_SANITY_H */

--- a/txzchk.c
+++ b/txzchk.c
@@ -255,7 +255,9 @@ usage(int exitcode, char const *str, char const *prog)
 /*
  * txzchk_sanity_chk - perform basic sanity checks
  *
- * We perform basic sanity checks on paths.
+ * We perform basic sanity checks on paths and the IOCCC contest ID as well as
+ * the IOCCC toolkit tables. Note that these tables are not used in txzchk but
+ * to make sure everything is sane in every tool we make these checks.
  *
  * given:
  *
@@ -416,6 +418,9 @@ txzchk_sanity_chk(char const *tar, char const *fnamchk)
 	err(12, __func__, "txzpath is not readable: %s", txzpath);
 	not_reached();
     }
+
+    /* we also check that all the tables across the IOCCC toolkit are sane */
+    ioccc_sanity_chk();
 
     return;
 }

--- a/txzchk.h
+++ b/txzchk.h
@@ -30,6 +30,11 @@
 #include "dbg.h"
 
 /*
+ * sanity
+ */
+#include "sanity.h"
+
+/*
  * IOCCC size and rule related limitations
  */
 #include "limit_ioccc.h"

--- a/utf8_posix_map.c
+++ b/utf8_posix_map.c
@@ -1524,5 +1524,38 @@ struct utf8_posix_map const hmap[] =
 
     /* more UTF-8 table entries can be added here */
 
-    {0, NULL}		/* MUST BE LAST */
+    {NULL, NULL}		/* MUST BE LAST */
 };
+
+size_t SIZEOF_UTF8_POSIX_MAP = sizeof(hmap)/sizeof(hmap[0]);
+
+/* check_utf8_posix_map	    - make sure that there are no embedded NULL elements
+ *			      in hmap and that the last element is NULL
+ *
+ * This function verifies that the only NULL element in the table is the very
+ * last element: if it's not there or there's another NULL element it's a
+ * problem that has to be fixed.
+ *
+ */
+void
+check_utf8_posix_map(void)
+{
+    size_t max = SIZEOF_UTF8_POSIX_MAP;
+
+    size_t i;
+
+    for (i = 0; i < max - 1 && hmap[i].utf8_str != NULL; )
+	++i;
+
+    if (max - 1 != i) {
+	err(10, __func__, "found embedded NULL element in UTF-8 POSIX map");
+	not_reached();
+    }
+
+    if (hmap[i].utf8_str != NULL || hmap[i].posix_str != NULL) {
+	err(11, __func__, "no final NULL element in UTF-8 POSIX map");
+	not_reached();
+    }
+}
+
+

--- a/utf8_posix_map.h
+++ b/utf8_posix_map.h
@@ -45,6 +45,16 @@
 #if !defined(INCLUDE_UTF8_POSIX_MAP_H)
 #    define  INCLUDE_UTF8_POSIX_MAP_H
 
+/*
+ * util - utility functions and definitions
+ */
+#include "util.h"
+
+/*
+ * dbg - debug, warning and error reporting facility
+ */
+#include "dbg.h"
+
 
 /*
  * map certain UTF-8 strings into safe lower case POSIX portable filenames plus +.
@@ -58,6 +68,11 @@ struct utf8_posix_map {
  * global variables
  */
 extern struct utf8_posix_map const hmap[];	/* name to author handle map */
+extern size_t SIZEOF_UTF8_POSIX_MAP;
 
+/*
+ * function prototypes
+ */
+extern void check_utf8_posix_map(void);
 
 #endif				/* INCLUDE_UTF8_POSIX_MAP_H */


### PR DESCRIPTION
...because sometimes we're all a little insane, some of us are a lot
insane and code is often very insane. :-)

What this commit does is add sanity.{h,c} which has a new function:
ioccc_sanity_chk() which runs sanity checks on all the tables: the
location table, the UTF-8 POSIX map and the three JSON fields tables.

The jinfochk and jauthchk fields tables checks were moved to json.c
because the tools which have a sanity check function all run the new
ioccc_sanity_chk (because if something is not right in one or more of
the tables it suggests there's a problem in the toolkit) and jinfochk.c
and jauthchk.c obviously have main() each as well as verbosity_level.