### PR TITLE
Complete commit 6ba89af and typo fix in json.h

### DIFF
--- a/json.h
+++ b/json.h
@@ -315,7 +315,7 @@ struct json_member {
 /*
  * JSON ordered array of values
  *
- * A JSON arras is of the form:
+ * A JSON array is of the form:
  *
  *	[ ]
  *	[ values ]

--- a/txzchk.1
+++ b/txzchk.1
@@ -2,7 +2,7 @@
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] txzpath
+\fBtxzchk [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] [\-E ext] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs and it is invoked by \fBmkiocccentry(1)\fP after forming the tarball.
 .PP
@@ -36,6 +36,10 @@ If this option is not specified the program looks under the current working dire
 .PP
 \fB\-T\fP
 Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
+.PP
+\fB\-E\fP
+Change extension to test (without the dot!).
+This is used in conjunction with \fb\-T\fP above for \fBTESTING\fP purposes only!
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 1 for errors or issues found; 0 for success.
@@ -75,5 +79,14 @@ Run the program on the tarball \fIentry.test-1.1644094311.txz\fP, specifying an 
 .RS
 \fB
  ./txzchk -t /path/to/tar -F ./filenamechk entry.test-1.1644094311.txz\fP
+.fi
+.RE
+.PP
+.nf
+Run the program on the file \fIentry.test-1.1644094311.txt\fP, specifying that it's a text file (which means \fB\-T\fP and \fB-E\fP have to be used):
+
+.RS
+\fB
+ ./txzchk -T -E txt entry.test-1.1644094311.txt\fP
 .fi
 .RE

--- a/txzchk.c
+++ b/txzchk.c
@@ -45,7 +45,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVF:t:T")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVF:t:TE:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(0, "-h help mode", program);
@@ -80,6 +80,9 @@ main(int argc, char **argv)
 	    break;
 	case 'T':
 	    text_file_flag_used = true; /* don't rely on tar: just read file as if it was a text file */
+	    break;
+	case 'E':
+	    ext = optarg;
 	    break;
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/
@@ -1146,7 +1149,7 @@ check_tarball(char const *tar, char const *fnamchk)
      * execute the fnamchk command
      */
     errno = 0;			/* pre-clear errno for errp() */
-    exit_code = shell_cmd(__func__, true, "% %", fnamchk, txzpath);
+    exit_code = shell_cmd(__func__, true, "% -E % -- %", fnamchk, ext, txzpath);
     if (exit_code != 0) {
 	warnp("txzchk", "%s: %s %s failed with exit code: %d", txzpath, fnamchk, txzpath, WEXITSTATUS(exit_code));
 	++txz_info.total_issues;
@@ -1169,7 +1172,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	/*
 	 * form pipe to the fnamchk command
 	 */
-	fnamchk_stream = pipe_open(__func__, true, "% -- %", fnamchk, txzpath);
+	fnamchk_stream = pipe_open(__func__, true, "% -E % -- %", fnamchk, ext, txzpath);
 	if (fnamchk_stream == NULL) {
 	    err(25, __func__, "popen for reading failed for: %s -- %s", fnamchk, txzpath);
 	    not_reached();

--- a/txzchk.h
+++ b/txzchk.h
@@ -44,13 +44,13 @@
  */
 #define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
 
-
-/* variable specific to txzchk */
+/* globals specific to txzchk */
 bool quiet = false;				/* true ==> quiet mode */
 /**/
 static char const *txzpath = NULL;		/* the current tarball being checked */
 static char const *program = NULL;		/* our name */
 static bool text_file_flag_used = false;	/* true ==> assume txzpath is a text file */
+static char const *ext = "txz";			/* force extension in fnamchk to be this value */
 
 /*
  * information about the tarball
@@ -103,7 +103,7 @@ static struct txz_line *txz_lines;
  * Use the usage() function to print the usage_msgX strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-t tar] [-F fnamchk] [-T] txzpath\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-t tar] [-F fnamchk] [-T] [-E ext] txzpath\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level: (def level: %d)\n"
@@ -114,7 +114,8 @@ static const char * const usage_msg =
     "\t-t tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
     "\t-F fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
     "\t\t\tfilename (def: %s)\n\n"
-    "\t-T\t\tassume txzpath is a text file with tar listing (for testing different formats)\n\n"
+    "\t-T\t\tassume txzpath is a text file with tar listing (for testing different formats)\n"
+    "\t-E ext\t\tchange extension to test (def: txz)\n\n"
     "\ttxzpath\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "txzchk version: %s\n";


### PR DESCRIPTION
In the second commit (commit a3e77b2cc) I include a long guide in how to write a test suite for `txzchk`. I'm duplicating it here so that it's in git log as well as here:

```git
commit a3e77b2cc3320d3bf3b99cb839d5c21b4d2ec7c2 (HEAD -> updates, origin/updates)
Author: Cody Boone Ferguson <53008573+xexyl@users.noreply.github.com>
Date:   Mon Apr 11 04:02:30 2022 -0700

    Update txzchk.1 for commit f7338647
    
    I did not specify how to write a test suite for txzchk here and although
    I did on GitHub I'll duplicate it here with more information.
    
    * How to write a test suite for txzchk
    
    First of all we might have a directory for txzchk like for the JSON with
    good and bad subdirectories (i.e. test_JSON) e.g. test_txz or
    test_txzchk.
    
    Then a script similar to json-test.sh but maybe txz-test.sh or maybe
    txzchk-test.sh that can test the good or bad or both files. Now here's
    where the magic happens.
    
    With each file in the subdirectories it can end in .txt: this way the
    files can be edited with a text editor and we don't have any destructive
    tarballs (and if nothing else no binary files added). Here's an example
    text file. The text file
    entry.12345678-1234-4321-abcd-1234567890ab-2.1649673512.txt with a tar
    output listing looks like:
    
        drwxr-xr-x  0 501    20          0 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/
        -rw-r--r--  0 501    20       1854 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/Makefile
        -rw-r--r--  0 501    20          4 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/extra2
        -rw-r--r--  0 501    20       2815 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/foo
        -rw-r--r--  0 501    20         61 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/prog.c
        -rw-r--r--  0 501    20       2806 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/.author.json
        -rw-r--r--  0 501    20       2869 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/remarks.md
        -rw-r--r--  0 501    20       5235 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/bar
        -rw-r--r--  0 501    20       1498 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/.info.json
        -rw-r--r--  0 501    20          4 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/extra1
    
    Now that that's in place we can run txzchk with both -T and -E txt so
    that txzchk does not open a pipe to tar but rather uses fopen(3) on the
    file. Here's how it looks:
    
        $ ./txzchk -T -E txt entry.12345678-1234-4321-abcd-1234567890ab-2.1649673512.txt
        Welcome to txzchk version: 0.10 2022-03-15
    
        Performing sanity checks on your environment ...
        ... environment looks OK
    
        Performing checks on tarball ...
        12345678-1234-4321-abcd-1234567890ab-2
        txzchk: entry.12345678-1234-4321-abcd-1234567890ab-2.1649673512.txt size of 946 bytes OK
        drwxr-xr-x  0 501    20          0 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/
        -rw-r--r--  0 501    20       1854 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/Makefile
        -rw-r--r--  0 501    20          4 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/extra2
        -rw-r--r--  0 501    20       2815 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/foo
        -rw-r--r--  0 501    20         61 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/prog.c
        -rw-r--r--  0 501    20       2806 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/.author.json
        -rw-r--r--  0 501    20       2869 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/remarks.md
        -rw-r--r--  0 501    20       5235 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/bar
        -rw-r--r--  0 501    20       1498 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/.info.json
        -rw-r--r--  0 501    20          4 Apr 11 10:38 12345678-1234-4321-abcd-1234567890ab-2/extra1
        txzchk: entry.12345678-1234-4321-abcd-1234567890ab-2.1649673512.txt total size of files 17146 rounded up to 1024 multiple: 17408 OK
        All checks passed.
    
    If -v > 0 more information is shown depending on the verbosity level.
    
    Note that in the shell_cmd() and pipe_open() functions we always specify
    -E with the new txzchk global char const *ext which defaults to "txz":
    this way we don't have to worry about checking if the user wanted to
    override the extension: it's always specified with either "txz" or the
    user supplied extension e.g. "txt" (as demonstrated above).
    
    The script then might run through all the files and if good files fail
    or if bad files pass there's a problem (it could also run only specific
    tests just like the json-test.sh script does).
    
    This feature allows for testing new formats as well: for example if we
    discover a tar listing output that does not match macOS/BSD or linux.
    This is why I implemented the -T option in the first place though I had
    actually thought of it prior to the discovery that linux has a different
    format than macOS for the above mentioned reason: it would be easier to
    test different tar outputs including those made by someone attempting to
    manipulate tar to create invalid and/or funny tarballs (like the IOCCC
    Judges did exactly to get a good set of invalid tarballs to test which
    was indeed very helpful).

```

