### PR TITLE
Makefile fixes + vfprintf usage in yyerror()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ limit_ioccc.sh: limit_ioccc.h version.h Makefile
 	    echo "export TRIGRAPHS="; \
 	fi >> $@
 
-# How to crrate jparse.tab.h and jparse.tab.c
+# How to create jparse.tab.h and jparse.tab.c
 #
 # Convert jparse.y into jparse.tab.as well as jparse.tab.c via bison,
 # if bison is found and has a recent enough version, otherwise

--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ parser: jparse.y jparse.l sorry.tm.ca.h Makefile
 	@# NOTE: jparse.c already begins with: "#line 1 jparse.c"
 	${CAT} jparse.c >> jparse.ref.c
 
-# restore reference code that was produced by previous successful make parse
+# restore reference code that was produced by previous successful make parser
 #
 # This rule forces the use of reference copies of JSON parser C code.
 #

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,9 @@ prep:
 
 # force the rebuild of the JSON parser and form reference copies of JSON parser C code
 #
+# XXX Currently if one does not do make parser use_ref the apology added to the
+# parser files will be removed. Using make prep will do both, preventing this
+# problem.
 parser: jparse.y jparse.l sorry.tm.ca.h Makefile
 	${BISON} -d jparse.y
 	${FLEX} -o jparse.c jparse.l
@@ -477,6 +480,9 @@ parser: jparse.y jparse.l sorry.tm.ca.h Makefile
 #
 # This rule forces the use of reference copies of JSON parser C code.
 #
+# XXX Currently if you do make parser not followed by running this rule the
+# apology added with make parser will not be added to all the files. Using make
+# prep will do both, preventing the problem.
 use_ref: jparse.tab.ref.c jparse.tab.ref.h jparse.ref.c
 	${RM} -f jparse.tab.c
 	${CP} -f -v jparse.tab.ref.c jparse.tab.c
@@ -511,6 +517,9 @@ rebuild_jfloat_test: jfloat.testset jfloat.c dbg.o json.o util.o Makefile
 
 # sequence exit codes
 #
+# XXX Currently running this rule followed by make will remove the apology from
+# some of the jparse related files. Using make prep (which runs make seqcexit)
+# will fix this problem. You can also do make seqcexit parser use_ref.
 seqcexit: Makefile
 	@HAVE_SEQCEXIT=`command -v ${SEQCEXIT}`; if [[ -z "$$HAVE_SEQCEXIT" ]]; then \
 	    echo 'If you have not installed the seqcexit tool, then' 1>&2; \

--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,7 @@ rebuild_jfloat_test: jfloat.testset jfloat.c dbg.o json.o util.o Makefile
 
 # sequence exit codes
 #
-seqcexit: ${ALL_CSRC} ${FLEXFILES} ${BISONFILES} Makefile
+seqcexit: Makefile
 	@HAVE_SEQCEXIT=`command -v ${SEQCEXIT}`; if [[ -z "$$HAVE_SEQCEXIT" ]]; then \
 	    echo 'If you have not installed the seqcexit tool, then' 1>&2; \
 	    echo 'you may not run this rule.'; 1>&2; \

--- a/jparse.h
+++ b/jparse.h
@@ -93,10 +93,10 @@ extern int token_type;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' a
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 /* lexer specific */
-void yyerror(char const *s, ...);
 int yylex(void);
 /* parser specific */
 void parse_json_file(char const *filename);
 void parse_json_string(char const *string);
+void yyerror(char const *format, ...);
 
 #endif /* INCLUDE_JPARSE_H */

--- a/jparse.tab.c
+++ b/jparse.tab.c
@@ -1925,13 +1925,23 @@ main(int argc, char **argv)
 }
 
 void
-yyerror(char const *err, ...)
+yyerror(char const *format, ...)
 {
+    va_list ap;
+
+    va_start(ap, format);
+
     /*
-     * We use dbg() instead of err() but in the future it'll probably use the
-     * jerr() function or some other error function.
+     * We use fprintf and vfprintf instead of err() but in the future it'll
+     * probably use an error function of some kind, perhaps a variant of jerr()
+     * (the parser cannot provide all the information that the jerr() function
+     * expects).
      */
-    dbg(DBG_NONE, "JSON parser error (num errors: %d) on line %d: %s\n", yynerrs, yylineno, err);
+    fprintf(stderr, "JSON parser error (num errors: %d) on line %d: ", yynerrs, yylineno);
+    vfprintf(stderr, format, ap);
+    fprintf(stderr, "\n");
+
+    va_end(ap);
 }
 
 /*

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1925,13 +1925,23 @@ main(int argc, char **argv)
 }
 
 void
-yyerror(char const *err, ...)
+yyerror(char const *format, ...)
 {
+    va_list ap;
+
+    va_start(ap, format);
+
     /*
-     * We use dbg() instead of err() but in the future it'll probably use the
-     * jerr() function or some other error function.
+     * We use fprintf and vfprintf instead of err() but in the future it'll
+     * probably use an error function of some kind, perhaps a variant of jerr()
+     * (the parser cannot provide all the information that the jerr() function
+     * expects).
      */
