### PR TITLE
Minor clean up parser/lexer + make seqcexit

### DIFF
--- a/jint.c
+++ b/jint.c
@@ -398,7 +398,7 @@ main(int argc, char *argv[])
 	 */
 	ival = malloc_json_conv_int_str(input, &retlen);
 	if (ival == NULL) {
-	    err(13, __func__, "malloc_json_conv_int_str() is not supposed to return NULL!");
+	    err(12, __func__, "malloc_json_conv_int_str() is not supposed to return NULL!");
 	    not_reached();
 	}
 
@@ -596,7 +596,7 @@ main(int argc, char *argv[])
      * All Done!!! - Jessica Noll, age 2
      */
     if (error == true) {
-	exit(15);
+	exit(13);
     }
     exit(0); /*ooo*/
 }
@@ -756,7 +756,7 @@ prinfo(bool sized, intmax_t value, char const *scomm, char const *vcomm)
      * firewall
      */
     if (scomm == NULL || vcomm == NULL) {
-	err(16, __func__, "NULL arg(s)");
+	err(14, __func__, "NULL arg(s)");
 	not_reached();
     }
 
@@ -798,7 +798,7 @@ pruinfo(bool sized, uintmax_t value, char const *scomm, char const *vcomm)
      * firewall
      */
     if (scomm == NULL || vcomm == NULL) {
-	err(17, __func__, "NULL arg(s)");
+	err(15, __func__, "NULL arg(s)");
 	not_reached();
     }
 

--- a/jparse.c
+++ b/jparse.c
@@ -1985,43 +1985,6 @@ void yyfree (void * ptr )
 /* Section 3: Code that's copied to the generated scanner */
 
 
-/* clearerr_or_fclose
- *
- * This function calls clearerr() or fclose() depending on if file is stdin or
- * some other file.
- *
- * given:
- *
- *	filename    - the filename of file
- *	file	    - the FILE * (stdin or another file)
- *
- *
- * NOTE: This function will do not return on NULL pointers.
- */
-void
-clearerr_or_fclose(char const *filename, FILE *file)
-{
-    int ret;
-
-    /*
-     * firewall
-     */
-    if (filename == NULL || file == NULL) {
-	err(35, __func__, "passed NULL arg(s)");
-	not_reached();
-    }
-
-    if (file == stdin)
-	clearerr(file);
-    else {
-	errno = 0;
-	ret = fclose(file);
-	if (ret != 0) {
-	    warnp(__func__, "error in fclose on file %s", filename);
-	}
-    }
-}
-
 /* parse_json_string	    - parse string as a JSON block
  *
  * given:
@@ -2067,7 +2030,7 @@ parse_json_string(char const *string)
     yy_delete_buffer(bp);
     bp = NULL;
 
-    print_newline();
+    print_newline(output_newline);
 }
 
 
@@ -2155,27 +2118,8 @@ parse_json_file(char const *filename)
     yyparse();
 
     clearerr_or_fclose(filename, yyin);
-    print_newline();
+    print_newline(output_newline);
 }
 
-/* print_newline	- prints a newline to stdout if -n not specified
- *
- * NOTE: We have this in a function because the same code is used every time we
- * print something out as long as -n was not specified.
- */
-void
-print_newline(void)
-{
-    int ret;
-
-    if (output_newline) {
-	errno = 0;		/* pre-clear errno for errp() */
-	ret = putchar('\n');
-	if (ret != '\n') {
-	    errp(36, __func__, "error while writing newline");
-	    not_reached();
-	}
-    }
-}
 
 

--- a/jparse.c
+++ b/jparse.c
@@ -2118,6 +2118,7 @@ parse_json_file(char const *filename)
     yyparse();
 
     clearerr_or_fclose(filename, yyin);
+    yyin = NULL;
     print_newline(output_newline);
 }
 

--- a/jparse.h
+++ b/jparse.h
@@ -98,7 +98,6 @@ extern int token_type;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' a
 /*
  * function prototypes
  */
-void print_newline(void);
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 /* lexer specific */
 void yyerror(char const *s, ...);

--- a/jparse.l
+++ b/jparse.l
@@ -120,43 +120,6 @@ JSON_COMMA		","
 /* Section 3: Code that's copied to the generated scanner */
 
 
