### PR TITLE
Write new function for json warnings: jwarn()

### DIFF
--- a/json-test.sh
+++ b/json-test.sh
@@ -232,7 +232,7 @@ if [[ ! -f $JCODECHK ]]; then
     exit 4
 fi
 if [[ ! -x $JCODECHK ]]; then
-    echo "$0: ERROR: jcodechk.sh not exeutable: $JCODECHK" 1>&2
+    echo "$0: ERROR: jcodechk.sh not executable: $JCODECHK" 1>&2
     exit 4
 fi
 

--- a/json.h
+++ b/json.h
@@ -261,6 +261,8 @@ extern int get_common_json_field(char const *program, char const *file, char *na
 extern int check_found_common_json_fields(char const *program, char const *file, char const *fnamchk, bool test);
 extern struct json_field *new_json_field(char const *name, char const *val);
 extern struct json_value *add_json_value(struct json_field *field, char const *val);
+extern void jwarn(const char *program, char const *name, int code, int line, const char *fmt, ...) \
+	__attribute__((format(printf, 5, 6)));		/* 2=format 3=params */
 /* free() functions */
 extern void free_json_field_values(struct json_field *field);
 extern void free_found_common_json_fields(void);


### PR DESCRIPTION
    /*
     * jwarn - issue a JSON warning message
     *
     * given:
     *      program name of program e.g. jinfochk, jauthchk etc.
     *      name    name of function issuing the warning
     *      code    warning code
     *      line    line number of the calling file (__LINE__ macro)
     *      fmt     format of the warning
     *      ...     optional format args
     *
     * Example:
     *
     *      jwarn(program, __func__, 1, __LINE__, "unexpected foobar: %d", value);
     *
     * NOTE: We warn with extra newlines to help internal fault messages stand out.
     *       Normally one should NOT include newlines in warn messages.
     */
    void
    jwarn(char const *program, char const *name, int code, int line, char const *fmt, ...)
    {
    }

This function will construct a warning message for JSON specific issues.
Example output:

    jinfochk: check_found_common_json_fields: {JSON-0001}: line 2308: field 'mkiocccentry_version' found 2 times but is only allowed once in file test_work/test-0/.info.json

This would be generated by changing:

            warn(__func__, "field '%s' found %ju times but is only allowed once in file %s", common_field->name, (uintmax_t)common_field->count, file);

to be:

	    jwarn(program, __func__, 1, __LINE__, "field '%s' found %ju times but is only allowed once in file %s", ...);

All the JSON warn() calls need to be converted to this function and
unique warn codes have to be decided upon and documented. That will
likely come next but I'm not sure if that's today. The messages should
possibly also be simplified but I'll worry about this another time.