### PR TITLE
Fix compilation under CentOS 7 + English updates

### DIFF
--- a/fnamchk.c
+++ b/fnamchk.c
@@ -58,17 +58,17 @@ main(int argc, char *argv[])
     char *filepath;		/* filepath argument to check */
     char *filename;		/* basename of filepath to check */
     int ret;			/* libc return code */
-    char *entry;		/* 1st '.' separated token - entry */
-    char *uuid;			/* 1st '-' separated token - test or UUID */
+    char *entry;		/* first '.' separated token - entry */
+    char *uuid;			/* first '-' separated token - test or UUID */
     size_t len;			/* UUID length */
     unsigned int a, b, c, d, e, f;	/* parts of the UUID string */
     unsigned int version = 0;	/* UUID version hex character */
     unsigned int variant = 0;	/* UUID variant hex character */
     char guard;			/* scanf guard to catch excess amount of input */
-    int entry_num;		/* 3rd .-separated token as a number */
-    char *timestamp_str;	/* 4th .-separated token - timestamp */
-    intmax_t timestamp;		/* 5th .-separated token as a timestamp */
-    char *extension;		/* 6th .-separated token as a filename extension */
+    int entry_num;		/* third .-separated token as a number */
+    char *timestamp_str;	/* fourth .-separated token - timestamp */
+    intmax_t timestamp;		/* fifth .-separated token as a timestamp */
+    char *extension;		/* sixth .-separated token as a filename extension */
     char *ext = "txz";		/* user supplied extension (def: txz): used for testing purposes only */
     int i;
     bool test_mode = false;	/* true ==> force check to test if it's a test entry filename */
