### PR TITLE
Spelling fix in sorry.tm.ca.h + various updates

### DIFF
--- a/bfok.sh
+++ b/bfok.sh
@@ -165,7 +165,7 @@ if [[ ! -f $VERGE ]]; then
     exit 3
 fi
 if [[ ! -x $VERGE ]]; then
-    echo "$0: ERROR: verge not a executable: $VERGE" 1>&2
+    echo "$0: ERROR: verge not an executable: $VERGE" 1>&2
     exit 3
 fi
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -724,7 +724,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 	 * If the field is not allowed in the list then it suggests there is a
 	 * problem in the code because only author fields should be added to the
 	 * list in the first place. Thus it's an error if a field that's in the
-	 * author list is not a author field name.
+	 * author list is not an author field name.
 	 */
 	if (author_field == NULL) {
 	    jerr(JSON_CODE_RESERVED(10), NULL, __func__, __FILE__, NULL, __LINE__,

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1186,7 +1186,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 	 * If the field is not allowed in the list then it suggests there is a
 	 * problem in the code because only info fields should be added to the
 	 * list in the first place. Thus it's an error if a field that's in the
-	 * info list is not a info field name.
+	 * info list is not an info field name.
 	 */
 	if (info_field == NULL) {
 	    jerr(JSON_CODE_RESERVED(10), NULL, __func__, __FILE__, NULL, __LINE__,

--- a/jparse.h
+++ b/jparse.h
@@ -83,7 +83,6 @@ extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern int yylineno;			/* line number in lexer */
 extern char *yytext;			/* current text */
 extern FILE *yyin;			/* input file lexer/parser reads from */
-extern int oldstate;
 extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern bool output_newline;		/* true ==> -n not specified, output new line after each arg processed */
 extern int token_type;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' and so on */

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -16,7 +16,7 @@
  * P.S. In 2022 April 04, when this comment was created, none of the people
  *	working on this repo were Canadian.  But some of them have several
  *	good friends who live in, or are from Canada. Those friends say sorry
- *	in a fun and friendly way, so we honor those friends in this comment.
+ *	in a fun and friendly way, so we honour those friends in this comment.
  */
 #line 1 "jparse.c"
 #line 1 "jparse.c"

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -16,7 +16,7 @@
  * P.S. In 2022 April 04, when this comment was created, none of the people
  *	working on this repo were Canadian.  But some of them have several
  *	good friends who live in, or are from Canada. Those friends say sorry
- *	in a fun and friendly way, so we honor those friends in this comment.
+ *	in a fun and friendly way, so we honour those friends in this comment.
  */
 #line 1 "jparse.tab.c"
 /* A Bison parser, made by GNU Bison 3.8.2.  */

--- a/jparse.tab.ref.h
+++ b/jparse.tab.ref.h
@@ -16,7 +16,7 @@
  * P.S. In 2022 April 04, when this comment was created, none of the people
  *	working on this repo were Canadian.  But some of them have several
  *	good friends who live in, or are from Canada. Those friends say sorry
- *	in a fun and friendly way, so we honor those friends in this comment.
+ *	in a fun and friendly way, so we honour those friends in this comment.
  */
 #line 1 "jparse.tab.h"
 /* A Bison parser, made by GNU Bison 3.8.2.  */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -6,7 +6,7 @@
  *
  * We will form the IOCCC entry compressed tarball "by hand" in C.
  * Not in some high level language, but standard vanilla C.
- * Why?  Because this is a obfuscated C contest.  But then why isn't
+ * Why?  Because this is an obfuscated C contest.  But then why isn't
  * this code obfuscated?  Because the IOCCC judges prefer to write
  * in robust unobfuscated code.  Besides, the IOCCC was started
  * as an ironic commentary on the Bourne shell source and finger daemon
@@ -3668,7 +3668,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	     "We will ask a GitHub account (must start with @), or press return to skip.",
 	     "We will ask for an affiliation (company, school, group) of the author.",
 	     "We will ask if you have won the IOCCC before. Your answer will not affect your chances of winning.",
-	     "We will ask you for a author handle. You should select the default unless you have won the IOCCC before.",
+	     "We will ask you for an author handle. You should select the default unless you have won the IOCCC before.",
 	     NULL);
     }
 

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -6,7 +6,7 @@
  *
  * We will form the IOCCC entry compressed tarball "by hand" in C.
  * Not in some high level language, but standard vanilla C.
- * Why?  Because this is a obfuscated C contest.  But then why isn't
+ * Why?  Because this is an obfuscated C contest.  But then why isn't
  * this code obfuscated?  Because the IOCCC judges prefer to write
  * in robust unobfuscated code.  Besides, the IOCCC was started
  * as an ironic commentary on the Bourne shell source and finger daemon

--- a/sorry.tm.ca.h
+++ b/sorry.tm.ca.h
@@ -16,5 +16,5 @@
  * P.S. In 2022 April 04, when this comment was created, none of the people
  *	working on this repo were Canadian.  But some of them have several
  *	good friends who live in, or are from Canada. Those friends say sorry
- *	in a fun and friendly way, so we honor those friends in this comment.
+ *	in a fun and friendly way, so we honour those friends in this comment.
  */

--- a/txzchk.c
+++ b/txzchk.c
@@ -430,7 +430,6 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
  * given:
  *
  *	txzpath		- the tarball (or text file) we're processing
- *	p		- the path
  *	dir_name	- the directory name (if fnamchk passed - else NULL)
  *	file		- file structure
  *
@@ -440,14 +439,14 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
  *
  */
 static void
-check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_file *file)
+check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 {
     bool allowed_dot_file = false;	/* true ==> basename is an allowed . file */
 
     /*
      * firewall
      */
-    if (txzpath == NULL || p == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
+    if (txzpath == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
 	err(13, __func__, "passed NULL arg(s)");
 	not_reached();
     }
@@ -908,7 +907,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     check_empty_file(txzpath, current_file_size, file);
 
     /* checks on this specific file */
-    check_txz_file(txzpath, p, dir_name, file);
+    check_txz_file(txzpath, dir_name, file);
 
     add_txz_file_to_list(file);
 }
@@ -1017,7 +1016,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     check_empty_file(txzpath, current_file_size, file);
 
     /* checks on this specific file */
-    check_txz_file(txzpath, p, dir_name, file);
+    check_txz_file(txzpath, dir_name, file);
 
     add_txz_file_to_list(file);
 }
@@ -1510,7 +1509,7 @@ free_txz_lines(void)
  *
  * given:
  *
- *	p	- file path
+ *	path	- file path
  *
  * Returns the newly allocated struct txz_file * with the file information. The
  * function does NOT add it to the list!
@@ -1518,14 +1517,14 @@ free_txz_lines(void)
  * This function does not return on error.
  */
 static struct txz_file *
-alloc_txz_file(char const *p)
+alloc_txz_file(char const *path)
 {
     struct txz_file *file; /* the file structure */
 
     /*
      * firewall
      */
-    if (p == NULL) {
+    if (path == NULL) {
 	err(38, __func__, "passed NULL path");
 	not_reached();
     }
@@ -1537,16 +1536,16 @@ alloc_txz_file(char const *p)
     }
 
     errno = 0;
-    file->filename = strdup(p);
+    file->filename = strdup(path);
     if (!file->filename) {
-	errp(40, __func__, "%s: unable to strdup filename %s", txzpath, p);
+	errp(40, __func__, "%s: unable to strdup filename %s", txzpath, path);
 	not_reached();
     }
 
     errno = 0;
-    file->basename = strdup(base_name(p)?base_name(p):"");
+    file->basename = strdup(base_name(path)?base_name(path):"");
     if (!file->basename || !strlen(file->basename)) {
-	errp(41, __func__, "%s: unable to strdup basename of filename %s", txzpath, p);
+	errp(41, __func__, "%s: unable to strdup basename of filename %s", txzpath, path);
 	not_reached();
     }
 

--- a/txzchk.h
+++ b/txzchk.h
@@ -136,14 +136,14 @@ static void parse_bsd_txz_line(char *p, char *line, char *line_dup, char const *
 static unsigned check_tarball(char const *tar, char const *fnamchk);
 static void show_txz_info(char const *txzpath);
 static void check_empty_file(char const *txzpath, off_t size, struct txz_file *file);
-static void check_txz_file(char const *txzpath, char *p, char const *dir_name, struct txz_file *file);
+static void check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file);
 static void check_all_txz_files(char const *dir_name);
 static void check_directories(struct txz_file *file, char const *dir_name, char const *txzpath);
 static bool has_special_bits(char const *str);
 static void add_txz_line(char const *str, int line_num);
 static void parse_all_txz_lines(char const *dir_name, char const *txzpath);
 static void free_txz_lines(void);
-static struct txz_file *alloc_txz_file(char const *p);
+static struct txz_file *alloc_txz_file(char const *path);
 static void add_txz_file_to_list(struct txz_file *file);
 static void free_txz_files_list(void);
 

--- a/util.c
+++ b/util.c
@@ -2720,38 +2720,6 @@ posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first)
     return true;
 }
 
