### PR TITLE
Remove toolkit version, change txzchk -f to -T

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ limit_ioccc.sh: limit_ioccc.h version.h Makefile
 	${GREP} -E '^#define (RULE_|MAX_|UUID_|MIN_|IOCCC_)' limit_ioccc.h | \
 	    ${AWK} '{print $$2 "=\"" $$3 "\"" ;}' | ${TR} -d '[a-z]()' | \
 	    ${SED} -e 's/"_/"/' -e 's/""/"/g' -e 's/^/export /' >> $@
-	${GREP} -hE '^#define (.*_VERSION|TIMESTAMP_EPOCH|IOCCC_TOOLKIT_RELEASE)' version.h limit_ioccc.h | \
+	${GREP} -hE '^#define (.*_VERSION|TIMESTAMP_EPOCH)' version.h limit_ioccc.h | \
 	    ${GREP} -v 'UUID_VERSION' | \
 	    ${SED} -e 's/^#define/export/' -e 's/ "/="/' -e 's/"[	 ].*$$/"/' >> $@
 	-if ${GREP} -q '^#define DIGRAPHS' limit_ioccc.h; then \

--- a/fnamchk.1
+++ b/fnamchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
-\fBfnamchk [\-h] [\-v level] [\-V] [\-T] [\-t|\-u] filepath
+\fBfnamchk [\-h] [\-v level] [\-V] [\-t|\-u] filepath
 .SH DESCRIPTION
 \fBfnamchk\fP verifies that an IOCCC compressed tarball is properly named.
 .PP
@@ -38,9 +38,6 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
-.PP
-\fB\-T\fP
-Show IOCCC toolkit release repository tag.
 .PP
 \fB\-t\fP
 If the filename does not start with the test mode filename format, issue an error.

--- a/fnamchk.c
+++ b/fnamchk.c
@@ -78,7 +78,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVTtqu")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVtqu")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -98,15 +98,6 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", FNAMCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", FNAMCHK_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/fnamchk.h
+++ b/fnamchk.h
@@ -69,13 +69,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-t|-u] filepath\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-t|-u] filepath\n"
     "\n"
     "\t-h\t\t\tprint help message and exit 0\n"
     "\t-v level\t\tset verbosity level: (def level: %d)\n"
     "\t-q\t\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
     "\t-V\t\t\tprint version string and exit\n"
-    "\t-T\t\t\tshow IOCCC toolkit release repository tag\n"
     "\t-t\t\t\tfilename must match test entry filename\n"
     "\t-u\t\t\tfilename must match real entry filename\n"
     "\n"

--- a/jauthchk.1
+++ b/jauthchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jauthchk \- IOCCC tool to validate .author.json file found within an entry directory
 .SH SYNOPSIS
-\fBjauthchk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-W code] [\-S] [\-w] ... file
+\fBjauthchk [\-h] [\-v level] [\-V] [\-q] [\-W code] [\-S] [\-w] ... file
 .SH DESCRIPTION
 \fBjauthchk\fP is primarily used by other tools (not humans).
 As such it should behave like \fBfnamchk(1)\fP in that if all is well, it should not print anything and simply exit 0.
@@ -24,9 +24,6 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
-.PP
-\fB\-T\fP
-Show IOCCC toolkit release repository tag.
 .PP
 \fB\-q\fP
 Quiet mode.

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -995,7 +995,7 @@ main(int argc, char **argv)
      */
     program = argv[0];
     program_basename = base_name(program);
