### PR TITLE
Fix make depend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ SPECIAL_OBJ= jparse.o jparse.tab.o utf8_posix_map.o
 FLEXFILES= jparse.l
 BISONFILES= jparse.y
 SRCFILES= $(patsubst %.o,%.c,$(OBJFILES))
+SRCFILES+= $(patsubst %.o,%.c,$(SPECIAL_OBJ))
 H_FILES= dbg.h jauthchk.h jinfochk.h json.h jstrdecode.h jstrencode.h limit_ioccc.h \
 	mkiocccentry.h txzchk.h util.h location.h utf8_posix_map.h jparse.h jint.h jfloat.h \
 	verge.h
@@ -677,8 +678,6 @@ jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h json.h limit_ioccc.h \
   version.h
 rule_count.o: rule_count.c iocccsize_err.h iocccsize.h
 location.o: location.c location.h util.h dbg.h
-utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dbg.h \
-  limit_ioccc.h version.h
 sanity.o: sanity.c sanity.h util.h dbg.h location.h utf8_posix_map.h \
   json.h
 utf8_test.o: utf8_test.c utf8_posix_map.h util.h dbg.h limit_ioccc.h \
@@ -687,3 +686,10 @@ jint.o: jint.c jint.h dbg.h util.h json.h limit_ioccc.h version.h
 jint.test.o: jint.test.c json.h
 jfloat.o: jfloat.c jfloat.h dbg.h util.h json.h limit_ioccc.h version.h
 jfloat.test.o: jfloat.test.c json.h
+verge.o: verge.c verge.h dbg.h util.h limit_ioccc.h version.h
+jparse.o: jparse.c jparse.h dbg.h util.h json.h sanity.h location.h \
+  utf8_posix_map.h limit_ioccc.h version.h jparse.tab.h
+jparse.tab.o: jparse.tab.c jparse.h dbg.h util.h json.h sanity.h \
+  location.h utf8_posix_map.h limit_ioccc.h version.h jparse.tab.h
+utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dbg.h \
+  limit_ioccc.h version.h


### PR DESCRIPTION
After splitting OBJFILES into two variables this broke the SRCFILES
variable which breaks make depend. As I put this in I'll explain how
the black magic of make depend works:

First of all the lines:

    OBJFILES= dbg.o util.o mkiocccentry.o iocccsize.o fnamchk.o txzchk.o jauthchk.o jinfochk.o \
        json.o jstrencode.o jstrdecode.o rule_count.o location.o sanity.o \
        utf8_test.o jint.o jint.test.o jfloat.o jfloat.test.o verge.o

    SPECIAL_OBJ= jparse.o jparse.tab.o utf8_posix_map.o

define object files that are generated by compiling the .c files. Next
the lines:

    SRCFILES= $(patsubst %.o,%.c,$(OBJFILES))
    SRCFILES+= $(patsubst %.o,%.c,$(SPECIAL_OBJ))

Create and append to the variable SRCFILES the .c files that are used to
create the object files (or more specifically it replaces all files in
the OBJFILES and SPECIAL_OBJ variables to be their .c counterparts).

Then the rule depend which looks like:

    depend:
        @LINE="`grep -n '^### DO NOT CHANGE' Makefile|awk -F : '{print $$1}'`"; \
        if [ "$$LINE" = "" ]; then                                              \
                echo "Make depend aborted, tag not found in Makefile.";         \
                exit;                                                           \
        fi;                                                                     \
        mv -f Makefile Makefile.orig;head -n $$LINE Makefile.orig > Makefile;   \
        echo "Generating dependencies.";                                        \
        ${CC} ${CFLAGS} -MM ${SRCFILES} >> Makefile
        @echo "Make depend completed.";

looks for the line number for the line that starts with
 '### DO NOT CHANGE' which is actually the final part of the Makefile
(and is important to have as we don't want to touch anything above it)
which in full looks like:

    ### DO NOT CHANGE MANUALLY BEYOND THIS LINE

If it does not find it it is an error and the make depend is aborted.
Else it makes a backup of the Makefile (Makefile.orig which is in
.gitignore) and then it prints the entire Makefile (from the backup
file) up to and including the make depend tag. From this point it has a
Makefile to work from. Yes awk might be overkill for this. Anyway to
continue explaining how this works:

Next it runs the compiler with the -MM option which is like -M (see
below) but it does not include header files that are in system header
directories nor those that are included directly or indirectly from
files within those header files. What -M does is it generates make
dependency rules which means the line:

	${CC} ${CFLAGS} -MM ${SRCFILES} >> Makefile

generates make dependency rules for all the files in SRCFILES which if
you recall is a list of the .c files based on the .o files. These rules
are appended to the Makefile which as you recall consists of everything
up and including the make depend tag.

This means that when make depend is run the Makefile now has proper
dependencies generated for all the object files which means that if e.g.
you modify a header file which is a dependency for five object files
then those five object files will be recompiled upon `make'.

Therefore if OBJFILES and SPECIAL_OBJ are ever split into yet another
variable a line after

        SRCFILES+= $(patsubst %.o,%.c,$(SPECIAL_OBJ))

will have to be created in the same form but instead of SPECIAL_OBJ it
will be whatever the new variable is.

Additionally I have run make depend after making this fix.

To the more astute reader there are two possible problems here to do
with remembering to do some things. First if a new .c file is added to
the repo this has to be added to the OBJFILES variable (with extension
.o instead of .c). Second is after adding a header file (that's not a
system header file) one has to remember to run make depend. These
however are technicalities that cannot be dealt with.