### PR TITLE
Fix commit b0813e09

### DIFF
--- a/jfloat.h
+++ b/jfloat.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [float ...]\n"

--- a/jfloat.h
+++ b/jfloat.h
@@ -76,7 +76,7 @@ static const char * const usage_msg =
     "\t\t\t    (def: test match to only 1 part in 4194304)\n"
     "\n"
     "\tNOTE: The -S mode is for information purposes only, and may fail\n"
-    "\t      on your system due to hardware and system differences.\n"
+    "\t      on your system due to hardware and/or other system differences.\n"
     "\t      The IOCCC mkiocccentry repo does not need -S to pass in order\n"
     "\t      to be able to create a valid IOCCC entry compressed tarball.\n"
     "\n"

--- a/jint.h
+++ b/jint.h
@@ -76,7 +76,7 @@ static const char * const usage_msg =
     "\t\t\t    (def: test only 8, 16, 32, 64 bit signed and unsigned integer types)\n"
     "\n"
     "\tNOTE: The -S mode is for information purposes only, and may fail\n"
-    "\t      on your system due to hardware and system differences.\n"
+    "\t      on your system due to hardware and/or other system differences.\n"
     "\t      The IOCCC mkiocccentry repo does not need -S to pass in order\n"
     "\t      to be able to create a valid IOCCC entry compressed tarball.\n"
     "\n"

--- a/jint.h
+++ b/jint.h
@@ -61,7 +61,7 @@
 /*
  * usage message
  *
- * Use the usage() function to print the these usage_msgX strings.
+ * Use the usage() function to print the these usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
     "usage: %s [-h] [-v level] [-V] [-q] [-t] [-S] [int ...]\n"


### PR DESCRIPTION
    The change was not done in jfloat.h or jint.h and I'm not sure why as I
    was pretty sure I used sed -i on *.h. However I've been having some
    issues with my fork today and when making this commit I noticed some
    additional things that are not right as well. Anyway this commit changes
    usage_msgX to be usage_msg([0-9]?)+ for the reasons I cited in the other
    commit.

The commits that are part of this pull request show some of the problems I'm having with my fork. It's incredibly annoying and I'll try working this out tomorrow but I wanted the change in all the files anyway.