### PR TITLE
Fix jfloat -t and jint -t (due to commit 2c47e4)

### DIFF
--- a/jfloat.c
+++ b/jfloat.c
@@ -225,7 +225,7 @@ main(int argc, char *argv[])
 	    not_reached();
 	}
 	dbg(DBG_LOW, "all tests PASSED");
-	exit(13);
+	exit(0); /*ooo*/
     }
 #endif /* JFLOAT_TEST_ENABLED */
 

--- a/jint.c
+++ b/jint.c
@@ -314,7 +314,7 @@ main(int argc, char *argv[])
 	    not_reached();
 	}
 	dbg(DBG_LOW, "all tests PASSED");
-	exit(13);
+	exit(0); /*ooo*/
     }
 #endif /* JINT_TEST_ENABLED */
 


### PR DESCRIPTION
When running ./jint -t and ./jfloat -t all was okay and you'd get with
debug level DBG_LOW all tests PASSED. However the exit code was 13
because when sequencing exit codes in commit 2c47e4 the /*ooo*/ comment
was missing so the exit code was changed to (for both) 13.