@@ -141,11 +141,11 @@ main(int argc, char *argv[])
     dbg(DBG_LOW, "filename: %s", filename);
 
     /*
-     * 1st .-separated token must be entry
+     * first .-separated token must be entry
      */
     entry = strtok(filename, ".");
     if (entry == NULL) {
-	err(2, __func__, "1st strtok() returned NULL");
+	err(2, __func__, "first strtok() returned NULL");
 	not_reached();
     }
     if (strcmp(entry, "entry") != 0) {
@@ -155,11 +155,11 @@ main(int argc, char *argv[])
     dbg(DBG_LOW, "filename starts with \"entry.\": %s", filename);
 
     /*
-     * 2nd '.' separated token must be test or a UUID
+     * second '.' separated token must be test or a UUID
      */
     uuid = strtok(NULL, ".");
     if (uuid == NULL) {
-	err(4, __func__, "nothing found after 1st '.'  separated token of entry");
+	err(4, __func__, "nothing found after first '.'  separated token of entry");
 	not_reached();
     }
     len = strlen(uuid);
@@ -174,22 +174,22 @@ main(int argc, char *argv[])
 	    not_reached();
 	}
 	if (len != LITLEN("test-")+MAX_ENTRY_CHARS) {
-	    err(6, __func__, "2nd '-' separated token length: %ju != %ju: %s",
+	    err(6, __func__, "second '-' separated token length: %ju != %ju: %s",
 			     (uintmax_t)len, (uintmax_t)(LITLEN("test-")+MAX_ENTRY_CHARS), filepath);
 	    not_reached();
 	}
 	ret = sscanf(uuid, "test-%d%c", &entry_num, &guard);
 	if (ret != 1) {
-	    err(7, __func__, "2nd '.' separated non-test not in test-entry_number format: %s", filepath);
+	    err(7, __func__, "second '.' separated non-test not in test-entry_number format: %s", filepath);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "entry ID is test: %s", uuid);
 	if (entry_num < 0) {
-	    err(8, __func__, "3rd '.' separated entry number: %d is < 0: %s", entry_num, filepath);
+	    err(8, __func__, "third '.' separated entry number: %d is < 0: %s", entry_num, filepath);
 	    not_reached();
 	}
 	if (entry_num > MAX_ENTRY_NUM) {
-	    err(9, __func__, "2nd '-' separated entry number: %d is > %d: %s", entry_num, MAX_ENTRY_NUM, filepath);
+	    err(9, __func__, "second '-' separated entry number: %d is > %d: %s", entry_num, MAX_ENTRY_NUM, filepath);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "entry number is valid: %d", entry_num);
@@ -208,64 +208,64 @@ main(int argc, char *argv[])
 	}
 
 	if (len != UUID_LEN+1+MAX_ENTRY_CHARS) {
-	    err(11, __func__, "2nd '-' separated token length: %ju != %ju: %s",
+	    err(11, __func__, "second '-' separated token length: %ju != %ju: %s",
 			     (uintmax_t)len, (uintmax_t)(UUID_LEN+1+MAX_ENTRY_CHARS), filepath);
 	    not_reached();
 	}
 	ret = sscanf(uuid, "%8x-%4x-%1x%3x-%1x%3x-%8x%4x-%d%c", &a, &b, &version, &c, &variant, &d, &e, &f, &entry_num, &guard);
 	if (ret != 9) {
-	    err(12, __func__, "2nd '.' separated non-test not in UUID-entry_number format: %s", filepath);
+	    err(12, __func__, "second '.' separated non-test not in UUID-entry_number format: %s", filepath);
 	    not_reached();
 	}
 	if (version != UUID_VERSION) {
-	    err(13, __func__, "2nd '.' separated UUID token version %x != %x: %s", version, UUID_VERSION, filepath);
+	    err(13, __func__, "second '.' separated UUID token version %x != %x: %s", version, UUID_VERSION, filepath);
 	    not_reached();
 	}
 	if (variant != UUID_VARIANT) {
-	    err(14, __func__, "2nd '.' separated UUID token variant %x != %x: %s", variant, UUID_VARIANT, filepath);
+	    err(14, __func__, "second '.' separated UUID token variant %x != %x: %s", variant, UUID_VARIANT, filepath);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "entry ID is a valid UUID: %s", uuid);
 	if (entry_num < 0) {
-	    err(15, __func__, "3rd '.' separated entry number: %d is < 0: %s", entry_num, filepath);
+	    err(15, __func__, "third '.' separated entry number: %d is < 0: %s", entry_num, filepath);
 	    not_reached();
 	}
 	if (entry_num > MAX_ENTRY_NUM) {
-	    err(16, __func__, "2nd '-' separated entry number: %d is > %d: %s", entry_num, MAX_ENTRY_NUM, filepath);
+	    err(16, __func__, "second '-' separated entry number: %d is > %d: %s", entry_num, MAX_ENTRY_NUM, filepath);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "entry number is valid: %d", entry_num);
     }
 
     /*
-     * 3rd '.' separated token must be a valid timestamp
+     * third '.' separated token must be a valid timestamp
      */
     timestamp_str = strtok(NULL, ".");
     if (timestamp_str == NULL) {
-	err(17, __func__, "nothing found after 2nd '.' separated token of entry number");
+	err(17, __func__, "nothing found after second '.' separated token of entry number");
 	not_reached();
     }
     ret = sscanf(timestamp_str, "%jd%c", &timestamp, &guard);
     if (ret != 1) {
-	err(18, __func__, "3rd '.' separated token: %s is not a timestamp: %s", timestamp_str, filepath);
+	err(18, __func__, "third '.' separated token: %s is not a timestamp: %s", timestamp_str, filepath);
 	not_reached();
     }
     if (timestamp < MIN_TIMESTAMP) {
-	err(19, __func__, "3rd '.' separated timestamp: %jd is < %jd: %s", timestamp, (intmax_t)MIN_TIMESTAMP, filepath);
+	err(19, __func__, "third '.' separated timestamp: %jd is < %jd: %s", timestamp, (intmax_t)MIN_TIMESTAMP, filepath);
 	not_reached();
     }
     dbg(DBG_LOW, "timestamp is valid: %jd", timestamp);
 
     /*
-     * 4th .-separated token must be the filename extension
+     * fourth .-separated token must be the filename extension
      */
     extension = strtok(NULL, ".");
     if (extension == NULL) {
-	err(20, __func__, "nothing found after 3rd '.' separated token of timestamp");
+	err(20, __func__, "nothing found after third '.' separated token of timestamp");
 	not_reached();
     }
     if (strcmp(extension, ext) != 0) {
-	err(21, __func__, "final 4th '.' separated token filename extension: %s != %s: %s", extension, ext, filepath);
+	err(21, __func__, "final fourth '.' separated token filename extension: %s != %s: %s", extension, ext, filepath);
 	not_reached();
     }
     dbg(DBG_LOW, "filename extension is valid: %s", extension);

