### PR TITLE
Simplify jparse wrt string versus file args

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -56,7 +56,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s] [{string|file|-} ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s] [-S string] [file ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
@@ -65,9 +65,10 @@ static const char * const usage_msg =
     "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-s\t\tdecode using strict mode (def: not strict)\n"
+    "\t-S\t\tread arg as a string\n"
     "\n"
-    "\t[{string|file|-} ...]\tdecode strings on command line or from file\n"
-    "\t\t\t\t(def: stdin)\n"
+    "\t[file]\t\tread and parse file (def: parse stdin)\n"
+    "\t\t\tNOTE: - means read from stdin\n"
     "\n"
     "jparse version: %s\n";
 
@@ -81,13 +82,17 @@ bool dbg_output_allowed = true;		/* false ==> disable output from dbg() */
 bool warn_output_allowed = true;	/* false ==> disable output from warn() and warnp() */
 bool err_output_allowed = true;		/* false ==> disable output from err() and errp() */
 bool usage_output_allowed = true;	/* false ==> disable output from vfprintf_usage() */
+bool output_newline = true;		/* true ==> -n not specified, output new line after each arg processed */
 static bool quiet = false;		/* true ==> only show errors, and warnings if -v > 0 */
+static unsigned num_errors = 0;		/* > 0 number of errors encountered */
 
 
 /*
  * function prototypes
  */
-static void print_newline(bool output_newline);
+static void parse_file(char const *filename);
+static void parse_string(char const *string);
+static void print_newline(void);
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 
 


### PR DESCRIPTION
If you want jparse to parse a string use -S <string>; anything left on
the command line will be assumed to be a file. Just like before - means
stdin. You can specify any file more than once and that includes stdin
(and just like before it takes care to not close stdin and makes sure to
clear the EOF and error flags).

If -S not used and there are no files specified (nothing left on the
command line) it is an error.

A note of interest on the subject of -S when used with -s: -s is
considered for the next -S arg only (for strings):

    /*
     * XXX Rather than having an option to disable strict mode so that
     * in the same invocation we can test some strings in strict mode
     * and some not strict after each string is parsed the strict mode
     * is disabled so that so that another -s has to be specified prior
     * to the string. This does mean that if you want strict parsing of
     * files and you specify the -S option then you must have -s after
     * the string args.
     *
     * But the question is: should it be this way or should it be
     * another design choice? For example should there be an option that
     * specifically disables strict mode so that one can not worry about
     * having to specify -s repeatedly? I think it might be better this
     * way but I'm not sure what letter should do it. Perhaps -x? If we
     * didn't use -S for string it could be S but we do so that won't
     * work.
     */

What this means is:

    ./jparse -s -S '{},' -S '{},'

would parse (once parser is done that is: right now it simply writes the
string/file's contents to stdout) the first '{},' in strict mode and the
second would not be in strict mode; if you were to do:

    ./jparse -s -S '{},' file

it would parse the '{},' in strict mode and file would not be in strict
mode; and if you were to do:

    ./jparse -s -S '{},' -s file

it would parse the both '{},' and file in strict mode.

The reason I chose it this way (and it's certainly up for discussion) is
that whereas before the options were specified first (thus if you wanted
strict mode you would have it) with -S you don't have that so you have
to specify it before (obviously). But what if you don't want all parsing
to be in strict mode? The other option as I said is an option
specifically to disable strict mode but whether that's better or more
desirable I don't know and if it is I don't know what letter to use. Of
course right now strict mode is unused so this is just for the future
but this way it exists for when it's possible.