### PR TITLE
make depend + typo fix in jfloat.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -555,6 +555,9 @@ utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dbg.h \
   limit_ioccc.h version.h
 sanity.o: sanity.c sanity.h util.h dbg.h location.h utf8_posix_map.h \
   json.h
-jparse.o: jparse.c util.h dbg.h jparse.tab.h
-jparse.tab.o: jparse.tab.c jparse.h dbg.h util.h json.h sanity.h \
-  location.h utf8_posix_map.h limit_ioccc.h version.h jparse.tab.h
+utf8_test.o: utf8_test.c utf8_posix_map.h util.h dbg.h limit_ioccc.h \
+  version.h
+jint.o: jint.c jint.h dbg.h util.h json.h limit_ioccc.h version.h
+jint.test.o: jint.test.c json.h
+jfloat.o: jfloat.c jfloat.h dbg.h util.h json.h limit_ioccc.h version.h
+jfloat.test.o: jfloat.test.c json.h

--- a/jfloat.h
+++ b/jfloat.h
@@ -64,7 +64,7 @@
  * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [int ...]\n"
+    "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [float ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
@@ -82,7 +82,7 @@ static const char * const usage_msg =
     "\tNOTE: Without -t, this program will output C code suitable for building\n"
     "\t      a JSON floating point conversion test suite.\n"
     "\n"
-    "\tint ...\tconvert JSON floating point strings\n"
+    "\tfloat ...\tconvert JSON floating point strings\n"
     "\n"
     "\tNOTE: Without -t, at least 1 argument is required.\n"
     "\t      With -t, no command arguments are allowed\n"


### PR DESCRIPTION
Several updates had the need for make depend. For example updating
jfloat.h would not recompile jfloat.c. In particular the following were
generated:

    +utf8_test.o: utf8_test.c utf8_posix_map.h util.h dbg.h limit_ioccc.h \
    +  version.h
    +jint.o: jint.c jint.h dbg.h util.h json.h limit_ioccc.h version.h
    +jint.test.o: jint.test.c json.h
    +jfloat.o: jfloat.c jfloat.h dbg.h util.h json.h limit_ioccc.h version.h
    +jfloat.test.o: jfloat.test.c json.h

jfloat usage message referred to 'int' instead of 'float' (yank/paste
and forgetting to update the string?).