--- a/jfloat.c
+++ b/jfloat.c
@@ -119,7 +119,7 @@ main(int argc, char *argv[])
 	usage(4, "without -t, no args allowed", program); /*ooo*/
 	not_reached();
     } else if (test_mode == false && arg_cnt < REQUIRED_ARGS) {
-	usage(4, "without -t, requires at least 1 argument", program); /*ooo*/
+	usage(4, "without -t, requires at least one argument", program); /*ooo*/
 	not_reached();
     }
     dbg(DBG_MED, "test mode: %s", (test_mode == true) ? "enabled" : "disabled");
@@ -440,7 +440,7 @@ check_val(bool *testp, char const *type, int testnum, bool size_a, bool size_b,
 	 long double val_a, long double val_b, bool int_a, bool int_b, bool strict)
 {
     long double diff;		/* absolute difference between val_a and val_b */
-    long double diff_part;	/* absolute difference between val_a and val_b as 1 part of val_a */
+    long double diff_part;	/* absolute difference between val_a and val_b as one part of val_a */
 
     /*
      * firewall
@@ -505,7 +505,7 @@ check_val(bool *testp, char const *type, int testnum, bool size_a, bool size_b,
 	    }
 
 	/*
-	 * case non-strict: test for match to 1 part in MATCH_PRECISION
+	 * case non-strict: test for match to one part in MATCH_PRECISION
 	 */
 	} else {
 

--- a/json.c
+++ b/json.c
@@ -1162,14 +1162,14 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
     size_t mlen = 0;	    /* length of malloced encoded string */
     char *p = NULL;	    /* next place to encode */
     char n = 0;		    /* next character beyond a \\ */
-    char a = 0;		    /* 1st hex character after \u */
-    int xa = 0;		    /* 1st hex character numeric value */
-    char b = 0;		    /* 2nd hex character after \u */
-    int xb = 0;		    /* 2nd hex character numeric value */
-    char c = 0;		    /* character to decode or 3rd hex character after \u */
+    char a = 0;		    /* first hex character after \u */
+    int xa = 0;		    /* first hex character numeric value */
+    char b = 0;		    /* second hex character after \u */
+    int xb = 0;		    /* second hex character numeric value */
+    char c = 0;		    /* character to decode or third hex character after \u */
     int xc = 0;		    /* 3nd hex character numeric value */
-    char d = 0;		    /* 4th hex character after \u */
-    int xd = 0;		    /* 4th hex character numeric value */
+    char d = 0;		    /* fourth hex character after \u */
+    int xd = 0;		    /* fourth hex character numeric value */
     size_t i;
 
     /*
@@ -3561,8 +3561,8 @@ alloc_json_code_ignore_set(void)
  * This function will allow qsort() to reverse sort the codes in ignore_json_code_set[].
  *
  * given:
- *	a	- pointer to 1st code to compare
- *	b	- pointer to 2nd code to compare
+ *	a	- pointer to first code to compare
+ *	b	- pointer to second code to compare
  *
  * returns:
  *	-1	a > b

--- a/json.h
+++ b/json.h
@@ -271,7 +271,7 @@ struct json_string
 
     bool slash;			/* true ==> / was found after decoding */
     bool posix_safe;		/* true ==> all chars are POSIX portable safe plus + and maybe / after decoding */
-    bool first_alphanum;	/* true ==> 1st char is alphanumeric after decoding */
+    bool first_alphanum;	/* true ==> first char is alphanumeric after decoding */
     bool upper;			/* true ==> UPPER case chars found after decoding */
 };
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1616,7 +1616,7 @@ get_entry_num(struct info *infop)
 	    para("",
 		 "As in C, Entry numbers start with 0.  If you are updating a previous entry, PLEASE",
 		 "use the same entry number that you previously uploaded so we know which entry we",
-		 "should replace. If this is your 1st entry to this given IOCCC, enter 0.",
+		 "should replace. If this is your first entry to this given IOCCC, enter 0.",
 		 "",
 		 NULL);
 	}