-/* find_matching_quote	find the next unescaped '"'
- *
- * Assuming *q == '"' find the matching (closing) '"' (i.e. the next unescaped
- * '"') and return a pointer to it (or NULL if not found). If *q != '"' && *q !=
- * '\0' it will return 'q'; else it'll return q updated to either the end of the
- * string (which means NULL return value) or the matching unescaped '"'.
- *
- * NOTE: This function does not return on NULL pointer passed in but it can
- * return a NULL pointer: this happens if no matching '"' is found (or the
- * string was empty in the first place).
- */
-char *
-find_matching_quote(char *q)
-{
-    /*
-     * firewall
-     */
-    if (q == NULL) {
-	err(181, __func__, "passed NULL pointer");
-	not_reached();
-    }
-
-    for (++q; *q && *q != '"'; ++q)
-	if (*q == '\\')
-	    ++q;
-
-    if (!*q)
-	return NULL;
-
-    return q;
-}
-
 /* clearerr_or_fclose
  *
  * This function calls clearerr() or fclose() depending on if file is stdin or
@@ -2774,7 +2742,7 @@ clearerr_or_fclose(char const *filename, FILE *file)
      * firewall
      */
     if (filename == NULL || file == NULL) {
-	err(182, __func__, "passed NULL arg(s)");
+	err(181, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
@@ -2813,7 +2781,7 @@ print_newline(bool output_newline)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = putchar('\n');
 	if (ret != '\n') {
-	    errp(183, __func__, "error while writing newline");
+	    errp(182, __func__, "error while writing newline");
 	    not_reached();
 	}
     }

--- a/util.h
+++ b/util.h
@@ -182,7 +182,6 @@ extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_number(char const *str);
 extern bool string_to_bool(char const *str);
 extern bool posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first);
