### PR TITLE
JSON parser + lexer updates and mkiocccentry fixes

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -444,8 +444,8 @@ check_author_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (author_field && author_field->can_be_empty);
-	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
-			     (author_field && (author_field->field_type == JTYPE_STRING));
+	    is_json_string = (common_field && common_field->field_type == JSON_STRING) ||
+			     (author_field && (author_field->field_type == JSON_STRING));
 	    /*
 	     * If the field type is a string we have to remove a single '"' and
 	     * from the beginning and end of the value.
@@ -772,7 +772,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 	     * valid values.
 	     */
 	    switch (author_field->field_type) {
-		case JTYPE_BOOL:
+		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       author_field->name, json_filename, val);
@@ -782,7 +782,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "%s is a bool", val);
 		    }
 		    break;
-		case JTYPE_INT:
+		case JSON_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       author_field->name, json_filename, val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -503,7 +503,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		/* only some array fields can have empty values (null string) */
 		can_be_empty = array_info_field && array_info_field->can_be_empty;
-		is_json_string = array_info_field && array_info_field->field_type == JTYPE_STRING;
+		is_json_string = array_info_field && array_info_field->field_type == JSON_STRING;
 
 
 		array_val = strtok_r(NULL, ":,", &array_saveptr);
@@ -682,8 +682,8 @@ check_info_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (info_field && info_field->can_be_empty);
-	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
-			     (info_field && info_field->field_type == JTYPE_STRING);
+	    is_json_string = (common_field && common_field->field_type == JSON_STRING) ||
+			     (info_field && info_field->field_type == JSON_STRING);
 
 	    /*
 	     * If the field type is a string we have to remove a single '"' from
@@ -1240,7 +1240,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 	     * name individually.
 	     */
 	    switch (info_field->field_type) {
-		case JTYPE_BOOL:
+		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       info_field->name, json_filename, val);
@@ -1250,7 +1250,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "... %s is a bool", val);
 		    }
 		    break;
-		case JTYPE_INT:
+		case JSON_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       info_field->name, json_filename, val);

--- a/jparse.l
+++ b/jparse.l
@@ -9,7 +9,7 @@
  * there might be some grammar that's not correct. Not all actions are complete
  * and some that have been added do not yet check for errors.
  *
- * The JSON_STRING action that uses strdup() will be changed to use struct
+ * The JTYPE_STRING action that uses strdup() will be changed to use struct
  * string at a later date (sometime after struct json_string is finished). Similar
  * will be done for the numbers: struct integer and struct json_floating. These
  * structs are finished but will not be integrated until later on.
@@ -71,41 +71,43 @@ YY_BUFFER_STATE bs;
  * NOTE: There are possibly (likely?) errors here and it's entirely possible
  * it's incomplete as well.
  */
-JSON_WHITESPACE         [ \t\r\n]+
-JSON_STRING		"(\"(((?=\\)\\([\"\\\/bfnrt]|u[0-9a-fA-F]{4}))|[^\"\\\0-\x1F\x7F]+)*\")"
-JSON_DIGIT		[0-9]
-JSON_DIGITS		{JSON_DIGIT}+
-JSON_EXPONENT		[Ee][-+]?[0-9]+
-JSON_INTMAX		-?{JSON_DIGITS}
-JSON_UINTMAX		{JSON_DIGITS}
-JSON_LONG_DOUBLE	-?{JSON_DIGITS}"."{JSON_DIGITS}{JSON_EXPONENT}?
-JSON_BOOLEAN		"true"|"false"
-JSON_NULL		"null"
-JSON_OPEN_BRACE		"{"
-JSON_CLOSE_BRACE	"}"
-JSON_OPEN_BRACKET	"["
-JSON_CLOSE_BRACKET	"]"
-JSON_COLON		":"
-JSON_COMMA		","
+JTYPE_WHITESPACE         [ \t\r\n]+
+JTYPE_STRING		"(\"(((?=\\)\\([\"\\\/bfnrt]|u[0-9a-fA-F]{4}))|[^\"\\\0-\x1F\x7F]+)*\")"
+JTYPE_DIGIT		[0-9]
+JTYPE_DIGITS		{JTYPE_DIGIT}+
+JTYPE_EXPONENT		[Ee][-+]?[0-9]+
+JTYPE_INTMAX		-?{JTYPE_DIGITS}
+JTYPE_UINTMAX		{JTYPE_DIGITS}
+JTYPE_LONG_DOUBLE	-?{JTYPE_DIGITS}"."{JTYPE_DIGITS}{JTYPE_EXPONENT}?
+JTYPE_BOOLEAN		"true"|"false"
+JTYPE_NULL		"null"
+JTYPE_OPEN_BRACE		"{"
+JTYPE_CLOSE_BRACE	"}"
+JTYPE_OPEN_BRACKET	"["
+JTYPE_CLOSE_BRACKET	"]"
+JTYPE_COLON		":"
+JTYPE_COMMA		","
 
 /* Actions.
  *
- * For now we just print out what it is and return the type. Once again this is
- * incomplete!
+ * TODO: Below we have to assign to yylval.json the appropriate values based on
+ * yytext.
+ *
+ * For now we just print the type and value and then return the type.
  */
 %%