@@ -2402,7 +2402,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 /*
  * inspect_Makefile - inspect the rule contents of Makefile
  *
- * Determine if the 1st rule contains all.  Determine if there is a clean rule.
+ * Determine if the first rule contains all.  Determine if there is a clean rule.
  * Determine if there is a clobber rule.  Determine if there is a try rule.
  *
  * NOTE: This is a simplistic Makefile line parser.  It is possible to
@@ -2524,7 +2524,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 		infop->found_all_rule = true;
 		if (rulenum == 1) {
 		    /*
-		     * all rule is in 1st rule line
+		     * all rule is in first rule line
 		     */
 		    infop->first_rule_is_all = true;
 		    break;
@@ -2683,7 +2683,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
 	fpara(stderr,
 	      "Makefiles must have the following Makefile rules:",
 	      "",
-	      "    all - compile the entry, must be the 1st entry",
+	      "    all - compile the entry, must be the first entry",
 	      "    clean - remove intermediate compilation files",
 	      "    clobber - clean, remove compiled entry, restore to the original entry state",
 	      "    try - invoke the entry at least once",
@@ -2914,7 +2914,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
  *      entry_dir       - newly created entry directory (by mk_entry_dir()) under work_dir
  *      cp              - cp utility path
  *      count           - number of extra data files arguments
- *      args            - pointer to an array of strings starting with 1st extra data file
+ *      args            - pointer to an array of strings starting with first extra data file
  *
  * This function does not return on error.
  */
@@ -4549,15 +4549,15 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     }
 
     /*
-     * read the 1st line - contains the total kibibyte (2^10) block line
+     * read the first line - contains the total kibibyte (2^10) block line
      */
