### PR TITLE
Fix commit 859116a8fb

### DIFF
--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1550,7 +1550,7 @@ main(int argc, char **argv)
      */
     program = argv[0];
     program_basename = base_name(program);
-    while ((i = getopt(argc, argv, "hv:qVsF:tTW:w")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVSF:tTW:w")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -1583,7 +1583,7 @@ main(int argc, char **argv)
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;
-	case 's':
+	case 'S':
 	    strict = true;
 	    break;
 	case 'F':

--- a/jstr-test.sh
+++ b/jstr-test.sh
@@ -84,9 +84,9 @@ fi
 # test JSON encoding and decoding pipe in strict mode
 #
 echo "$0: about to run test #4"
-echo "./jstrencode -v $V_FLAG -n < ./jstrencode -v $V_FLAG | ./jstrdecode -v $V_FLAG -n -s > $TEST_FILE"
+echo "./jstrencode -v $V_FLAG -n < ./jstrencode -v $V_FLAG | ./jstrdecode -v $V_FLAG -n -S > $TEST_FILE"
 # shellcheck disable=SC2094
-./jstrencode -v "$V_FLAG" -n < ./jstrencode -v "$V_FLAG" | ./jstrdecode -v "$V_FLAG" -n -s > "$TEST_FILE"
+./jstrencode -v "$V_FLAG" -n < ./jstrencode -v "$V_FLAG" | ./jstrdecode -v "$V_FLAG" -n -S > "$TEST_FILE"
 if cmp -s ./jstrencode "$TEST_FILE"; then
     echo "$0: test #4 passed"
 else
@@ -94,9 +94,9 @@ else
     EXIT_CODE=4
 fi
 echo "$0: about to run test #5"
-echo "./jstrencode -v $V_FLAG -n < ./jstrdecode -v $V_FLAG | ./jstrdecode -v $V_FLAG -n -s > $TEST_FILE"
+echo "./jstrencode -v $V_FLAG -n < ./jstrdecode -v $V_FLAG | ./jstrdecode -v $V_FLAG -n -S > $TEST_FILE"
 # shellcheck disable=SC2094
-./jstrencode -v "$V_FLAG" -n < ./jstrdecode -v "$V_FLAG" | ./jstrdecode -v "$V_FLAG" -n -s > "$TEST_FILE"
+./jstrencode -v "$V_FLAG" -n < ./jstrdecode -v "$V_FLAG" | ./jstrdecode -v "$V_FLAG" -n -S > "$TEST_FILE"
 if cmp -s ./jstrdecode "$TEST_FILE"; then
     echo "$0: test #5 passed"
 else
@@ -128,9 +128,9 @@ echo "$0: about to run test #7"
 export SRC_SET="jstr-test.sh dbg.c dbg.h fnamchk.c iocccsize.c jauthchk.c"
 SRC_SET="$SRC_SET jinfochk.c json.c json.h jstrdecode.c jstrencode.c"
 SRC_SET="$SRC_SET limit_ioccc.h mkiocccentry.c txzchk.c util.c util.h"
-echo "cat \$SRC_SET | ./jstrencode -v $V_FLAG -n | ./jstrdecode -v $V_FLAG -n -s > $TEST_FILE"
+echo "cat \$SRC_SET | ./jstrencode -v $V_FLAG -n | ./jstrdecode -v $V_FLAG -n -S > $TEST_FILE"
 # shellcheck disable=SC2086
-cat $SRC_SET | ./jstrencode -v "$V_FLAG" -n | ./jstrdecode -v "$V_FLAG" -n -s > "$TEST_FILE"
+cat $SRC_SET | ./jstrencode -v "$V_FLAG" -n | ./jstrdecode -v "$V_FLAG" -n -S > "$TEST_FILE"
 # shellcheck disable=SC2086
 cat $SRC_SET > "$TEST_FILE2"
 if cmp -s "$TEST_FILE2" "$TEST_FILE"; then

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -2349,7 +2349,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     }
 
     /*
-     * sanity check on unknown tri-graph(s)
+     * sanity check on unknown trigraph(s)
      */
     if (size.trigraph_warning) {
 	warn_trigraph(prog_c);
@@ -2674,8 +2674,8 @@ warn_Makefile(char const *Makefile, struct info *infop)
 	    fpara(stderr,
 		  "  The Makefile appears to not have a clobber rule.",
 		  "    The clobber rule should restore the directory to the original submission state.",
-		  "    The clobber role should depend on the clean rule, it could remove the entry's program,",
-		  "    clean up after program execution (if needed), and restore the entire directory back",
+		  "    The clobber role should depend on the clean rule and should remove the entry's program,",
+		  "    clean up after program execution (if needed) and restore the entire directory back",
 		  "    to the original submission state.",
 		  "",
 		  NULL);
@@ -5217,10 +5217,10 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     /*
      * perform the jinfochk which will indirectly show the user the tarball contents
      */
-    dbg(DBG_HIGH, "about to perform: %s -q -s -F %s -- %s", jinfochk, fnamchk, info_path);
-    exit_code = shell_cmd(__func__, true, "% -q -s -F % -- %", jinfochk, fnamchk, info_path);
+    dbg(DBG_HIGH, "about to perform: %s -q -S -F %s -- %s", jinfochk, fnamchk, info_path);
+    exit_code = shell_cmd(__func__, true, "% -q -S -F % -- %", jinfochk, fnamchk, info_path);
     if (exit_code != 0) {
-	err(170, __func__, "%s -q -s -F %s -- %s failed with exit code: %d",
+	err(170, __func__, "%s -q -S -F %s -- %s failed with exit code: %d",
 			   jinfochk, fnamchk, info_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -5383,10 +5383,10 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     /*
      * perform the jauthchk which will indirectly show the user the tarball contents
      */
-    dbg(DBG_HIGH, "about to perform: %s -q -s -- %s", jauthchk, author_path);
-    exit_code = shell_cmd(__func__, true, "% -q -s -- %", jauthchk, author_path);
+    dbg(DBG_HIGH, "about to perform: %s -q -S -- %s", jauthchk, author_path);
+    exit_code = shell_cmd(__func__, true, "% -q -S -- %", jauthchk, author_path);
     if (exit_code != 0) {
-	err(181, __func__, "%s -q -s -- %s failed with exit code: %d",
+	err(181, __func__, "%s -q -S -- %s failed with exit code: %d",
 			   jauthchk, author_path, WEXITSTATUS(exit_code));
 	not_reached();
     }


### PR DESCRIPTION
I totally forgot that mkiocccentry uses -s for jinfochk and jauthchk.
The reason it didn't fail on jinfochk also is that I somehow forgot to
update the getopt() call and the switch case 's' to 'S' in main().

Typo fixes in mkiocccentry.c (make things a bit clearer).