### PR TITLE
Spelling updates and fix commit 463ec301

### DIFF
--- a/dyn_alloc_test.h
+++ b/dyn_alloc_test.h
@@ -60,7 +60,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V]\n"

--- a/fnamchk.h
+++ b/fnamchk.h
@@ -66,7 +66,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-q] [-V] [-E ext] [-t|-u] filepath\n"

--- a/jauthchk.h
+++ b/jauthchk.h
@@ -68,7 +68,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
 "usage: %s [-h] [-v level] [-V] [-q] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"

--- a/jfloat.c
+++ b/jfloat.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
     extern int optind;		/* argv index of the next arg */
     char *input;		/* argument to process */
     size_t inputlen;		/* length of argument string */
-    size_t retlen;		/* length of the string given to malloc_json_conv_float_str() */
+    size_t retlen;		/* length of the string given to calloc_json_conv_float_str() */
     bool error = false;		/* true ==> JSON floating point conversion test suite error */
     bool test_mode = false;	/* true ==> perform JSON floating point conversion test suite */
     bool strict = false;	/* true ==> JSON decode in strict mode */
@@ -152,9 +152,9 @@ main(int argc, char *argv[])
 	    /*
 	     * convert test into struct json_floating
 	     */
-	    node = malloc_json_conv_float_str(test, &retlen);
+	    node = calloc_json_conv_float_str(test, &retlen);
 	    if (node == NULL) {
-		err(11, __func__, "malloc_json_conv_float_str() is not supposed to return NULL!");
+		err(11, __func__, "calloc_json_conv_float_str() is not supposed to return NULL!");
 		not_reached();
 	    }
 	    item = &(node->element.floating);
@@ -311,13 +311,13 @@ main(int argc, char *argv[])
 	/*
 	 * Convert the JSON floating point string
 	 *
-	 * We call the malloc_json_conv_float_str() interface, which in
-	 * turn calls the malloc_json_conv_float() interface in order
+	 * We call the calloc_json_conv_float_str() interface, which in
+	 * turn calls the calloc_json_conv_float() interface in order
 	 * to check the inputlen vs *retlen value.
 	 */
-	node = malloc_json_conv_float_str(input, &retlen);
+	node = calloc_json_conv_float_str(input, &retlen);
 	if (node == NULL) {
-	    err(13, __func__, "malloc_json_conv_flot_str() is not supposed to return NULL!");
+	    err(13, __func__, "calloc_json_conv_flot_str() is not supposed to return NULL!");
 	    not_reached();
 	}
 	item = &(node->element.floating);

--- a/jfloat.h
+++ b/jfloat.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
+ * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [float ...]\n"
@@ -76,7 +76,7 @@ static const char * const usage_msg =
     "\t\t\t    (def: test match to only 1 part in 4194304)\n"
     "\n"
     "\tNOTE: The -S mode is for information purposes only, and may fail\n"
-    "\t      on your system due to hardware and system differences.\n"
+    "\t      on your system due to hardware and/or other system differences.\n"
     "\t      The IOCCC mkiocccentry repo does not need -S to pass in order\n"
     "\t      to be able to create a valid IOCCC entry compressed tarball.\n"
     "\n"

--- a/jfloat.h
+++ b/jfloat.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [float ...]\n"

--- a/jinfochk.h
+++ b/jinfochk.h
@@ -74,7 +74,7 @@ static struct manifest_file *manifest_files_list; /* list of files in the manife
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
 "usage: %s [-h] [-v level] [-q] [-V] [-S] [-F fnamchk] [-t] [-W code] [-w] ... file\n"

--- a/jint.c
+++ b/jint.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     extern int optind;		/* argv index of the next arg */
     char *input;		/* argument to process */
     size_t inputlen;		/* length of argument string */
-    size_t retlen;		/* length of the string given to malloc_json_conv_int_str() */
+    size_t retlen;		/* length of the string given to calloc_json_conv_int_str() */
     bool error = false;		/* true ==> JSON integer conversion test suite error */
     bool test_mode = false;	/* true ==> perform JSON integer conversion test suite */
     bool strict = false;	/* true ==> JSON decode in strict mode */
@@ -150,9 +150,9 @@ main(int argc, char *argv[])
 	    /*
 	     * convert test into struct json_integer
 	     */