-    while ((i = getopt(argc, argv, "hv:VqSF:tTW:w")) != -1) {
+    while ((i = getopt(argc, argv, "hv:VqSF:tW:w")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -1015,15 +1015,6 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JAUTHCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JAUTHCHK_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -71,13 +71,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-V] [-q] [-T]  [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
+"usage: %s [-h] [-v level] [-V] [-q] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
 "\n"
 "\t-h\t\tprint help message and exit 0\n"
 "\t-v level\tset verbosity level: (def level: %d)\n"
 "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
 "\t-V\t\tprint version string and exit\n"
-"\t-T\t\tshow IOCCC toolkit release repository tag\n"
 "\t-S\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F fnamchk\tpath to fnamchk tool (def: %s)\n"
 "\t-t\t\ttest mode: only issue warnings in some cases\n"

--- a/jinfochk.1
+++ b/jinfochk.1
@@ -2,7 +2,7 @@
 .SH NAME
 jinfochk \- IOCCC tool to validate .info.json file found within an entry directory
 .SH SYNOPSIS
-\fBjinfochk [\-h] [\-v level] [\-V] [\-T] [\-q] [\-t] [\-W code] [\-w] [\-S] ... file
+\fBjinfochk [\-h] [\-v level] [\-V] [\-q] [\-t] [\-W code] [\-w] [\-S] ... file
 .SH DESCRIPTION
 \fBjinfochk\fP is primarily used by other tools (not humans).
 It behaves like \fBfnamchk(1)\fP in that if all is well, it does not print anything and simply exit 0.
@@ -23,9 +23,6 @@ Set verbosity level.
 .PP
 \fB\-V\fP
 Show version and exit.
-.PP
-\fB\-T\fP
-Show IOCCC toolkit release repository tag.
 .PP
 \fB\-q\fP
 Quiet mode.

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1546,7 +1546,7 @@ main(int argc, char **argv)
      */
     program = argv[0];
     program_basename = base_name(program);
-    while ((i = getopt(argc, argv, "hv:qVSF:tTW:w")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVSF:tW:w")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program); /*ooo*/
@@ -1566,15 +1566,6 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JINFOCHK_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JINFOCHK_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -76,13 +76,12 @@ static struct manifest_file *manifest_files_list; /* list of files in the manife
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-"usage: %s [-h] [-v level] [-q] [-V] [-T] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
+"usage: %s [-h] [-v level] [-q] [-V] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"
 "\n"
 "\t-h\t\tprint help message and exit 0\n"
 "\t-v level\tset verbosity level: (def level: %d)\n"
 "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
 "\t-V\t\tprint version string and exit\n"
-"\t-T\t\tshow IOCCC toolkit release repository tag\n"
 "\t-S\t\tstrict mode: be more strict on what is allowed (def: not strict)\n"
 "\t-F fnamchk\tpath to fnamchk tool (def: %s)\n"
 "\t-t\t\ttest mode: only issue warnings in some cases\n"

--- a/jparse.tab.c
+++ b/jparse.tab.c
@@ -1821,7 +1821,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVnSTs:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVnSs:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -1841,15 +1841,6 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JPARSE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JPARSE_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag: %s", IOCCC_TOOLKIT_RELEASE);
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jparse.y
+++ b/jparse.y
@@ -166,7 +166,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVnSTs:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVnSs:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -186,15 +186,6 @@ main(int argc, char **argv)
 	    ret = printf("%s\n", JPARSE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JPARSE_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag: %s", IOCCC_TOOLKIT_RELEASE);
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVtnST")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVtnS")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -92,15 +92,6 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", JSTRDECODE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JSTRDECODE_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag: %s", IOCCC_TOOLKIT_RELEASE);
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -64,13 +64,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-t] [-n] [-S] [string ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-t] [-n] [-S] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit 0\n"
-    "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-t\t\tperform jencchk test on code JSON decode/decode functions\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-S\t\tdecode using strict mode (def: not strict)\n"

--- a/jstrencode.c
+++ b/jstrencode.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVtnT")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVtn")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -91,15 +91,6 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", JSTRENCODE_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", JSTRENCODE_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag: %s", IOCCC_TOOLKIT_RELEASE);
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -65,13 +65,12 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-t] [-n] [string ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-t] [-n] [string ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level: (def level: %d)\n"
     "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit 0\n"
-    "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-t\t\tperform jencchk test on code JSON encode/decode functions\n"
     "\t-n\t\tdo not output newline after encode output\n"
     "\n"

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -2,7 +2,7 @@
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
-\fBmkiocccentry [\-h] [\-v level] [\-V] [\-T] [\-t tar] [\-c cp] [\-l ls] [\-C txzchk] [\-F fnamchk] [{\-a|\-A|\-i} answers] [\-j jinfochk] [\-J jauthchk] [\-W] [\-q] work_dir prog.c Makefile remarks.md [file ...]\fP
+\fBmkiocccentry [\-h] [\-v level] [\-V] [\-t tar] [\-c cp] [\-l ls] [\-C txzchk] [\-F fnamchk] [{\-a|\-A|\-i} answers] [\-j jinfochk] [\-J jauthchk] [\-W] [\-q] work_dir prog.c Makefile remarks.md [file ...]\fP
 .SH DESCRIPTION
 \fBmkiocccentry\fP gathers your source file, Makefile, remarks as well as any other files and creates a XZ compressed tarball.
 The tool runs \fBiocccsize\fP and it also runs a test on the Makefile to verify that everything seems in order.
@@ -26,9 +26,6 @@ Show IOCCC toolkit release repository tag.
 .PP
 \fB\-V\fP
 Show version and exit.
-.PP
-\fB\-T\fP
-Show IOCCC toolkit release repository tag.
 .PP
 \fB\-t\fP
 Specify path to tar that accepts the \fB\-J\fP option.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -149,7 +149,7 @@ main(int argc, char *argv[])
      */
     input_stream = stdin;	/* default to reading from standard in */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVTt:c:l:a:i:A:WC:F:j:J:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVt:c:l:a:i:A:WC:F:j:J:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(1, "-h help mode", program);
@@ -169,15 +169,6 @@ main(int argc, char *argv[])
 	    ret = printf("%s\n", MKIOCCCENTRY_VERSION);
 	    if (ret <= 0) {
 		warnp(__func__, "printf error printing version string: %s", MKIOCCCENTRY_VERSION);
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag");
 	    }
 	    exit(0); /*ooo*/
 	    not_reached();

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -138,7 +138,6 @@ static const char * const usage_msg0 =
     "\t-v level\tset verbosity level: (def level: %d)\n"
     "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit\n"
-    "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-W\t\tignore all warnings (this does NOT mean the judges will! :) )\n";
 static const char * const usage_msg1 =
     "\t-t tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"

--- a/txzchk.1
+++ b/txzchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-T] [\-t tar] [\-F fnamchk] [\-f] txzpath
+\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked by \fBmkiocccentry(1)\fP after forming the tarball.
 .PP
@@ -26,9 +26,6 @@ This does not include warnings, errors or the output of the \fBtar\fP command.
 \fB\-V\fP
 Show version and exit.
 .PP
-\fB\-T\fP
-Show IOCCC toolkit release repository tag.
-.PP
 \fB\-t\fP
 Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 \fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
@@ -37,7 +34,7 @@ Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
 .PP
-\fB\-f\fP
+\fB\-T\fP
 Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
 .SH EXIT STATUS
 .PP

--- a/txzchk.c
+++ b/txzchk.c
@@ -45,7 +45,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVF:t:fT")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVF:t:T")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(0, "-h help mode", program);
@@ -77,17 +77,8 @@ main(int argc, char **argv)
 	    tar = optarg;
 	    tar_flag_used = true;
 	    break;
-	case 'f':
+	case 'T':
 	    text_file_flag_used = true; /* don't rely on tar: just read file as if it was a text file */
-	    break;
-	case 'T':		/* -T (IOCCC toolkit release repository tag) */
-	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = printf("%s\n", IOCCC_TOOLKIT_RELEASE);
-	    if (ret <= 0) {
-		warnp(__func__, "printf error printing IOCCC toolkit release repository tag");
-	    }
-	    exit(0); /*ooo*/
-	    not_reached();
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/
@@ -129,7 +120,7 @@ main(int argc, char **argv)
      * On some systems where /usr/bin != /bin, the distribution made the mistake of
      * moving historic critical applications, look to see if the alternate path works instead.
      *
-     * If -f was used we don't actually need tar(1) so we test for that
+     * If -T was used we don't actually need tar(1) so we test for that
      * specifically.
      */
 
@@ -1113,7 +1104,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
  *
  * given:
  *
- *	tar		- path to executable tar program (if -f was not
+ *	tar		- path to executable tar program (if -T was not
  *			  specified)
  *	fnamchk		- path to fnamchk tool
  *
@@ -1129,7 +1120,7 @@ check_tarball(char const *tar, char const *fnamchk)
 {
     unsigned line_num = 0; /* line number of tar output */
     char *cmd = NULL;	/* fnamchk and tar -tJvf */
-    FILE *input_stream = NULL; /* pipe for tar output (or if -f specified read as a text file) */
+    FILE *input_stream = NULL; /* pipe for tar output (or if -T specified read as a text file) */
     FILE *fnamchk_stream = NULL; /* pipe for fnamchk output */
     char *linep = NULL;		/* allocated line read from tar (or text file) */
     char *dir_name = NULL;	/* line read from fnamchk (directory name) */
@@ -1238,7 +1229,7 @@ check_tarball(char const *tar, char const *fnamchk)
     dbg(DBG_MED, "txzchk: %s size in bytes: %jd", txzpath, (intmax_t)txz_info.size);
 
     /*
-     * free cmd for tar (if -f wasn't specified) command
+     * free cmd for tar (if -T wasn't specified) command
      */
     free(cmd);
     cmd = NULL;
@@ -1256,7 +1247,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	    warnp(__func__, "setvbuf failed for %s", txzpath);
 	}
 
-    } else { /* if -f not specified we have to do more to set up input stream */
+    } else { /* if -T not specified we have to do more to set up input stream */
 
 	/*
 	 * execute the tar command
@@ -1270,7 +1261,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 
 	/*
-	 * If we get here -f was not specified so open pipe to tar command.
+	 * If we get here -T was not specified so open pipe to tar command.
 	 */
 	input_stream = pipe_open(__func__, true, "% -tJvf %", tar, txzpath);
 	if (input_stream == NULL) {
@@ -1333,7 +1324,7 @@ check_tarball(char const *tar, char const *fnamchk)
 
     } while (readline_len >= 0);
     /*
-     * free cmd (it'll be NULL if -f was specified but this is safe)
+     * free cmd (it'll be NULL if -T was specified but this is safe)
      */
     free(cmd);
     cmd = NULL;

--- a/txzchk.h
+++ b/txzchk.h
@@ -108,18 +108,17 @@ static struct txz_line *txz_lines;
  * Use the usage() function to print the usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-t tar] [-F fnamchk] [-f] txzpath\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-t tar] [-F fnamchk] [-T] txzpath\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level: (def level: %d)\n"
     "\t-q\t\tquiet mode, unless verbosity level > 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit\n"
-    "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\n"
     "\t-t tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
     "\t-F fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
     "\t\t\tfilename (def: %s)\n\n"
-    "\t-f\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
+    "\t-T\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
     "\ttxzpath\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "txzchk version: %s\n";

--- a/version.h
+++ b/version.h
@@ -63,11 +63,6 @@
 
 
 /*
- * overall IOCCC entry toolkit release version
- */
-#define IOCCC_TOOLKIT_RELEASE "0.2"		/* format: major.minor */
-
-/*
  * official iocccsize version
  */
 #define IOCCCSIZE_VERSION "28.10 2022-03-15"	/* format: major.minor YYYY-MM-DD */


### PR DESCRIPTION
As discussed with Landon at
https://github.com/ioccc-src/mkiocccentry/issues/132#issuecomment-1079967380
and
https://github.com/ioccc-src/mkiocccentry/issues/132#issuecomment-1079978436
I have removed the -T option from all the tools. This includes usage
messages, from all the getopt() calls and the man pages.

Because of this I've changed back the txzchk option -f to -T which is
slightly more clear as to what it's purpose is - the file is a text file
rather than just any file (as -f might suggest).