-    dbg(DBG_HIGH, "reading 1st line from popen of ls of entry_dir: %s", entry_dir);
+    dbg(DBG_HIGH, "reading first line from popen of ls of entry_dir: %s", entry_dir);
     readline_len = readline(&linep, ls_stream);
     if (readline_len < 0) {
-	err(150, __func__, "EOF while reading 1st line from ls: %s", ls);
+	err(150, __func__, "EOF while reading first line from ls: %s", ls);
 	not_reached();
     } else {
-	dbg(DBG_HIGH, "ls 1st line read length: %jd buffer: %s", (intmax_t)readline_len, linep);
+	dbg(DBG_HIGH, "ls first line read length: %jd buffer: %s", (intmax_t)readline_len, linep);
     }
 
     /*

--- a/rule_count.c
+++ b/rule_count.c
@@ -259,7 +259,7 @@ rule_count(FILE *fp_in)
 				}
 			}
 
-			/* Unknown trigraph, push back the 3rd character. */
+			/* Unknown trigraph, push back the third character. */
 			if (*t == '\0') {
 				if (ch != EOF && ungetc(ch, fp_in) == EOF) {
 					counts.ungetc_warning = true;

--- a/utf8_posix_map.c
+++ b/utf8_posix_map.c
@@ -1743,9 +1743,9 @@ default_handle(char const *name)
      */
     if (def_len <= 0) {
 
-	long a;		/* 1st call to random() */
-	long b;		/* 2nd call to random() */
-	long c;		/* 3rd call to random() */
+	long a;		/* first call to random() */
+	long b;		/* second call to random() */
+	long c;		/* third call to random() */
 
         /*
 	 * NOTE: We do not need a very strong, let alone, cryptographically

--- a/util.c
+++ b/util.c
@@ -594,7 +594,7 @@ cmdprintf(char const *format, ...)
 char *
 vcmdprintf(char const *format, va_list ap)
 {
-    va_list ap2;		/* copy of original va_list for 2nd pass */
+    va_list ap2;		/* copy of original va_list for second pass */
     size_t size = 0;
     char const *next;
     char const *p;
@@ -614,7 +614,7 @@ vcmdprintf(char const *format, va_list ap)
     }
 
     /*
-     * copy va_list for 2nd pass
+     * copy va_list for second pass
      */
     va_copy(ap2, ap);
 
@@ -1114,7 +1114,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
  *      para("line 1", "line 2", "", "prev line 3 was an empty line", NULL);
  *
  * given:
- *      line    - 1st paragraph line to print
+ *      line    - first paragraph line to print
  *      ...     - strings as paragraph lines to print
  *      NULL    - end of string list
  *
@@ -1242,7 +1242,7 @@ para(char const *line, ...)
  *
  * given:
  *      stream  - open file stream to print a paragraph onto
- *      line    - 1st paragraph line to print
+ *      line    - first paragraph line to print
  *      ...     - strings as paragraph lines to print
  *      NULL    - end of string list
  *
@@ -2603,8 +2603,8 @@ string_to_bool(char const *str)
  *			- false ==> both UPPER and lower case characters are allowed
  *	slash_ok	- true ==> / is allowed as str can be a path
  *			  false ==> / is NOT allowed, str is a basename only
- *	first		- true ==> str is at beginning, perform 1st char check
- *			  false ==> str may be in the middle, skip 1st char check
+ *	first		- true ==> str is at beginning, perform first char check
+ *			  false ==> str may be in the middle, skip first char check
  *
  * returns:
  *	true ==> str is a valid POSIX portable safe + filename, AND
@@ -2639,7 +2639,7 @@ posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first)
     if (first == true) {
 	if (str[0] == '/') {
 		if (slash_ok == false) {
-		    dbg(DBG_VVHIGH, "str[0]: slash_ok is false and 1st character is /");
+		    dbg(DBG_VVHIGH, "str[0]: slash_ok is false and first character is /");
 		    return false;
 		}
 
@@ -2649,27 +2649,27 @@ posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first)
 	} else {
 	    /* ASCII non-/ check */
 	    if (!isascii(str[0])) {
-		dbg(DBG_VVHIGH, "str[0]: 1st character is non-ASCII: 0x%02x", (unsigned int)str[0]);
+		dbg(DBG_VVHIGH, "str[0]: first character is non-ASCII: 0x%02x", (unsigned int)str[0]);
 		return false;
 	    }
 	    /* alphanumeric non-/ check */
 	    if (!isalnum(str[0])) {
-		dbg(DBG_VVHIGH, "str[0]: 1st character not alphanumeric: 0x%02x", (unsigned int)str[0]);
+		dbg(DBG_VVHIGH, "str[0]: first character not alphanumeric: 0x%02x", (unsigned int)str[0]);
 		return false;
 	    }
 	    /* special case: lower_only is true, alphanumeric lower case only */
 	    if (lower_only == true && isupper(str[0])) {
-		dbg(DBG_VVHIGH, "str[0]: lower_only is true and 1st character is upper case: 0x%02x",
+		dbg(DBG_VVHIGH, "str[0]: lower_only is true and first character is upper case: 0x%02x",
 				(unsigned int)str[0]);
 		return false;
 	    }
 	}
-	/* 1st character already checked, scan beyond 1st character next */
+	/* first character already checked, scan beyond first character next */
 	start = 1;
     }
 
     /*
-     * Beyond the 1st character, they must be POSIX portable filename or +
+     * Beyond the first character, they must be POSIX portable filename or +
      */
     for (i=start; i < len; ++i) {
 
@@ -2730,8 +2730,8 @@ posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first)
  *			  set to false ==> no / was found
  *	*posix_safe	- set to true ==> all chars are POSIX portable safe plus +/
  *			- set to false ==> one or more chars are not portable safe plus +/
- *	*first_alphanum	- set to true ==> 1st char is alphanumeric
- *			  set to false ==> 1st char is not alphanumeric
+ *	*first_alphanum	- set to true ==> first char is alphanumeric
+ *			  set to false ==> first char is not alphanumeric
  *	*upper		- set to true ==> UPPER case chars found
  *			- set to false ==> no UPPER case chars found
  *
@@ -2768,19 +2768,19 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
     }
 
     /*
-     * test 1st character
+     * test first character
      */
     if (isascii(str[0])) {
 
 	/*
-	 * case: 1st character is /
+	 * case: first character is /
 	 */
 	if (str[0] == '/') {
 	    *slash = true;
 	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is /: 0x%02x", (unsigned int)str[0]);
 
 	/*
-	 * case: 1st character is alphanumeric
+	 * case: first character is alphanumeric
 	 */
 	} else if (isalnum(str[0])) {
 	    *first_alphanum = true;
@@ -2792,14 +2792,14 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	    }
 
 	/*
-	 * case: 1st character is non-alphanumeric portable POSIX safe plus +
+	 * case: first character is non-alphanumeric portable POSIX safe plus +
 	 */
 	} else if (str[0] == '.' || str[0] == '_' || str[0] == '+') {
 	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is ASCII non-alphanumeric POSIX portable safe plus +: 0x%02x",
 			     (unsigned int)str[0]);
 
 	/*
-	 * case: 1st character is not POSIX portable safe plus +
+	 * case: first character is not POSIX portable safe plus +
 	 */
 	} else {
 	    found_unsafe = true;
@@ -2808,7 +2808,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	}
 
     /*
-     * case: 1st character is not ASCII
+     * case: first character is not ASCII
      */
     } else {
 	found_unsafe = true;
@@ -2817,7 +2817,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
     }
 
     /*
-     * example 2nd to last characters
+     * example second to last characters
      */
     for (i=1; i < len; ++i) {
 
@@ -2831,7 +2831,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    if (str[i] == '/') {
 		if (*slash == false) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found 1st / at str[%ju]: 0x%02x",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first / at str[%ju]: 0x%02x",
 				     (uintmax_t)i, (unsigned int)str[i]);
 		}
 		*slash = true;
