### PR TITLE
Various updates and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,23 @@ MANDIR = /usr/local/share/man/man1
 DESTDIR= /usr/local/bin
 TARGETS= mkiocccentry iocccsize dbg limit_ioccc.sh fnamchk txzchk jauthchk jinfochk \
 	jstrencode jstrdecode utf8_test jparse jint jfloat verge
-MANPAGES = mkiocccentry.1 txzchk.1 fnamchk.1 iocccsize.1 jinfochk.1 jauthchk.1
+
+# man pages
+#
+# Currently we explicitly specify a variable for man page targets as not all
+# targets have a man page but probably all targets should have a man page. When
+# this is done we can change the below two uncommented lines to be just:
+#
+#   MANPAGES = $(TARGETS:=.1)
+# 
+# But until then it must be the next two lines (alternatively we could
+# explicitly specify the man pages but this makes it simpler). When a new man
+# page is written the MAN_TARGETS should have the tool name (without any
+# extension) added to it.  Eventually MAN_TARGETS can be removed entirely and
+# MANPAGES will act on TARGETS.
+MAN_TARGETS = mkiocccentry txzchk fnamchk iocccsize jinfochk jauthchk
+MANPAGES= $(MAN_TARGETS:=.1)
+
 TEST_TARGETS= dbg utf8_test
 OBJFILES= dbg.o util.o mkiocccentry.o iocccsize.o fnamchk.o txzchk.o jauthchk.o jinfochk.o \
 	json.o jstrencode.o jstrdecode.o rule_count.o location.o sanity.o \
@@ -778,8 +794,8 @@ clobber: clean
 distclean nuke: clobber
 
 install: all
-	${INSTALL} -m 0555 ${TARGETS} ${DESTDIR}
-	${INSTALL} -m 0644 ${MANPAGES} ${MANDIR}
+	${INSTALL} -v -m 0555 ${TARGETS} ${DESTDIR}
+	${INSTALL} -v -m 0644 ${MANPAGES} ${MANDIR} 2>/dev/null
 
 tags: ${ALL_CSRC} ${H_FILES}
 	-${CTAGS} -- ${ALL_CSRC} ${H_FILES} 2>&1 | \

--- a/Makefile
+++ b/Makefile
@@ -175,12 +175,20 @@ GENERATED_HSRC= jparse.tab.h
 GENERATED_OBJ= jparse.o jparse.tab.o
 FLEXFILES= jparse.l
 BISONFILES= jparse.y
-SRCFILES= $(patsubst %.o,%.c,$(OBJFILES))
+# This is a simpler way to do:
+#
+#   SRCFILES =  $(patsubst %.o,%.c,$(OBJFILES))
+#
+SRCFILES= $(OBJFILES:.o=.c)
 ALL_CSRC= ${LESS_PICKY_CSRC} ${GENERATED_CSRC} ${SRCFILES}
 H_FILES= dbg.h jauthchk.h jinfochk.h json.h jstrdecode.h jstrencode.h limit_ioccc.h \
 	mkiocccentry.h txzchk.h util.h location.h utf8_posix_map.h jparse.h jint.h jfloat.h \
 	verge.h sorry.tm.ca.h
-DSYMDIRS= $(patsubst %,%.dSYM,$(TARGETS))
+# This is a simpler way to do:
+#
+#   DSYMDIRS= $(patsubst %,%.dSYM,$(TARGETS))
+#
+DSYMDIRS= $(TARGETS:=.dSYM)
 SH_FILES= iocccsize-test.sh jstr-test.sh limit_ioccc.sh mkiocccentry-test.sh json-test.sh \
 	  jcodechk.sh vermod.sh bfok.sh
 

--- a/iocccsize-test.sh
+++ b/iocccsize-test.sh
@@ -26,7 +26,7 @@ usage()
 	echo "usage: $0 [-h] [-b] [-v lvl] [-V] [-t tool]"
 	echo
 	echo "	-h	    print usage message and exit 2"
-	echo "	-b	    make disclean all (def: make all)"
+	echo "	-b	    make distclean all (def: make all)"
 	echo "	-v lvl	    set debugging level to lvl (def: no debugging)"
 	echo "	-V	    print tool version and exit 3"
 	echo "	-t tool	    test with tool (def: test with ./iocccsize)"

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -444,10 +444,8 @@ check_author_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (author_field && author_field->can_be_empty);
-	    is_json_string = (common_field && (common_field->field_type == JSON_CHARS ||
-			      common_field->field_type == JSON_ARRAY_CHARS)) ||
-			     (author_field && (author_field->field_type == JSON_CHARS ||
-			      author_field->field_type == JSON_ARRAY_CHARS));
+	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
+			     (author_field && (author_field->field_type == JTYPE_STRING));
 	    /*
 	     * If the field type is a string we have to remove a single '"' and
 	     * from the beginning and end of the value.
@@ -774,7 +772,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 	     * valid values.
 	     */
 	    switch (author_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       author_field->name, json_filename, val);