-    dbg(DBG_NONE, "JSON parser error (num errors: %d) on line %d: %s\n", yynerrs, yylineno, err);
+    fprintf(stderr, "JSON parser error (num errors: %d) on line %d: ", yynerrs, yylineno);
+    vfprintf(stderr, format, ap);
+    fprintf(stderr, "\n");
+
+    va_end(ap);
 }
 
 /*

--- a/jparse.y
+++ b/jparse.y
@@ -248,13 +248,23 @@ main(int argc, char **argv)
 }
 
 void
-yyerror(char const *err, ...)
+yyerror(char const *format, ...)
 {
+    va_list ap;
+
+    va_start(ap, format);
+
     /*
-     * We use dbg() instead of err() but in the future it'll probably use the
-     * jerr() function or some other error function.
+     * We use fprintf and vfprintf instead of err() but in the future it'll
+     * probably use an error function of some kind, perhaps a variant of jerr()
+     * (the parser cannot provide all the information that the jerr() function
+     * expects).
      */
-    dbg(DBG_NONE, "JSON parser error (num errors: %d) on line %d: %s\n", yynerrs, yylineno, err);
+    fprintf(stderr, "JSON parser error (num errors: %d) on line %d: ", yynerrs, yylineno);
+    vfprintf(stderr, format, ap);
+    fprintf(stderr, "\n");
+
+    va_end(ap);
 }
 
 /*

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -5203,6 +5203,10 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     /*
      * perform the jinfochk which will indirectly show the user the tarball contents
      */
+    if (!quiet) {
+	para("",
+	    "Checking the format of .info.json ...", NULL);
+    }
     dbg(DBG_HIGH, "about to perform: %s -q -S -F %s -- %s", jinfochk, fnamchk, info_path);
     exit_code = shell_cmd(__func__, true, "% -q -S -F % -- %", jinfochk, fnamchk, info_path);
     if (exit_code != 0) {
@@ -5363,8 +5367,10 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	not_reached();
     }
 
-    para("",
-	"Checking the format of .author.json ...", NULL);
+    if (!quiet) {
+	para("",
+	    "Checking the format of .author.json ...", NULL);
+    }
 
     /*
      * perform the jauthchk which will indirectly show the user the tarball contents


### PR DESCRIPTION
NOTE: For information I've discovered after the fact see comments below (comment https://github.com/ioccc-src/mkiocccentry/pull/145#issuecomment-1090423738).

There's a fun bug fix in the Makefile which I described in detail in the git log but which I am duplicating here. Actually I did a git pull and recommit as I figured out the second half of the puzzle and I wanted it in the git log as well. **THERE'S STILL A PROBLEM WITH `make seqcexit` FOLLOWED BY `make`!**

```git
    Fix issue where make seqcexit updated parser/lexer
    
    If one were to do:
    
        make seqcexit
        make seqcexit
    
    They would see something like:
    
        $ make seqcexit
        seqcexit -c -- jparse.l jparse.y
        seqcexit -- utf8_posix_map.c jparse.c jparse.tab.c dbg.c util.c mkiocccentry.c iocccsize.c fnamchk.c txzchk.c jauthchk.c jinfochk.c json.c jstrencode.c jstrdecode.c rule_count.c location.c sanity.c utf8_test.c jint.c jint.test.c jfloat.c jfloat.test.c verge.c
    
        $ make seqcexit
        rm -f jparse.tab.h jparse.tab.c
        /opt/local/bin/bison -d jparse.y
        rm -f jparse.c
        /opt/local/bin/flex -o jparse.c jparse.l
        seqcexit -c -- jparse.l jparse.y
        seqcexit -- utf8_posix_map.c jparse.c jparse.tab.c dbg.c util.c mkiocccentry.c iocccsize.c fnamchk.c txzchk.c jauthchk.c jinfochk.c json.c jstrencode.c jstrdecode.c rule_count.c location.c sanity.c utf8_test.c jint.c jint.test.c jfloat.c jfloat.test.c verge.c
    
    What happened? There are two parts to this one of which I can explain
    certainly and the other I am pretty sure to be the case but I'm not
    absolutely certain. First of all the seqcexit tool updates the files
    including the lexer and parser source files.

    Now because the make seqcexit rule depended on the source files
    including jparse.c _which itself depends on the lexer and parser files_
    (which have just been updated) the files had to be regenerated. I believe
    this might be because of commit 54722313 and in particular:
    
            Removed the built-in rules for both ".c <== .y" and ".c <== .l".
    
    but I am not sure of this because the reason I disabled those did not
    actually occur after the second run of make seqcexit. But the fact that
    make seqcexit always runs seqcexit on the files even if the files have
    not changed means this fix should be fine.
    
    The fix is removing the dependency of
    
        ${ALL_CSRC} ${FLEXFILES} ${BISONFILES}
    
    from make seqcexit (Makefile is still a dependency though).
    
    As for the problem with the running make seqcexit: Most people probably
    wouldn't and I'm not even sure how I discovered it but because it would
    regenerate the files not everything was updated as make parser use_ref
    was not done.
    
    Interestingly running:
    
        make seqcexit seqcexit
    
    did not cause the problem: it would run seqcexit once and then it would
    say seqcexit is up to date.
```

I am aware of another strange bug in the Makefile which I've describe in the other issue about flex/bison improvement in the Makefile.

I am done for the day here I'm afraid. Sorry about that!