### PR TITLE
Typo fixes in dyn_array.h and jparse.l

### DIFF
--- a/dyn_array.h
+++ b/dyn_array.h
@@ -76,7 +76,7 @@
  *	struct dyn_array *array_p;
  *	intmax_t pos;
  *
- *	pos = dyn_array_tell((array_p);
+ *	pos = dyn_array_tell(array_p);
  *
  * Address of the element just beyond the elements in use:
  *
@@ -90,14 +90,14 @@
  *	struct dyn_array *array_p;
  *	intmax_t size;
  *
- *	size = dyn_array_alloced((array_p);
+ *	size = dyn_array_alloced(array_p);
  *
  * Number of elements available (allocated but not in use) for the dynamic array:
  *
  *	struct dyn_array *array_p;
  *	intmax_t avail;
  *
- *	avail = dyn_array_avail((array_p);
+ *	avail = dyn_array_avail(array_p);
  *
  * Rewind a dynamic array back to zero elements:
  *

--- a/jparse.l
+++ b/jparse.l
@@ -128,7 +128,7 @@ JTYPE_COMMA		","
 {JTYPE_INTMAX}		    { printf("\nintmax: '%s'\n", yytext); return JTYPE_INTMAX; }
 {JTYPE_LONG_DOUBLE}	    { printf("\nlong double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
 {JTYPE_NULL}		    { printf("\nnull: '%s'\n", yytext); return JTYPE_NULL; }
-{JTYPE_BOOLEAN}		    { printf("\ntrue: '%s'\n", yytext); return JTYPE_BOOLEAN; }
+{JTYPE_BOOLEAN}		    { printf("\nboolean: '%s'\n", yytext); return JTYPE_BOOLEAN; }
 {JTYPE_OPEN_BRACE}	    { printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
 {JTYPE_CLOSE_BRACE}	    { printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
 {JTYPE_OPEN_BRACKET}	    { printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -992,7 +992,7 @@ YY_RULE_SETUP
 case 7:
 YY_RULE_SETUP
 #line 131 "jparse.l"
-{ printf("\ntrue: '%s'\n", yytext); return JTYPE_BOOLEAN; }
+{ printf("\nboolean: '%s'\n", yytext); return JTYPE_BOOLEAN; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP


### PR DESCRIPTION
Extra '(' in a few examples in comment dyn_array.h.

Change 'true: ' prefix in jparse.l to 'boolean: '. This happened as an
artefact of when I had separate tokens for true and false.