@@ -784,9 +782,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "%s is a bool", val);
 		    }
 		    break;
-		case JSON_ARRAY_BOOL:
-		    break; /* arrays are not handled yet */
-		case JSON_NUM:
+		case JTYPE_INT|JTYPE_FLOAT:
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       author_field->name, json_filename, val);
@@ -796,8 +792,6 @@ check_found_author_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "%s is a number", val);
 		    }
 		    break;
-		case JSON_ARRAY_NUMBER:
-		    break; /* arrays are not handled yet */
 		default:
 		    break;
 	    }

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -782,7 +782,34 @@ check_found_author_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "%s is a bool", val);
 		    }
 		    break;
-		case JTYPE_INT|JTYPE_FLOAT:
+		case JTYPE_INT:
+		    /*
+		     * XXX - important notes on is_number() - XXX
+		     *
+		     * The is_number() function does not allow for floating
+		     * point numbers and in fact it's very rudimentary as the
+		     * comments there suggest.
+		     *
+		     * This function was added as a simple way for validating
+		     * json numbers that we might encounter in the IOCCC json
+		     * files none of which are floating point. This is why
+		     * is_number() did not allow for floating point.
+		     *
+		     * In the future we will make use of the struct integer and
+		     * struct floating point via the json parser (the real one -
+		     * not the one currently unfinished one in place in this
+		     * file jauthchk.c, jinfochk.c and json.c) and not only will
+		     * this function have to change (most likely drastically)
+		     * but these tests on the data types probably won't even be
+		     * needed because the parser explicitly extracts the type
+		     * based on regular expressions.
+		     *
+		     * If however one were to want to check for either JTYPE_INT
+		     * or JTYPE_FLOAT one could just use the bitwise OR like
+		     * JTYPE_INT|JTYPE_FLOAT. This however is unnecessary.
+		     * There's no case statement for JTYPE_FLOAT as there's no
+		     * check to be done though one could easily be devised.
+		     */
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       author_field->name, json_filename, val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1250,7 +1250,34 @@ check_found_info_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "... %s is a bool", val);
 		    }
 		    break;
-		case JTYPE_INT|JTYPE_FLOAT:
+		case JTYPE_INT:
+		    /*
+		     * XXX - important notes on is_number() - XXX
+		     *
+		     * The is_number() function does not allow for floating
+		     * point numbers and in fact it's very rudimentary as the
+		     * comments there suggest.
+		     *
+		     * This function was added as a simple way for validating
+		     * json numbers that we might encounter in the IOCCC json
+		     * files none of which are floating point. This is why
+		     * is_number() did not allow for floating point.
+		     *
+		     * In the future we will make use of the struct integer and
+		     * struct floating point via the json parser (the real one -
+		     * not the one currently unfinished one in place in this
+		     * file jinfochk.c, jauthchk.c and json.c) and not only will
+		     * this function have to change (most likely drastically)
+		     * but these tests on the data types probably won't even be
+		     * needed because the parser explicitly extracts the type
+		     * based on regular expressions.
+		     *
+		     * If however one were to want to check for either JTYPE_INT
+		     * or JTYPE_FLOAT one could just use the bitwise OR like
+		     * JTYPE_INT|JTYPE_FLOAT. This however is unnecessary.
+		     * There's no case statement for JTYPE_FLOAT as there's no
+		     * check to be done though one could easily be devised.
+		     */
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       info_field->name, json_filename, val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -503,7 +503,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		/* only some array fields can have empty values (null string) */
 		can_be_empty = array_info_field && array_info_field->can_be_empty;
-		is_json_string = array_info_field && array_info_field->field_type == JSON_ARRAY_CHARS;
+		is_json_string = array_info_field && array_info_field->field_type == JTYPE_STRING;
 
 
 		array_val = strtok_r(NULL, ":,", &array_saveptr);