-{JSON_STRING}		    { printf("string: '%s'\n", yytext); yylval.string = strdup(yytext); return JSON_STRING; }
-{JSON_UINTMAX}		    { printf("uintmax: '%s'\n", yytext); yylval.uintmax = string_to_uintmax(yytext); return JSON_UINTMAX; }
-{JSON_INTMAX}		    { printf("intmax: '%s'\n", yytext); yylval.intmax = string_to_intmax(yytext); return JSON_INTMAX; }
-{JSON_LONG_DOUBLE}	    { printf("long double: '%s'\n", yytext); yylval.ldouble = string_to_float(yytext); return JSON_LONG_DOUBLE; }
-{JSON_NULL}		    { printf("null: '%s'\n", yytext); return JSON_NULL; }
-{JSON_BOOLEAN}		    { printf("true: '%s'\n", yytext); yylval.boolean = string_to_bool(yytext); return JSON_BOOLEAN; }
-{JSON_OPEN_BRACE}	    { printf("open brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
-{JSON_CLOSE_BRACE}	    { printf("close brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
-{JSON_OPEN_BRACKET}	    { printf("open bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
-{JSON_CLOSE_BRACKET}	    { printf("close bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
-{JSON_COLON}		    { printf("equals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
-{JSON_COMMA}		    { printf("comma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
+{JTYPE_STRING}		    { printf("string: '%s'\n", yytext); return JTYPE_STRING; }
+{JTYPE_UINTMAX}		    { printf("uintmax: '%s'\n", yytext); return JTYPE_UINTMAX; }
+{JTYPE_INTMAX}		    { printf("intmax: '%s'\n", yytext); return JTYPE_INTMAX; }
+{JTYPE_LONG_DOUBLE}	    { printf("long double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
+{JTYPE_NULL}		    { printf("null: '%s'\n", yytext); return JTYPE_NULL; }
+{JTYPE_BOOLEAN}		    { printf("true: '%s'\n", yytext); return JTYPE_BOOLEAN; }
+{JTYPE_OPEN_BRACE}	    { printf("open brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
+{JTYPE_CLOSE_BRACE}	    { printf("close brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
+{JTYPE_OPEN_BRACKET}	    { printf("open bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }
+{JTYPE_CLOSE_BRACKET}	    { printf("close bracket: '%c'\n", *yytext); token_type = ']'; return JTYPE_CLOSE_BRACKET; }
+{JTYPE_COLON}		    { printf("equals/colon: '%c'\n", *yytext); token_type = ':'; return JTYPE_COLON; }
+{JTYPE_COMMA}		    { printf("comma: '%c'\n", *yytext); token_type = ','; return JTYPE_COMMA; }
 %%
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -562,7 +562,7 @@ char *yytext;
  * there might be some grammar that's not correct. Not all actions are complete
  * and some that have been added do not yet check for errors.
  *
- * The JSON_STRING action that uses strdup() will be changed to use struct
+ * The JTYPE_STRING action that uses strdup() will be changed to use struct
  * string at a later date (sometime after struct json_string is finished). Similar
  * will be done for the numbers: struct integer and struct json_floating. These
  * structs are finished but will not be integrated until later on.
@@ -620,10 +620,12 @@ YY_BUFFER_STATE bs;
  */
 /* Actions.
  *
- * For now we just print out what it is and return the type. Once again this is
- * incomplete!
+ * TODO: Below we have to assign to yylval.json the appropriate values based on
+ * yytext.
+ *
+ * For now we just print the type and value and then return the type.
  */
-#line 605 "jparse.c"
+#line 607 "jparse.c"
 
 #define INITIAL 0
 
@@ -840,9 +842,9 @@ YY_DECL
 		}
 
 	{
-#line 96 "jparse.l"
+#line 98 "jparse.l"
 
-#line 824 "jparse.c"
+#line 826 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -911,70 +913,70 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 97 "jparse.l"
-{ printf("string: '%s'\n", yytext); yylval.string = strdup(yytext); return JSON_STRING; }
+#line 99 "jparse.l"
+{ printf("string: '%s'\n", yytext); return JTYPE_STRING; }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 98 "jparse.l"
-{ printf("uintmax: '%s'\n", yytext); yylval.uintmax = string_to_uintmax(yytext); return JSON_UINTMAX; }
+#line 100 "jparse.l"
+{ printf("uintmax: '%s'\n", yytext); return JTYPE_UINTMAX; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 99 "jparse.l"
-{ printf("intmax: '%s'\n", yytext); yylval.intmax = string_to_intmax(yytext); return JSON_INTMAX; }
+#line 101 "jparse.l"
+{ printf("intmax: '%s'\n", yytext); return JTYPE_INTMAX; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 100 "jparse.l"
-{ printf("long double: '%s'\n", yytext); yylval.ldouble = string_to_float(yytext); return JSON_LONG_DOUBLE; }
+#line 102 "jparse.l"
+{ printf("long double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 101 "jparse.l"
-{ printf("null: '%s'\n", yytext); return JSON_NULL; }
+#line 103 "jparse.l"
+{ printf("null: '%s'\n", yytext); return JTYPE_NULL; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 102 "jparse.l"
-{ printf("true: '%s'\n", yytext); yylval.boolean = string_to_bool(yytext); return JSON_BOOLEAN; }
+#line 104 "jparse.l"
+{ printf("true: '%s'\n", yytext); return JTYPE_BOOLEAN; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 103 "jparse.l"
-{ printf("open brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
+#line 105 "jparse.l"
+{ printf("open brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 104 "jparse.l"
-{ printf("close brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
+#line 106 "jparse.l"
+{ printf("close brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 105 "jparse.l"
-{ printf("open bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
+#line 107 "jparse.l"
+{ printf("open bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 106 "jparse.l"
-{ printf("close bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
+#line 108 "jparse.l"
+{ printf("close bracket: '%c'\n", *yytext); token_type = ']'; return JTYPE_CLOSE_BRACKET; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 107 "jparse.l"
-{ printf("equals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
+#line 109 "jparse.l"
+{ printf("equals/colon: '%c'\n", *yytext); token_type = ':'; return JTYPE_COLON; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 108 "jparse.l"
-{ printf("comma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
+#line 110 "jparse.l"
+{ printf("comma: '%c'\n", *yytext); token_type = ','; return JTYPE_COMMA; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 109 "jparse.l"
+#line 111 "jparse.l"
 ECHO;
 	YY_BREAK
-#line 956 "jparse.c"
+#line 958 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1991,7 +1993,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 109 "jparse.l"
+#line 111 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -136,18 +136,18 @@ enum yysymbol_kind_t
   YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
   YYSYMBOL_YYerror = 1,                    /* error  */
   YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
-  YYSYMBOL_JSON_OPEN_BRACE = 3,            /* JSON_OPEN_BRACE  */
-  YYSYMBOL_JSON_CLOSE_BRACE = 4,           /* JSON_CLOSE_BRACE  */
-  YYSYMBOL_JSON_OPEN_BRACKET = 5,          /* JSON_OPEN_BRACKET  */
-  YYSYMBOL_JSON_CLOSE_BRACKET = 6,         /* JSON_CLOSE_BRACKET  */
-  YYSYMBOL_JSON_COMMA = 7,                 /* JSON_COMMA  */
-  YYSYMBOL_JSON_COLON = 8,                 /* JSON_COLON  */
-  YYSYMBOL_JSON_NULL = 9,                  /* JSON_NULL  */
-  YYSYMBOL_JSON_STRING = 10,               /* JSON_STRING  */
-  YYSYMBOL_JSON_INTMAX = 11,               /* JSON_INTMAX  */
-  YYSYMBOL_JSON_UINTMAX = 12,              /* JSON_UINTMAX  */
-  YYSYMBOL_JSON_LONG_DOUBLE = 13,          /* JSON_LONG_DOUBLE  */
-  YYSYMBOL_JSON_BOOLEAN = 14,              /* JSON_BOOLEAN  */
+  YYSYMBOL_JTYPE_OPEN_BRACE = 3,           /* JTYPE_OPEN_BRACE  */
+  YYSYMBOL_JTYPE_CLOSE_BRACE = 4,          /* JTYPE_CLOSE_BRACE  */
+  YYSYMBOL_JTYPE_OPEN_BRACKET = 5,         /* JTYPE_OPEN_BRACKET  */
+  YYSYMBOL_JTYPE_CLOSE_BRACKET = 6,        /* JTYPE_CLOSE_BRACKET  */
+  YYSYMBOL_JTYPE_COMMA = 7,                /* JTYPE_COMMA  */
+  YYSYMBOL_JTYPE_COLON = 8,                /* JTYPE_COLON  */
+  YYSYMBOL_JTYPE_NULL = 9,                 /* JTYPE_NULL  */
+  YYSYMBOL_JTYPE_STRING = 10,              /* JTYPE_STRING  */
+  YYSYMBOL_JTYPE_UINTMAX = 11,             /* JTYPE_UINTMAX  */
+  YYSYMBOL_JTYPE_INTMAX = 12,              /* JTYPE_INTMAX  */
+  YYSYMBOL_JTYPE_LONG_DOUBLE = 13,         /* JTYPE_LONG_DOUBLE  */
+  YYSYMBOL_JTYPE_BOOLEAN = 14,             /* JTYPE_BOOLEAN  */
   YYSYMBOL_YYACCEPT = 15,                  /* $accept  */
   YYSYMBOL_json = 16,                      /* json  */
   YYSYMBOL_json_value = 17,                /* json_value  */
@@ -520,9 +520,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   112,   112,   113,   114,   117,   118,   119,   120,   121,
-     122,   123,   124,   127,   130,   131,   134,   137,   140,   141,
-     144
+       0,   103,   103,   104,   105,   108,   109,   110,   111,   112,
+     113,   114,   115,   118,   121,   122,   125,   128,   131,   132,
+     135
 };
 #endif
 
@@ -539,12 +539,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 {
   static const char *const yy_sname[] =
   {
-  "end of file", "error", "invalid token", "JSON_OPEN_BRACE",
-  "JSON_CLOSE_BRACE", "JSON_OPEN_BRACKET", "JSON_CLOSE_BRACKET",
-  "JSON_COMMA", "JSON_COLON", "JSON_NULL", "JSON_STRING", "JSON_INTMAX",
-  "JSON_UINTMAX", "JSON_LONG_DOUBLE", "JSON_BOOLEAN", "$accept", "json",
-  "json_value", "json_object", "json_members", "json_member", "json_array",
-  "json_elements", "json_element", YY_NULLPTR
+  "end of file", "error", "invalid token", "JTYPE_OPEN_BRACE",
+  "JTYPE_CLOSE_BRACE", "JTYPE_OPEN_BRACKET", "JTYPE_CLOSE_BRACKET",
+  "JTYPE_COMMA", "JTYPE_COLON", "JTYPE_NULL", "JTYPE_STRING",
+  "JTYPE_UINTMAX", "JTYPE_INTMAX", "JTYPE_LONG_DOUBLE", "JTYPE_BOOLEAN",
+  "$accept", "json", "json_value", "json_object", "json_members",
+  "json_member", "json_array", "json_elements", "json_element", YY_NULLPTR
   };
   return yy_sname[yysymbol];
 }
@@ -574,7 +574,7 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     0,    12,     7,     8,     9,    10,    11,     0,
+       2,     0,     0,    12,     7,     9,     8,    10,    11,     0,
       20,     5,     6,     3,     4,     0,     0,    14,     0,     0,
       18,     1,     0,    13,     0,    17,     0,    16,    15,    19
 };
@@ -1810,7 +1810,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 147 "jparse.y"
+#line 138 "jparse.y"
 
 /* Section 3: C code */
 int

--- a/jparse.tab.ref.h
+++ b/jparse.tab.ref.h
@@ -75,18 +75,18 @@ extern int yydebug;
     YYEOF = 0,                     /* "end of file"  */
     YYerror = 256,                 /* error  */
     YYUNDEF = 257,                 /* "invalid token"  */
-    JSON_OPEN_BRACE = 258,         /* JSON_OPEN_BRACE  */
-    JSON_CLOSE_BRACE = 259,        /* JSON_CLOSE_BRACE  */
-    JSON_OPEN_BRACKET = 260,       /* JSON_OPEN_BRACKET  */
-    JSON_CLOSE_BRACKET = 261,      /* JSON_CLOSE_BRACKET  */
-    JSON_COMMA = 262,              /* JSON_COMMA  */
-    JSON_COLON = 263,              /* JSON_COLON  */
-    JSON_NULL = 264,               /* JSON_NULL  */
-    JSON_STRING = 265,             /* JSON_STRING  */
-    JSON_INTMAX = 266,             /* JSON_INTMAX  */
-    JSON_UINTMAX = 267,            /* JSON_UINTMAX  */
-    JSON_LONG_DOUBLE = 268,        /* JSON_LONG_DOUBLE  */
-    JSON_BOOLEAN = 269             /* JSON_BOOLEAN  */
+    JTYPE_OPEN_BRACE = 258,        /* JTYPE_OPEN_BRACE  */
+    JTYPE_CLOSE_BRACE = 259,       /* JTYPE_CLOSE_BRACE  */
+    JTYPE_OPEN_BRACKET = 260,      /* JTYPE_OPEN_BRACKET  */
+    JTYPE_CLOSE_BRACKET = 261,     /* JTYPE_CLOSE_BRACKET  */
+    JTYPE_COMMA = 262,             /* JTYPE_COMMA  */
+    JTYPE_COLON = 263,             /* JTYPE_COLON  */
+    JTYPE_NULL = 264,              /* JTYPE_NULL  */
+    JTYPE_STRING = 265,            /* JTYPE_STRING  */
+    JTYPE_UINTMAX = 266,           /* JTYPE_UINTMAX  */
+    JTYPE_INTMAX = 267,            /* JTYPE_INTMAX  */
+    JTYPE_LONG_DOUBLE = 268,       /* JTYPE_LONG_DOUBLE  */
+    JTYPE_BOOLEAN = 269            /* JTYPE_BOOLEAN  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -98,14 +98,9 @@ union json_type
 {
 #line 89 "jparse.y"
 
-    struct json *json;
-    char *string;
-    uintmax_t uintmax;
-    intmax_t intmax;
-    long double ldouble;
-    bool boolean;
+    struct json json;
 
-#line 88 "jparse.tab.h"
+#line 83 "jparse.tab.h"
 
 };
 #line 89 "jparse.y"

--- a/jparse.y
+++ b/jparse.y
@@ -12,7 +12,7 @@
  * There are no actions yet. I'm not sure when I will be adding the actions and
  * it's very likely that I won't add all at once.
  *
- * The memory returned by strdup() (json_parser.l action for JSON_STRING) will
+ * The memory returned by strdup() (json_parser.l action for JTYPE_STRING) will
  * not yet be freed but since the parser doesn't do anything but just finishes
  * until a parse error or EOF (or end of string) this is not a problem. Actually
  * struct json_string will be used in this case so the way strings are handled will
@@ -59,7 +59,7 @@ int token_type = 0;
 /* This union is not complete and will need to be fixed in one or more ways as
  * well.
  *
- * For example it might (not sure) be better if there was JSON_NUMBER but
+ * For example it might (not sure) be better if there was JTYPE_NUMBER but
  * depending on a type variable the proper member in the union would be
  * addressd, thereby simplifying the rules below. Perhaps this will be the int
  * token_type above (I am not yet entirely sure of the use of that but it might
@@ -87,20 +87,11 @@ int token_type = 0;
  * struct json * is not even used here yet.
  */
 %union json_type {
-    struct json *json;
-    char *string;
-    uintmax_t uintmax;
-    intmax_t intmax;
-    long double ldouble;
-    bool boolean;
+    struct json json;
 }
-%token JSON_OPEN_BRACE JSON_CLOSE_BRACE JSON_OPEN_BRACKET JSON_CLOSE_BRACKET
-%token JSON_COMMA JSON_COLON JSON_NULL
-%token <string> JSON_STRING
-%token <intmax> JSON_INTMAX
-%token <uintmax> JSON_UINTMAX
-%token <ldouble> JSON_LONG_DOUBLE
-%token <boolean> JSON_BOOLEAN
+%token JTYPE_OPEN_BRACE JTYPE_CLOSE_BRACE JTYPE_OPEN_BRACKET JTYPE_CLOSE_BRACKET
+%token JTYPE_COMMA JTYPE_COLON JTYPE_NULL JTYPE_STRING
+%token JTYPE_UINTMAX JTYPE_INTMAX JTYPE_LONG_DOUBLE JTYPE_BOOLEAN
 
 /* Section 2: Rules
  *
@@ -111,34 +102,34 @@ int token_type = 0;
 %%
 json:		%empty |
 		json_element |
-		JSON_OPEN_BRACE JSON_CLOSE_BRACE
+		JTYPE_OPEN_BRACE JTYPE_CLOSE_BRACE
 		;
 
 json_value:	json_object |
 		json_array  |
-		JSON_STRING |
-		JSON_INTMAX |
-		JSON_UINTMAX |
-		JSON_LONG_DOUBLE |
-		JSON_BOOLEAN   |
-		JSON_NULL
+		JTYPE_STRING |
+		JTYPE_INTMAX |
+		JTYPE_UINTMAX |
+		JTYPE_LONG_DOUBLE |
+		JTYPE_BOOLEAN   |
+		JTYPE_NULL
 		;
 
-json_object:	JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE
+json_object:	JTYPE_OPEN_BRACE json_members JTYPE_CLOSE_BRACE
 		;
 
 json_members:	json_member |
-		json_member JSON_COMMA json_members
+		json_member JTYPE_COMMA json_members
 		;
 
-json_member:	JSON_STRING JSON_COLON json_element
+json_member:	JTYPE_STRING JTYPE_COLON json_element
 		;
 
-json_array:	JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET
+json_array:	JTYPE_OPEN_BRACKET json_elements JTYPE_CLOSE_BRACKET
 		;
 
 json_elements:	json_element |
-		json_element JSON_COMMA json_elements
+		json_element JTYPE_COMMA json_elements
 		;
 
 json_element:	json_value

--- a/json.c
+++ b/json.c
@@ -238,20 +238,20 @@ struct ignore_json_code *ignore_json_code_set = NULL;
  */
 struct json_field common_json_fields[] =
 {
-    { "ioccc_contest",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "ioccc_year",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
-    { "mkiocccentry_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "fnamchk_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "IOCCC_contest_id",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "entry_num",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
-    { "tarball",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "formed_timestamp",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
-    { "formed_timestamp_usec",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
-    { "timestamp_epoch",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "min_timestamp",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
-    { "formed_UTC",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
-    { "test_mode",		    NULL, 0, 1, false, JTYPE_BOOL,	false, NULL },
-    { NULL,			    NULL, 0, 0, false, JTYPE_EOT,	false, NULL } /* this **MUST** be last! */
+    { "ioccc_contest",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "ioccc_year",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
+    { "mkiocccentry_version",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "fnamchk_version",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "IOCCC_contest_id",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "entry_num",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
+    { "tarball",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "formed_timestamp",	    NULL, 0, 1, false, JSON_INT,	false, NULL },
+    { "formed_timestamp_usec",	    NULL, 0, 1, false, JSON_INT,	false, NULL },
+    { "timestamp_epoch",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "min_timestamp",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
+    { "formed_UTC",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
+    { "test_mode",		    NULL, 0, 1, false, JSON_BOOL,	false, NULL },
+    { NULL,			    NULL, 0, 0, false, JSON_EOT,	false, NULL } /* this **MUST** be last! */
 };
 size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
 
@@ -264,37 +264,37 @@ size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
  */
 struct json_field info_json_fields[] =
 {
-    { "IOCCC_info_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "jinfochk_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "iocccsize_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "txzchk_version",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "title",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "abstract",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "rule_2a_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
-    { "rule_2b_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
-    { "empty_override",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "rule_2a_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "rule_2a_mismatch",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "rule_2b_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "highbit_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "nul_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "trigraph_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "wordbuf_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "ungetc_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "Makefile_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "first_rule_is_all",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "found_all_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "found_clean_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "found_clobber_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "found_try_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
-    { "manifest",		NULL, 0, 1, false, JTYPE_ARRAY,	    false,  NULL },
-    { "info_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "author_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "c_src",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "Makefile",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "remarks",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
-    { "extra_file",		NULL, 0, 0, false, JTYPE_STRING,    false,  NULL },
-    { NULL,			NULL, 0, 0, false, JTYPE_EOT,	    false,  NULL } /* this **MUST** be last */
+    { "IOCCC_info_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "jinfochk_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "iocccsize_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "txzchk_version",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "title",			NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "abstract",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "rule_2a_size",		NULL, 0, 1, false, JSON_INT,	    false,  NULL },
+    { "rule_2b_size",		NULL, 0, 1, false, JSON_INT,	    false,  NULL },
+    { "empty_override",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "rule_2a_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "rule_2a_mismatch",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "rule_2b_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "highbit_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "nul_warning",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "trigraph_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "wordbuf_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "ungetc_warning",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "Makefile_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "first_rule_is_all",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "found_all_rule",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "found_clean_rule",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "found_clobber_rule",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "found_try_rule",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
+    { "manifest",		NULL, 0, 1, false, JSON_ARRAY,	    false,  NULL },
+    { "info_JSON",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "author_JSON",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "c_src",			NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "Makefile",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "remarks",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
+    { "extra_file",		NULL, 0, 0, false, JSON_STRING,    false,  NULL },
+    { NULL,			NULL, 0, 0, false, JSON_EOT,	    false,  NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
 
@@ -313,22 +313,22 @@ size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
  */
 struct json_field author_json_fields[] =
 {
-    { "IOCCC_author_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
-    { "jauthchk_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
-    { "author_count",		NULL, 0, 1, false, JTYPE_INT,		false,  NULL },
-    { "authors",		NULL, 0, 1, false, JTYPE_ARRAY,		false,	NULL },
-    { "name",			NULL, 0, 5, false, JTYPE_STRING,	false,  NULL },
-    { "location_code",		NULL, 0, 5, false, JTYPE_STRING,	false,	NULL },
-    { "email",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "url",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "twitter",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "github",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "affiliation",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "past_winner",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
-    { "default_handle",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
-    { "author_handle",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
-    { "author_number",		NULL, 0, 5, false, JTYPE_INT,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JTYPE_EOT,		false,	NULL } /* this **MUST** be last */
+    { "IOCCC_author_version",	NULL, 0, 1, false, JSON_STRING,		false,	NULL },
+    { "jauthchk_version",	NULL, 0, 1, false, JSON_STRING,		false,	NULL },
+    { "author_count",		NULL, 0, 1, false, JSON_INT,		false,  NULL },
+    { "authors",		NULL, 0, 1, false, JSON_ARRAY,		false,	NULL },
+    { "name",			NULL, 0, 5, false, JSON_STRING,	false,  NULL },
+    { "location_code",		NULL, 0, 5, false, JSON_STRING,	false,	NULL },
+    { "email",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "url",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "twitter",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "github",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "affiliation",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "past_winner",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
+    { "default_handle",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
+    { "author_handle",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
+    { "author_number",		NULL, 0, 5, false, JSON_INT,	false,	NULL },
+    { NULL,			NULL, 0, 0, false, JSON_EOT,		false,	NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_AUTHOR_JSON_FIELDS_TABLE = TBLLEN(author_json_fields);
 
@@ -2250,7 +2250,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
  * check_info_json_fields_table() and check_author_json_fields_table() to make
  * sure that they're all sane.
  *
- * This means that the only element with the JTYPE_EOT type is the last element,
+ * This means that the only element with the JSON_EOT type is the last element,
  * that the field types are valid (see json.h), that there are no embedded NULL
  * elements (name == NULL) and that the final element _IS_ NULL.
  *
@@ -2276,7 +2276,7 @@ check_json_fields_tables(void)
 /* check_common_json_fields_table	    - perform some sanity checks on the
  *					      common_json_fields table
  *
- * This function checks if JTYPE_EOT is used on any field other than the NULL
+ * This function checks if JSON_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2298,20 +2298,20 @@ check_common_json_fields_table(void)
 
     for (i = 0; i < max-1 && common_json_fields[i].name != NULL; ++i) {
 	switch (common_json_fields[i].field_type) {
-	    case JTYPE_EOT:
+	    case JSON_EOT:
 		if (common_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JTYPE_EOT element with non NULL name '%s' location %ju "
+						"found JSON_EOT element with non NULL name '%s' location %ju "
 						"in common_json_fields table; fix table and recompile",
                             common_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JTYPE_INT:
-	    case JTYPE_FLOAT:
-	    case JTYPE_BOOL:
-	    case JTYPE_STRING:
-	    case JTYPE_ARRAY:
+	    case JSON_INT:
+	    case JSON_FLOAT:
+	    case JSON_BOOL:
+	    case JSON_STRING:
+	    case JSON_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2339,7 +2339,7 @@ check_common_json_fields_table(void)
 /*
  * check_info_json_fields_table	 - sanity check info_json_fields table
  *
- * This function checks if JTYPE_EOT is used on any field other than the NULL
+ * This function checks if JSON_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2366,20 +2366,20 @@ check_info_json_fields_table(void)
 	}
 
 	switch (info_json_fields[i].field_type) {
-	    case JTYPE_EOT:
+	    case JSON_EOT:
 		if (info_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JTYPE_EOT element with non NULL name '%s' location %ju "
+						"found JSON_EOT element with non NULL name '%s' location %ju "
 						"in info_json_fields table; fix table and recompile",
 			    info_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JTYPE_INT:
-	    case JTYPE_FLOAT:
-	    case JTYPE_BOOL:
-	    case JTYPE_STRING:
-	    case JTYPE_ARRAY:
+	    case JSON_INT:
+	    case JSON_FLOAT:
+	    case JSON_BOOL:
+	    case JSON_STRING:
+	    case JSON_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2414,7 +2414,7 @@ check_info_json_fields_table(void)
 /*
  * check_author_json_fields_table - perform author_json_fields table sanity checks
  *
- * This function checks if JTYPE_EOT is used on any field other than the NULL
+ * This function checks if JSON_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid.  Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -2441,20 +2441,20 @@ check_author_json_fields_table(void)
 	}
 
 	switch (author_json_fields[i].field_type) {
-	    case JTYPE_EOT:
+	    case JSON_EOT:
 		if (author_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JTYPE_EOT element with non NULL name '%s' location %ju "
+						"found JSON_EOT element with non NULL name '%s' location %ju "
 						"in author_json_fields table; fix table and recompile",
                             author_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JTYPE_INT:
-	    case JTYPE_FLOAT:
-	    case JTYPE_BOOL:
-	    case JTYPE_STRING:
-	    case JTYPE_ARRAY:
+	    case JSON_INT:
+	    case JSON_FLOAT:
+	    case JSON_BOOL:
+	    case JSON_STRING:
+	    case JSON_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -2876,7 +2876,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 	    }
 	    /* first we do checks on the field type */
 	    switch (common_field->field_type) {
-		case JTYPE_BOOL:
+		case JSON_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       common_field->name, json_filename, val);
@@ -2884,7 +2884,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 			continue;
 		    }
 		    break;
-		case JTYPE_INT:
+		case JSON_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       common_field->name, json_filename, val);

--- a/json.h
+++ b/json.h
@@ -355,16 +355,16 @@ struct json_array
  * element_type - JSON element type - an enum for each union element member in struct json
  */
 enum element_type {
-    JTYPE_EOT	    = -1,   /* special end of the table value */
-    JTYPE_UNSET	    = 0,    /* JSON element has not been set */
-    JTYPE_INT,		    /* JSON element is an integer - see struct json_integer */
-    JTYPE_FLOAT,	    /* JSON element is a float - see struct json_floating */
-    JTYPE_STRING,	    /* JSON element is a string - see struct json_string */
-    JTYPE_BOOL,		    /* JSON element is a boolean - see struct json_boolean */
-    JTYPE_NULL,		    /* JSON element is a null - see struct json_null */
-    JTYPE_OBJECT,	    /* JSON element is a { members } */
-    JTYPE_MEMBER,	    /* JSON element is a member */
-    JTYPE_ARRAY,	    /* JSON element is a [ elements ] */
+    JSON_EOT	    = -1,   /* special end of the table value */
+    JSON_UNSET	    = 0,    /* JSON element has not been set */
+    JSON_INT,		    /* JSON element is an integer - see struct json_integer */
+    JSON_FLOAT,	    /* JSON element is a float - see struct json_floating */
+    JSON_STRING,	    /* JSON element is a string - see struct json_string */
+    JSON_BOOL,		    /* JSON element is a boolean - see struct json_boolean */
+    JSON_NULL,		    /* JSON element is a null - see struct json_null */
+    JSON_OBJECT,	    /* JSON element is a { members } */
+    JSON_MEMBER,	    /* JSON element is a member */
+    JSON_ARRAY,	    /* JSON element is a [ elements ] */
 };
 
 /*
@@ -377,14 +377,14 @@ struct json
 {
     enum element_type type;		/* union element specifier */
     union json_union {
-	struct json_string string;	/* JTYPE_STRING - value is a string */
-	struct json_integer integer;	/* JTYPE_INT - value is either a signed or unsigned integer */
-	struct json_floating floating;	/* JTYPE_FLOAT - value is a floating point */
-	struct json_boolean boolean;	/* JTYPE_BOOL - value is a JSON boolean */
-	struct json_null null;		/* JTYPE_NULL - value is a JSON null value */
-	struct json_object object;	/* JTYPE_OBJECT - value is a JSON { members } */
-	struct json_member member;	/* JTYPE_MEMBER - value is a JSON member: name : value */
-	struct json_array array;	/* JTYPE_ARRAY - value is a JSON [ elements ] */
+	struct json_string string;	/* JSON_STRING - value is a string */
+	struct json_integer integer;	/* JSON_INT - value is either a signed or unsigned integer */
+	struct json_floating floating;	/* JSON_FLOAT - value is a floating point */
+	struct json_boolean boolean;	/* JSON_BOOL - value is a JSON boolean */
+	struct json_null null;		/* JSON_NULL - value is a JSON null value */
+	struct json_object object;	/* JSON_OBJECT - value is a JSON { members } */
+	struct json_member member;	/* JSON_MEMBER - value is a JSON member: name : value */
+	struct json_array array;	/* JSON_ARRAY - value is a JSON [ elements ] */
     } element;
 
     /*

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1552,10 +1552,6 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
     /*
      * report on the result of the contest ID validation
      */
-    if (ret != 8) {
-	errp(50, __func__, "retry prompt is disabled");
-	not_reached();
-    }
     dbg(DBG_MED, "IOCCC contest ID is a UUID: %s", malloc_ret);
 
     /*
@@ -1594,7 +1590,7 @@ get_entry_num(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(51, __func__, "called with NULL arg(s)");
+	err(50, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1610,7 +1606,7 @@ get_entry_num(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = printf("\nYou are allowed to submit up to %d entries to a given IOCCC.\n", MAX_ENTRY_NUM + 1);
 	    if (ret <= 0) {
-		errp(52, __func__, "printf error printing number of entries allowed");
+		errp(51, __func__, "printf error printing number of entries allowed");
 		not_reached();
 	    }
 	    para("",
@@ -1648,15 +1644,11 @@ get_entry_num(struct info *infop)
 	    entry_str = NULL;
 	}
 
-    } while ((entry_num < 0 || entry_num > MAX_ENTRY_NUM));
+    } while (entry_num < 0 || entry_num > MAX_ENTRY_NUM);
 
     /*
      * report on the result of the entry number validation
      */
-    if (entry_num < 0 || entry_num > MAX_ENTRY_NUM) {
-	err(53, __func__, "retry prompt is disabled");
-	not_reached();
-    }
     dbg(DBG_MED, "IOCCC entry number is valid: %d", entry_num);
 
     /*
@@ -1696,11 +1688,11 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
      * firewall
      */
     if (work_dir == NULL || ioccc_id == NULL || tarball_path == NULL) {
-	err(54, __func__, "called with NULL arg(s)");
+	err(52, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (entry_num < 0 || entry_num > MAX_ENTRY_NUM) {
-	err(55, __func__, "entry number: %d must >= 0 and <= %d", entry_num, MAX_ENTRY_NUM);
+	err(53, __func__, "entry number: %d must >= 0 and <= %d", entry_num, MAX_ENTRY_NUM);
 	not_reached();
     }
 
@@ -1714,13 +1706,13 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     entry_dir = (char *)malloc(entry_dir_len + 1);
     if (entry_dir == NULL) {
-	errp(56, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(entry_dir_len + 1));
+	errp(54, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(entry_dir_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(entry_dir, entry_dir_len + 1, "%s/%s-%d", work_dir, ioccc_id, entry_num);
     if (ret <= 0) {
-	errp(57, __func__, "snprintf to form entry directory failed");
+	errp(55, __func__, "snprintf to form entry directory failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "entry directory path: %s", entry_dir);
@@ -1739,7 +1731,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
 	      "You need to move that directory, or remove it, or use a different work_dir.",
 	      "",
 	      NULL);
-	err(58, __func__, "entry directory exists: %s", entry_dir);
+	err(56, __func__, "entry directory exists: %s", entry_dir);
 	not_reached();
     }
     dbg(DBG_HIGH, "entry directory path: %s", entry_dir);
@@ -1750,7 +1742,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     ret = mkdir(entry_dir, 0755);
     if (ret < 0) {
-	errp(59, __func__, "cannot mkdir %s with mode 0755", entry_dir);
+	errp(57, __func__, "cannot mkdir %s with mode 0755", entry_dir);
 	not_reached();
     }
 
@@ -1763,13 +1755,13 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
     errno = 0;			/* pre-clear errno for errp() */
     *tarball_path = (char *)malloc(tarball_len + 1);
     if (*tarball_path == NULL) {
-	errp(60, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(tarball_len + 1));
+	errp(58, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(tarball_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(*tarball_path, tarball_len + 1, "entry.%s-%d.%ld.txz", ioccc_id, entry_num, (long)tstamp);
     if (ret <= 0) {
-	errp(61, __func__, "snprintf to form compressed tarball path failed");
+	errp(59, __func__, "snprintf to form compressed tarball path failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "compressed tarball path: %s", *tarball_path);
@@ -1799,7 +1791,7 @@ warn_empty_prog(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(62, __func__, "called with NULL arg(s)");
+	err(60, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1822,7 +1814,7 @@ warn_empty_prog(char const *prog_c)
 	  NULL);
 	    yorn = yes_or_no("Are you sure you want to submit an empty prog.c file? [yn]");
 	    if (!yorn) {
-		err(63, __func__, "please fix your prog.c file: %s", prog_c);
+		err(61, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that their empty prog.c: %s is OK", prog_c);
@@ -1852,7 +1844,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(64, __func__, "called with NULL arg(s)");
+	err(62, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1877,7 +1869,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
 	      NULL);
 	    yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	    if (!yorn) {
-		err(65, __func__, "please fix your prog.c file: %s", prog_c);
+		err(63, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that their prog.c %s size: %jd > Rule 2a max size: %jd is OK", prog_c,
@@ -1899,7 +1891,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
 	    }
 	    yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	    if (!yorn) {
-		err(66, __func__, "please fix your prog.c file: %s", prog_c);
+		err(64, __func__, "please fix your prog.c file: %s", prog_c);
 		not_reached();
 	    }
 	    dbg(DBG_LOW, "user says that prog.c %s size: %jd != rule_count function size: %jd is OK", prog_c,
@@ -1910,7 +1902,7 @@ warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount si
      * invalid mode
      */
     } else {
-	err(67, __func__, "invalid mode used: %d", mode);
+	err(65, __func__, "invalid mode used: %d", mode);
 	not_reached();
     }
     return;
@@ -1935,7 +1927,7 @@ warn_high_bit(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(68, __func__, "called with NULL arg(s)");
+	err(66, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1951,7 +1943,7 @@ warn_high_bit(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(69, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(67, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having non-ASCII and/or character(s) with high bit is OK", prog_c);
@@ -1977,7 +1969,7 @@ warn_nul_chars(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(70, __func__, "called with NULL arg(s)");
+	err(68, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1993,7 +1985,7 @@ warn_nul_chars(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(71, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(69, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having NUL character(s) is OK", prog_c);
@@ -2020,7 +2012,7 @@ warn_trigraph(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(72, __func__, "called with NULL arg(s)");
+	err(70, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2036,7 +2028,7 @@ warn_trigraph(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(73, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(71, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s having unknown or invalid trigraph(s) is OK", prog_c);
@@ -2062,7 +2054,7 @@ warn_wordbuf(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(74, __func__, "called with NULL arg(s)");
+	err(72, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2079,7 +2071,7 @@ warn_wordbuf(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(75, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(73, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s triggered a word buffer overflow is OK", prog_c);
@@ -2106,7 +2098,7 @@ warn_ungetc(char const *prog_c)
      * firewall
      */
     if (prog_c == NULL) {
-	err(76, __func__, "called with NULL arg(s)");
+	err(74, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2123,7 +2115,7 @@ warn_ungetc(char const *prog_c)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(77, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(75, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that prog.c %s triggered an ungetc warning OK", prog_c);
@@ -2149,7 +2141,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(78, __func__, "called with NULL arg(s)");
+	err(76, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2161,7 +2153,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
 	ret = fprintf(stderr, "\nWARNING: The prog.c %s size: %ju > Rule 2b maximum: %ju\n", prog_c,
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
 	if (ret <= 0) {
-	    errp(79, __func__, "printf error printing prog.c size > Rule 2b maximum");
+	    errp(77, __func__, "printf error printing prog.c size > Rule 2b maximum");
 	    not_reached();
 	}
 
@@ -2173,7 +2165,7 @@ warn_rule_2b_size(struct info *infop, char const *prog_c)
 	      NULL);
 	yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	if (!yorn) {
-	    err(80, __func__, "please fix your prog.c file: %s", prog_c);
+	    err(78, __func__, "please fix your prog.c file: %s", prog_c);
 	    not_reached();
 	}
 	dbg(DBG_LOW, "user says that their prog.c %s size: %ju > Rule 2B max size: %ju is OK", prog_c,
@@ -2212,17 +2204,17 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || prog_c == NULL) {
-	err(81, __func__, "called with NULL arg(s)");
+	err(79, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     entry_dir_len = strlen(entry_dir);
     if (entry_dir_len <= 0) {
-	err(82, __func__, "entry_dir arg is an empty string");
+	err(80, __func__, "entry_dir arg is an empty string");
 	not_reached();
     }
     prog_c_len = strlen(prog_c);
     if (prog_c_len <= 0) {
-	err(83, __func__, "prog_c arg is an empty string");
+	err(81, __func__, "prog_c arg is an empty string");
 	not_reached();
     }
 
@@ -2235,7 +2227,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(84, __func__, "prog.c does not exist: %s", prog_c);
+	err(82, __func__, "prog.c does not exist: %s", prog_c);
 	not_reached();
     }
     if (!is_file(prog_c)) {
@@ -2244,7 +2236,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "The prog.c path, while it exists, is not a file.",
 	      "",
 	      NULL);
-	err(85, __func__, "prog.c is not a file: %s", prog_c);
+	err(83, __func__, "prog.c is not a file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -2253,7 +2245,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "The prog.c, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(86, __func__, "prog.c is not a readable file: %s", prog_c);
+	err(84, __func__, "prog.c is not a readable file: %s", prog_c);
 	not_reached();
     }
 
@@ -2267,7 +2259,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     prog_stream = fopen(prog_c, "r");
     if (prog_stream == NULL) {
-	errp(87, __func__, "failed to fopen: %s", prog_c);
+	errp(85, __func__, "failed to fopen: %s", prog_c);
 	not_reached();
     }
     size = rule_count(prog_stream);
@@ -2276,7 +2268,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(prog_stream);
     if (ret != 0) {
-	errp(88, __func__, "failed to fclose: %s", prog_c);
+	errp(86, __func__, "failed to fclose: %s", prog_c);
 	not_reached();
     }
 
@@ -2286,7 +2278,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     infop->rule_2a_size = file_size(prog_c);
     dbg(DBG_MED, "Rule 2a size: %jd", (intmax_t)infop->rule_2a_size);
     if (infop->rule_2a_size < 0) {
-	err(89, __func__, "file_size error: %jd on prog_c: %s", (intmax_t)infop->rule_2a_size, prog_c);
+	err(87, __func__, "file_size error: %jd on prog_c: %s", (intmax_t)infop->rule_2a_size, prog_c);
 	not_reached();
     } else if (infop->rule_2a_size == 0 || infop->rule_2b_size == 0) {
 	warn_empty_prog(prog_c);
@@ -2381,7 +2373,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     dbg(DBG_HIGH, "about to perform: %s -- %s %s/prog.c", cp, prog_c, entry_dir);
     exit_code = shell_cmd(__func__, true, "% -- % %/prog.c", cp, prog_c, entry_dir);
     if (exit_code != 0) {
-	err(90, __func__, "%s -- %s %s/prog.c failed with exit code: %d",
+	err(88, __func__, "%s -- %s %s/prog.c failed with exit code: %d",
 			  cp, prog_c, entry_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -2392,7 +2384,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
     errno = 0;			/* pre-clear errno for errp() */
     infop->prog_c = strdup("prog.c");
     if (infop->prog_c == NULL) {
-	errp(91, __func__, "malloc #2 of %ju bytes failed", (uintmax_t)(LITLEN("prog.c") + 1));
+	errp(89, __func__, "malloc #2 of %ju bytes failed", (uintmax_t)(LITLEN("prog.c") + 1));
 	not_reached();
     }
     return size;
@@ -2433,7 +2425,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(92, __func__, "called with NULL arg(s)");
+	err(90, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2443,7 +2435,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     stream = fopen(Makefile, "r");
     if (stream == NULL) {
-	errp(93, __func__, "cannot open Makefile: %s", Makefile);
+	errp(91, __func__, "cannot open Makefile: %s", Makefile);
 	not_reached();
     }
 
@@ -2579,7 +2571,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(stream);
     if (ret < 0) {
-	errp(94, __func__, "fclose error");
+	errp(92, __func__, "fclose error");
 	not_reached();
     }
 
@@ -2624,7 +2616,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(95, __func__, "called with NULL arg(s)");
+	err(93, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (need_confirm && !ignore_warnings) {
@@ -2703,7 +2695,7 @@ warn_Makefile(char const *Makefile, struct info *infop)
 	 */
 	yorn = yes_or_no("Do you still want to submit this Makefile in the hopes that it is OK? [yn]");
 	if (!yorn) {
-	    err(96, __func__, "Use a different Makefile or modify this file: %s", Makefile);
+	    err(94, __func__, "Use a different Makefile or modify this file: %s", Makefile);
 	    not_reached();
 	}
     }
@@ -2735,7 +2727,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || Makefile == NULL) {
-	err(97, __func__, "called with NULL arg(s)");
+	err(95, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2748,7 +2740,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(98, __func__, "Makefile does not exist: %s", Makefile);
+	err(96, __func__, "Makefile does not exist: %s", Makefile);
 	not_reached();
     }
     if (!is_file(Makefile)) {
@@ -2757,7 +2749,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	       "The Makefile path, while it exists, is not a file.",
 	       "",
 	       NULL);
-	err(99, __func__, "Makefile is not a file: %s", Makefile);
+	err(97, __func__, "Makefile is not a file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -2766,15 +2758,15 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	      "The Makefile, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(100, __func__, "Makefile is not readable file: %s", Makefile);
+	err(98, __func__, "Makefile is not readable file: %s", Makefile);
 	not_reached();
     }
     filesize = file_size(Makefile);
     if (filesize < 0) {
-	err(101, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
+	err(99, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
 	not_reached();
     } else if (filesize == 0) {
-	err(102, __func__, "Makefile cannot be empty: %s", Makefile);
+	err(100, __func__, "Makefile cannot be empty: %s", Makefile);
 	not_reached();
     }
 
@@ -2794,7 +2786,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     dbg(DBG_HIGH, "about to perform: %s --  %s %s/Makefile", cp, Makefile, entry_dir);
     exit_code = shell_cmd(__func__, true, "% -- % %/Makefile", cp, Makefile, entry_dir);
     if (exit_code != 0) {
-	err(103, __func__, "%s --  %s %s/Makefile failed with exit code: %d",
+	err(101, __func__, "%s --  %s %s/Makefile failed with exit code: %d",
 			   cp, Makefile, entry_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -2805,7 +2797,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
     errno = 0;			/* pre-clear errno for errp() */
     infop->Makefile = strdup("Makefile");
     if (infop->Makefile == NULL) {
-	errp(104, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(LITLEN("Makefile") + 1));
+	errp(102, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(LITLEN("Makefile") + 1));
 	not_reached();
     }
     return;
@@ -2837,7 +2829,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || remarks_md == NULL) {
-	err(105, __func__, "called with NULL arg(s)");
+	err(103, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -2850,7 +2842,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	       "We cannot find the remarks.md file.",
 	       "",
 	       NULL);
-	err(106, __func__, "remarks.md does not exist: %s", remarks_md);
+	err(104, __func__, "remarks.md does not exist: %s", remarks_md);
 	not_reached();
     }
     if (!is_file(remarks_md)) {
@@ -2858,7 +2850,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	      "The remarks.md path, while it exists, is not a file.",
 	      "",
 	      NULL);
-	err(107, __func__, "remarks_md is not a file: %s", remarks_md);
+	err(105, __func__, "remarks_md is not a file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -2867,15 +2859,15 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	      "The remarks.md, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(108, __func__, "remarks_md is not readable file: %s", remarks_md);
+	err(106, __func__, "remarks_md is not readable file: %s", remarks_md);
 	not_reached();
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(109, __func__, "file_size error: %jd on remarks_md %s", (intmax_t)filesize, remarks_md);
+	err(107, __func__, "file_size error: %jd on remarks_md %s", (intmax_t)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
-	err(110, __func__, "remarks.md cannot be empty: %s", remarks_md);
+	err(108, __func__, "remarks.md cannot be empty: %s", remarks_md);
 	not_reached();
     }
 
@@ -2885,7 +2877,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     dbg(DBG_HIGH, "about to perform: %s -- %s %s/remarks.md", cp, remarks_md, entry_dir);
     exit_code = shell_cmd(__func__, true, "% -- % %/remarks.md", cp, remarks_md, entry_dir);
     if (exit_code != 0) {
-	err(111, __func__, "%s -- %s %s/remarks.md failed with exit code: %d",
+	err(109, __func__, "%s -- %s %s/remarks.md failed with exit code: %d",
 			   cp, remarks_md, entry_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -2896,7 +2888,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     errno = 0;			/* pre-clear errno for errp() */
     infop->remarks_md = strdup("remarks.md");
     if (infop->remarks_md == NULL) {
-	errp(112, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(LITLEN("remarks.md") + 1));
+	errp(110, __func__, "malloc #1 of %ju bytes failed", (uintmax_t)(LITLEN("remarks.md") + 1));
 	not_reached();
     }
     return;
@@ -2934,11 +2926,11 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || cp == NULL || args == NULL) {
-	err(113, __func__, "called with NULL arg(s)");
+	err(111, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (count < 0) {
-	err(114, __func__, "count :%d < 0", count);
+	err(112, __func__, "count :%d < 0", count);
 	not_reached();
     }
 
@@ -2954,7 +2946,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
     /* + 1 for trailing NULL */
     infop->extra_file = (char **)calloc((size_t)(count + 1), sizeof(char *));
     if (infop->extra_file == NULL) {
-	errp(115, __func__, "calloc #0 of %d char * pointers failed", count + 1);
+	errp(113, __func__, "calloc #0 of %d char * pointers failed", count + 1);
 	not_reached();
     }
 
@@ -2974,7 +2966,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "We cannot find an extra data file.",
 		  "",
 		  NULL);
-	    err(116, __func__, "extra[%i] does not exist: %s", i, args[i]);
+	    err(114, __func__, "extra[%i] does not exist: %s", i, args[i]);
 	    not_reached();
 	}
 	if (!is_file(args[i])) {
@@ -2983,7 +2975,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		   "The file, while it exists, is not a regular file.",
 		   "",
 		   NULL);
-	    err(117, __func__, "extra[%i] is not a file: %s", i, args[i]);
+	    err(115, __func__, "extra[%i] is not a file: %s", i, args[i]);
 	    not_reached();
 	}
 	if (!is_read(args[i])) {
@@ -2992,7 +2984,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "The file, while it is a file, is not readable.",
 		  "",
 		  NULL);
-	    err(118, __func__, "extra[%i] is not readable file: %s", i, args[i]);
+	    err(116, __func__, "extra[%i] is not readable file: %s", i, args[i]);
 	    not_reached();
 	}
 
@@ -3003,7 +2995,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	dbg(DBG_VHIGH, "basename(%s): %s", args[i], base);
 	base_len = strlen(base);
 	if (base_len == 0) {
-	    err(119, __func__, "basename of extra data file: %s has a length of 0", args[i]);
+	    err(117, __func__, "basename of extra data file: %s has a length of 0", args[i]);
 	    not_reached();
 	} else if (base_len > MAX_BASENAME_LEN) {
 	    fpara(stderr,
@@ -3011,7 +3003,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "The basename of an extra file is too long.",
 		  "",
 		  NULL);
-	    err(120, __func__, "basename of extra data file: %s is %ju characters an is > the limit: %ju",
+	    err(118, __func__, "basename of extra data file: %s is %ju characters an is > the limit: %ju",
 			       args[i], (uintmax_t)base_len, (uintmax_t)MAX_BASENAME_LEN);
 	    not_reached();
 	}
@@ -3027,7 +3019,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "    ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
 		  "",
 		  NULL);
-	    err(121, __func__, "basename of %s does not match regexp: ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
+	    err(119, __func__, "basename of %s does not match regexp: ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
 			       args[i]);
 	    not_reached();
 	}
@@ -3040,12 +3032,12 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	errno = 0;		/* pre-clear errno for errp() */
 	dest = (char *)malloc(dest_len + 1);
 	if (dest == NULL) {
-	    errp(122, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(dest_len + 1));
+	    errp(120, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(dest_len + 1));
 	    not_reached();
 	}
 	ret = snprintf(dest, dest_len, "%s/%s", entry_dir, base);
 	if (ret <= 0) {
-	    errp(123, __func__, "snprintf #0 error: %d", ret);
+	    errp(121, __func__, "snprintf #0 error: %d", ret);
 	    not_reached();
 	}
 	dbg(DBG_VHIGH, "destination path: %s", dest);
@@ -3059,7 +3051,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		  "extra data files cannot overwrite other files.",
 		  "",
 		  NULL);
-	    err(124, __func__, "for extra file: %s destination already exists: %s", args[i], dest);
+	    err(122, __func__, "for extra file: %s destination already exists: %s", args[i], dest);
 	    not_reached();
 	}
 
@@ -3069,7 +3061,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	dbg(DBG_HIGH, "about to perform: %s -- %s %s", cp, args[i], dest);
 	exit_code = shell_cmd(__func__, true, "% -- % %", cp, args[i], dest);
 	if (exit_code != 0) {
-	    err(125, __func__, "%s -- %s %s failed with exit code: %d",
+	    err(123, __func__, "%s -- %s %s failed with exit code: %d",
 			       cp, args[i], dest, WEXITSTATUS(exit_code));
 	    not_reached();
 	}
@@ -3107,7 +3099,7 @@ lookup_location_name(char const *upper_code)
      * firewall
      */
     if (upper_code == NULL) {
-	err(126, __func__, "called with NULL arg(s)");
+	err(124, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3148,7 +3140,7 @@ yes_or_no(char const *question)
      * firewall
      */
     if (question == NULL) {
-	err(128, __func__, "called with NULL arg(s)");
+	err(125, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3217,10 +3209,6 @@ yes_or_no(char const *question)
 	}
 
     } while (response == NULL);
-    if (response == NULL) {
-	errp(129, __func__, "retry prompt is disabled");
-	not_reached();
-    }
 
     /*
      * free storage
@@ -3262,7 +3250,7 @@ get_title(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(130, __func__, "called with NULL arg(s)");
+	err(126, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3380,13 +3368,6 @@ get_title(struct info *infop)
 	}
     } while (title == NULL);
 
-    /*
-     * check the result of the title validation
-     */
-    if (title == NULL) {
-	errp(131, __func__, "retry prompt is disabled");
-	not_reached();
-    }
 
     /*
      * returned malloced title
@@ -3420,7 +3401,7 @@ get_abstract(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(132, __func__, "called with NULL arg(s)");
+	err(128, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3497,14 +3478,6 @@ get_abstract(struct info *infop)
     } while (abstract == NULL);
 
     /*
-     * check the result of the abstract validation
-     */
-    if (abstract == NULL) {
-	errp(133, __func__, "retry prompt is disabled");
-	not_reached();
-    }
-
-    /*
      * returned malloced abstract
      */
     return abstract;
@@ -3543,7 +3516,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
      * firewall
      */
     if (infop == NULL || ioccc_id == NULL || author_set_p == NULL) {
-	err(134, __func__, "called with NULL arg(s)");
+	err(129, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3590,11 +3563,6 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 
     } while ((author_count < 1 || author_count > MAX_AUTHORS));
 
-    if (author_count < 1 || author_count > MAX_AUTHORS) {
-	errp(135, __func__, "retry prompt is disabled");
-	not_reached();
-    }
-
     dbg(DBG_HIGH, "will request information on %d authors", author_count);
 
     /*
@@ -3603,7 +3571,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
     errno = 0;			/* pre-clear errno for errp() */
     author_set = (struct author *) malloc(sizeof(struct author) * (size_t)author_count);
     if (author_set == NULL) {
-	errp(136, __func__, "malloc a struct author array of length: %d failed", author_count);
+	errp(130, __func__, "malloc a struct author array of length: %d failed", author_count);
 	not_reached();
     }
 
@@ -3743,10 +3711,6 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		}
 	    }
 	} while (author_set[i].name == NULL);
-	if (author_set[i].name == NULL) {
-	    errp(137, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
 	dbg(DBG_MED, "Author #%d Name %s", i, author_set[i].name);
 
 	/*
@@ -3907,11 +3871,8 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		    yorn = true;
 		}
 	    }
-	} while ((author_set[i].location_code == NULL || author_set[i].location_name == NULL || !yorn));
-	if (author_set[i].location_code == NULL || author_set[i].location_name == NULL || !yorn) {
-	    errp(138, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+	} while (author_set[i].location_code == NULL || author_set[i].location_name == NULL || !yorn);
+
 	dbg(DBG_MED, "Author #%d location/country: %s (%s)", i, author_set[i].location_code, author_set[i].location_name);
 
 	/*
@@ -3984,10 +3945,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		}
 	    }
 	} while (author_set[i].email == NULL);
-	if (author_set[i].email == NULL) {
-	    errp(139, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+
 	dbg(DBG_MED, "Author #%d Email: %s", i, author_set[i].email);
 
 	/*
@@ -4072,10 +4030,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		}
 	    }
 	} while (author_set[i].url == NULL);
-	if (author_set[i].url == NULL) {
-	    errp(140, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+
 	dbg(DBG_MED, "Author #%d URL: %s", i, author_set[i].url);
 
 	/*
@@ -4149,10 +4104,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		}
 	    }
 	} while (author_set[i].twitter == NULL);
-	if (author_set[i].twitter == NULL) {
-	    errp(141, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+
 	dbg(DBG_MED, "Author #%d twitter: %s", i, author_set[i].twitter);
 
 	/*
@@ -4228,10 +4180,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		}
 	    }
 	} while (author_set[i].github == NULL);
-	if (author_set[i].github == NULL) {
-	    errp(142, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+
 	dbg(DBG_MED, "Author #%d GitHub: %s", i, author_set[i].github);
 
 	/*
@@ -4278,10 +4227,6 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 		continue;
 	    }
 	} while (author_set[i].affiliation == NULL);
-	if (author_set[i].affiliation == NULL) {
-	    errp(143, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
 	dbg(DBG_MED, "Author #%d affiliation: %s", i, author_set[i].affiliation);
 
 	/*
@@ -4333,7 +4278,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	     */
 	    def_handle = default_handle(author_set[i].name);
 	    if (def_handle == NULL) {
-		err(144, __func__, "default_handle() returned NULL!");
+		err(131, __func__, "default_handle() returned NULL!");
 		not_reached();
 	    }
 	    dbg(DBG_VHIGH, "default IOCCC author handle: <%s>", def_handle);
@@ -4427,13 +4372,10 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 			free(author_set[i].author_handle);
 			author_set[i].author_handle = NULL;
 		    }
-		    break;
+		    continue;
 	    }
 	} while (author_set[i].author_handle == NULL);
-	if (author_set[i].author_handle == NULL) {
-	    errp(145, __func__, "retry prompt is disabled");
-	    not_reached();
-	}
+
 	dbg(DBG_MED, "Author #%d IOCCC author handle: %s", i, author_set[i].author_handle);
 
 	/*
@@ -4459,7 +4401,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 						      printf("IOCCC author handle was manually entered\n"))  <= 0 ||
 	    ((author_set[i].author_handle[0] == '\0') ? printf("IOCCC author handle\n\n") :
 						        printf("IOCCC author handle: %s\n\n", author_set[i].author_handle)) <= 0) {
-	    errp(146, __func__, "error while printing author #%d information\n", i);
+	    errp(132, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -4511,7 +4453,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      * firewall
      */
     if (entry_dir == NULL || ls == NULL) {
-	err(147, __func__, "called with NULL arg(s)");
+	err(133, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4533,7 +4475,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     dbg(DBG_HIGH, "about to perform: cd -- %s && %s -lak .", entry_dir, ls);
     exit_code = shell_cmd(__func__, true, "cd -- % && % -lak .", entry_dir, ls);
     if (exit_code != 0) {
-	err(148, __func__, "cd -- %s && %s -lak . failed with exit code: %d",
+	err(134, __func__, "cd -- %s && %s -lak . failed with exit code: %d",
 			   entry_dir, ls, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -4544,7 +4486,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     dbg(DBG_HIGH, "about to popen: cd -- %s && %s -lak .", entry_dir, ls);
     ls_stream = pipe_open(__func__, true, "cd -- % && % -lak .", entry_dir, ls);
     if (ls_stream == NULL) {
-	err(149, __func__, "popen filed for: cd -- %s && %s -lak .", entry_dir, ls);
+	err(135, __func__, "popen filed for: cd -- %s && %s -lak .", entry_dir, ls);
 	not_reached();
     }
 
@@ -4554,7 +4496,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
     dbg(DBG_HIGH, "reading first line from popen of ls of entry_dir: %s", entry_dir);
     readline_len = readline(&linep, ls_stream);
     if (readline_len < 0) {
-	err(150, __func__, "EOF while reading first line from ls: %s", ls);
+	err(136, __func__, "EOF while reading first line from ls: %s", ls);
 	not_reached();
     } else {
 	dbg(DBG_HIGH, "ls first line read length: %jd buffer: %s", (intmax_t)readline_len, linep);
@@ -4565,11 +4507,11 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      */
     ret = sscanf(linep, "total %d%c", &kdirsize, &guard);
     if (ret != 1) {
-	err(151, __func__, "failed to parse block line from ls: %s", linep);
+	err(137, __func__, "failed to parse block line from ls: %s", linep);
 	not_reached();
     }
     if (kdirsize <= 0) {
-	err(152, __func__, "ls k block value: %d <= 0", kdirsize);
+	err(138, __func__, "ls k block value: %d <= 0", kdirsize);
 	not_reached();
     }
     if (kdirsize > MAX_DIR_KSIZE) {
@@ -4582,10 +4524,10 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	ret = fprintf(stderr, "The entry directory %s is %d kibibyte (1024 byte blocks) in length.\n"
 			      "It must be <= %d kibibyte (1024 byte blocks).\n\n", entry_dir, kdirsize, MAX_DIR_KSIZE);
 	if (ret <= 0) {
-	    errp(153, __func__, "fprintf error while printing entry directory kibibyte sizes");
+	    errp(139, __func__, "fprintf error while printing entry directory kibibyte sizes");
 	    not_reached();
 	}
-	err(154, __func__, "The entry directory is too large: %s", entry_dir);
+	err(140, __func__, "The entry directory is too large: %s", entry_dir);
 	not_reached();
     }
     dbg(DBG_LOW, "entry directory %s size in kibibyte (1024 byte blocks): %d", entry_dir, kdirsize);
@@ -4610,7 +4552,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
 	      "We suggest you remove the existing entry directory, and then",
 	      "rerun this tool with the correct set of file arguments.",
 	      NULL);
-	err(155, __func__, "user rejected listing of entry_dir: %s", entry_dir);
+	err(141, __func__, "user rejected listing of entry_dir: %s", entry_dir);
 	not_reached();
     }
 
@@ -5008,7 +4950,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
      * firewall
      */
     if (infop == NULL || entry_dir == NULL || jinfochk == NULL || fnamchk == NULL) {
-	err(156, __func__, "called with NULL arg(s)");
+	err(142, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->extra_count < 0) {
@@ -5026,7 +4968,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     infop->common.epoch = strdup(TIMESTAMP_EPOCH);
     if (infop->common.epoch == NULL) {
-	errp(157, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
+	errp(143, __func__, "strdup of %s failed", TIMESTAMP_EPOCH);
 	not_reached();
     }
     dbg(DBG_VVHIGH, "infop->common.epoch: %s", infop->common.epoch);
@@ -5037,13 +4979,13 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(158, __func__, "cannot set TZ=UTC");
+	errp(144, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = gmtime(&(infop->common.tstamp));
     if (timeptr == NULL) {
-	errp(159, __func__, "localtime #1 returned NULL");
+	errp(145, __func__, "localtime #1 returned NULL");
 	not_reached();
     }
 
@@ -5054,7 +4996,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     infop->common.utctime = (char *)calloc(utctime_len + 1, sizeof(char)); /* + 1 for paranoia padding */
     if (infop->common.utctime == NULL) {
-	errp(160, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
+	errp(146, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
 	not_reached();
     }
 
@@ -5069,7 +5011,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     strftime_ret = strftime(infop->common.utctime, utctime_len, "%a %b %d %H:%M:%S %Y UTC", timeptr);
     if (strftime_ret == 0) {
-	errp(161, __func__, "strftime returned 0");
+	errp(147, __func__, "strftime returned 0");
 	not_reached();
     }
     dbg(DBG_VHIGH, "infop->common.utctime: %s", infop->common.utctime);
@@ -5081,20 +5023,20 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(162, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
+	errp(148, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/.info.json", entry_dir);
     if (ret <= 0) {
-	errp(163, __func__, "snprintf #0 error: %d", ret);
+	errp(149, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(164, __func__, "failed to open for writing: %s", info_path);
+	errp(150, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -5136,7 +5078,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
 	json_fprintf_value_bool(info_stream, "\t", "test_mode", " : ", infop->common.test_mode, ",\n") &&
 	fprintf(info_stream, "\t\"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(165, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(151, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5150,7 +5092,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
 	  json_fprintf_value_string(info_stream, "\t\t{", "remarks", " : ", infop->remarks_md,
 				    ((infop->extra_count > 0) ?  "},\n" : "}\n"));
     if (!ret) {
-	errp(166, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(152, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -5160,7 +5102,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     for (i=0, q=infop->extra_file; i < infop->extra_count && *q != NULL; ++i, ++q) {
         if (json_fprintf_value_string(info_stream, "\t\t{", "extra_file", " : ", *q,
 				     (((i+1) < infop->extra_count) ? "},\n" : "}\n")) != true) {
-	    errp(167, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
+	    errp(153, __func__, "fprintf error writing extra filename[%d] to %s", i, info_path);
 	    not_reached();
 	}
     }
@@ -5177,7 +5119,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
 	json_fprintf_value_string(info_stream, "\t", "formed_UTC", " : ", infop->common.utctime, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(168, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(154, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -5187,7 +5129,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(169, __func__, "fclose error");
+	errp(155, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5201,7 +5143,7 @@ write_info(struct info *infop, char const *entry_dir, char const *jinfochk, char
     dbg(DBG_HIGH, "about to perform: %s -q -S -F %s -- %s", jinfochk, fnamchk, info_path);
     exit_code = shell_cmd(__func__, true, "% -q -S -F % -- %", jinfochk, fnamchk, info_path);
     if (exit_code != 0) {
-	err(170, __func__, "%s -q -S -F %s -- %s failed with exit code: %d",
+	err(156, __func__, "%s -q -S -F %s -- %s failed with exit code: %d",
 			   jinfochk, fnamchk, info_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -5249,14 +5191,14 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
      * firewall
      */
     if (infop == NULL || authorp == NULL || entry_dir == NULL || jauthchk == NULL) {
-	err(171, __func__, "called with NULL arg(s)");
+	err(157, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (author_count <= 0) {
-	err(172, __func__, "author_count %d <= 0", author_count);
+	err(158, __func__, "author_count %d <= 0", author_count);
 	not_reached();
     } else if (author_count > MAX_AUTHORS) {
-	err(173, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
+	err(159, __func__, "author count %d > max authors %d", author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -5268,20 +5210,20 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     author_path = (char *)malloc(author_path_len + 1);
     if (author_path == NULL) {
-	errp(174, __func__, "malloc of %ju bytes failed", (uintmax_t)author_path_len + 1);
+	errp(160, __func__, "malloc of %ju bytes failed", (uintmax_t)author_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(author_path, author_path_len, "%s/.author.json", entry_dir);
     if (ret <= 0) {
-	errp(175, __func__, "snprintf #0 error: %d", ret);
+	errp(161, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".author.json path: %s", author_path);
     errno = 0;			/* pre-clear errno for errp() */
     author_stream = fopen(author_path, "w");
     if (author_stream == NULL) {
-	errp(176, __func__, "failed to open for writing: %s", author_path);
+	errp(162, __func__, "failed to open for writing: %s", author_path);
 	not_reached();
     }
 
@@ -5303,7 +5245,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_bool(author_stream, "\t", "test_mode", " : ", infop->common.test_mode, ",\n") &&
 	fprintf(author_stream, "\t\"authors\" : [\n") > 0;
     if (!ret) {
-	errp(177, __func__, "fprintf error writing leading part of authorship to %s", author_path);
+	errp(163, __func__, "fprintf error writing leading part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5327,7 +5269,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	    json_fprintf_value_long(author_stream, "\t\t\t", "author_number", " : ", authorp[i].author_num, "\n") &&
 	    fprintf(author_stream, "\t\t}%s\n", (((i + 1) < author_count) ? "," : "")) > 0;
 	if (ret < 0) {
-	    errp(178, __func__, "fprintf error writing author info to %s", author_path);
+	    errp(164, __func__, "fprintf error writing author info to %s", author_path);
 	    not_reached();
 	}
     }
@@ -5344,7 +5286,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	json_fprintf_value_string(author_stream, "\t", "formed_UTC", " : ", infop->common.utctime, "\n") &&
 	fprintf(author_stream, "}\n") > 0;
     if (!ret) {
-	errp(179, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
+	errp(165, __func__, "fprintf error writing trailing part of authorship to %s", author_path);
 	not_reached();
     }
 
@@ -5354,7 +5296,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(author_stream);
     if (ret < 0) {
-	errp(180, __func__, "fclose error");
+	errp(166, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5369,7 +5311,7 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
     dbg(DBG_HIGH, "about to perform: %s -q -S -- %s", jauthchk, author_path);
     exit_code = shell_cmd(__func__, true, "% -q -S -- %", jauthchk, author_path);
     if (exit_code != 0) {
-	err(181, __func__, "%s -q -S -- %s failed with exit code: %d",
+	err(167, __func__, "%s -q -S -- %s failed with exit code: %d",
 			   jauthchk, author_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -5423,7 +5365,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
      */
     if (work_dir == NULL || entry_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(182, __func__, "called with NULL arg(s)");
+	err(168, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5439,7 +5381,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(183, __func__, "cannot open .");
+	errp(169, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -5449,7 +5391,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(work_dir);
     if (ret < 0) {
-	errp(184, __func__, "cannot cd %s", work_dir);
+	errp(170, __func__, "cannot cd %s", work_dir);
 	not_reached();
     }
 
@@ -5477,7 +5419,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     exit_code = shell_cmd(__func__, true, "% --format=v7 -cJf % -- %",
 				    tar, basename_tarball_path, basename_entry_dir);
     if (exit_code != 0) {
-	err(185, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
+	err(171, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
 			   tar, basename_tarball_path, basename_entry_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -5488,7 +5430,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(186, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(172, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -5497,7 +5439,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(187, __func__, "The compressed tarball: %s size: %ju > %jd",
+	err(173, __func__, "The compressed tarball: %s size: %ju > %jd",
 		 basename_tarball_path, (uintmax_t)buf.st_size, (intmax_t)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -5508,13 +5450,13 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(188, __func__, "cannot fchdir to the previous current directory");
+	errp(174, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(189, __func__, "close of previous current directory failed");
+	errp(175, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -5526,7 +5468,7 @@ form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_pa
     exit_code = shell_cmd(__func__, true, "% -q -F % -- %/../%",
 					  txzchk, fnamchk, entry_dir, basename_tarball_path);
     if (exit_code != 0) {
-	err(190, __func__, "%s -q -F %s -- %s/../%s failed with exit code: %d",
+	err(176, __func__, "%s -q -F %s -- %s/../%s failed with exit code: %d",
 			   txzchk, fnamchk, entry_dir, basename_tarball_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -5573,13 +5515,13 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
      * firewall
      */
     if (work_dir == NULL || entry_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(191, __func__, "called with NULL arg(s)");
+	err(177, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     entry_dir_esc = cmdprintf("%", entry_dir);
     if (entry_dir_esc == NULL) {
-	err(192, __func__, "failed to cmdprintf: entry_dir");
+	err(178, __func__, "failed to cmdprintf: entry_dir");
 	not_reached();
     }
 
@@ -5592,14 +5534,14 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    rm -rf %s%s\n", entry_dir[0] == '-' ? "-- " : "", entry_dir_esc);
     if (ret <= 0) {
-	errp(193, __func__, "printf #0 error");
+	errp(179, __func__, "printf #0 error");
 	not_reached();
     }
     free(entry_dir_esc);
 
     work_dir_esc = cmdprintf("%", work_dir);
     if (work_dir_esc == NULL) {
-	err(194, __func__, "failed to cmdprintf: work_dir");
+	err(180, __func__, "failed to cmdprintf: work_dir");
 	not_reached();
     }
 
@@ -5610,7 +5552,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, work_dir[0] == '-' ? "./" : "", work_dir_esc, tarball_path);
     if (ret <= 0) {
-	errp(195, __func__, "printf #2 error");
+	errp(181, __func__, "printf #2 error");
 	not_reached();
     }
     free(work_dir_esc);
@@ -5644,7 +5586,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s/%s\n", work_dir, tarball_path);
 	if (ret <= 0) {
-	    errp(196, __func__, "printf #2 error");
+	    errp(182, __func__, "printf #2 error");
 	    not_reached();
 	}
     }
@@ -5660,7 +5602,7 @@ remind_user(char const *work_dir, char const *entry_dir, char const *tar, char c
 	     NULL);
 	ret = printf("    %s\n\n", IOCCC_SUBMIT_URL);
 	if (ret < 0) {
-	    errp(197, __func__, "printf #4 error");
+	    errp(183, __func__, "printf #4 error");
 	    not_reached();
 	}
     }


### PR DESCRIPTION
The JTYPE_ enum in jparse.h have been renamed with the prefix JSON_ and
the JSON_ in the lexer and parser have been prefixed instead with JTYPE_
as nobody in their right mind will look at the parser or scanner code
but people will look at the other code. Actually nobody in their left
(wrong) mind would look at the generated code either because anyone who
does will have horrible nightmares about spaghetti code with very long
tentacles attached to the pasta that tries to grab them and pull them
into its mouth before consuming them with insatiable craving for humans
in its eyes. Okay you get the point: JTYPE_ is a better name for the
ugly, offensive code that can't be maintained whereas JSON_ is better
for code that can be maintained and is not ugly or offensive.

In the %union block in the parser change struct json *json to struct
json. Also removed the other members as the struct json has a union
itself. Functions that have yet to be written will be used for this (in
the parser and the lexer).

In the lexer I've naturally removed the assignment of
yylval.union_member as those members no longer exist. I still do print
what it is and I return the now JTYPE_ prefixed types but that's all.
Well for some the token_type int (that probably will be removed at some
point) is also used for the punctuation tokens but that hasn't changed.