### PR TITLE
JSON tests, typo and other fixes and updates 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ dkms.conf
 
 # Makefile backup (make depend specific)
 Makefile.orig
+
+# macOS files
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ CFLAGS= ${STD_SRC} ${COPT} -pedantic -Wall -Wextra -Werror
 #CFLAGS= ${STD_SRC} ${COPT} -pedantic -Wall -Wextra -Werror
 
 # NOTE: There are some things clang -Weverything warns about that are not relevant
-# 	and this for the -Weverything case, we exclude several directives
+# 	and thus for the -Weverything case, we exclude several directives
 #
 #CFLAGS= ${STD_SRC} ${COPT} -pedantic -Wall -Wextra -Werror -Weverything \
 #     -Wno-poison-system-directories -Wno-unreachable-code-break -Wno-padded

--- a/Makefile.example
+++ b/Makefile.example
@@ -19,7 +19,7 @@ RM= rm
 #
 CSTD= -std=gnu17
 
-# How to optimzie and set debug levels
+# How to optimize and set debug levels
 #
 COPT= -O3 -g3
 
@@ -27,12 +27,12 @@ COPT= -O3 -g3
 #
 CWARN= -Wall -Wextra -pedantic
 
-# Add various -Wno-foo flags to CSLIENCE to silence,
+# Add various -Wno-foo flags to CSILENCE to silence,
 # if needed, common compiler warnings.
 #
-CSLIENCE=
+CSILENCE=
 
-# Add and -Dfoo line defines here
+# Add -Dfoo line defines here
 #
 CDEFINE=
 
@@ -42,8 +42,8 @@ COTHER=
 
 # compile and link options
 #
-CFLAGS= ${CSTD} ${COPT} ${CWARN} ${CSLIENCE} ${CDEFINE} ${COTHER}
-LFLAGS=
+CFLAGS= ${CSTD} ${COPT} ${CWARN} ${CSILENCE} ${CDEFINE} ${COTHER}
+LDFLAGS=
 
 # list any data files supplied with the entry
 #

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -419,7 +419,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    ++p;
 	} else {
 	    /* if no '"' there's a problem */
-	    warn(__func__, "found no leading '\"' for field '%s' in file %s", p, file);
+	    warn(__func__, "found no leading '\"' for field '%s' in file %s: '%c'", p, file, *p);
 	    ++issues;
 	}
 
@@ -437,7 +437,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    *end = '\0';
 	} else {
 	    /* if no trailing '"' there's also a problem */
-	    warn(__func__, "found no trailing '\"': '%s' in file %s", p, file);
+	    warn(__func__, "found no trailing '\"': '%s' in file %s: '%c'", p, file, *p);
 	    ++issues;
 	}
 