@@ -682,8 +682,8 @@ check_info_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (info_field && info_field->can_be_empty);
-	    is_json_string = (common_field && common_field->field_type == JSON_CHARS) ||
-			     (info_field && info_field->field_type == JSON_CHARS);
+	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
+			     (info_field && info_field->field_type == JTYPE_STRING);
 
 	    /*
 	     * If the field type is a string we have to remove a single '"' from
@@ -1240,7 +1240,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 	     * name individually.
 	     */
 	    switch (info_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       info_field->name, json_filename, val);
@@ -1250,7 +1250,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "... %s is a bool", val);
 		    }
 		    break;
-		case JSON_NUM:
+		case JTYPE_INT|JTYPE_FLOAT:
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       info_field->name, json_filename, val);
@@ -1261,8 +1261,6 @@ check_found_info_json_fields(char const *json_filename, bool test)
 		    }
 		    break;
 		default:
-		case JSON_ARRAY_NUMBER: /* no array fields are of number type */
-		case JSON_ARRAY_BOOL: /* no array fields are of bool type */
 		    break;
 	    }
 

--- a/json.c
+++ b/json.c
@@ -237,20 +237,20 @@ struct ignore_json_code *ignore_json_code_set = NULL;
  */
 struct json_field common_json_fields[] =
 {
-    { "ioccc_contest",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "ioccc_year",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
-    { "mkiocccentry_version",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "fnamchk_version",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "IOCCC_contest_id",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "entry_num",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
-    { "tarball",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "formed_timestamp",	    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
-    { "formed_timestamp_usec",	    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
-    { "timestamp_epoch",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "min_timestamp",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
-    { "formed_UTC",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
-    { "test_mode",		    NULL, 0, 1, false, JTYPE_BOOL,   false, NULL },
-    { NULL,			    NULL, 0, 0, false, JTYPE_EOT,   false, NULL } /* this **MUST** be last! */
+    { "ioccc_contest",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "ioccc_year",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "mkiocccentry_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "fnamchk_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "IOCCC_contest_id",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "entry_num",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "tarball",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "formed_timestamp",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "formed_timestamp_usec",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "timestamp_epoch",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "min_timestamp",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "formed_UTC",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "test_mode",		    NULL, 0, 1, false, JTYPE_BOOL,	false, NULL },
+    { NULL,			    NULL, 0, 0, false, JTYPE_EOT,	false, NULL } /* this **MUST** be last! */
 };
 size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
 
@@ -263,37 +263,37 @@ size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
  */
 struct json_field info_json_fields[] =
 {
-    { "IOCCC_info_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "jinfochk_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "iocccsize_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "txzchk_version",		NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "title",			NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "abstract",		NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
-    { "rule_2a_size",		NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT,		false, NULL },
-    { "rule_2b_size",		NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT,		false, NULL },
-    { "empty_override",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "rule_2a_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "rule_2a_mismatch",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "rule_2b_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "highbit_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "nul_warning",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "trigraph_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "wordbuf_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "ungetc_warning",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "Makefile_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "first_rule_is_all",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "found_all_rule",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "found_clean_rule",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "found_clobber_rule",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "found_try_rule",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
-    { "manifest",		NULL, 0, 1, false, JTYPE_ARRAY,		false, NULL },
-    { "info_JSON",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
-    { "author_JSON",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
-    { "c_src",			NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
-    { "Makefile",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
-    { "remarks",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
-    { "extra_file",		NULL, 0, 0, false, JTYPE_STRING,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JTYPE_EOT,		false,	NULL } /* this **MUST** be last */
+    { "IOCCC_info_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "jinfochk_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "iocccsize_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "txzchk_version",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "title",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "abstract",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "rule_2a_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
+    { "rule_2b_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
+    { "empty_override",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2a_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2a_mismatch",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2b_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "highbit_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "nul_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "trigraph_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "wordbuf_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "ungetc_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "Makefile_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "first_rule_is_all",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_all_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_clean_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_clobber_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_try_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "manifest",		NULL, 0, 1, false, JTYPE_ARRAY,	    false,  NULL },
+    { "info_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "author_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "c_src",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "Makefile",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "remarks",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "extra_file",		NULL, 0, 0, false, JTYPE_STRING,    false,  NULL },
+    { NULL,			NULL, 0, 0, false, JTYPE_EOT,	    false,  NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
 
@@ -2306,6 +2306,8 @@ check_common_json_fields_table(void)
 		    not_reached();
 		}
 		break;
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
 	    case JTYPE_INT|JTYPE_FLOAT:
 	    case JTYPE_BOOL:
 	    case JTYPE_STRING:
@@ -2373,6 +2375,8 @@ check_info_json_fields_table(void)
 		    not_reached();
 		}
 		break;
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
 	    case JTYPE_INT|JTYPE_FLOAT:
 	    case JTYPE_BOOL:
 	    case JTYPE_STRING:
@@ -2881,7 +2885,34 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 			continue;
 		    }
 		    break;
-		case JTYPE_INT|JTYPE_FLOAT:
+		case JTYPE_INT:
+		    /*
+		     * XXX - important notes on is_number() - XXX
+		     *
+		     * The is_number() function does not allow for floating
+		     * point numbers and in fact it's very rudimentary as the
+		     * comments there suggest.
+		     *
+		     * This function was added as a simple way for validating
+		     * json numbers that we might encounter in the IOCCC json
+		     * files none of which are floating point. This is why
+		     * is_number() did not allow for floating point.
+		     *
+		     * In the future we will make use of the struct integer and
+		     * struct floating point via the json parser (the real one -
+		     * not the one currently unfinished one in place in this
+		     * file json.c, jauthchk.c and jinfochk.c) and not only will
+		     * this function have to change (most likely drastically)
+		     * but these tests on the data types probably won't even be
+		     * needed because the parser explicitly extracts the type
+		     * based on regular expressions.
+		     *
+		     * If however one were to want to check for either JTYPE_INT
+		     * or JTYPE_FLOAT one could just use the bitwise OR like
+		     * JTYPE_INT|JTYPE_FLOAT. This however is unnecessary.
+		     * There's no case statement for JTYPE_FLOAT as there's no
+		     * check to be done though one could easily be devised.
+		     */
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       common_field->name, json_filename, val);

--- a/json.c
+++ b/json.c
@@ -2308,7 +2308,6 @@ check_common_json_fields_table(void)
 		break;
 	    case JTYPE_INT:
 	    case JTYPE_FLOAT:
-	    case JTYPE_INT|JTYPE_FLOAT:
 	    case JTYPE_BOOL:
 	    case JTYPE_STRING:
 	    case JTYPE_ARRAY:
@@ -2377,7 +2376,6 @@ check_info_json_fields_table(void)
 		break;
 	    case JTYPE_INT:
 	    case JTYPE_FLOAT:
-	    case JTYPE_INT|JTYPE_FLOAT:
 	    case JTYPE_BOOL:
 	    case JTYPE_STRING:
 	    case JTYPE_ARRAY:

--- a/json.c
+++ b/json.c
@@ -237,20 +237,20 @@ struct ignore_json_code *ignore_json_code_set = NULL;
  */
 struct json_field common_json_fields[] =
 {
-    { "ioccc_contest",		    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "ioccc_year",		    NULL, 0, 1, false, JSON_NUM, false, NULL },
-    { "mkiocccentry_version",	    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "fnamchk_version",	    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "IOCCC_contest_id",	    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "entry_num",		    NULL, 0, 1, false, JSON_NUM, false, NULL },
-    { "tarball",		    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "formed_timestamp",	    NULL, 0, 1, false, JSON_NUM, false, NULL },
-    { "formed_timestamp_usec",	    NULL, 0, 1, false, JSON_NUM, false, NULL },
-    { "timestamp_epoch",	    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "min_timestamp",		    NULL, 0, 1, false, JSON_NUM, false, NULL },
-    { "formed_UTC",		    NULL, 0, 1, false, JSON_CHARS, false, NULL },
-    { "test_mode",		    NULL, 0, 1, false, JSON_BOOL,   false, NULL },
-    { NULL,			    NULL, 0, 0, false, JSON_EOT,   false, NULL } /* this **MUST** be last! */
+    { "ioccc_contest",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "ioccc_year",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
+    { "mkiocccentry_version",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "fnamchk_version",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "IOCCC_contest_id",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "entry_num",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
+    { "tarball",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "formed_timestamp",	    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
+    { "formed_timestamp_usec",	    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
+    { "timestamp_epoch",	    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "min_timestamp",		    NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT, false, NULL },
+    { "formed_UTC",		    NULL, 0, 1, false, JTYPE_STRING, false, NULL },
+    { "test_mode",		    NULL, 0, 1, false, JTYPE_BOOL,   false, NULL },
+    { NULL,			    NULL, 0, 0, false, JTYPE_EOT,   false, NULL } /* this **MUST** be last! */
 };
 size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
 
@@ -263,37 +263,37 @@ size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
  */
 struct json_field info_json_fields[] =
 {
-    { "IOCCC_info_version",	NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "jinfochk_version",	NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "iocccsize_version",	NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "txzchk_version",		NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "title",			NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "abstract",		NULL, 0, 1, false, JSON_CHARS,		false, NULL },
-    { "rule_2a_size",		NULL, 0, 1, false, JSON_NUM,		false, NULL },
-    { "rule_2b_size",		NULL, 0, 1, false, JSON_NUM,		false, NULL },
-    { "empty_override",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2a_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2a_mismatch",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "rule_2b_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "highbit_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "nul_warning",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "trigraph_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "wordbuf_warning",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "ungetc_warning",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "Makefile_override",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "first_rule_is_all",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_all_rule",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_clean_rule",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_clobber_rule",	NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "found_try_rule",		NULL, 0, 1, false, JSON_BOOL,		false, NULL },
-    { "manifest",		NULL, 0, 1, false, JSON_ARRAY,		false, NULL },
-    { "info_JSON",		NULL, 0, 1, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "author_JSON",		NULL, 0, 1, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "c_src",			NULL, 0, 1, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "Makefile",		NULL, 0, 1, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "remarks",		NULL, 0, 1, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "extra_file",		NULL, 0, 0, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_EOT,		false,	NULL } /* this **MUST** be last */
+    { "IOCCC_info_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "jinfochk_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "iocccsize_version",	NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "txzchk_version",		NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "title",			NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "abstract",		NULL, 0, 1, false, JTYPE_STRING,		false, NULL },
+    { "rule_2a_size",		NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT,		false, NULL },
+    { "rule_2b_size",		NULL, 0, 1, false, JTYPE_INT|JTYPE_FLOAT,		false, NULL },
+    { "empty_override",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "rule_2a_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "rule_2a_mismatch",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "rule_2b_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "highbit_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "nul_warning",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "trigraph_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "wordbuf_warning",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "ungetc_warning",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "Makefile_override",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "first_rule_is_all",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "found_all_rule",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "found_clean_rule",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "found_clobber_rule",	NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "found_try_rule",		NULL, 0, 1, false, JTYPE_BOOL,		false, NULL },
+    { "manifest",		NULL, 0, 1, false, JTYPE_ARRAY,		false, NULL },
+    { "info_JSON",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
+    { "author_JSON",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
+    { "c_src",			NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
+    { "Makefile",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
+    { "remarks",		NULL, 0, 1, false, JTYPE_STRING,	false,	NULL },
+    { "extra_file",		NULL, 0, 0, false, JTYPE_STRING,	false,	NULL },
+    { NULL,			NULL, 0, 0, false, JTYPE_EOT,		false,	NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
 
@@ -312,22 +312,22 @@ size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
  */
 struct json_field author_json_fields[] =
 {
-    { "IOCCC_author_version",	NULL, 0, 1, false, JSON_CHARS,		false,	NULL },
-    { "jauthchk_version",	NULL, 0, 1, false, JSON_CHARS,		false,	NULL },
-    { "author_count",		NULL, 0, 1, false, JSON_NUM,		false,  NULL },
-    { "authors",		NULL, 0, 1, false, JSON_ARRAY,		false,	NULL },
-    { "name",			NULL, 0, 5, false, JSON_ARRAY_CHARS,	false,  NULL },
-    { "location_code",		NULL, 0, 5, false, JSON_ARRAY_CHARS,	false,	NULL },
-    { "email",			NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "url",			NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "twitter",		NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "github",			NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "affiliation",		NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "past_winner",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
-    { "default_handle",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
-    { "author_handle",		NULL, 0, 5, false, JSON_ARRAY_CHARS,	true,	NULL },
-    { "author_number",		NULL, 0, 5, false, JSON_ARRAY_NUMBER,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_EOT,		false,	NULL } /* this **MUST** be last */
+    { "IOCCC_author_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
+    { "jauthchk_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
+    { "author_count",		NULL, 0, 1, false, JTYPE_INT,		false,  NULL },
+    { "authors",		NULL, 0, 1, false, JTYPE_ARRAY,		false,	NULL },
+    { "name",			NULL, 0, 5, false, JTYPE_STRING,	false,  NULL },
+    { "location_code",		NULL, 0, 5, false, JTYPE_STRING,	false,	NULL },
+    { "email",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "url",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "twitter",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "github",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "affiliation",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "past_winner",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
+    { "default_handle",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
+    { "author_handle",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "author_number",		NULL, 0, 5, false, JTYPE_INT,	false,	NULL },
+    { NULL,			NULL, 0, 0, false, JTYPE_EOT,		false,	NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_AUTHOR_JSON_FIELDS_TABLE = TBLLEN(author_json_fields);
 
@@ -2249,7 +2249,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
  * check_info_json_fields_table() and check_author_json_fields_table() to make
  * sure that they're all sane.
  *
- * This means that the only element with the JSON_EOT type is the last element,
+ * This means that the only element with the JTYPE_EOT type is the last element,
  * that the field types are valid (see json.h), that there are no embedded NULL
  * elements (name == NULL) and that the final element _IS_ NULL.
  *
@@ -2275,7 +2275,7 @@ check_json_fields_tables(void)
 /* check_common_json_fields_table	    - perform some sanity checks on the
  *					      common_json_fields table
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2297,22 +2297,19 @@ check_common_json_fields_table(void)
 
     for (i = 0; i < max-1 && common_json_fields[i].name != NULL; ++i) {
 	switch (common_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (common_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in common_json_fields table; fix table and recompile",
                             common_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_NUM:
-	    case JSON_BOOL:
-	    case JSON_CHARS:
-	    case JSON_ARRAY:
-	    case JSON_ARRAY_NUMBER:
-	    case JSON_ARRAY_BOOL:
-	    case JSON_ARRAY_CHARS:
+	    case JTYPE_INT|JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2340,7 +2337,7 @@ check_common_json_fields_table(void)
 /*
  * check_info_json_fields_table	 - sanity check info_json_fields table
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2367,22 +2364,19 @@ check_info_json_fields_table(void)
 	}
 
 	switch (info_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (info_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in info_json_fields table; fix table and recompile",
 			    info_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_NUM:
-	    case JSON_BOOL:
-	    case JSON_CHARS:
-	    case JSON_ARRAY:
-	    case JSON_ARRAY_NUMBER:
-	    case JSON_ARRAY_BOOL:
-	    case JSON_ARRAY_CHARS:
+	    case JTYPE_INT|JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2417,7 +2411,7 @@ check_info_json_fields_table(void)
 /*
  * check_author_json_fields_table - perform author_json_fields table sanity checks
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid.  Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2444,22 +2438,20 @@ check_author_json_fields_table(void)
 	}
 
 	switch (author_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (author_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in author_json_fields table; fix table and recompile",
                             author_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_NUM:
-	    case JSON_BOOL:
-	    case JSON_CHARS:
-	    case JSON_ARRAY:
-	    case JSON_ARRAY_NUMBER:
-	    case JSON_ARRAY_BOOL:
-	    case JSON_ARRAY_CHARS:
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2881,7 +2873,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 	    }
 	    /* first we do checks on the field type */
 	    switch (common_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       common_field->name, json_filename, val);
@@ -2889,7 +2881,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 			continue;
 		    }
 		    break;
-		case JSON_NUM:
+		case JTYPE_INT|JTYPE_FLOAT:
 		    if (!is_number(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       common_field->name, json_filename, val);
@@ -2897,9 +2889,6 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 			continue;
 		    }
 		    break;
-		case JSON_ARRAY_BOOL: /* there aren't any arrays common to both .info.json and .author.json */
-		case JSON_ARRAY_NUMBER: /* there aren't any arrays common to both .info.json and .author.json */
-		case JSON_ARRAY_CHARS: /* there aren't any arrays common to both .info.json and .author.json */
 		default:
 		    break;
 	    }

--- a/json.h
+++ b/json.h
@@ -348,16 +348,16 @@ struct json_array
  * element_type - JSON element type - an enum for each union element member in struct json
  */
 enum element_type {
-    JTYPE_EOT	    = -1,	/* special end of the table value */
-    JTYPE_UNSET	    = 0,	/* JSON element has not been set */
-    JTYPE_INT	    = 1,	/* JSON element is an integer - see struct json_integer */
-    JTYPE_FLOAT	    = 2,	/* JSON element is a float - see struct json_floating */
-    JTYPE_STRING    = 4,	/* JSON element is a string - see struct json_string */
-    JTYPE_BOOL	    = 8,	/* JSON element is a boolean - see struct json_boolean */
-    JTYPE_NULL	    = 16,	/* JSON element is a null - see struct json_null */
-    JTYPE_OBJECT    = 32,	/* JSON element is a { members } */
-    JTYPE_MEMBER    = 64,	/* JSON element is a member */
-    JTYPE_ARRAY	    = 128,	/* JSON element is a [ elements ] */
+    JTYPE_EOT	    = -1,   /* special end of the table value */
+    JTYPE_UNSET	    = 0,    /* JSON element has not been set */
+    JTYPE_INT,		    /* JSON element is an integer - see struct json_integer */
+    JTYPE_FLOAT,	    /* JSON element is a float - see struct json_floating */
+    JTYPE_STRING,	    /* JSON element is a string - see struct json_string */
+    JTYPE_BOOL,		    /* JSON element is a boolean - see struct json_boolean */
+    JTYPE_NULL,		    /* JSON element is a null - see struct json_null */
+    JTYPE_OBJECT,	    /* JSON element is a { members } */
+    JTYPE_MEMBER,	    /* JSON element is a member */
+    JTYPE_ARRAY,	    /* JSON element is a [ elements ] */
 };
 
 /*

--- a/json.h
+++ b/json.h
@@ -348,16 +348,16 @@ struct json_array
  * element_type - JSON element type - an enum for each union element member in struct json
  */
 enum element_type {
-    JTYPE_EOT = -1,		/* special end of the table value */
-    JTYPE_UNSET = 0,		/* JSON element has not been set */
-    JTYPE_INT,			/* JSON element is an integer - see struct json_integer */
-    JTYPE_FLOAT,		/* JSON element is a float - see struct json_floating */
-    JTYPE_STRING,		/* JSON element is a string - see struct json_string */
-    JTYPE_BOOL,			/* JSON element is a boolean - see struct json_boolean */
-    JTYPE_NULL,			/* JSON element is a null - see struct json_null */
-    JTYPE_OBJECT,		/* JSON element is a { members } */
-    JTYPE_MEMBER,		/* JSON element is a member */
-    JTYPE_ARRAY,		/* JSON element is a [ elements ] */
+    JTYPE_EOT	    = -1,	/* special end of the table value */
+    JTYPE_UNSET	    = 0,	/* JSON element has not been set */
+    JTYPE_INT	    = 1,	/* JSON element is an integer - see struct json_integer */
+    JTYPE_FLOAT	    = 2,	/* JSON element is a float - see struct json_floating */
+    JTYPE_STRING    = 4,	/* JSON element is a string - see struct json_string */
+    JTYPE_BOOL	    = 8,	/* JSON element is a boolean - see struct json_boolean */
+    JTYPE_NULL	    = 16,	/* JSON element is a null - see struct json_null */
+    JTYPE_OBJECT    = 32,	/* JSON element is a { members } */
+    JTYPE_MEMBER    = 64,	/* JSON element is a member */
+    JTYPE_ARRAY	    = 128,	/* JSON element is a [ elements ] */
 };
 
 /*
@@ -391,31 +391,6 @@ struct json
     struct json *next;		/* next in a JSON parse tree linked list, or NULL is link tail or unlinked */
 };
 
-/*
- * XXX - this probably should be replaced with enum element_type - XXX
- *
- * defines of the JSON types for the json fields tables.
- *
- * NOTE: As the parser is built these might be removed entirely: the parser
- * already has very similarly named tokens and the enum above does as well so
- * this quite possibly will happen. However because the current version of
- * jinfochk and jauthchk rely on the tables (based these constants and the
- * structs json_field and json_value) and because we won't want to cause make
- * test to fail we have them in here. Another possibility is to comment out the
- * execution of jinfochk and jauthchk so that we can get rid of these but I'd
- * rather keep these and the structs json_value and json_field and the
- * associated tables as well as the checks in json.c, jinfochk.c and jauthchk.c
- * because I hope to make use of them once the parser is complete; see above for
- * how I'm currently thinking about it (it's 9 April 2022).
- */
-#define JSON_NUM	    (0)	    /* json field is supposed to be a number */
-#define JSON_BOOL	    (1)	    /* json field is supposed to be a boolean */
-#define JSON_CHARS	    (2)	    /* json field is supposed to be a string */
-#define JSON_ARRAY	    (3)	    /* json field is supposed to be an array */
-#define JSON_ARRAY_NUMBER   (5)	    /* json field is supposed to be a number in an array */
-#define JSON_ARRAY_BOOL	    (6)	    /* json field is supposed to be a bool in an array (NB: not used) */
-#define JSON_ARRAY_CHARS    (7)	    /* json field is supposed to be a string in an array */
-#define JSON_EOT	    (-1)    /* json field is NULL (not null): used internally to mark end of the tables */
 
 /*
  * JSON value: a linked list of all values of the same json_field (below).

--- a/jstr-test.sh
+++ b/jstr-test.sh
@@ -104,7 +104,7 @@ else
     EXIT_CODE=5
 fi
 
-# test some text foles in the encoding and decoding pipe
+# test some text holes in the encoding and decoding pipe
 #
 echo "$0: about to run test #6"
 export SRC_SET="jstr-test.sh dbg.c dbg.h fnamchk.c iocccsize.c jauthchk.c"
@@ -122,7 +122,7 @@ else
     EXIT_CODE=6
 fi
 
-# test some text foles in the encoding and decoding pipe in strict mode
+# test some text holes in the encoding and decoding pipe in strict mode
 #
 echo "$0: about to run test #7"
 export SRC_SET="jstr-test.sh dbg.c dbg.h fnamchk.c iocccsize.c jauthchk.c"

--- a/jstr-test.sh
+++ b/jstr-test.sh
@@ -112,6 +112,7 @@ SRC_SET="$SRC_SET jinfochk.c json.c json.h jstrdecode.c jstrencode.c"
 SRC_SET="$SRC_SET limit_ioccc.h mkiocccentry.c txzchk.c util.c util.h"
 echo "cat \$SRC_SET | ./jstrencode -v $V_FLAG -n | ./jstrdecode -v $V_FLAG -n > $TEST_FILE"
 # shellcheck disable=SC2086
+# shellcheck disable=SC2002
 cat $SRC_SET | ./jstrencode -v "$V_FLAG" -n | ./jstrdecode -v "$V_FLAG" -n > "$TEST_FILE"
 # shellcheck disable=SC2086
 cat $SRC_SET > "$TEST_FILE2"
@@ -130,6 +131,7 @@ SRC_SET="$SRC_SET jinfochk.c json.c json.h jstrdecode.c jstrencode.c"
 SRC_SET="$SRC_SET limit_ioccc.h mkiocccentry.c txzchk.c util.c util.h"
 echo "cat \$SRC_SET | ./jstrencode -v $V_FLAG -n | ./jstrdecode -v $V_FLAG -n -S > $TEST_FILE"
 # shellcheck disable=SC2086
+# shellcheck disable=SC2002
 cat $SRC_SET | ./jstrencode -v "$V_FLAG" -n | ./jstrdecode -v "$V_FLAG" -n -S > "$TEST_FILE"
 # shellcheck disable=SC2086
 cat $SRC_SET > "$TEST_FILE2"

--- a/vermod.sh
+++ b/vermod.sh
@@ -213,11 +213,23 @@ if [[ -n $LIST_CHANGE && -n $LIST_NOCHANGE ]]; then
 # case: -l (list .json files that will change)
 #
 elif [[ -n $LIST_CHANGE ]]; then
+# shellcheck disable=SC2063
+#
+# This warning is an example where shellcheck is incorrect. Yes '*.json' is a
+# glob but --include '*.json' is not the actual pattern to search for.
+# Specifically this option if specified says that only files matching the given
+# filename pattern are searched.
      grep -F -R --include '*.json' -l -- "$OLD_VER" "$JSON_TREE" 2>/dev/null | sort -u
 
 # case: -L (list .json files that will NOT change)
 #
 elif [[ -n $LIST_NOCHANGE ]]; then
+# shellcheck disable=SC2063
+#
+# This warning is an example where shellcheck is incorrect. Yes '*.json' is a
+# glob but --include '*.json' is not the actual pattern to search for.
+# Specifically this option if specified says that only files matching the given
+# filename pattern are searched.
      grep -F -R --include '*.json' -L -- "$OLD_VER" "$JSON_TREE" 2>/dev/null | sort -u
 fi
 


### PR DESCRIPTION
I removed the `#define JSON_` in json.h and instead  we use the enum element_type with the prefix JTYPE_.

Additionally the JTYPE_ enum values are powers of two. This might not be
strictly necessary: the reason I used it is because currently the
checkers check for json numbers and not specific types so this way I
could do JTYPE_INT|JTYPE_FLOAT. Once a proper parser is complete this
might not be necessary at all - not sure yet how the checker functions
will work.

There still remains the issue that the parser has an enum with the
prefix JSON_ but I cannot control that and it's not yet worked out how
to integrate the two but using that enum is not yet worked out either as
nothing in the parser is worked out yet.

Running make prep passes all tests. Whether this change breaks some of
the working tests in test_JSON or not I do not know: I'm not too worried
about that because the parser isn't written yet and so what matters now
is that make test passes and it does: any files that are not made by
mkiocccentry can be tested later.

As for renaming the JTYPE_ to JSON_ this might be possible but it might
require changing the names of the symbols in jparse.y; I will worry
about that later - or not - but either way it's low priority right now.