### PR TITLE
Fix memory leak in jint.c

### DIFF
--- a/jint.c
+++ b/jint.c
@@ -558,7 +558,7 @@ main(int argc, char *argv[])
 	/*
 	 * free buffer
 	 */
-	if (ival == NULL) {
+	if (ival != NULL) {
 	    free(ival);
 	    ival = NULL;
 	}


### PR DESCRIPTION
free() was called if the pointer was == NULL rather than != NULL.