@@ -545,24 +545,24 @@ check_author_json(char const *file, char const *fnamchk)
 		(author_field && (author_field->field_type == JSON_STRING || author_field->field_type == JSON_ARRAY_STRING))) {
 		if (!strcmp(val, "\"\"")) {
 		    /* make sure that it's not an empty string ("") */
-		    warn(__func__, "found empty string for field '%s'", p);
+		    warn(__func__, "found empty string for field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		} else if (!strcmp(val, "null") && !can_be_empty) {
 		    /* if it's null and it cannot be empty it's an issue */
-		    warn(__func__, "found invalid null value for field '%s' in file %s", p, file);
+		    warn(__func__, "found invalid null value for field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		} else if (strchr(val, '"') == NULL && !can_be_empty) {
 		    /* if there's no '"' and it cannot be empty it's an issue */
-		    warn(__func__, "string field '%s' value '%s' does not have any '\"'s in file %s", p, val, file);
+		    warn(__func__, "string field '%s' does not have any '\"'s in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		} else if (can_be_empty && strcmp(val, "null") && strchr(val, '"') == NULL) {
 		    /* if it can be empty and it's not 'null' and there's no '"'
 		     * it's an issue.
 		     */
-		    warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: %s", p, file, val);
+		    warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -575,14 +575,14 @@ check_author_json(char const *file, char const *fnamchk)
 		     * If no '"' and the value is not exactly "null" (null
 		     * object) it's an issue
 		     */
-		    warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s", p, file);
+		    warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
 
 		/* if nothing left continue to the next iteration of loop */
 		if (!*val) {
-		    warn(__func__, "found empty string field '%s' in file %s", p, file);
+		    warn(__func__, "found empty string value for field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -596,7 +596,7 @@ check_author_json(char const *file, char const *fnamchk)
 		     * if there's no trailing '"' and it's not a null object
 		     * ("null") then it's an issue
 		     */
-		    warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s", p, file);
+		    warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -623,7 +623,7 @@ check_author_json(char const *file, char const *fnamchk)
 		 * '"'s.
 		 */
 		if (strchr(val, '"') != NULL) {
-		    warn(__func__, "found '\"' in non-string field '%s' value '%s' in file %s", p, val, file);
+		    warn(__func__, "found '\"' in non-string field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -652,7 +652,7 @@ check_author_json(char const *file, char const *fnamchk)
 	    } else if (get_author_json_field(file, p, val_esc)) {
 	    } else {
 		/* this should actually never be reached */
-		warn(__func__, "invalid field '%s' found in file %s", p, file);
+		warn(__func__, "invalid field found in file %s: '%s'", file, p);
 		++issues;
 	    }
 
@@ -818,8 +818,8 @@ check_found_author_json_fields(char const *file, bool test)
 	dbg(DBG_VHIGH, "checking field '%s' in file %s", field->name, file);
 	/* make sure the field is not over the limit allowed */
 	if (author_field->max_count > 0 && author_field->count > author_field->max_count) {
-	    warn(__func__, "field '%s' found %ju times but is only allowed %ju time%s", author_field->name,
-		    (uintmax_t)author_field->count, (uintmax_t)author_field->max_count, author_field->max_count==1?"":"s");
+	    warn(__func__, "field found %ju times but is only allowed %ju time%s in file %s: '%s'",
+		    (uintmax_t)author_field->count, (uintmax_t)author_field->max_count, author_field->max_count==1?"":"s", file, author_field->name);
 	    ++issues;
 	}
 
@@ -828,7 +828,7 @@ check_found_author_json_fields(char const *file, bool test)
 	    val_length = strlen(val);
 
 	    if (!val_length) {
-		warn(__func__, "empty value found for field '%s' in file %s", field->name, file);
+		warn(__func__, "empty value found for field '%s' in file %s: '%s'", field->name, file, val);
 		/* don't increase issues because the below checks will do that
 		 * too: this warning only notes the reason the test will fail.
 		 */
@@ -844,7 +844,7 @@ check_found_author_json_fields(char const *file, bool test)
 	    switch (author_field->field_type) {
 		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
-			warn(__func__, "bool field '%s' has invalid value '%s' in file %s", author_field->name, val, file);
+			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'", author_field->name, file, val);
 			++issues;
 			continue;
 		    } else {
@@ -855,7 +855,7 @@ check_found_author_json_fields(char const *file, bool test)
 		    break; /* arrays are not handled yet */
 		case JSON_NUMBER:
 		    if (!is_number(val)) {
-			warn(__func__, "number field '%s' has non-number value '%s' in file %s", author_field->name, val, file);
+			warn(__func__, "number field '%s' has non-number value in file %s: '%s'", author_field->name, file, val);
 			++issues;
 			continue;
 		    } else {
@@ -870,12 +870,12 @@ check_found_author_json_fields(char const *file, bool test)
 
 	    if (!strcmp(field->name, "IOCCC_author_version")) {
 		if (!test && strcmp(val, AUTHOR_VERSION)) {
-		    warn(__func__, "IOCCC_author_version \"%s\" != \"%s\" in file %s", val, AUTHOR_VERSION, file);
+		    warn(__func__, "IOCCC_author_version != \"%s\" in file %s: \"%s\"", AUTHOR_VERSION, file, val);
 		    ++issues;
 		}
 	    } else {
 		/* this should never actually be reached but just in case */
-		warn(__func__, "found invalid field '%s'", field->name);
+		warn(__func__, "found invalid field in file %s: '%s'", file, field->name);
 		++issues;
 	    }
 	}
@@ -1003,7 +1003,7 @@ free_found_author_json_fields(void)
  * usage - print usage to stderr
  *
  * Example:
- *      usage(3, "missing required argument(s), program: %s", program);
+ *      usage(3, "missing required argument(s), program: '%s'", program);
  *
  * given:
  *	exitcode        value to exit with

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -113,7 +113,7 @@ main(int argc, char **argv)
 	para("", "Performing sanity checks on your environment ...", NULL);
     }
 
-    jauthchk_sanity_chk(file, fnamchk);
+    jauthchk_sanity_chks(file, fnamchk);
     if (!quiet) {
 	para("... environment looks OK", "", NULL);
     }
@@ -142,7 +142,7 @@ main(int argc, char **argv)
 
 
 /*
- * jauthchk_sanity_chk - perform basic sanity checks
+ * jauthchk_sanity_chks - perform basic sanity checks
  *
  * We perform basic sanity checks on paths.
  *
@@ -154,7 +154,7 @@ main(int argc, char **argv)
  * NOTE: This function does not return on error or if things are not sane.
  */
 static void
-jauthchk_sanity_chk(char const *file, char const *fnamchk)
+jauthchk_sanity_chks(char const *file, char const *fnamchk)
 {
     /*
      * firewall
@@ -262,11 +262,8 @@ jauthchk_sanity_chk(char const *file, char const *fnamchk)
 	not_reached();
     }
 
-    /* check the common_json_fields table */
-    check_common_json_fields_table();
-
-    /* check our author_json_fields table */
-    check_author_json_fields_table();
+    /* we also check that all the tables across the IOCCC toolkit are sane */
+    ioccc_sanity_chks();
 
     return;
 }

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -32,6 +32,10 @@
  */
 #include "json.h"
 
+/*
+ * sanity - sanity checks on the IOCCC toolkit
+ */
+#include "sanity.h"
 
 /*
  * IOCCC size and rule related limitations
@@ -90,7 +94,7 @@ extern size_t SIZEOF_AUTHOR_JSON_FIELDS_TABLE;	/* number of elements in the auth
  * forward declarations
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
-static void jauthchk_sanity_chk(char const *file, char const *fnamchk);
+static void jauthchk_sanity_chks(char const *file, char const *fnamchk);
 static int check_author_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_author_json_field(char const *name, char const *val);
 static int get_author_json_field(char const *file, char *name, char *val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1323,7 +1323,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 
 		/* check for valid title chars */
-		if (posix_plus_safe(val, true, false, true) == false) {
+		if (!posix_plus_safe(val, true, false, true)) {
 		    warn(__func__, "title: '%s' does not match regexp ^[0-9a-z][0-9a-z._+-]*$", val);
 		    ++issues;
 		}
@@ -1393,7 +1393,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	        /* extra_file must use only POSIX portable filename and + chars */
 		/* XXX - should the lower_only (2nd) arg to posix_plus_safe() be true or false? */
-		if (posix_plus_safe(val, false, false, true) == false) {
+		if (!posix_plus_safe(val, false, false, true)) {
 		    warn(__func__, "extra data file: '%s' does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$", val);
 		    ++issues;
 		    break;

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -112,7 +112,7 @@ main(int argc, char **argv)
 	       false, NULL, false, NULL);
 
 
-    jinfochk_sanity_chk(file, fnamchk);
+    jinfochk_sanity_chks(file, fnamchk);
     if (!quiet) {
 	para("... environment looks OK", "", NULL);
     }
@@ -137,7 +137,7 @@ main(int argc, char **argv)
 }
 
 /*
- * jinfochk_sanity_chk - perform basic sanity checks
+ * jinfochk_sanity_chks - perform basic sanity checks
  *
  * We perform basic sanity checks on paths and tables.
  *
@@ -149,7 +149,7 @@ main(int argc, char **argv)
  * NOTE: This function does not return on error or if things are not sane.
  */
 static void
-jinfochk_sanity_chk(char const *file, char const *fnamchk)
+jinfochk_sanity_chks(char const *file, char const *fnamchk)
 {
     /*
      * firewall
@@ -257,8 +257,8 @@ jinfochk_sanity_chk(char const *file, char const *fnamchk)
 	not_reached();
     }
 
-
-    ioccc_sanity_chk();
+    /* we also check that all the tables across the IOCCC toolkit are sane */
+    ioccc_sanity_chks();
 
     return;
 }

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -413,7 +413,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    ++p;
 	} else {
 	    /* if no '"' there's a problem */
-	    warn(__func__, "found no leading '\"' for field '%s' in file %s", p, file);
+	    warn(__func__, "found no leading '\"' for field '%s' in file %s: '%c'", p, file, *p);
 	    ++issues;
 	    continue;
 	}
@@ -432,7 +432,7 @@ check_info_json(char const *file, char const *fnamchk)
 	    *end = '\0';
 	} else {
 	    /* if no trailing '"' there's also a problem */
-	    warn(__func__, "found no trailing '\"': '%s' in file %s", p, file);
+	    warn(__func__, "found no trailing '\"': '%s' in file %s: '%c'", p, file, *p);
 	    ++issues;
 	}
 
@@ -461,7 +461,7 @@ check_info_json(char const *file, char const *fnamchk)
 	 * which is an error regardless of test mode.
 	 */
 	if (info_field == NULL && common_field == NULL) {
-	    err(21, __func__, "invalid field '%s'", p);
+	    err(21, __func__, "invalid field '%s' in file %s", p, file);
 	    not_reached();
 	}
 
@@ -519,7 +519,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 
 	    if (!check_last_json_char(file, array_dup, false, &p, ',')) {
-		warn(__func__, "last array element ends with ',' in file %s", file);
+		warn(__func__, "last array element ends with ',' in file %s: '%c'", file, *p);
 		++issues;
 	    }
 
@@ -539,7 +539,7 @@ check_info_json(char const *file, char const *fnamchk)
 		    ++array_field;
 		} else {
 		    /* if no '"' there's a problem */
-		    warn(__func__, "found no leading '\"' in array field '%s' in file %s", array_field, file);
+		    warn(__func__, "found no leading '\"' in array field in file %s: '%s'", file, array_field);
 		    ++issues;
 		    break;
 		}
@@ -558,7 +558,7 @@ check_info_json(char const *file, char const *fnamchk)
 		    *end = '\0';
 		} else {
 		    /* if there's no trailing '"' there's also a problem */
-		    warn(__func__, "found no trailing '\"' in array field '%s' in file %s", array_field, file);
+		    warn(__func__, "found no trailing '\"' in array field in file %s: '%s'", file, array_field);
 		    ++issues;
 		    break;
 		}
@@ -573,7 +573,7 @@ check_info_json(char const *file, char const *fnamchk)
 		     * TODO: Make this an error once all testing has been
 		     * finished.
 		     */
-		    warn(__func__, "found empty array field in file %s", file);
+		    warn(__func__, "found empty array field in file %s: '%s'", file, array_field);
 		    ++issues;
 		    continue;
 		}
@@ -584,7 +584,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 * error regardless of test mode.
 		 */
 		if (array_info_field == NULL) {
-		    err(27, __func__, "invalid field '%s' in manifest array", array_field);
+		    err(27, __func__, "invalid field '%s' in manifest array of file %s", array_field, file);
 		    not_reached();
 		}
 
@@ -622,24 +622,24 @@ check_info_json(char const *file, char const *fnamchk)
 		if (array_info_field->field_type == JSON_ARRAY_STRING) {
 		    if (!strcmp(array_val, "\"\"")) {
 			/* make sure that it's not an empty string ("") */
-			warn(__func__, "found empty string for array field '%s'", array_field);
+			warn(__func__, "found empty string for array field '%s': '%s'", array_field, array_val);
 			++issues;
 			continue;
 		    } else if (!strcmp(array_val, "null") && !can_be_empty) {
 			/* if it's null and it cannot be empty it's an issue */
-			warn(__func__, "found invalid null value for field '%s' in file %s", array_field, file);
+			warn(__func__, "found invalid null value for field '%s' in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    } else if (strchr(array_val, '"') == NULL && !can_be_empty) {
 			/* if there's no '"' and it cannot be empty it's an issue */
-			warn(__func__, "string field '%s' value '%s' does not have any '\"'s in file %s", array_field, array_val, file);
+			warn(__func__, "string field '%s' value does not have any '\"'s in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    } else if (can_be_empty && strcmp(array_val, "null") && strchr(array_val, '"') == NULL) {
 			/* if it can be empty and it's not 'null' and there's no '"'
 			 * it's an issue.
 			 */
-			warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: %s", array_field, file, array_val);
+			warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    }
@@ -648,7 +648,7 @@ check_info_json(char const *file, char const *fnamchk)
 		    if (*array_val == '"') {
 			++array_val;
 		    } else if (!strcmp(array_val, "null") && !can_be_empty) {
-			warn(__func__, "found invalid null value for field '%s' in file %s", array_field, file);
+			warn(__func__, "found invalid null value for field '%s' in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    } else if (strcmp(array_val, "null")) {
@@ -656,7 +656,7 @@ check_info_json(char const *file, char const *fnamchk)
 			 * If no '"' and the value is not exactly "null" (null
 			 * object) it's an issue
 			 */
-			warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s", array_field, file);
+			warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    }
@@ -670,7 +670,7 @@ check_info_json(char const *file, char const *fnamchk)
 			 * if there's no trailing '"' and it's not a null object
 			 * ("null") then it's an issue
 			 */
-			warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s", array_field, file);
+			warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    }
@@ -680,7 +680,7 @@ check_info_json(char const *file, char const *fnamchk)
 		     * of the loop
 		     */
 		    if (!*array_val) {
-			warn(__func__, "found empty string value for array field '%s' in file %s", array_field, file);
+			warn(__func__, "found empty string value for array field '%s' in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    }
@@ -693,7 +693,7 @@ check_info_json(char const *file, char const *fnamchk)
 		     * non-string array is added to the array.
 		     */
 		    if (strchr(array_val, '"') != NULL) {
-			warn(__func__, "found '\"' in non-string array field '%s' value '%s' in file %s", array_field, array_val, file);
+			warn(__func__, "found '\"' in non-string array field '%s' value in file %s: '%s'", array_field, file, array_val);
 			++issues;
 			continue;
 		    }
@@ -718,7 +718,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		if (!get_info_json_field(file, array_field, array_val_esc)) {
 		    /* this should actually never be reached */
-		    warn(__func__, "found invalid field in array");
+		    warn(__func__, "found invalid field in array in file %s: '%s'", file, array_field);
 		    ++issues;
 		}
 
@@ -768,24 +768,24 @@ check_info_json(char const *file, char const *fnamchk)
 		(info_field && (info_field->field_type == JSON_STRING || info_field->field_type == JSON_ARRAY_STRING))) {
 		if (!strcmp(val, "\"\"")) {
 		    /* make sure that it's not an empty string ("") */
-		    warn(__func__, "found empty string for field '%s'", p);
+		    warn(__func__, "found empty string for field '%s': '%s'", p, val);
 		    ++issues;
 		    continue;
 		} else if (!strcmp(val, "null") && !can_be_empty) {
 		    /* if it's null and it cannot be empty it's an issue */
-		    warn(__func__, "found invalid null value for field '%s' in file %s", p, file);
+		    warn(__func__, "found invalid null value for field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		} else if (strchr(val, '"') == NULL && !can_be_empty) {
 		    /* if there's no '"' and it cannot be empty it's an issue */
-		    warn(__func__, "string field '%s' value '%s' does not have any '\"'s in file %s", p, val, file);
+		    warn(__func__, "string field '%s' value does not have any '\"'s in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		} else if (can_be_empty && strcmp(val, "null") && strchr(val, '"') == NULL) {
 		    /* if it can be empty and it's not 'null' and there's no '"'
 		     * it's an issue.
 		     */
-		    warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: %s", p, file, val);
+		    warn(__func__, "string field '%s' value that's not 'null' has no '\"'s in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -798,14 +798,14 @@ check_info_json(char const *file, char const *fnamchk)
 		     * If no '"' and the value is not exactly "null" (null
 		     * object) it's an issue
 		     */
-		    warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s", p, file);
+		    warn(__func__, "found non-null string field '%s' without '\"' at the beginning in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
 
 		/* if nothing left continue to the next iteration of loop */
 		if (!*val) {
-		    warn(__func__, "found empty string field '%s' in file %s", p, file);
+		    warn(__func__, "found empty string field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -819,7 +819,7 @@ check_info_json(char const *file, char const *fnamchk)
 		     * if there's no trailing '"' and it's not a null object
 		     * ("null") then it's an issue
 		     */
-		    warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s", p, file);
+		    warn(__func__, "found non-null string field '%s' without '\"' at the end in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -829,7 +829,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 * of the loop
 		 */
 		if (!*val) {
-		    warn(__func__, "found empty string value for field '%s' in file %s", p, file);
+		    warn(__func__, "found empty string value for field '%s' in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -847,7 +847,7 @@ check_info_json(char const *file, char const *fnamchk)
 		 * '"'s.
 		 */
 		if (strchr(val, '"') != NULL) {
-		    warn(__func__, "found '\"' in non-string field '%s' value '%s' in file %s", p, val, file);
+		    warn(__func__, "found '\"' in non-string field '%s' value in file %s: '%s'", p, file, val);
 		    ++issues;
 		    continue;
 		}
@@ -1284,7 +1284,7 @@ check_found_info_json_fields(char const *file, bool test)
 	    switch (info_field->field_type) {
 		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
-			warn(__func__, "bool field '%s' has invalid value '%s' in file %s", info_field->name, val, file);
+			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'", info_field->name, file, val);
 			++issues;
 			continue;
 		    } else {
@@ -1293,7 +1293,7 @@ check_found_info_json_fields(char const *file, bool test)
 		    break;
 		case JSON_NUMBER:
 		    if (!is_number(val)) {
-			warn(__func__, "number field '%s' has non-number value '%s' in file %s", info_field->name, val, file);
+			warn(__func__, "number field '%s' has non-number value in file %s: '%s'", info_field->name, file, val);
 			++issues;
 			continue;
 		    } else {
@@ -1308,37 +1308,37 @@ check_found_info_json_fields(char const *file, bool test)
 
 	    if (!strcmp(field->name, "IOCCC_info_version")) {
 		if (!test && strcmp(val, INFO_VERSION)) {
-		    warn(__func__, "IOCCC_info_version \"%s\" != INFO_VERSION \"%s\" in file %s", val, INFO_VERSION, file);
+		    warn(__func__, "IOCCC_info_version != INFO_VERSION \"%s\" in file %s: \"%s\"", INFO_VERSION, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "title")) {
 		/* check for valid title length */
 		if (!val_length) {
-		    warn(__func__, "title length zero");
+		    warn(__func__, "title length zero in file %s", file);
 		    ++issues;
 		} else if (val_length > MAX_TITLE_LEN) {
-		    warn(__func__, "title length %ju > max %d",
-				      (uintmax_t)val_length, MAX_TITLE_LEN);
+		    warn(__func__, "title length %ju > max %d in file %s: '%s'",
+				      (uintmax_t)val_length, MAX_TITLE_LEN, file, val);
 		    ++issues;
 		}
 
 		/* check for valid title chars */
 		if (!posix_plus_safe(val, true, false, true)) {
-		    warn(__func__, "title: '%s' does not match regexp ^[0-9a-z][0-9a-z._+-]*$", val);
+		    warn(__func__, "title does not match regexp ^[0-9a-z][0-9a-z._+-]*$ in file %s: '%s'", file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "abstract")) {
 		if (!val_length) {
-		    warn(__func__, "abstract value zero length");
+		    warn(__func__, "abstract value zero length in file %s", file);
 		    ++issues;
 		} else if (val_length > MAX_ABSTRACT_LEN) {
-		    warn(__func__, "abstract length %ju > max %d",
-				      (uintmax_t)val_length, MAX_ABSTRACT_LEN);
+		    warn(__func__, "abstract length %ju > max %d in file %s: '%s'",
+				      (uintmax_t)val_length, MAX_ABSTRACT_LEN, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "info_JSON")) {
 		if (strcmp(val, ".info.json")) {
-		    warn(__func__, "found invalid info_JSON value: '%s'", val);
+		    warn(__func__, "found invalid info_JSON value in file %s: '%s'", file, val);
 		    ++issues;
 		}
 		manifest_file = add_manifest_file(val);
@@ -1348,7 +1348,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	    } else if (!strcmp(field->name, "author_JSON")) {
 		if (strcmp(val, ".author.json")) {
-		    warn(__func__, "found invalid author_JSON value: '%s'", val);
+		    warn(__func__, "found invalid author_JSON value in file %s: '%s'", file, val);
 		    ++issues;
 		}
 		manifest_file = add_manifest_file(val);
@@ -1358,7 +1358,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	    } else if (!strcmp(field->name, "c_src")) {
 		if (strcmp(val, "prog.c")) {
-		    warn(__func__, "found invalid c_src value: '%s'", val);
+		    warn(__func__, "found invalid c_src value in file %s: '%s'", file, val);
 		    ++issues;
 		}
 		manifest_file = add_manifest_file(val);
@@ -1368,7 +1368,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	    } else if (!strcmp(field->name, "Makefile")) {
 		if (strcmp(val, "Makefile")) {
-		    warn(__func__, "found invalid Makefile value: '%s'", val);
+		    warn(__func__, "found invalid Makefile value in file %s: '%s'", file, val);
 		    ++issues;
 		}
 		manifest_file = add_manifest_file(val);
@@ -1378,7 +1378,7 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	    } else if (!strcmp(field->name, "remarks")) {
 		if (strcmp(val, "remarks.md")) {
-		    warn(__func__, "found invalid remarks value: '%s'", val);
+		    warn(__func__, "found invalid remarks value in file %s: '%s'", file, val);
 		    ++issues;
 		}
 		manifest_file = add_manifest_file(val);
@@ -1388,19 +1388,19 @@ check_found_info_json_fields(char const *file, bool test)
 		}
 	    } else if (!strcmp(field->name, "extra_file")) {
 		if (val_length > MAX_BASENAME_LEN) {
-		    warn(__func__, "extra file name length %ju > the limit %ju", (uintmax_t)val_length, (uintmax_t)MAX_BASENAME_LEN);
+		    warn(__func__, "extra file name length %ju > the limit %ju: '%s'", (uintmax_t)val_length, (uintmax_t)MAX_BASENAME_LEN, val);
 		    ++issues;
 		}
 	        /* extra_file must use only POSIX portable filename and + chars */
 		/* XXX - should the lower_only (2nd) arg to posix_plus_safe() be true or false? */
 		if (!posix_plus_safe(val, false, false, true)) {
-		    warn(__func__, "extra data file: '%s' does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$", val);
+		    warn(__func__, "extra data file does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$ in file %s: '%s'", file, val);
 		    ++issues;
 		    break;
 		}
 		manifest_file = add_manifest_file(val);
 		if (manifest_file == NULL) {
-		    err(49, __func__, "couldn't add extra_file file '%s'", val);
+		    err(49, __func__, "couldn't add extra_file file '%s' in file %s", val, file);
 		    not_reached();
 		}
 	    } else if (!strcmp(field->name, "rule_2a_size")) {
@@ -1439,7 +1439,7 @@ check_found_info_json_fields(char const *file, bool test)
 		info.found_try_rule = string_to_bool(val);
 	    } else if (strcmp(field->name, "manifest")) {
 		/* this should never actually be reached but just in case */
-		warn(__func__, "found invalid field '%s'", field->name);
+		warn(__func__, "found invalid field in file %s: '%s'", file, field->name);
 		++issues;
 	    }
 	}
@@ -1453,7 +1453,7 @@ check_found_info_json_fields(char const *file, bool test)
      */
     if (info.Makefile_override && info.first_rule_is_all && info.found_all_rule &&
 	    info.found_clean_rule && info.found_clobber_rule && info.found_try_rule) {
-	warn(__func__, "Makefile_override == true but all expected Makefile rules found and 'all:' is first");
+	warn(__func__, "Makefile_override == true but all expected Makefile rules found and 'all:' is first in file %s", file);
 	++issues;
     }
 
@@ -1462,13 +1462,13 @@ check_found_info_json_fields(char const *file, bool test)
      * there's a mismatch: check this and report if this is the case.
      */
     if (!info.found_all_rule && info.first_rule_is_all) {
-	warn(__func__, "'all:' rule not found but first_rule_is_all == true");
+	warn(__func__, "'all:' rule not found but first_rule_is_all == true in file %s", file);
 	++issues;
     }
 
     /* if empty_override == true and prog.c is not size 0 there's a problem */
     if (info.empty_override && info.rule_2a_size > 0 && info.rule_2b_size > 0) {
-	warn(__func__, "empty_override == true but prog.c size > 0");
+	warn(__func__, "empty_override == true but prog.c size > 0 in file %s", file);
 	++issues;
     }
 
@@ -1477,7 +1477,7 @@ check_found_info_json_fields(char const *file, bool test)
      * there's a problem.
      */
     if (!info.empty_override && (info.rule_2a_size == 0 || info.rule_2b_size == 0)) {
-	warn(__func__, "empty_override == false but rule 2a and/or rule 2b size == 0");
+	warn(__func__, "empty_override == false but rule 2a and/or rule 2b size == 0 in file %s", file);
 	++issues;
     }
 
@@ -1497,7 +1497,7 @@ check_found_info_json_fields(char const *file, bool test)
      */
     for (loc = 0; !test && info_json_fields[loc].name != NULL; ++loc) {
 	if (!info_json_fields[loc].found && info_json_fields[loc].max_count > 0) {
-	    warn(__func__, "field '%s' not found in found_info_json_fields list", info_json_fields[loc].name);
+	    warn(__func__, "required field not found in found_info_json_fields list in file %s: '%s'", file, info_json_fields[loc].name);
 	    ++issues;
 	}
     }
@@ -1509,7 +1509,7 @@ check_found_info_json_fields(char const *file, bool test)
      */
     for (manifest_file = manifest_files; manifest_file; manifest_file = manifest_file->next) {
 	if (manifest_file->count > 1) {
-	    warn(__func__, "found duplicate file '%s' (count: %ju)", manifest_file->filename, (uintmax_t)manifest_file->count);
+	    warn(__func__, "found duplicate file (count: %ju) in file %s: '%s'", (uintmax_t)manifest_file->count, file, manifest_file->filename);
 	    ++issues;
 	}
     }

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -39,7 +39,7 @@
 #include "json.h"
 
 /*
- * sanity
+ * sanity - sanity checks on the IOCCC toolkit
  */
 #include "sanity.h"
 
@@ -101,7 +101,7 @@ extern size_t SIZEOF_INFO_JSON_FIELDS_TABLE;
  * forward declarations
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
-static void jinfochk_sanity_chk(char const *file, char const *fnamchk);
+static void jinfochk_sanity_chks(char const *file, char const *fnamchk);
 static int check_info_json(char const *file, char const *fnamchk);
 static struct json_field *add_found_info_json_field(char const *name, char const *val);
 static int get_info_json_field(char const *file, char *name, char *val);

--- a/json-test.sh
+++ b/json-test.sh
@@ -29,7 +29,7 @@ exit codes:
     0 - all is well
     1 - at least one test failed
     2 - help mode exit
-    3 - invalid command linw
+    3 - invalid command line
     >= 4 - internal error"
 export JINFOCHK="./jinfochk"
 export JAUTHCHK="./jauthchk"

--- a/json-test.sh
+++ b/json-test.sh
@@ -221,7 +221,7 @@ run_test()
     # parse args
     #
     if [[ $# -ne 5 ]]; then
-	echo "$0: ERROR: expected 5 args to run_test, founbd $#" 1>&2
+	echo "$0: ERROR: expected 5 args to run_test, found $#" 1>&2
 	exit 4
     fi
     typeset test_prog="$1"
@@ -242,11 +242,11 @@ run_test()
 	exit 4
     fi
     if [[ $pass_fail != pass && $pass_fail != fail ]]; then
-	echo "$0: in run_test: pass_fail neither pass nor fail: $pass_fail" 1>&2
+	echo "$0: in run_test: pass_fail neither 'pass' nor 'fail': $pass_fail" 1>&2
 	exit 4
     fi
     if [[ $strict != strict && $strict != notstrict ]]; then
-	echo "$0: in run_test: strict neither strict nor notstrict: $strict" 1>&2
+	echo "$0: in run_test: strict strict neither 'strict' nor 'notstrict': $strict" 1>&2
 	exit 4
     fi
     if [[ ! -e $test_prog ]]; then
@@ -258,7 +258,7 @@ run_test()
 	exit 4
     fi
     if [[ ! -r $test_prog ]]; then
-	echo "$0: in run_test: json_test_file not readabke: $json_test_file"
+	echo "$0: in run_test: json_test_file not readable: $json_test_file"
 	exit 4
     fi
 

--- a/json.c
+++ b/json.c
@@ -2219,8 +2219,8 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	 * uncommon fields some are allowed more than once.
 	 */
 	if (common_field->count > common_field->max_count) {
-	    warn(__func__, "field '%s' found %ju times but is only allowed once",
-			   common_field->name, (uintmax_t)common_field->count);
+	    warn(__func__, "field '%s' found %ju times but is only allowed once in file %s",
+			   common_field->name, (uintmax_t)common_field->count, file);
 	    ++issues;
 	}
 
@@ -2229,7 +2229,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	    val_length = strlen(val);
 
 	    if (!val_length) {
-		warn(__func__, "empty value found for field '%s' in file %s", field->name, file);
+		warn(__func__, "empty value found for field '%s' in file %s: '%s'", field->name, file, val);
 		/* don't increase issues because the below checks will do that
 		 * too: this warning only notes the reason the test will fail.
 		 */
@@ -2238,7 +2238,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 	    switch (common_field->field_type) {
 		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
-			warn(__func__, "bool field '%s' has no boolean value '%s' in file %s", common_field->name, val, file);
+			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'", common_field->name, file, val);
 			++issues;
 			continue;
 		    }
@@ -2247,7 +2247,7 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		    break; /* arrays are not handled yet */
 		case JSON_NUMBER:
 		    if (!is_number(val)) {
-			warn(__func__, "number field '%s' has non-number value '%s' in file %s", common_field->name, val, file);
+			warn(__func__, "number field '%s' has non-number value in file %s: '%s'", common_field->name, file, val);
 			++issues;
 			continue;
 		    }
@@ -2260,34 +2260,34 @@ check_found_common_json_fields(char const *program, char const *file, char const
 
 	    if (!strcmp(field->name, "ioccc_contest")) {
 		if (strcmp(val, IOCCC_CONTEST)) {
-		    warn(__func__, "ioccc_contest \"%s\" != \"%s\" in file %s", val, IOCCC_CONTEST, file);
+		    warn(__func__, "ioccc_contest != \"%s\" in file %s: \"%s\"", IOCCC_CONTEST, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "ioccc_year")) {
 		year = string_to_int(val);
 		if (year != IOCCC_YEAR) {
-		    warn(__func__, "ioccc_year %d != IOCCC_YEAR %d", year, IOCCC_YEAR);
+		    warn(__func__, "ioccc_year != IOCCC_YEAR %d in file %s: '%s' (%d)", IOCCC_YEAR, file, val, year);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "mkiocccentry_version")) {
 		if (!test && strcmp(val, MKIOCCCENTRY_VERSION)) {
-		    warn(__func__, "mkiocccentry_version \"%s\" != MKIOCCCENTRY_VERSION \"%s\"", val, MKIOCCCENTRY_VERSION);
+		    warn(__func__, "mkiocccentry_version != MKIOCCCENTRY_VERSION \"%s\" in file %s: \"%s\"", MKIOCCCENTRY_VERSION, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "iocccsize_version")) {
 		if (!test && strcmp(val, IOCCCSIZE_VERSION)) {
-		    warn(__func__, "iocccsize_version \"%s\" != IOCCCSIZE_VERSION \"%s\"", val, IOCCCSIZE_VERSION);
+		    warn(__func__, "iocccsize_version != IOCCCSIZE_VERSION \"%s\" in file %s: \"%s\"", IOCCCSIZE_VERSION, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "IOCCC_contest_id")) {
 		if (!valid_contest_id(val)) {
-		    warn(__func__, "IOCCC_contest_id \"%s\" is invalid", val);
+		    warn(__func__, "IOCCC_contest_id is invalid in file %s: \"%s\"", file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "min_timestamp")) {
 		ts = string_to_long(val);
 		if (ts != MIN_TIMESTAMP) {
-		    warn(__func__, "min_timestamp '%ld' != MIN_TIMESTAMP '%ld'", ts, MIN_TIMESTAMP);
+		    warn(__func__, "min_timestamp != MIN_TIMESTAMP '%ld' in file %s: '%s' (%ld)", MIN_TIMESTAMP, file, val, ts);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "timestamp_epoch")) {
@@ -2298,38 +2298,38 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		 * remove ALT_TIMESTAMP_EPOCH in its entirety.
 		 */
 		if (strcmp(val, TIMESTAMP_EPOCH) && strcmp(val, ALT_TIMESTAMP_EPOCH)) {
-		    warn(__func__, "timestamp_epoch \"%s\" != TIMESTAMP_EPOCH \"%s\"", val, TIMESTAMP_EPOCH);
+		    warn(__func__, "timestamp_epoch != TIMESTAMP_EPOCH \"%s\" in file %s: \"%s\"", TIMESTAMP_EPOCH, file, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_timestamp_usec")) {
 		errno = 0;
 		ts = string_to_long(val);
 		if (ts < 0 || ts > 999999) {
-		    warnp(__func__, "formed_timestamp_usec '%ld' out of range of >= 0 && <= 999999", ts);
+		    warnp(__func__, "formed_timestamp_usec out of range of >= 0 && <= 999999 in file %s: '%ld'", file, ts);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "entry_num")) {
 		entry_num = string_to_int(val);
 		if (!(entry_num >= 0 && entry_num <= MAX_ENTRY_NUM)) {
-		    warn(__func__, "entry number %d out of range", entry_num);
+		    warn(__func__, "entry number out of range in file %s: %d", file, entry_num);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "author_count")) {
 		author_count = string_to_int(val);
 		if (!(author_count > 0 && author_count <= MAX_AUTHORS)) {
-		    warn(__func__, "author count %d out of range of > 1 && <= %d", author_count, MAX_AUTHORS);
+		    warn(__func__, "author count out of range of > 1 && <= %d in file %s: '%s' (%d)", MAX_AUTHORS, file, val, author_count);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_UTC")) {
 		p = strptime(val, FORMED_UTC_FMT, &tm);
 		if (p == NULL) {
-		    warn(__func__, "formed_UTC \"%s\" does not match FORMED_UTC_FMT \"%s\"", val, FORMED_UTC_FMT);
+		    warn(__func__, "formed_UTC does not match FORMED_UTC_FMT \"%s\": \"%s\"", FORMED_UTC_FMT, val);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_timestamp")) {
 		ts = string_to_long(val);
 		if (ts < MIN_TIMESTAMP) {
-		    warn(__func__, "formed_timestamp '%ld' < MIN_TIMESTAMP '%ld'", ts, MIN_TIMESTAMP);
+		    warn(__func__, "formed_timestamp < MIN_TIMESTAMP '%ld' in file %s: '%s' (%ld)", MIN_TIMESTAMP, file, val, ts);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "tarball")) {
@@ -2373,14 +2373,14 @@ check_found_common_json_fields(char const *program, char const *file, char const
      */
     for (loc = 0; !test && common_json_fields[loc].name != NULL; ++loc) {
 	if (!common_json_fields[loc].found && common_json_fields[loc].max_count > 0) {
-	    warn(__func__, "field '%s' not found in found_common_json_fields list", common_json_fields[loc].name);
+	    warn(__func__, "required field not found in found_common_json_fields list in file %s: '%s'", file, common_json_fields[loc].name);
 	    ++issues;
 	}
     }
 
     /* test consistency of test_mode and tarball field */
     if (tarball_field == NULL) {
-	warn(__func__, "didn't find tarball path in file %s", file);
+	warn(__func__, "required field not found in found_common_json_fields list in file %s: 'tarball'", file);
 	++issues;
     } else if (test_mode) {
 	/*

--- a/location.h
+++ b/location.h
@@ -58,4 +58,9 @@ struct location {
 extern struct location loc[];		/* location/country codes */
 extern size_t SIZEOF_LOCATION_TABLE;
 
+/*
+ * function prototypes
+ */
+extern void check_location_table(void);
+
 #endif				/* INCLUDE_LOCATION_H */

--- a/mkiocccentry-test.sh
+++ b/mkiocccentry-test.sh
@@ -100,7 +100,7 @@ answers >>answers.txt
 
 # run the test, looking for an exit
 #
-yes | ./mkiocccentry -i answers.txt -- "${work_dir}" "${src_dir}"/{prog.c,Makefile,remarks.md,extra1,extra2}
+yes | ./mkiocccentry -q -i answers.txt -- "${work_dir}" "${src_dir}"/{prog.c,Makefile,remarks.md,extra1,extra2}
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: FATAL: mkiocccentry non-zero exit code: $status" 1>&2
@@ -110,7 +110,7 @@ fi
 # delete the work directory for next test
 find "${work_dir_esc}" -mindepth 1 -depth -delete
 # test empty prog.c, ignoring the warning about it
-yes | ./mkiocccentry -W -i answers.txt -- "${work_dir}" "${src_dir}"/{empty.c,Makefile,remarks.md,extra1,extra2}
+yes | ./mkiocccentry -q -W -i answers.txt -- "${work_dir}" "${src_dir}"/{empty.c,Makefile,remarks.md,extra1,extra2}
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: FATAL: mkiocccentry non-zero exit code: $status" 1>&2

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -2,7 +2,7 @@
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
-\fBmkiocccentry [\-h] [\-v level] [\-V] [\-T] [\-t tar] [\-c cp] [\-l ls] [\-C txzchk] [\-F fnamchk] [{\-a|\-A|\-i} answers] [\-j jinfochk] [\-J jauthchk] [\-W] work_dir prog.c Makefile remarks.md [file ...]\fP
+\fBmkiocccentry [\-h] [\-v level] [\-V] [\-T] [\-t tar] [\-c cp] [\-l ls] [\-C txzchk] [\-F fnamchk] [{\-a|\-A|\-i} answers] [\-j jinfochk] [\-J jauthchk] [\-W] [\-q] work_dir prog.c Makefile remarks.md [file ...]\fP
 .SH DESCRIPTION
 \fBmkiocccentry\fP gathers your source file, Makefile, remarks as well as any other files and creates a XZ compressed tarball.
 The tool runs \fBiocccsize\fP and it also runs a test on the Makefile to verify that everything seems in order.
@@ -69,6 +69,8 @@ Specify path to \fBjauthchk\fP tool.
 Ignore all warnings.
 When this option is specified the program warns you that you've ignored all warnings (therefore not ignoring all warnings :) ), informing you that the judges will not ignore all warnings.
 .PP
+\fP\-q\fP
+Quiet mode: suppress some warnings.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 0 on success; if there's an error the end is not reached.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -332,7 +332,7 @@ main(int argc, char *argv[])
     if (!quiet) {
 	para("", "Performing sanity checks on your environment ...", NULL);
     }
-    mkiocccentry_sanity_chk(&info, work_dir, tar, cp, ls, txzchk, fnamchk, jinfochk, jauthchk);
+    mkiocccentry_sanity_chks(&info, work_dir, tar, cp, ls, txzchk, fnamchk, jinfochk, jauthchk);
     if (!quiet) {
 	para("... environment looks OK", "", NULL);
     }
@@ -788,7 +788,7 @@ usage(int exitcode, char const *str, char const *program)
 
 
 /*
- * mkiocccentry_sanity_chk - perform basic sanity checks
+ * mkiocccentry_sanity_chks - perform basic sanity checks
  *
  * We perform basic sanity checks on paths and the IOCCC contest ID as well as
  * the IOCCC toolkit tables.
@@ -808,7 +808,7 @@ usage(int exitcode, char const *str, char const *program)
  * NOTE: This function does not return on error or if things are not sane.
  */
 static void
-mkiocccentry_sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp, char const *ls,
+mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *tar, char const *cp, char const *ls,
 	   char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk)
 {
     /*
@@ -1262,7 +1262,7 @@ mkiocccentry_sanity_chk(struct info *infop, char const *work_dir, char const *ta
     infop->common.iocccsize_ver = IOCCCSIZE_VERSION;
 
     /* we also check that all the tables across the IOCCC toolkit are sane */
-    ioccc_sanity_chk();
+    ioccc_sanity_chks();
 
     return;
 }

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3557,7 +3557,6 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
     char guard;			/* scanf guard to catch excess amount of input */
     char *p;
     int i = 0;
-    int j = 0;
 
     /*
      * firewall
@@ -4308,7 +4307,6 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	 * ask for IOCCC winner handle
 	 */
 	do {
-	    j = 0; /* set j to 0 for when there's more than one author */
 
 	    /*
 	     * request IOCCC author handle

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -149,7 +149,7 @@ main(int argc, char *argv[])
      */
     input_stream = stdin;	/* default to reading from standard in */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:VTt:c:l:a:i:A:WC:F:j:J:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VTt:c:l:a:i:A:WC:F:j:J:q")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program);
@@ -224,6 +224,9 @@ main(int argc, char *argv[])
 	    jauthchk_flag_used = true;
 	    jauthchk = optarg;
 	    break;
+	case 'q':
+	    quiet = true;
+	    break;
 	default:
 	    usage(3, "invalid -flag", program); /*ooo*/
 	    not_reached();
@@ -293,11 +296,13 @@ main(int argc, char *argv[])
     /*
      * Welcome
      */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = printf("Welcome to mkiocccentry version: %s\n", MKIOCCCENTRY_VERSION);
-    if (ret <= 0) {
-	errp(3, __func__, "printf error printing the welcome string");
-	not_reached();
+    if (!quiet) {
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = printf("Welcome to mkiocccentry version: %s\n", MKIOCCCENTRY_VERSION);
+	if (ret <= 0) {
+	    errp(3, __func__, "printf error printing the welcome string");
+	    not_reached();
+	}
     }
 
     /*
@@ -317,16 +322,20 @@ main(int argc, char *argv[])
 	     "you any additional warnings, you should note that The Judges will NOT",
 	     "ignore warnings! If this was unintentional, run the program again",
 	     "without specifying -W. We cannot stress the importance of this enough!",
+	     "",
 	     NULL);
     }
 
     /*
      * environment sanity checks
      */
-    para("", "Performing sanity checks on your environment ...", NULL);
+    if (!quiet) {
+	para("", "Performing sanity checks on your environment ...", NULL);
+    }
     mkiocccentry_sanity_chk(&info, work_dir, tar, cp, ls, txzchk, fnamchk, jinfochk, jauthchk);
-    para("... environment looks OK", "", NULL);
-
+    if (!quiet) {
+	para("... environment looks OK", "", NULL);
+    }
     /*
      * if -a answers was specified and answers file exists, prompt user if they
      * want to overwrite it; if they don't tell them how to use it and abort.
@@ -437,30 +446,48 @@ main(int argc, char *argv[])
     /*
      * check prog.c
      */
-    para("", "Checking prog.c ...", NULL);
+    if (!quiet) {
+	para("", "Checking prog.c ...", NULL);
+    }
     size = check_prog_c(&info, entry_dir, cp, prog_c);
-    para("... completed prog.c check.", "", NULL);
+    if (!quiet) {
+	para("... completed prog.c check.", "", NULL);
+    }
 
     /*
      * check Makefile
      */
-    para("Checking Makefile ...", NULL);
-    check_Makefile(&info, entry_dir, cp, Makefile);
-    para("... completed Makefile check.", "", NULL);
+    if (!quiet) {
+	para("Checking Makefile ...", NULL);
+    }
 
+    check_Makefile(&info, entry_dir, cp, Makefile);
+
+    if (!quiet) {
+	para("... completed Makefile check.", "", NULL);
+    }
     /*
      * check remarks.md
      */
-    para("Checking remarks.md ...", NULL);
+    if (!quiet) {
+	para("Checking remarks.md ...", NULL);
+    }
     check_remarks_md(&info, entry_dir, cp, remarks_md);
-    para("... completed remarks.md check.", "", NULL);
+    if (!quiet) {
+	para("... completed remarks.md check.", "", NULL);
+    }
 
     /*
      * check, if needed, extra data files
      */
-    para("Checking extra data files ...", NULL);
+    if (!quiet) {
+	para("Checking extra data files ...", NULL);
+    }
+
     check_extra_data_files(&info, entry_dir, cp, extra_count, extra_list);
-    para("... completed extra data files check.", "", NULL);
+    if (!quiet) {
+	para("... completed extra data files check.", "", NULL);
+    }
 
     /*
      * obtain the title
@@ -531,16 +558,23 @@ main(int argc, char *argv[])
     /*
      * write the .info.json file
      */
-    para("", "Forming the .info.json file ...", NULL);
+    if (!quiet) {
+	para("", "Forming the .info.json file ...", NULL);
+    }
     write_info(&info, entry_dir, jinfochk, fnamchk, author_count);
-    para("... completed the .info.json file.", "", NULL);
-
+    if (!quiet) {
+	para("... completed the .info.json file.", "", NULL);
+    }
     /*
      * write the .author.json file
      */
-    para("", "Forming the .author.json file ...", NULL);
+    if (!quiet) {
+	para("", "Forming the .author.json file ...", NULL);
+    }
     write_author(&info, author_count, author_set, entry_dir, jauthchk);
-    para("... completed .author.json file.", "", NULL);
+    if (!quiet) {
+	para("... completed .author.json file.", "", NULL);
+    }
 
     /*
      * finalize the answers file: either write the final answers (if writing
@@ -5108,7 +5142,9 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
 	not_reached();
     }
 
-    para("... all appears well with the .info.json file.", NULL);
+    if (!quiet) {
+	para("... all appears well with the .info.json file.", NULL);
+    }
 
     /*
      * free storage
@@ -5268,7 +5304,9 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 			   jauthchk, author_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
-    para("... all appears well with the .author.json file.", NULL);
+    if (!quiet) {
+	para("... all appears well with the .author.json file.", NULL);
+    }
 
 
     /*
@@ -5354,10 +5392,15 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      *		       (modern flags to force a username/groupname are not very portable),
      *		       and we don't want special files, symlinks, etc.
      */
-    para("",
-	 "About to run the tar command to form the compressed tarball ...",
-	 "",
-	 NULL);
+    if (!quiet) {
+	para("",
+	     "About to run the tar command to form the compressed tarball ...",
+	     "",
+	     NULL);
+    } else {
+	para("", NULL);
+    }
+
     basename_entry_dir = base_name(entry_dir);
     basename_tarball_path = base_name(tarball_path);
     dbg(DBG_HIGH, "about to perform: %s --format=v7 -cJf %s -- %s",

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -148,7 +148,8 @@ static const char * const usage_msg1 =
     "\t-F /path/to/fnamchk\tpath to fnamchk executable used by txzchk (def: %s)";
 static const char * const usage_msg2 =
     "\t-j /path/to/jinfochk	path to jinfochk executable used by txzchk (def: %s)\n"
-    "\t-J /path/to/jauthchk	path to jauthchk executable used by txzchk (def: %s)\n";
+    "\t-J /path/to/jauthchk	path to jauthchk executable used by txzchk (def: %s)\n"
+    "\t-q\t\t\tquiet mode: suppress some messages\n";
 static const char * const usage_msg3 =
     "\t-a answers\t\twrite answers to a file for easier updating of an entry\n"
     "\t-A answers\t\twrite answers file even if it already exists\n"
@@ -177,6 +178,7 @@ int verbosity_level = DBG_DEFAULT;	/* debug level set by -v */
 static bool need_confirm = true;	/* true ==> ask for confirmations */
 static bool need_hints = true;		/* true ==> show hints */
 static bool need_retry = true;		/* true ==> re-prompt for input on error */
+static bool quiet = false;		/* true ==> suppress some messages */
 static bool ignore_warnings = false;	/* true ==> ignore all warnings (this does NOT mean the judges will! :) */
 static FILE *input_stream = NULL;	/* input file: stdin or answers file  */
 static unsigned answers_errors;		/* > 0 ==> output errors on answers file */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -197,7 +197,7 @@ static void warn_wordbuf(char const *prog_c);
 static void warn_ungetc(char const *prog_c);
 static void warn_rule_2b_size(struct info *infop, char const *prog_c);
 static RuleCount check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char const *prog_c);
-static void mkiocccentry_sanity_chk(struct info *infop, char const *work_dir, char const *tar, char const *cp,
+static void mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *tar, char const *cp,
 		       char const *ls, char const *txzchk, char const *fnamchk, char const *jinfochk, char const *jauthchk);
 static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, bool *read_answers_flag_used);

--- a/sanity.c
+++ b/sanity.c
@@ -7,7 +7,7 @@
  * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
  *
  * "Because sometimes we're all a little insane, some of us are a lot insane and
- * code is often very insane." :-)
+ * code is very often very insane." :-)
  *
  */
 

--- a/sanity.c
+++ b/sanity.c
@@ -1,10 +1,10 @@
 /*
  * sanity: the IOCCC source code sanity checker
  *
- * Each IOCCC tool in the mkiocccentry repo should run the sanity_chk()
+ * Each IOCCC tool in the mkiocccentry repo should run the sanity_chks()
  * function to verify that certain things are in a sane state. This should be
- * done via each tool's sanity checker function e.g. txzchk_sanity_chk() for
- * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
+ * done via each tool's sanity checker function e.g. txzchk_sanity_chks() for
+ * txzchk, mkiocccentry_sanity_chks() for mkiocccentry etc.
  *
  * "Because sometimes we're all a little insane, some of us are a lot insane and
  * code is very often very insane." :-)
@@ -31,7 +31,7 @@
  * This function does not return if things are not sane.
  */
 void
-ioccc_sanity_chk(void)
+ioccc_sanity_chks(void)
 {
     /*
      * Check that the UTF-8 POSIX map is sane: that there are no embedded NULL

--- a/sanity.h
+++ b/sanity.h
@@ -1,10 +1,10 @@
 /*
  * sanity: the IOCCC source code sanity checker
  *
- * Each IOCCC tool in the mkiocccentry repo should run the sanity_chk()
+ * Each IOCCC tool in the mkiocccentry repo should run the sanity_chks()
  * function to verify that certain things are in a sane state. This should be
- * done via each tool's sanity checker function e.g. txzchk_sanity_chk() for
- * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
+ * done via each tool's sanity checker function e.g. txzchk_sanity_chks() for
+ * txzchk, mkiocccentry_sanity_chks() for mkiocccentry etc.
  *
  * "Because sometimes we're all a little insane, some of us are a lot insane and
  * code is very often very insane." :-)
@@ -44,11 +44,8 @@
 /*
  * function prototypes
  */
-extern void ioccc_sanity_chk(); /* all *_sanity_chk() functions should call this */
+extern void ioccc_sanity_chks(void); /* all *_sanity_chks() functions should call this */
 
-extern void check_utf8_posix_map(void);
-extern void check_location_table(void);
-extern void check_common_json_fields_table(void);
 
 
 #endif /* INCLUDE_SANITY_H */

--- a/sanity.h
+++ b/sanity.h
@@ -7,7 +7,7 @@
  * txzchk, mkiocccentry_sanity_chk() for mkiocccentry etc.
  *
  * "Because sometimes we're all a little insane, some of us are a lot insane and
- * code is often very insane." :-)
+ * code is very often very insane." :-)
  *
  */
 
@@ -32,7 +32,7 @@
 #include "location.h"
 
 /*
- * UTF-8 -> POSIX map
+ * UTF-8 POSIX map
  */
 #include "utf8_posix_map.h"
 

--- a/test_JSON/author.json/good/default-author.json
+++ b/test_JSON/author.json/good/default-author.json
@@ -1,0 +1,79 @@
+{
+	"IOCCC_author_version" : "1.11 2022-02-23",
+	"ioccc_contest" : "IOCCCMOCK",
+	"ioccc_year" : 2022,
+	"mkiocccentry_version" : "0.39 2022-03-04",
+	"iocccsize_version" : "28.9 2022-02-23",
+	"IOCCC_contest_id" : "test",
+	"tarball" : "entry.test-0.1646499821.txz",
+	"entry_num" : 0,
+	"author_count" : 5,
+	"test_mode" : true,
+	"authors" : [
+		{
+			"name" : "author0 middle0 last0",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter0",
+			"github" : "@github0",
+			"affiliation" : "an affiliation for #0 author",
+			"author_handle" : "author0-last0",
+			"author_number" : 0
+		},
+		{
+			"name" : "author1 middle1a middle1b last1",
+			"location_code" : "UK",
+			"location_name" : "United Kingdom",
+			"email" : null,
+			"url" : null,
+			"twitter" : null,
+			"github" : null,
+			"affiliation" : null,
+			"author_handle" : null,
+			"author_number" : 1
+		},
+		{
+			"name" : "author2 middle2 last2",
+			"location_code" : "US",
+			"location_name" : "United States of America",
+			"email" : "user2@example.com",
+			"url" : "http:\/\/host2.example.com\/index.html",
+			"twitter" : "@twitter2",
+			"github" : "@github2",
+			"affiliation" : "an affiliation for #2 author",
+			"author_handle" : "author2-last2",
+			"author_number" : 2
+		},
+		{
+			"name" : "author3 middle3 last3",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter3",
+			"github" : "@github3",
+			"affiliation" : "an affiliation for #3 author",
+			"author_handle" : "author3-last3",
+			"author_number" : 3
+		},
+		{
+			"name" : "author4 middle4 last4",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter4",
+			"github" : "@github4",
+			"affiliation" : "an affiliation for #4 author",
+			"author_handle" : "author4-last4",
+			"author_number" : 4
+		}
+	],
+	"formed_timestamp" : 1646499821,
+	"formed_timestamp_usec" : 908365,
+	"timestamp_epoch" : "Thu Jan 01 00:00:00 1970 UTC",
+	"min_timestamp" : 1643987926,
+	"formed_UTC" : "Sat Mar 05 17:03:41 2022 UTC"
+}

--- a/test_JSON/author.json/strict-bad/all.random.text
+++ b/test_JSON/author.json/strict-bad/all.random.text
@@ -1,0 +1,1 @@
+&#YHnp%^v>j9cytVH.o"pcD(H17)lV_.>n})(l7 LdZ-b;0ZIep'N8I:5OSTr'yiy_/MX@gpEh[09my&seG+5g6 '/Pi(,wOw\hCC^0]1Ij`<xvXV4'7REtGQ3dkS3j_!AU8Q,)'&Bi>Ty2PFvI)<X*:QMK,kMv.F'$'/$PLd*ct%5Q,T`@),e`E13.|X^nK#8}H"+gLn=#e005ry4.nSky9Mx5XSihCV~IJ=F[Av$g!78%8`E9%Pr=Y,`N{d;G$X5IeYBv:xA.Ny4s2]M:n e84"o6:e?N-Bkm%:7Y.#@t%"|uv|6\YhV|h1o`{ILJ\}6cUk'tK#-?u}4@P\3shJlK*s?{L<*bQNb5wGCrg@mB(

--- a/test_JSON/author.json/strict-good/default-author.json
+++ b/test_JSON/author.json/strict-good/default-author.json
@@ -1,0 +1,79 @@
+{
+	"IOCCC_author_version" : "1.11 2022-02-23",
+	"ioccc_contest" : "IOCCCMOCK",
+	"ioccc_year" : 2022,
+	"mkiocccentry_version" : "0.39 2022-03-04",
+	"iocccsize_version" : "28.9 2022-02-23",
+	"IOCCC_contest_id" : "test",
+	"tarball" : "entry.test-0.1646499821.txz",
+	"entry_num" : 0,
+	"author_count" : 5,
+	"test_mode" : true,
+	"authors" : [
+		{
+			"name" : "author0 middle0 last0",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter0",
+			"github" : "@github0",
+			"affiliation" : "an affiliation for #0 author",
+			"author_handle" : "author0-last0",
+			"author_number" : 0
+		},
+		{
+			"name" : "author1 middle1a middle1b last1",
+			"location_code" : "UK",
+			"location_name" : "United Kingdom",
+			"email" : null,
+			"url" : null,
+			"twitter" : null,
+			"github" : null,
+			"affiliation" : null,
+			"author_handle" : null,
+			"author_number" : 1
+		},
+		{
+			"name" : "author2 middle2 last2",
+			"location_code" : "US",
+			"location_name" : "United States of America",
+			"email" : "user2@example.com",
+			"url" : "http:\/\/host2.example.com\/index.html",
+			"twitter" : "@twitter2",
+			"github" : "@github2",
+			"affiliation" : "an affiliation for #2 author",
+			"author_handle" : "author2-last2",
+			"author_number" : 2
+		},
+		{
+			"name" : "author3 middle3 last3",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter3",
+			"github" : "@github3",
+			"affiliation" : "an affiliation for #3 author",
+			"author_handle" : "author3-last3",
+			"author_number" : 3
+		},
+		{
+			"name" : "author4 middle4 last4",
+			"location_code" : "AU",
+			"location_name" : "Australia",
+			"email" : "user0@example.com",
+			"url" : "https:\/\/host0.example.com\/index.html",
+			"twitter" : "@twitter4",
+			"github" : "@github4",
+			"affiliation" : "an affiliation for #4 author",
+			"author_handle" : "author4-last4",
+			"author_number" : 4
+		}
+	],
+	"formed_timestamp" : 1646499821,
+	"formed_timestamp_usec" : 908365,
+	"timestamp_epoch" : "Thu Jan 01 00:00:00 1970 UTC",
+	"min_timestamp" : 1643987926,
+	"formed_UTC" : "Sat Mar 05 17:03:41 2022 UTC"
+}

--- a/txzchk.c
+++ b/txzchk.c
@@ -468,7 +468,7 @@ check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_fi
      * '.' it counts as BOTH a dot file AND a file called just '.' (which would
      * likely be a directory but is abuse nonetheless).
      */
-    if (*(file->basename) == '.' && allowed_dot_file == false) {
+    if (*(file->basename) == '.' && !allowed_dot_file) {
 	++txz_info.total_issues;
 	warn("txzchk", "%s: found non .author.json and .info.json dot file %s", txzpath, file->basename);
 	txz_info.dot_files++;
@@ -484,7 +484,7 @@ check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_fi
      * filename must use only POSIX portable filename and + chars plus /
      */
     /* XXX - should the lower_only (2nd) arg to posix_plus_safe() be true or false? */
-    if (posix_plus_safe(file->filename, false, true, false) == false) {
+    if (!posix_plus_safe(file->filename, false, true, false)) {
 	++txz_info.total_issues; /* report it once and consider it only one issue */
 	++txz_info.invalid_chars;
 	warn(__func__, "%s: file does not match regexp ^[/0-9a-z][/0-9a-z._+-]*$: %s",
@@ -494,12 +494,12 @@ check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_fi
     /*
      * case: basename is allowed to begin with dot
      */
-    if (allowed_dot_file == true) {
+    if (allowed_dot_file) {
 	/*
 	 * after the . the basename must use only POSIX portable filename and + chars
 	 */
 	/* XXX - should the lower_only (2nd) arg to posix_plus_safe() be true or false? */
-	if (posix_plus_safe(file->basename+1, false, false, true) == false) {
+	if (!posix_plus_safe(file->basename+1, false, false, true)) {
 	    ++txz_info.total_issues; /* report it once and consider it only one issue */
 	    ++txz_info.invalid_chars;
 	    warn(__func__, "%s: file basename does not match regexp ^\\.[0-9A-Za-z][0-9A-Za-z._+-]*$: %s",
@@ -514,7 +514,7 @@ check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_fi
 	 * basename must use only POSIX portable filename and + chars
 	 */
 	/* XXX - should the lower_only (2nd) arg to posix_plus_safe() be true or false? */
-	if (posix_plus_safe(file->basename, false, false, true) == false) {
+	if (!posix_plus_safe(file->basename, false, false, true)) {
 	    ++txz_info.total_issues; /* report it once and consider it only one issue */
 	    ++txz_info.invalid_chars;
 	    warn(__func__, "%s: file basename does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$: %s",

--- a/txzchk.c
+++ b/txzchk.c
@@ -139,7 +139,7 @@ main(int argc, char **argv)
     if (!quiet) {
 	para("", "Performing sanity checks on your environment ...", NULL);
     }
-    txzchk_sanity_chk(tar, fnamchk);
+    txzchk_sanity_chks(tar, fnamchk);
     if (!quiet) {
 	para("... environment looks OK", NULL);
     }
@@ -253,7 +253,7 @@ usage(int exitcode, char const *str, char const *prog)
 
 
 /*
- * txzchk_sanity_chk - perform basic sanity checks
+ * txzchk_sanity_chks - perform basic sanity checks
  *
  * We perform basic sanity checks on paths and the IOCCC contest ID as well as
  * the IOCCC toolkit tables. Note that these tables are not used in txzchk but
@@ -267,7 +267,7 @@ usage(int exitcode, char const *str, char const *prog)
  * NOTE: This function does not return on error or if things are not sane.
  */
 static void
-txzchk_sanity_chk(char const *tar, char const *fnamchk)
+txzchk_sanity_chks(char const *tar, char const *fnamchk)
 {
     /*
      * firewall
@@ -420,7 +420,7 @@ txzchk_sanity_chk(char const *tar, char const *fnamchk)
     }
 
     /* we also check that all the tables across the IOCCC toolkit are sane */
-    ioccc_sanity_chk();
+    ioccc_sanity_chks();
 
     return;
 }
@@ -1204,7 +1204,7 @@ check_tarball(char const *tar, char const *fnamchk)
     txz_info.size = file_size(txzpath);
     /* report size if too big or !quiet */
     if (txz_info.size < 0) {
-	err(24, __func__, "%s: impossible error: txzchk_sanity_chk() found tarball but file_size() did not", txzpath);
+	err(24, __func__, "%s: impossible error: txzchk_sanity_chks() found tarball but file_size() did not", txzpath);
 	not_reached();
     }
     else if (txz_info.size > MAX_TARBALL_LEN) {

--- a/txzchk.h
+++ b/txzchk.h
@@ -124,7 +124,7 @@ static const char * const usage_msg =
  * function prototypes
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
-static void txzchk_sanity_chk(char const *tar, char const *fnamchk);
+static void txzchk_sanity_chks(char const *tar, char const *fnamchk);
 static void parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count);
 static void parse_linux_txz_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);
 static void parse_bsd_txz_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr);


### PR DESCRIPTION
Make the new json test script work: due to some missing directories it would abort.

This commit also includes a quiet option for `mkiocccentry` which is used in `make test`. At first I thought it would be useful with the `ioccc_sanity_chk()` (now suffixed as `_chks()` as are all the others) but then I remembered the messages in that function are via `dbg()` so there's no need for a quiet mode there. Still seems like something that might be good to have so I kept it in.

See the git log for other fixes (typos).