-/* clearerr_or_fclose
- *
- * This function calls clearerr() or fclose() depending on if file is stdin or
- * some other file.
- *
- * given:
- *
- *	filename    - the filename of file
- *	file	    - the FILE * (stdin or another file)
- *
- *
- * NOTE: This function will do not return on NULL pointers.
- */
-void
-clearerr_or_fclose(char const *filename, FILE *file)
-{
-    int ret;
-
-    /*
-     * firewall
-     */
-    if (filename == NULL || file == NULL) {
-	err(35, __func__, "passed NULL arg(s)");
-	not_reached();
-    }
-
-    if (file == stdin)
-	clearerr(file);
-    else {
-	errno = 0;
-	ret = fclose(file);
-	if (ret != 0) {
-	    warnp(__func__, "error in fclose on file %s", filename);
-	}
-    }
-}
-
 /* parse_json_string	    - parse string as a JSON block
  *
  * given:
@@ -202,7 +165,7 @@ parse_json_string(char const *string)
     yy_delete_buffer(bp);
     bp = NULL;
 
-    print_newline();
+    print_newline(output_newline);
 }
 
 
@@ -290,26 +253,7 @@ parse_json_file(char const *filename)
     yyparse();
 
     clearerr_or_fclose(filename, yyin);
-    print_newline();
+    print_newline(output_newline);
 }
 
-/* print_newline	- prints a newline to stdout if -n not specified
- *
- * NOTE: We have this in a function because the same code is used every time we
- * print something out as long as -n was not specified.
- */
-void
-print_newline(void)
-{
-    int ret;
-
-    if (output_newline) {
-	errno = 0;		/* pre-clear errno for errp() */
-	ret = putchar('\n');
-	if (ret != '\n') {
-	    errp(36, __func__, "error while writing newline");
-	    not_reached();
-	}
-    }
-}
 

--- a/jparse.l
+++ b/jparse.l
@@ -253,6 +253,7 @@ parse_json_file(char const *filename)
     yyparse();
 
     clearerr_or_fclose(filename, yyin);
+    yyin = NULL;
     print_newline(output_newline);
 }
 

--- a/util.c
+++ b/util.c
@@ -2751,3 +2751,70 @@ find_matching_quote(char *q)
 
     return q;
 }
+
+/* clearerr_or_fclose
+ *
+ * This function calls clearerr() or fclose() depending on if file is stdin or
+ * some other file.
+ *
+ * given:
+ *
+ *	filename    - the filename of file
+ *	file	    - the FILE * (stdin or another file)
+ *
+ *
+ * NOTE: This function will not return on NULL pointers.
+ */
+void
+clearerr_or_fclose(char const *filename, FILE *file)
+{
+    int ret;
+
+    /*
+     * firewall
+     */
+    if (filename == NULL || file == NULL) {
+	err(182, __func__, "passed NULL arg(s)");
+	not_reached();
+    }
+
+    if (file == stdin)
+	clearerr(file);
+    else {
+	errno = 0;
+	ret = fclose(file);
+	if (ret != 0) {
+	    warnp(__func__, "error in fclose on file %s", filename);
+	}
+    }
+}
+
+/* print_newline	- prints a newline to stdout if output_newline == true
+ *
+ * given:
+ *
+ *	output_newline	- true ==> write a newline of output
+ *
+ * This function is used when we want to print a newline after some input. This
+ * is currently only used in jparse if -n is not specified but there are other
+ * tools that have this same functionality and they could make use of this too.
+ * The reason it is not in jparse.l or jparse.y is because I'm trying to keep
+ * the lexer and parser as clutter free as possible and this doesn't seem to
+ * belong there with that in mind.
+ *
+ * This function does not return on error.
+ */
+void
+print_newline(bool output_newline)
+{
+    int ret;
+
+    if (output_newline) {
+	errno = 0;		/* pre-clear errno for errp() */
+	ret = putchar('\n');
+	if (ret != '\n') {
+	    errp(183, __func__, "error while writing newline");
+	    not_reached();
+	}
+    }
+}

--- a/util.h
+++ b/util.h
@@ -183,5 +183,7 @@ extern bool is_number(char const *str);
 extern bool string_to_bool(char const *str);
 extern bool posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first);
 extern char *find_matching_quote(char *q);
+extern void clearerr_or_fclose(char const *filename, FILE *file);
+extern void print_newline(bool output_newline);
 
 #endif				/* INCLUDE_UTIL_H */


### PR DESCRIPTION
The functions clearerr_or_fclose() and print_newline() have been moved
to util.c so that the definitions are not needed in the lexer.

The print_newline() function now takes a bool output_newline. I'm aware
of another file that prints a newline based on a bool but that file does
not use this routine. Whether util.c is the best file I don't know and
I'm more than fine with it elsewhere.

Sequenced exit codes.