@@ -2841,7 +2841,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    } else if (isalnum(str[i])) {
 		if (*upper == false) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found 1st UPPER case at str[%ju]: 0x%02x",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first UPPER case at str[%ju]: 0x%02x",
 				     (uintmax_t)i, (unsigned int)str[i]);
 		    *upper = true;
 		}
@@ -2851,7 +2851,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    } else if (str[i] != '.' && str[i] != '_' && str[i] != '+' && str[i] != '-') {
 		if (found_unsafe == false) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%ju] found 1st non-POSIX portable safe plus +/: 0x%02x",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%ju] found first non-POSIX portable safe plus +/: 0x%02x",
 				      (uintmax_t)i, (unsigned int)str[i]);
 		}
 		found_unsafe = true;
@@ -2862,7 +2862,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	 */
 	} else {
 	    if (found_unsafe == false) {
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%ju] found 1st non-ASCII: 0x%02x",
+		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%ju] found first non-ASCII: 0x%02x",
 				  (uintmax_t)i, (unsigned int)str[i]);
 	    }
 	    found_unsafe = true;

--- a/verge.c
+++ b/verge.c
@@ -1,6 +1,6 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * verge - determine if 1st version is >= 2nd version
+ * verge - determine if first version is >= second version
  *
  * "Because the JSON co-founders flawed minimalism is sub-minimal." :-)
  *
@@ -58,12 +58,12 @@ main(int argc, char *argv[])
     extern char *optarg;	/* option argument */
     extern int optind;		/* argv index of the next arg */
     int arg_cnt = 0;		/* number of args to process */
-    char *ver1 = NULL;		/* 1st version string */
-    char *ver2 = NULL;		/* 2nd version string */
-    int ver1_levels = 0;	/* number of version levels for 1st version string */
-    int ver2_levels = 0;	/* number of version levels for 2nd version string */
-    long *vlevel1 = NULL;	/* malloced version levels from 1st version string */
-    long *vlevel2 = NULL;	/* malloced version levels from 2nd version string */
+    char *ver1 = NULL;		/* first version string */
+    char *ver2 = NULL;		/* second version string */
+    int ver1_levels = 0;	/* number of version levels for first version string */
+    int ver2_levels = 0;	/* number of version levels for second version string */
+    long *vlevel1 = NULL;	/* malloced version levels from first version string */
+    long *vlevel2 = NULL;	/* malloced version levels from second version string */
     int i;
 
     /*
@@ -95,29 +95,29 @@ main(int argc, char *argv[])
     }
     arg_cnt = argc - optind;
     if (arg_cnt != REQUIRED_ARGS) {
-	usage(4, "2 args are required", program); /*ooo*/
+	usage(4, "two args are required", program); /*ooo*/
 	not_reached();
     }
     ver1 = argv[optind];
     ver2 = argv[optind+1];
