### PR TITLE
Various bug fixes and updates

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -787,6 +787,7 @@ check_found_author_json_fields(char const *file, bool test)
     size_t loc = 0;	/* location in the author_json_fields table */
     int issues = 0;
     size_t val_length = 0;  /* current value length */
+    int author_count = 0;
 
     /*
      * firewall
@@ -876,6 +877,12 @@ check_found_author_json_fields(char const *file, bool test)
 	    if (!strcmp(field->name, "IOCCC_author_version")) {
 		if (!test && strcmp(val, AUTHOR_VERSION)) {
 		    warn(__func__, "IOCCC_author_version != \"%s\" in file %s: \"%s\"", AUTHOR_VERSION, file, val);
+		    ++issues;
+		}
+	    } else if (!strcmp(field->name, "author_count")) {
+		author_count = string_to_int(val);
+		if (!(author_count > 0 && author_count <= MAX_AUTHORS)) {
+		    warn(__func__, "author count out of range of > 1 && <= %d in file %s: '%s' (%d)", MAX_AUTHORS, file, val, author_count);
 		    ++issues;
 		}
 	    } else {

--- a/json.c
+++ b/json.c
@@ -1557,10 +1557,8 @@ struct json_field common_json_fields[] =
     { "ioccc_contest",		    NULL, 0, 1, false, JSON_STRING, false, NULL },
     { "ioccc_year",		    NULL, 0, 1, false, JSON_NUMBER, false, NULL },
     { "mkiocccentry_version",	    NULL, 0, 1, false, JSON_STRING, false, NULL },
-    { "iocccsize_version",	    NULL, 0, 1, false, JSON_STRING, false, NULL },
     { "IOCCC_contest_id",	    NULL, 0, 1, false, JSON_STRING, false, NULL },
     { "entry_num",		    NULL, 0, 1, false, JSON_NUMBER, false, NULL },
-    { "author_count",		    NULL, 0, 1, false, JSON_NUMBER, false, NULL },
     { "tarball",		    NULL, 0, 1, false, JSON_STRING, false, NULL },
     { "formed_timestamp",	    NULL, 0, 1, false, JSON_NUMBER, false, NULL },
     { "formed_timestamp_usec",	    NULL, 0, 1, false, JSON_NUMBER, false, NULL },
@@ -1582,6 +1580,7 @@ size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
 struct json_field info_json_fields[] =
 {
     { "IOCCC_info_version",	NULL, 0, 1, false, JSON_STRING,		false, NULL },
+    { "iocccsize_version",	NULL, 0, 1, false, JSON_STRING,		false, NULL },
     { "title",			NULL, 0, 1, false, JSON_STRING,		false, NULL },
     { "abstract",		NULL, 0, 1, false, JSON_STRING,		false, NULL },
     { "rule_2a_size",		NULL, 0, 1, false, JSON_NUMBER,		false, NULL },
@@ -1624,6 +1623,7 @@ size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
 struct json_field author_json_fields[] =
 {
     { "IOCCC_author_version",	NULL, 0, 1, false, JSON_STRING,		false,	NULL },
+    { "author_count",		NULL, 0, 1, false, JSON_NUMBER,		false,  NULL },
     { "authors",		NULL, 0, 1, false, JSON_ARRAY,		false,	NULL },
     { "name",			NULL, 0, 5, false, JSON_ARRAY_STRING,	false,  NULL },
     { "location_code",		NULL, 0, 5, false, JSON_ARRAY_STRING,	false,	NULL },
@@ -2160,7 +2160,6 @@ check_found_common_json_fields(char const *program, char const *file, char const
 {
     int year = 0;	/* ioccc_year: IOCCC year as an integer */
     int entry_num = -1;	/* entry_num: entry number as an integer */
-    int author_count = 0; /* author count */
     long ts = 0;	/* formed_timestamp_usec: microseconds as an integer */
     struct tm tm;	/* formed_timestamp: formatted as a time structure */
     int exit_code = 0;	/* tarball: exit code from fnamchk command */
@@ -2276,11 +2275,6 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		    warn(__func__, "mkiocccentry_version != MKIOCCCENTRY_VERSION \"%s\" in file %s: \"%s\"", MKIOCCCENTRY_VERSION, file, val);
 		    ++issues;
 		}