-	    node = malloc_json_conv_int_str(test, &retlen);
+	    node = calloc_json_conv_int_str(test, &retlen);
 	    if (node == NULL) {
-		err(11, __func__, "malloc_json_conv_int_str() is not supposed to return NULL!");
+		err(11, __func__, "calloc_json_conv_int_str() is not supposed to return NULL!");
 		not_reached();
 	    }
 	    item = &(node->element.integer);
@@ -391,13 +391,13 @@ main(int argc, char *argv[])
 	/*
 	 * Convert the JSON integer string
 	 *
-	 * We call the malloc_json_conv_int_str() interface, which in
-	 * turn calls the malloc_json_conv_int() interface in order
+	 * We call the calloc_json_conv_int_str() interface, which in
+	 * turn calls the calloc_json_conv_int() interface in order
 	 * to check the inputlen vs *retlen value.
 	 */
-	node = malloc_json_conv_int_str(input, &retlen);
+	node = calloc_json_conv_int_str(input, &retlen);
 	if (node == NULL) {
-	    err(12, __func__, "malloc_json_conv_int_str() is not supposed to return NULL!");
+	    err(12, __func__, "calloc_json_conv_int_str() is not supposed to return NULL!");
 	    not_reached();
 	}
 	item = &(node->element.integer);

--- a/jint.h
+++ b/jint.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
+ * Use the usage() function to print the these usage_msgX strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [int ...]\n"
@@ -76,7 +76,7 @@ static const char * const usage_msg =
     "\t\t\t    (def: test only 8, 16, 32, 64 bit signed and unsigned integer types)\n"
     "\n"
     "\tNOTE: The -S mode is for information purposes only, and may fail\n"
-    "\t      on your system due to hardware and system differences.\n"
+    "\t      on your system due to hardware and/or other system differences.\n"
     "\t      The IOCCC mkiocccentry repo does not need -S to pass in order\n"
     "\t      to be able to create a valid IOCCC entry compressed tarball.\n"
     "\n"

--- a/jint.h
+++ b/jint.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [int ...]\n"

--- a/jparse.h
+++ b/jparse.h
@@ -54,7 +54,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s string] [-S] [file ...]\n"

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -26,7 +26,7 @@
  * to the output of Bison and Flex borders on programming sanctimoniousness.
  * At first glance, this incongruence is unsustainable.  In response
  * we opine that one of the fundamental undertones of the IOCCC are
- * the promotion of good programming thru the irony awarding highly
+ * the promotion of good programming through the irony awarding highly
  * obfuscated C code.  So, if it helps, we suggest you view this apology
  * in a satirical light, even if you are humour impaired.  Nevertheless,
  * we still recommend you to eschew modifying the code below.

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -26,7 +26,7 @@
  * to the output of Bison and Flex borders on programming sanctimoniousness.
  * At first glance, this incongruence is unsustainable.  In response
  * we opine that one of the fundamental undertones of the IOCCC are
- * the promotion of good programming thru the irony awarding highly
+ * the promotion of good programming through the irony awarding highly
  * obfuscated C code.  So, if it helps, we suggest you view this apology
  * in a satirical light, even if you are humour impaired.  Nevertheless,
  * we still recommend you to eschew modifying the code below.

--- a/jparse.tab.ref.h
+++ b/jparse.tab.ref.h
@@ -26,7 +26,7 @@
  * to the output of Bison and Flex borders on programming sanctimoniousness.
  * At first glance, this incongruence is unsustainable.  In response
  * we opine that one of the fundamental undertones of the IOCCC are
- * the promotion of good programming thru the irony awarding highly
+ * the promotion of good programming through the irony awarding highly
  * obfuscated C code.  So, if it helps, we suggest you view this apology
  * in a satirical light, even if you are humour impaired.  Nevertheless,
  * we still recommend you to eschew modifying the code below.

