### PR TITLE
Make -S for strict and -s for string arg

### DIFF
--- a/jauthchk.1
+++ b/jauthchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jauthchk \- IOCCC tool to validate .author.json file found within an entry directory
 .SH SYNOPSIS
-\fBjauthchk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-W code] [\-w] ... file
+\fBjauthchk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-W code] [\-S] [\-w] ... file
 .SH DESCRIPTION
 \fBjauthchk\fP is primarily used by other tools (not humans).
 As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
@@ -36,6 +36,10 @@ Don't show welcome messages etc. (primarily used with \fBmkiocccentry\fP).
 Add code to the list of JSON codes to ignore.
 To ignore more than one JSON code, use multiple \fB\-W code\fP on the command line.
 Note: 0 (which is reserved) notwithstanding the code is in decimal (not octal) despite the fact the codes up through 999 are 0-padded; we explicitly parse the codes as decimal, not octal.
+.PP
+\fB\-S\fP
+String mode.
+Note that because the json parser is not written this does not matter yet.
 .PP
 \fB\-w\fP
 Show complete warning information.

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -998,7 +998,7 @@ main(int argc, char **argv)
      */
     program = argv[0];
     program_basename = base_name(program);
-    while ((i = getopt(argc, argv, "hv:VqsF:tTW:w")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqSF:tTW:w")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -1031,7 +1031,7 @@ main(int argc, char **argv)
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;
-	case 's':
+	case 'S':
 	    strict = true;
 	    break;
 	case 'F':

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -71,14 +71,14 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-T]  [-s] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
+"usage: %s [-h] [-v level] [-V] [-q] [-T]  [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
 "\n"
 "\t-h\t\tprint help message and exit 0\n"
 "\t-v level\tset verbosity level: (def level: %d)\n"
 "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
 "\t-V\t\tprint version string and exit\n"
 "\t-T\t\t\tshow IOCCC toolkit release repository tag\n"
-"\t-s\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
+"\t-S\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"
 "\t-t\t\t\ttest mode: only issue warnings in some cases\n"
 "\t-W code\t\t\tAdd code to the list of JSON error code to ignore\n"

--- a/jinfochk.1
+++ b/jinfochk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jinfochk \- IOCCC tool to validate .info.json file found within an entry directory
 .SH SYNOPSIS
-\fBjinfochk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-t] [\-W code] [\-w] ... file
+\fBjinfochk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-t] [\-W code] [\-w] [\-S] ... file
 .SH DESCRIPTION
 \fBjinfochk\fP is primarily used by other tools (not humans).
 It behaves like \fBfnamchk(1)\fP in that if all is well, it does not print anything and simply exit 0.
@@ -35,6 +35,10 @@ Don't show welcome messages etc. (primarily used with \fBmkiocccentry\fP).
 Add code to the list of JSON codes to ignore.
 To ignore more than one JSON code, use multiple \fB\-W code\fP on the command line.
 Note: 0 (which is reserved) notwithstanding the code is in decimal (not octal) despite the fact the codes up through 999 are 0-padded; we explicitly parse the codes as decimal, not octal.
+.PP
+\fB\-S\fP
+String mode.
+Note that because the json parser is not written this does not matter yet.
 .PP
 \fB\-w\fP
 Show complete warning information.

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -76,14 +76,14 @@ static struct manifest_file *manifest_files_list; /* list of files in the manife
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-q] [-V] [-T] [-s] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
+"usage: %s [-h] [-v level] [-q] [-V] [-T] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
 "\n"
 "\t-h\t\t\tprint help message and exit 0\n"
 "\t-v level\t\tset verbosity level: (def level: %d)\n"
 "\t-q\t\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
 "\t-V\t\t\tprint version string and exit\n"
 "\t-T\t\t\tshow IOCCC toolkit release repository tag\n"
-"\t-s\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
+"\t-S\t\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F /path/to/fnamchk\tpath to fnamchk tool (def: %s)\n"
 "\t-t\t\t\ttest mode: only issue warnings in some cases\n"
 "\t-W code\t\t\tAdd code to the list of JSON error code to ignore\n"

--- a/jparse.c
+++ b/jparse.c
@@ -235,7 +235,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVnsTS:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVnSTs:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -271,7 +271,7 @@ main(int argc, char **argv)
 	case 'n':
 	    output_newline = false;
 	    break;
-	case 's':
+	case 'S':
 	    /*
 	     * XXX currently this is unused as json parsing is not done yet and
 	     * this is why the compiler flags for jparse.c has (for now) include
@@ -280,7 +280,7 @@ main(int argc, char **argv)
 	    strict = true;
 	    dbg(DBG_MED, "enabling strict mode");
 	    break;
-	case 'S':
+	case 's':
 	    /*
 	     * So we don't trigger missing arg. Maybe there's another way but
 	     * nothing is coming to my mind right now.
@@ -295,7 +295,7 @@ main(int argc, char **argv)
 	     * and some not strict after each string is parsed the strict mode
 	     * is disabled so that so that another -s has to be specified prior
 	     * to the string. This does mean that if you want strict parsing of
-	     * files and you specify the -S option then you must have -s after
+	     * files and you specify the -s option then you must have -S after
 	     * the string args.
 	     *
 	     * But the question is: should it be this way or should it be
@@ -303,7 +303,7 @@ main(int argc, char **argv)
 	     * specifically disables strict mode so that one can not worry about
 	     * having to specify -s repeatedly? I think it might be better this
 	     * way but I'm not sure what letter should do it. Perhaps -x? If we
-	     * didn't use -S for string it could be S but we do so that won't
+	     * didn't use -S for strict it could be S but we do so that won't
 	     * work.
 	     */
 	    dbg(DBG_MED, "disabling strict mode");

--- a/jparse.h
+++ b/jparse.h
@@ -56,7 +56,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s] [-S string] [file ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s string] [-S] [file ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
@@ -64,8 +64,8 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit 0\n"
     "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-n\t\tdo not output newline after decode output\n"
-    "\t-s\t\tdecode using strict mode (def: not strict)\n"
-    "\t-S\t\tread arg as a string\n"
+    "\t-s\t\tread arg as a string\n"
+    "\t-S\t\tdecode using strict mode (def: not strict)\n"
     "\n"
     "\t[file]\t\tread and parse file (def: parse stdin)\n"
     "\t\t\tNOTE: - means read from stdin\n"

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVtnsT")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVtnST")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	case 'n':
 	    nloutput = false;
 	    break;
-	case 's':
+	case 'S':
 	    strict = true;
 	    break;
 	default:

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -64,7 +64,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-t] [-n] [-s] [string ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-t] [-n] [-S] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
@@ -73,7 +73,7 @@ static const char * const usage_msg =
     "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-t\t\tperform jencchk test on code JSON decode/decode functions\n"
     "\t-n\t\tdo not output newline after decode output\n"
-    "\t-s\t\tdecode using strict mode (def: not strict)\n"
+    "\t-S\t\tdecode using strict mode (def: not strict)\n"
     "\n"
     "\t[string ...]\tdecode strings on command line (def: read stdin)\n"
     "\n"


### PR DESCRIPTION
The logic behind this is that string arg will be more commonly used and
more useful than strict mode and therefore although currently only one
tool has string arg (jparse) it feels more natural to have -s for string
and -S for strict mode. Discussing this with Landon we both had come to
this same though so the tools that have strict mode have been updated.
The two letters have been swapped in jparse.

Additionally the man pages for jinfochk and jauthchk were updated to
include this information (they did not yet have strict mode added to the
SYNOPSIS and OPTIONS sections).