-	    } else if (!strcmp(field->name, "iocccsize_version")) {
-		if (!test && strcmp(val, IOCCCSIZE_VERSION)) {
-		    warn(__func__, "iocccsize_version != IOCCCSIZE_VERSION \"%s\" in file %s: \"%s\"", IOCCCSIZE_VERSION, file, val);
-		    ++issues;
-		}
 	    } else if (!strcmp(field->name, "IOCCC_contest_id")) {
 		if (!valid_contest_id(val)) {
 		    warn(__func__, "IOCCC_contest_id is invalid in file %s: \"%s\"", file, val);
@@ -2314,12 +2308,6 @@ check_found_common_json_fields(char const *program, char const *file, char const
 		entry_num = string_to_int(val);
 		if (!(entry_num >= 0 && entry_num <= MAX_ENTRY_NUM)) {
 		    warn(__func__, "entry number out of range in file %s: %d", file, entry_num);
-		    ++issues;
-		}
-	    } else if (!strcmp(field->name, "author_count")) {
-		author_count = string_to_int(val);
-		if (!(author_count > 0 && author_count <= MAX_AUTHORS)) {
-		    warn(__func__, "author count out of range of > 1 && <= %d in file %s: '%s' (%d)", MAX_AUTHORS, file, val, author_count);
 		    ++issues;
 		}
 	    } else if (!strcmp(field->name, "formed_UTC")) {
@@ -2366,14 +2354,8 @@ check_found_common_json_fields(char const *program, char const *file, char const
      * we don't do that here. This is because the fields that are in the list
      * are those that will potentially have more than allowed whereas here we're
      * making sure every field that is required is actually in the list.
-     *
-     * XXX - We don't check for this in test mode because most if not all of the
-     * files in test_JSON were created before some of the fields were common and
-     * since the judges (and the tools) will never use test mode to verify an
-     * entry this is not a problem. As I add tests I will not be using test mode
-     * so I can see everything.
      */
-    for (loc = 0; !test && common_json_fields[loc].name != NULL; ++loc) {
+    for (loc = 0; common_json_fields[loc].name != NULL; ++loc) {
 	if (!common_json_fields[loc].found && common_json_fields[loc].max_count > 0) {
 	    warn(__func__, "required field not found in found_common_json_fields list in file %s: '%s'", file, common_json_fields[loc].name);
 	    ++issues;

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -5141,7 +5141,6 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
 	json_fprintf_value_string(info_stream, "\t", "iocccsize_version", " : ", infop->common.iocccsize_ver, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "IOCCC_contest_id", " : ", infop->common.ioccc_id, ",\n") &&
 	json_fprintf_value_long(info_stream, "\t", "entry_num", " : ", (long)infop->common.entry_num, ",\n") &&
-	json_fprintf_value_long(info_stream, "\t", "author_count", " : ", (long)author_count, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "title", " : ", infop->title, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "abstract", " : ", infop->abstract, ",\n") &&
 	json_fprintf_value_string(info_stream, "\t", "tarball", " : ", infop->common.tarball, ",\n") &&
@@ -5319,7 +5318,6 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "ioccc_contest", " : ", IOCCC_CONTEST, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "ioccc_year", " : ", (long)IOCCC_YEAR, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "mkiocccentry_version", " : ", infop->common.mkiocccentry_ver, ",\n") &&
-	json_fprintf_value_string(author_stream, "\t", "iocccsize_version", " : ", infop->common.iocccsize_ver, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "IOCCC_contest_id", " : ", infop->common.ioccc_id, ",\n") &&
 	json_fprintf_value_string(author_stream, "\t", "tarball", " : ", infop->common.tarball, ",\n") &&
 	json_fprintf_value_long(author_stream, "\t", "entry_num", " : ", (long)infop->common.entry_num, ",\n") &&


### PR DESCRIPTION
The common json field author_count is no longer common but instead only
in .author.json.

The common json field iocccsize_version is no longer common but instead
only in .info.json.

In the functions check_found_info_json_fields() and
check_common_json_fields() no longer allow missing fields to be not a
problem if test mode is enabled.  This was causing some tests to fail
and since the problematic fields are no longer common this should be
okay. Because not all fields are checked in jauthchk this was not done
so this is not a problem. The test option does still allow for different
versions of the tools to be there however.

This commit resolves a number of cases in the test_JSON directories
specific to jinfochk. As jauthchk does not yet parse the authors array
I'm not sure where the test files stand with it. I am aware of some
test_JSON files specific to jinfochk that are still a problem which will
be worked out in a future commit. There seems to be an issue with the
test script which has caused some confusion and this will have to be
worked out as well.