-    dbg(DBG_LOW, "1st version: <%s>", ver1);
-    dbg(DBG_LOW, "2nd version: <%s>", ver2);
+    dbg(DBG_LOW, "first version: <%s>", ver1);
+    dbg(DBG_LOW, "second version: <%s>", ver2);
 
     /*
-     * convert 1st version string
+     * convert first version string
      */
     ver1_levels = malloc_vers(ver1, &vlevel1);
     if (ver1_levels <= 0) {
-	err(2, program, "1st version string is invalid"); /*ooo*/
+	err(2, program, "first version string is invalid"); /*ooo*/
 	not_reached();
     }
 
     /*
-     * convert 2nd version string
+     * convert second version string
      */
     ver2_levels = malloc_vers(ver2, &vlevel2);
     if (ver2_levels <= 0) {
-	err(2, program, "2nd version string is invalid"); /*ooo*/
+	err(2, program, "second version string is invalid"); /*ooo*/
 	not_reached();
     }
 
@@ -274,7 +274,7 @@ malloc_vers(char *str, long **pvers)
      */
     for (i=0; i < len; ++i) {
 	if (isascii(wstr[i]) && isdigit(wstr[i])) {
-	    /* stop on 1st digit */
+	    /* stop on first digit */
 	    break;
 	}
     }
@@ -302,7 +302,7 @@ malloc_vers(char *str, long **pvers)
      */
     for (i=len-1; i > 0; --i) {
 	if (isascii(wstr[i]) && isdigit(wstr[i])) {
-	    /* stop on 1st digit */
+	    /* stop on first digit */
 	    break;
 	}
     }

--- a/verge.h
+++ b/verge.h
@@ -1,6 +1,6 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * verge - determine if 1st version is >= 2nd version
+ * verge - determine if first version is >= second version
  *
  * "Because the JSON co-founders flawed minimalism is sub-minimal." :-)
  *
@@ -64,13 +64,13 @@ static const char * const usage_msg =
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-V\t\tprint version string and exit 3\n"
     "\n"
-    "\tver.sion.1\t1st version\n"
-    "\tver.sion.2\t2nd version\n"
+    "\tver.sion.1\tfirst version\n"
+    "\tver.sion.2\tsecond version\n"
     "\n"
     "Exit codes:\n"
-    "    0\t1st version >= 2nd version\n"
-    "    1\t1st version < 2nd version\n"
-    "    2\t1st and/or 2nd version is an invalid version\n"
+    "    0\tfirst version >= second version\n"
+    "    1\tfirst version < second version\n"
+    "    2\tfirst and/or second version is an invalid version\n"
     "    3\t-h and help string printed or -V and version string printed\n"
     "    4\tcommand line error\n"
     "    >=5\tinternal error\n"

--- a/vermod.sh
+++ b/vermod.sh
@@ -112,7 +112,7 @@ done
 #
 shift $(( OPTIND - 1 ));
 if [[ $# -ne 2 ]]; then
-    echo "$0: ERROR: expected 2 arguments, found $#" 1>&2
+    echo "$0: ERROR: expected two arguments, found $#" 1>&2
     exit 6
 fi
 OLD_VER="$QUOTE$1$QUOTE"


### PR DESCRIPTION
The function floorl() requires -lm under CentOS 7 (the proper feature
test macros were already enabled although I have also changed
_XOPEN_SOURCE to be 600 up from 500: not sure if this is strictly
necessary but it doesn't hurt to have it at 600).

The Makefile has had some changes in the way warnings are handled
described below as thus:

First the warning flags -Wall -Wextra -Werror have been moved to the new
variable WARN_FLAGS. After this in WARN_FLAGS specific warnings have
been disabled in particular:

     -Wno-unused-command-line-argument -Wno-poison-system-directories -Wno-unreachable-code-break -Wno-padded

The first one is important for macOS as after adding -lm to the CFLAGS
(via the standard LDFLAGS variable) we get that error for the fewer
objects that don't use -lm. Since many of the objects do link in json.o
(which is what needs -lm) we simply add disable the warning in the
WARN_FLAGS variable. There is at least one warning that we explicitly
disable in some rules as they're not needed in many: for example the
parser needs some warnings disabled.

As for the others they're enabled by -Weverything and although we don't
enable that they're here in case we ever do as they're irrelevant here.

With this commit everything should compile under macOS and also CentOS 7
(and other linux systems should be fine as well: CentOS is in a sense
behind as it's built for stability). In 2024 CentOS 7 will reach EOL and
some of the things we include for CentOS 7 should thus no longer be
needed.