-extern char *find_matching_quote(char *q);
 extern void clearerr_or_fclose(char const *filename, FILE *file);
 extern void print_newline(bool output_newline);
 

--- a/verge.c
+++ b/verge.c
@@ -235,7 +235,7 @@ main(int argc, char *argv[])
  *
  * NOTE: This function does not return on malloc failure or arg error.
  */
-static int
+static size_t
 malloc_vers(char *str, long **pvers)
 {
     char *wstr = NULL;		/* working malloced copy of orig_str */

--- a/verge.h
+++ b/verge.h
@@ -89,7 +89,7 @@ static const char * const usage_msg =
 /*
  * function prototypes
  */
-static int malloc_vers(char *str, long **pvers);
+static size_t malloc_vers(char *str, long **pvers);
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 
 

--- a/version.h
+++ b/version.h
@@ -6,7 +6,7 @@
  *
  * We will form the IOCCC entry compressed tarball "by hand" in C.
  * Not in some high level language, but standard vanilla C.
- * Why?  Because this is a obfuscated C contest.  But then why isn't
+ * Why?  Because this is an obfuscated C contest.  But then why isn't
  * this code obfuscated?  Because the IOCCC judges prefer to write
  * in robust unobfuscated code.  Besides, the IOCCC was started
  * as an ironic commentary on the Bourne shell source and finger daemon


### PR DESCRIPTION
Specifically honor -> honour. There are two reasons but one was only
argued to plead my case of the other (yes this might be a bit
manipulative :( in the mind of some but my reasoning is below and I
think it's more than fair).

The first one is that I'm the one working on the parser and since I use
British English and it also goes against my honour to spell honour honor
:) and in fact the removal of 'u' in American English goes against my
very nature so I think it's fair to keep my honour by spelling it
honour not honor.

The second one is that honor is a US spelling so I argued that to truly
honour Canadians one should actually use their spelling! :)

Of course as a logophile and amateur philologist I will point out that
yes I do know that American English actually keeps some of the original
English more than British English (and maybe Canadian English as well:
not sure) but I'm not going to start a logomachy over a simple spelling
especially when I get my way. :)

Thank you Landon for not objecting to this change - I appreciate it a
lot!