--- a/json.c
+++ b/json.c
@@ -1224,11 +1224,11 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 		    return NULL;
 		}
 		switch (c) {
-		case '"':   /*fallthru*/
-		case '/':   /*fallthru*/
-		case '\\':  /*fallthru*/
-		case '&':   /*fallthru*/
-		case '<':   /*fallthru*/
+		case '"':   /*fallthrough*/
+		case '/':   /*fallthrough*/
+		case '\\':  /*fallthrough*/
+		case '&':   /*fallthrough*/
+		case '<':   /*fallthrough*/
 		case '>':
 		    /* error - clear malloced length */
 		    if (retlen != NULL) {
@@ -1255,10 +1255,10 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 		 * disallow characters that should have been escaped
 		 */
 		switch (c) {
-		case '\b':  /*fallthru*/
-		case '\t':  /*fallthru*/
-		case '\n':  /*fallthru*/
-		case '\f':  /*fallthru*/
+		case '\b':  /*fallthrough*/
+		case '\t':  /*fallthrough*/
+		case '\n':  /*fallthrough*/
+		case '\f':  /*fallthrough*/
 		case '\r':
 		    /* error - clear malloced length */
 		    if (retlen != NULL) {
@@ -1267,8 +1267,8 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 		    warn(__func__, "non-strict encoding found \\-escaped char: 0x%02x", (uint8_t)c);
 		    return NULL;
 		    break;
-		case '"':   /*fallthru*/
-		case '/':   /*fallthru*/
+		case '"':   /*fallthrough*/
+		case '/':   /*fallthrough*/
 		case '\\':
 		    /* error - clear malloced length */
 		    if (retlen != NULL) {
@@ -1313,13 +1313,13 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 	     * process single \c escaped pairs
 	     */
 	    switch (n) {
-	    case 'b':	/*fallthru*/
-	    case 't':	/*fallthru*/
-	    case 'n':	/*fallthru*/
-	    case 'f':	/*fallthru*/
-	    case 'r':	/*fallthru*/
-	    case '"':	/*fallthru*/
-	    case '/':	/*fallthru*/
+	    case 'b':	/*fallthrough*/
+	    case 't':	/*fallthrough*/
+	    case 'n':	/*fallthrough*/
+	    case 'f':	/*fallthrough*/
+	    case 'r':	/*fallthrough*/
+	    case '"':	/*fallthrough*/
+	    case '/':	/*fallthrough*/
 	    case '\\':
 		/*
 		 * count \c escaped pair as 1 character
@@ -1396,8 +1396,8 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 	    /*
 	     * valid C escape sequence but unusual JSON \-escape character
 	     */
-	    case 'a':	/* ASCII bell */ /*fallthru*/
-	    case 'v':	/* ASCII vertical tab */ /*fallthru*/
+	    case 'a':	/* ASCII bell */ /*fallthrough*/
+	    case 'v':	/* ASCII vertical tab */ /*fallthrough*/
 	    case 'e':	/* ASCII escape */
 
 		/*
@@ -1528,8 +1528,8 @@ malloc_json_decode(char const *ptr, size_t len, size_t *retlen, bool strict)
 		++i;
 		*p++ = 0x0b;  /* no all C compilers understand /e */
 		break;
-	    case '"':	/*fallthru*/
-	    case '/':	/*fallthru*/
+	    case '"':	/*fallthrough*/
+	    case '/':	/*fallthrough*/
 	    case '\\':
 		++i;
 		*p++ = n;	/* escape decodes to itself */

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-q] [-V] [-t] [-n] [-S] [string ...]\n"

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -62,7 +62,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-q] [-V] [-t] [-n] [string ...]\n"

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1629,7 +1629,7 @@ get_entry_num(struct info *infop)
 	ret = sscanf(entry_str, "%d%c", &entry_num, &guard);
 	if (ret != 1 || entry_num < 0 || entry_num > MAX_ENTRY_NUM) {
 	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = fprintf(stderr, "\nThe entry number must be a number from 0 thru %d, please re-enter.\n", MAX_ENTRY_NUM);
+	    ret = fprintf(stderr, "\nThe entry number must be a number from 0 through %d, please re-enter.\n", MAX_ENTRY_NUM);
 	    if (ret <= 0) {
 		warnp(__func__, "fprintf error while informing about the valid entry number range");
 	    }
@@ -3536,7 +3536,7 @@ get_author_info(struct info *infop, char *ioccc_id, struct author **author_set_p
 	ret = sscanf(author_count_str, "%d%c", &author_count, &guard);
 	if (ret != 1 || author_count < 1 || author_count > MAX_AUTHORS) {
 	    errno = 0;		/* pre-clear errno for warnp() */
-	    ret = fprintf(stderr, "\nThe number of authors must a number from 1 thru %d, please re-enter.\n", MAX_AUTHORS);
+	    ret = fprintf(stderr, "\nThe number of authors must a number from 1 through %d, please re-enter.\n", MAX_AUTHORS);
 	    if (ret <= 0) {
 		warnp(__func__, "fprintf error #0 while printing author number range");
 	    }

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -129,7 +129,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg0 =
     "usage: %s [options] work_dir prog.c Makefile remarks.md [file ...]\n"

--- a/sorry.tm.ca.h
+++ b/sorry.tm.ca.h
@@ -26,7 +26,7 @@
  * to the output of Bison and Flex borders on programming sanctimoniousness.
  * At first glance, this incongruence is unsustainable.  In response
  * we opine that one of the fundamental undertones of the IOCCC are
- * the promotion of good programming thru the irony awarding highly
+ * the promotion of good programming through the irony awarding highly
  * obfuscated C code.  So, if it helps, we suggest you view this apology
  * in a satirical light, even if you are humour impaired.  Nevertheless,
  * we still recommend you to eschew modifying the code below.

--- a/txzchk.h
+++ b/txzchk.h
@@ -103,7 +103,7 @@ static struct txz_line *txz_lines;
 /*
  * usage message
  *
- * Use the usage() function to print the usage_msgX strings.
+ * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-q] [-V] [-t tar] [-F fnamchk] [-T] [-E ext] txzpath\n"

--- a/utf8_posix_map.c
+++ b/utf8_posix_map.c
@@ -238,7 +238,7 @@ struct utf8_posix_map hmap[] =
     {"~", "", -1, -1},			/* ^ */
     {"\x7f", "", -1, -1},		/* DEL */
 
-    /* U+0080 thru U+058f */
+    /* U+0080 through U+058f */
     { "\xc2\x80", "" , -1, -1},		/*  U+0080 -   - <control> */
     { "\xc2\x81", "" , -1, -1},		/*  U+0081 -   - <control> */
     { "\xc2\x82", "" , -1, -1},		/*  U+0082 -   - <control> */
@@ -1580,7 +1580,7 @@ check_utf8_posix_map(void)
     }
 
     /*
-     * check hmap[] for non-NULL thru next to last table entry
+     * check hmap[] for non-NULL through next to last table entry
      * and fill in table lengths
      */
     if (max <= 0) {

--- a/util.c
+++ b/util.c
@@ -2020,7 +2020,7 @@ is_string(char const * const ptr, size_t len)
      * process the result of the NUL byte search
      */
     if (nul_found == NULL) {
-	dbg(DBG_VVHIGH, "is_string: no NUL found from ptr thru ptr[%jd]",
+	dbg(DBG_VVHIGH, "is_string: no NUL found from ptr through ptr[%jd]",
 			(intmax_t)(len-1));
 	return false;
     }

--- a/verge.h
+++ b/verge.h
@@ -55,7 +55,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] major.minor.patch-1 major.minor.patch-2\n"


### PR DESCRIPTION
For non-standard thru -> through:

As part of making this repo ready for public consumption (even though
the code is not ready for that :) ) I've made this change. Besides that
it triggers vim spelllocal highlight which shouldn't happen except
perhaps for American English[0] versus British English[0] (and other
Englishes[1] I guess): whereas the Judges and others use American
English I use British English but they keep my spelling and I do
likewise with theirs.

[0] Well OK 'should' is actually subjective: I would prefer it all be
British English but it is an international contest so we should all be
fair to everyone else with languages ... unless of course someone tries
putting in other computer languages (especially that ghastly C++ or any
references to it :) ).

[1] The astute reader who wants to be (or if they're like me: cannot
help but be :) ) cynical might point out that English is a mass noun so
the plural is the same: Englishes is with this logic incorrect and in
fact it does trigger spelllocal. However it's amusing to me to complain
about spelllocal being triggered and at the same time trigger it when
explaining an exception to the rule.

But there's also a point to make to refute this logic: a mass
noun can also be something that normally is not countable but can be
when referring to different units or types and I'll argue that British
versus American English are two types of the same (though normally I'd
argue that in many respects they're actually two different languages).

Anyway the point is that non-standard spellings should be avoided and
with the exception of computer terms (that might trigger spelllocal in
vim), punning (which I'm doing with Englishes here) and American versus
British or some other English spelllocal should also be avoided.