### PR TITLE
Several updates including typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,23 +505,29 @@ jparse.c: jparse.l jparse.tab.h bfok.sh limit_ioccc.sh verge jparse.ref.c Makefi
 # repo tools - rules for those who maintain the mkiocccentry repo #
 ###################################################################
 
-# things to do before a release, forming a pull request and/or updating the GitHub repo
+# things to do before a release, forming a pull request and/or updating the
+# GitHub repo
 #
-# Run thru all of the prep steps.  If some step failed along the way, exit non-zero at the end.
+# Run through all of the prep steps.  If some step failed along the way, exit
+# non-zero at the end.
 #
 prep: prep.sh
 	${RM} -f ${BUILD_LOG}
 	./prep.sh 2>&1 | ${TEE} ${BUILD_LOG}
+	@echo NOTE: The above details were saved to ${BUILD_LOG}.
 
-# things to do before a release, forming a pull request and/or updating the GitHub repo
+# things to do before a release, forming a pull request and/or updating the
+# GitHub repo.
 #
-# Run thru all of the prep steps.  If a step fails, exit immediately.
+# Run through all of the prep steps.  If a step fails, exit immediately.
 #
-build: prep.sh
+build release pull: prep.sh
 	${RM} -f ${BUILD_LOG}
 	./prep.sh -e 2>&1 | ${TEE} ${BUILD_LOG}
+	@echo NOTE: The above details were saved to ${BUILD_LOG}.
 
-# force the rebuild of the JSON parser and form reference copies of JSON parser C code
+# force the rebuild of the JSON parser and form reference copies of JSON parser
+# C code.
 #
 parser: jparse.y jparse.l Makefile
 	${RM} -f jparse.tab.c jparse.tab.h

--- a/dyn_array.c
+++ b/dyn_array.c
@@ -231,7 +231,7 @@ dyn_array_create(size_t elm_size, intmax_t chunk, intmax_t start_elm_count, bool
     ret->chunk = chunk;
 
     /*
-     * determine the size of the malloced area
+     * determine the size of the allocated area
      */
     /* +chunk for guard chunk */
     number_of_bytes = (ret->allocated+chunk) * elm_size;

--- a/jfloat.c
+++ b/jfloat.c
@@ -64,7 +64,7 @@ main(int argc, char *argv[])
     bool error = false;		/* true ==> JSON floating point conversion test suite error */
     bool test_mode = false;	/* true ==> perform JSON floating point conversion test suite */
     bool strict = false;	/* true ==> JSON decode in strict mode */
-    struct json *node = NULL;		/* malloced JSON parser tree node */
+    struct json *node = NULL;		/* allocated JSON parser tree node */
     struct json_floating *item = NULL;	/* floating element in JSON parser tree node */
     int arg_cnt = 0;		/* number of args to process */
 #if defined(JFLOAT_TEST_ENABLED)
@@ -340,7 +340,7 @@ main(int argc, char *argv[])
 	    /*
 	     * output as_str
 	     */
-	    print("\t/* malloced JSON floating point string, whitespace trimmed if needed */\n"
+	    print("\t/* allocated JSON floating point string, whitespace trimmed if needed */\n"
 		  "\t\"%s\",\n\n", input);
 
 	    /*

--- a/jfloat.test.c
+++ b/jfloat.test.c
@@ -342,7 +342,7 @@ char *test_set[TEST_COUNT+1] = {
 struct json_floating test_result[TEST_COUNT] = {
     /* test_result[0]: "-8589934594" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934594",
 
 	11,	/* length of original JSON floating point string */
@@ -366,7 +366,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[1]: "-8589934594.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934594.1",
 
 	13,	/* length of original JSON floating point string */
@@ -390,7 +390,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[2]: "-8589934594.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934594.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -414,7 +414,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[3]: "-8589934593" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934593",
 
 	11,	/* length of original JSON floating point string */
@@ -438,7 +438,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[4]: "-8589934593.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934593.1",
 
 	13,	/* length of original JSON floating point string */
@@ -462,7 +462,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[5]: "-8589934593.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934593.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -486,7 +486,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[6]: "-8589934592" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934592",
 
 	11,	/* length of original JSON floating point string */
@@ -510,7 +510,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[7]: "-8589934592.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934592.1",
 
 	13,	/* length of original JSON floating point string */
@@ -534,7 +534,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[8]: "-8589934592.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934592.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -558,7 +558,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[9]: "-8589934591" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934591",
 
 	11,	/* length of original JSON floating point string */
@@ -582,7 +582,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[10]: "-8589934591.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934591.1",
 
 	13,	/* length of original JSON floating point string */
@@ -606,7 +606,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[11]: "-8589934591.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934591.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -630,7 +630,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[12]: "-8589934590" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934590",
 
 	11,	/* length of original JSON floating point string */
@@ -654,7 +654,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[13]: "-8589934590.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934590.1",
 
 	13,	/* length of original JSON floating point string */
@@ -678,7 +678,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[14]: "-8589934590.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-8589934590.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -702,7 +702,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[15]: "-4294967298" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967298",
 
 	11,	/* length of original JSON floating point string */
@@ -726,7 +726,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[16]: "-4294967298.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967298.1",
 
 	13,	/* length of original JSON floating point string */
@@ -750,7 +750,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[17]: "-4294967298.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967298.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -774,7 +774,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[18]: "-4294967297" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967297",
 
 	11,	/* length of original JSON floating point string */
@@ -798,7 +798,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[19]: "-4294967297.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967297.1",
 
 	13,	/* length of original JSON floating point string */
@@ -822,7 +822,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[20]: "-4294967297.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967297.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -846,7 +846,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[21]: "-4294967296" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967296",
 
 	11,	/* length of original JSON floating point string */
@@ -870,7 +870,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[22]: "-4294967296.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967296.1",
 
 	13,	/* length of original JSON floating point string */
@@ -894,7 +894,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[23]: "-4294967296.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967296.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -918,7 +918,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[24]: "-4294967295" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967295",
 
 	11,	/* length of original JSON floating point string */
@@ -942,7 +942,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[25]: "-4294967295.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967295.1",
 
 	13,	/* length of original JSON floating point string */
@@ -966,7 +966,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[26]: "-4294967295.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967295.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -990,7 +990,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[27]: "-4294967294" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967294",
 
 	11,	/* length of original JSON floating point string */
@@ -1014,7 +1014,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[28]: "-4294967294.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967294.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1038,7 +1038,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[29]: "-4294967294.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-4294967294.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1062,7 +1062,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[30]: "-2147483650" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483650",
 
 	11,	/* length of original JSON floating point string */
@@ -1086,7 +1086,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[31]: "-2147483650.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483650.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1110,7 +1110,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[32]: "-2147483650.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483650.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1134,7 +1134,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[33]: "-2147483649" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483649",
 
 	11,	/* length of original JSON floating point string */
@@ -1158,7 +1158,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[34]: "-2147483649.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483649.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1182,7 +1182,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[35]: "-2147483649.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483649.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1206,7 +1206,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[36]: "-2147483648" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483648",
 
 	11,	/* length of original JSON floating point string */
@@ -1230,7 +1230,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[37]: "-2147483648.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483648.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1254,7 +1254,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[38]: "-2147483648.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483648.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1278,7 +1278,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[39]: "-2147483647" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483647",
 
 	11,	/* length of original JSON floating point string */
@@ -1302,7 +1302,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[40]: "-2147483647.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483647.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1326,7 +1326,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[41]: "-2147483647.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483647.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1350,7 +1350,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[42]: "-2147483646" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483646",
 
 	11,	/* length of original JSON floating point string */
@@ -1374,7 +1374,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[43]: "-2147483646.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483646.1",
 
 	13,	/* length of original JSON floating point string */
@@ -1398,7 +1398,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[44]: "-2147483646.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2147483646.2e0",
 
 	15,	/* length of original JSON floating point string */
@@ -1422,7 +1422,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[45]: "-131074" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131074",
 
 	7,	/* length of original JSON floating point string */
@@ -1446,7 +1446,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[46]: "-131074.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131074.1",
 
 	9,	/* length of original JSON floating point string */
@@ -1470,7 +1470,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[47]: "-131074.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131074.2e0",
 
 	11,	/* length of original JSON floating point string */
@@ -1494,7 +1494,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[48]: "-131073" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131073",
 
 	7,	/* length of original JSON floating point string */
@@ -1518,7 +1518,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[49]: "-131073.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131073.1",
 
 	9,	/* length of original JSON floating point string */
@@ -1542,7 +1542,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[50]: "-131073.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131073.2e0",
 
 	11,	/* length of original JSON floating point string */
@@ -1566,7 +1566,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[51]: "-131072" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131072",
 
 	7,	/* length of original JSON floating point string */
@@ -1590,7 +1590,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[52]: "-131072.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131072.1",
 
 	9,	/* length of original JSON floating point string */
@@ -1614,7 +1614,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[53]: "-131072.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131072.2e0",
 
 	11,	/* length of original JSON floating point string */
@@ -1638,7 +1638,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[54]: "-131071" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131071",
 
 	7,	/* length of original JSON floating point string */
@@ -1662,7 +1662,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[55]: "-131071.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131071.1",
 
 	9,	/* length of original JSON floating point string */
@@ -1686,7 +1686,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[56]: "-131071.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131071.2e0",
 
 	11,	/* length of original JSON floating point string */
@@ -1710,7 +1710,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[57]: "-131070" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131070",
 
 	7,	/* length of original JSON floating point string */
@@ -1734,7 +1734,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[58]: "-131070.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131070.1",
 
 	9,	/* length of original JSON floating point string */
@@ -1758,7 +1758,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[59]: "-131070.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-131070.2e0",
 
 	11,	/* length of original JSON floating point string */
@@ -1782,7 +1782,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[60]: "-65538" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65538",
 
 	6,	/* length of original JSON floating point string */
@@ -1806,7 +1806,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[61]: "-65538.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65538.1",
 
 	8,	/* length of original JSON floating point string */
@@ -1830,7 +1830,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[62]: "-65538.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65538.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -1854,7 +1854,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[63]: "-65537" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65537",
 
 	6,	/* length of original JSON floating point string */
@@ -1878,7 +1878,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[64]: "-65537.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65537.1",
 
 	8,	/* length of original JSON floating point string */
@@ -1902,7 +1902,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[65]: "-65537.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65537.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -1926,7 +1926,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[66]: "-65536" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65536",
 
 	6,	/* length of original JSON floating point string */
@@ -1950,7 +1950,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[67]: "-65536.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65536.1",
 
 	8,	/* length of original JSON floating point string */
@@ -1974,7 +1974,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[68]: "-65536.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65536.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -1998,7 +1998,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[69]: "-65535" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65535",
 
 	6,	/* length of original JSON floating point string */
@@ -2022,7 +2022,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[70]: "-65535.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65535.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2046,7 +2046,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[71]: "-65535.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65535.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2070,7 +2070,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[72]: "-65534" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65534",
 
 	6,	/* length of original JSON floating point string */
@@ -2094,7 +2094,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[73]: "-65534.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65534.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2118,7 +2118,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[74]: "-65534.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-65534.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2142,7 +2142,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[75]: "-32770" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32770",
 
 	6,	/* length of original JSON floating point string */
@@ -2166,7 +2166,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[76]: "-32770.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32770.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2190,7 +2190,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[77]: "-32770.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32770.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2214,7 +2214,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[78]: "-32769" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32769",
 
 	6,	/* length of original JSON floating point string */
@@ -2238,7 +2238,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[79]: "-32769.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32769.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2262,7 +2262,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[80]: "-32769.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32769.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2286,7 +2286,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[81]: "-32768" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32768",
 
 	6,	/* length of original JSON floating point string */
@@ -2310,7 +2310,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[82]: "-32768.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32768.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2334,7 +2334,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[83]: "-32768.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32768.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2358,7 +2358,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[84]: "-32767" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32767",
 
 	6,	/* length of original JSON floating point string */
@@ -2382,7 +2382,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[85]: "-32767.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32767.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2406,7 +2406,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[86]: "-32767.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32767.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2430,7 +2430,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[87]: "-32766" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32766",
 
 	6,	/* length of original JSON floating point string */
@@ -2454,7 +2454,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[88]: "-32766.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32766.1",
 
 	8,	/* length of original JSON floating point string */
@@ -2478,7 +2478,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[89]: "-32766.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-32766.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -2502,7 +2502,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[90]: "-514" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-514",
 
 	4,	/* length of original JSON floating point string */
@@ -2526,7 +2526,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[91]: "-514.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-514.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2550,7 +2550,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[92]: "-514.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-514.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2574,7 +2574,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[93]: "-513" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-513",
 
 	4,	/* length of original JSON floating point string */
@@ -2598,7 +2598,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[94]: "-513.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-513.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2622,7 +2622,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[95]: "-513.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-513.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2646,7 +2646,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[96]: "-512" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-512",
 
 	4,	/* length of original JSON floating point string */
@@ -2670,7 +2670,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[97]: "-512.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-512.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2694,7 +2694,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[98]: "-512.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-512.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2718,7 +2718,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[99]: "-511" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-511",
 
 	4,	/* length of original JSON floating point string */
@@ -2742,7 +2742,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[100]: "-511.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-511.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2766,7 +2766,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[101]: "-511.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-511.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2790,7 +2790,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[102]: "-510" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-510",
 
 	4,	/* length of original JSON floating point string */
@@ -2814,7 +2814,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[103]: "-510.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-510.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2838,7 +2838,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[104]: "-510.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-510.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2862,7 +2862,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[105]: "-258" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-258",
 
 	4,	/* length of original JSON floating point string */
@@ -2886,7 +2886,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[106]: "-258.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-258.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2910,7 +2910,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[107]: "-258.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-258.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -2934,7 +2934,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[108]: "-257" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-257",
 
 	4,	/* length of original JSON floating point string */
@@ -2958,7 +2958,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[109]: "-257.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-257.1",
 
 	6,	/* length of original JSON floating point string */
@@ -2982,7 +2982,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[110]: "-257.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-257.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3006,7 +3006,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[111]: "-256" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-256",
 
 	4,	/* length of original JSON floating point string */
@@ -3030,7 +3030,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[112]: "-256.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-256.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3054,7 +3054,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[113]: "-256.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-256.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3078,7 +3078,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[114]: "-255" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-255",
 
 	4,	/* length of original JSON floating point string */
@@ -3102,7 +3102,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[115]: "-255.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-255.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3126,7 +3126,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[116]: "-255.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-255.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3150,7 +3150,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[117]: "-254" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-254",
 
 	4,	/* length of original JSON floating point string */
@@ -3174,7 +3174,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[118]: "-254.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-254.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3198,7 +3198,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[119]: "-254.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-254.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3222,7 +3222,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[120]: "-130" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-130",
 
 	4,	/* length of original JSON floating point string */
@@ -3246,7 +3246,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[121]: "-130.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-130.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3270,7 +3270,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[122]: "-130.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-130.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3294,7 +3294,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[123]: "-129" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-129",
 
 	4,	/* length of original JSON floating point string */
@@ -3318,7 +3318,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[124]: "-129.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-129.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3342,7 +3342,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[125]: "-129.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-129.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3366,7 +3366,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[126]: "-128" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-128",
 
 	4,	/* length of original JSON floating point string */
@@ -3390,7 +3390,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[127]: "-128.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-128.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3414,7 +3414,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[128]: "-128.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-128.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3438,7 +3438,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[129]: "-127" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-127",
 
 	4,	/* length of original JSON floating point string */
@@ -3462,7 +3462,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[130]: "-127.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-127.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3486,7 +3486,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[131]: "-127.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-127.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3510,7 +3510,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[132]: "-126" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-126",
 
 	4,	/* length of original JSON floating point string */
@@ -3534,7 +3534,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[133]: "-126.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-126.1",
 
 	6,	/* length of original JSON floating point string */
@@ -3558,7 +3558,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[134]: "-126.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-126.2e0",
 
 	8,	/* length of original JSON floating point string */
@@ -3582,7 +3582,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[135]: "-2" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2",
 
 	2,	/* length of original JSON floating point string */
@@ -3606,7 +3606,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[136]: "-2.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2.1",
 
 	4,	/* length of original JSON floating point string */
@@ -3630,7 +3630,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[137]: "-2.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-2.2e0",
 
 	6,	/* length of original JSON floating point string */
@@ -3654,7 +3654,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[138]: "-1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-1",
 
 	2,	/* length of original JSON floating point string */
@@ -3678,7 +3678,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[139]: "-1.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-1.1",
 
 	4,	/* length of original JSON floating point string */
@@ -3702,7 +3702,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[140]: "-1.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"-1.2e0",
 
 	6,	/* length of original JSON floating point string */
@@ -3726,7 +3726,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[141]: "0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"0",
 
 	1,	/* length of original JSON floating point string */
@@ -3750,7 +3750,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[142]: "0.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"0.1",
 
 	3,	/* length of original JSON floating point string */
@@ -3774,7 +3774,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[143]: "0.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"0.2e0",
 
 	5,	/* length of original JSON floating point string */
@@ -3798,7 +3798,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[144]: "1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"1",
 
 	1,	/* length of original JSON floating point string */
@@ -3822,7 +3822,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[145]: "1.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"1.1",
 
 	3,	/* length of original JSON floating point string */
@@ -3846,7 +3846,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[146]: "1.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"1.2e0",
 
 	5,	/* length of original JSON floating point string */
@@ -3870,7 +3870,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[147]: "2" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2",
 
 	1,	/* length of original JSON floating point string */
@@ -3894,7 +3894,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[148]: "2.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2.1",
 
 	3,	/* length of original JSON floating point string */
@@ -3918,7 +3918,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[149]: "2.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2.2e0",
 
 	5,	/* length of original JSON floating point string */
@@ -3942,7 +3942,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[150]: "126" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"126",
 
 	3,	/* length of original JSON floating point string */
@@ -3966,7 +3966,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[151]: "126.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"126.1",
 
 	5,	/* length of original JSON floating point string */
@@ -3990,7 +3990,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[152]: "126.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"126.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4014,7 +4014,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[153]: "127" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"127",
 
 	3,	/* length of original JSON floating point string */
@@ -4038,7 +4038,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[154]: "127.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"127.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4062,7 +4062,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[155]: "127.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"127.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4086,7 +4086,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[156]: "128" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"128",
 
 	3,	/* length of original JSON floating point string */
@@ -4110,7 +4110,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[157]: "128.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"128.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4134,7 +4134,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[158]: "128.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"128.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4158,7 +4158,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[159]: "129" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"129",
 
 	3,	/* length of original JSON floating point string */
@@ -4182,7 +4182,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[160]: "129.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"129.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4206,7 +4206,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[161]: "129.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"129.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4230,7 +4230,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[162]: "130" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"130",
 
 	3,	/* length of original JSON floating point string */
@@ -4254,7 +4254,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[163]: "130.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"130.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4278,7 +4278,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[164]: "130.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"130.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4302,7 +4302,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[165]: "254" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"254",
 
 	3,	/* length of original JSON floating point string */
@@ -4326,7 +4326,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[166]: "254.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"254.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4350,7 +4350,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[167]: "254.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"254.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4374,7 +4374,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[168]: "255" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"255",
 
 	3,	/* length of original JSON floating point string */
@@ -4398,7 +4398,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[169]: "255.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"255.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4422,7 +4422,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[170]: "255.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"255.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4446,7 +4446,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[171]: "256" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"256",
 
 	3,	/* length of original JSON floating point string */
@@ -4470,7 +4470,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[172]: "256.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"256.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4494,7 +4494,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[173]: "256.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"256.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4518,7 +4518,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[174]: "257" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"257",
 
 	3,	/* length of original JSON floating point string */
@@ -4542,7 +4542,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[175]: "257.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"257.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4566,7 +4566,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[176]: "257.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"257.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4590,7 +4590,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[177]: "258" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"258",
 
 	3,	/* length of original JSON floating point string */
@@ -4614,7 +4614,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[178]: "258.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"258.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4638,7 +4638,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[179]: "258.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"258.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4662,7 +4662,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[180]: "510" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"510",
 
 	3,	/* length of original JSON floating point string */
@@ -4686,7 +4686,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[181]: "510.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"510.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4710,7 +4710,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[182]: "510.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"510.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4734,7 +4734,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[183]: "511" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"511",
 
 	3,	/* length of original JSON floating point string */
@@ -4758,7 +4758,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[184]: "511.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"511.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4782,7 +4782,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[185]: "511.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"511.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4806,7 +4806,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[186]: "512" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"512",
 
 	3,	/* length of original JSON floating point string */
@@ -4830,7 +4830,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[187]: "512.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"512.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4854,7 +4854,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[188]: "512.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"512.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4878,7 +4878,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[189]: "513" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"513",
 
 	3,	/* length of original JSON floating point string */
@@ -4902,7 +4902,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[190]: "513.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"513.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4926,7 +4926,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[191]: "513.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"513.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -4950,7 +4950,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[192]: "514" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"514",
 
 	3,	/* length of original JSON floating point string */
@@ -4974,7 +4974,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[193]: "514.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"514.1",
 
 	5,	/* length of original JSON floating point string */
@@ -4998,7 +4998,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[194]: "514.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"514.2e0",
 
 	7,	/* length of original JSON floating point string */
@@ -5022,7 +5022,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[195]: "32766" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32766",
 
 	5,	/* length of original JSON floating point string */
@@ -5046,7 +5046,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[196]: "32766.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32766.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5070,7 +5070,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[197]: "32766.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32766.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5094,7 +5094,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[198]: "32767" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32767",
 
 	5,	/* length of original JSON floating point string */
@@ -5118,7 +5118,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[199]: "32767.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32767.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5142,7 +5142,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[200]: "32767.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32767.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5166,7 +5166,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[201]: "32768" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32768",
 
 	5,	/* length of original JSON floating point string */
@@ -5190,7 +5190,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[202]: "32768.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32768.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5214,7 +5214,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[203]: "32768.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32768.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5238,7 +5238,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[204]: "32769" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32769",
 
 	5,	/* length of original JSON floating point string */
@@ -5262,7 +5262,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[205]: "32769.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32769.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5286,7 +5286,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[206]: "32769.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32769.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5310,7 +5310,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[207]: "32770" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32770",
 
 	5,	/* length of original JSON floating point string */
@@ -5334,7 +5334,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[208]: "32770.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32770.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5358,7 +5358,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[209]: "32770.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"32770.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5382,7 +5382,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[210]: "65534" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65534",
 
 	5,	/* length of original JSON floating point string */
@@ -5406,7 +5406,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[211]: "65534.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65534.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5430,7 +5430,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[212]: "65534.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65534.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5454,7 +5454,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[213]: "65535" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65535",
 
 	5,	/* length of original JSON floating point string */
@@ -5478,7 +5478,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[214]: "65535.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65535.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5502,7 +5502,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[215]: "65535.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65535.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5526,7 +5526,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[216]: "65536" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65536",
 
 	5,	/* length of original JSON floating point string */
@@ -5550,7 +5550,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[217]: "65536.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65536.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5574,7 +5574,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[218]: "65536.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65536.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5598,7 +5598,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[219]: "65537" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65537",
 
 	5,	/* length of original JSON floating point string */
@@ -5622,7 +5622,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[220]: "65537.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65537.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5646,7 +5646,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[221]: "65537.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65537.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5670,7 +5670,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[222]: "65538" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65538",
 
 	5,	/* length of original JSON floating point string */
@@ -5694,7 +5694,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[223]: "65538.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65538.1",
 
 	7,	/* length of original JSON floating point string */
@@ -5718,7 +5718,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[224]: "65538.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"65538.2e0",
 
 	9,	/* length of original JSON floating point string */
@@ -5742,7 +5742,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[225]: "131070" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131070",
 
 	6,	/* length of original JSON floating point string */
@@ -5766,7 +5766,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[226]: "131070.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131070.1",
 
 	8,	/* length of original JSON floating point string */
@@ -5790,7 +5790,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[227]: "131070.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131070.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -5814,7 +5814,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[228]: "131071" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131071",
 
 	6,	/* length of original JSON floating point string */
@@ -5838,7 +5838,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[229]: "131071.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131071.1",
 
 	8,	/* length of original JSON floating point string */
@@ -5862,7 +5862,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[230]: "131071.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131071.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -5886,7 +5886,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[231]: "131072" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131072",
 
 	6,	/* length of original JSON floating point string */
@@ -5910,7 +5910,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[232]: "131072.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131072.1",
 
 	8,	/* length of original JSON floating point string */
@@ -5934,7 +5934,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[233]: "131072.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131072.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -5958,7 +5958,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[234]: "131073" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131073",
 
 	6,	/* length of original JSON floating point string */
@@ -5982,7 +5982,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[235]: "131073.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131073.1",
 
 	8,	/* length of original JSON floating point string */
@@ -6006,7 +6006,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[236]: "131073.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131073.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -6030,7 +6030,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[237]: "131074" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131074",
 
 	6,	/* length of original JSON floating point string */
@@ -6054,7 +6054,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[238]: "131074.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131074.1",
 
 	8,	/* length of original JSON floating point string */
@@ -6078,7 +6078,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[239]: "131074.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"131074.2e0",
 
 	10,	/* length of original JSON floating point string */
@@ -6102,7 +6102,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[240]: "2147483646" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483646",
 
 	10,	/* length of original JSON floating point string */
@@ -6126,7 +6126,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[241]: "2147483646.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483646.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6150,7 +6150,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[242]: "2147483646.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483646.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6174,7 +6174,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[243]: "2147483647" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483647",
 
 	10,	/* length of original JSON floating point string */
@@ -6198,7 +6198,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[244]: "2147483647.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483647.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6222,7 +6222,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[245]: "2147483647.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483647.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6246,7 +6246,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[246]: "2147483648" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483648",
 
 	10,	/* length of original JSON floating point string */
@@ -6270,7 +6270,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[247]: "2147483648.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483648.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6294,7 +6294,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[248]: "2147483648.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483648.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6318,7 +6318,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[249]: "2147483649" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483649",
 
 	10,	/* length of original JSON floating point string */
@@ -6342,7 +6342,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[250]: "2147483649.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483649.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6366,7 +6366,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[251]: "2147483649.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483649.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6390,7 +6390,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[252]: "2147483650" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483650",
 
 	10,	/* length of original JSON floating point string */
@@ -6414,7 +6414,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[253]: "2147483650.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483650.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6438,7 +6438,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[254]: "2147483650.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"2147483650.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6462,7 +6462,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[255]: "4294967294" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967294",
 
 	10,	/* length of original JSON floating point string */
@@ -6486,7 +6486,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[256]: "4294967294.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967294.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6510,7 +6510,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[257]: "4294967294.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967294.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6534,7 +6534,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[258]: "4294967295" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967295",
 
 	10,	/* length of original JSON floating point string */
@@ -6558,7 +6558,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[259]: "4294967295.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967295.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6582,7 +6582,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[260]: "4294967295.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967295.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6606,7 +6606,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[261]: "4294967296" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967296",
 
 	10,	/* length of original JSON floating point string */
@@ -6630,7 +6630,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[262]: "4294967296.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967296.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6654,7 +6654,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[263]: "4294967296.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967296.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6678,7 +6678,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[264]: "4294967297" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967297",
 
 	10,	/* length of original JSON floating point string */
@@ -6702,7 +6702,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[265]: "4294967297.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967297.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6726,7 +6726,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[266]: "4294967297.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967297.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6750,7 +6750,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[267]: "4294967298" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967298",
 
 	10,	/* length of original JSON floating point string */
@@ -6774,7 +6774,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[268]: "4294967298.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967298.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6798,7 +6798,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[269]: "4294967298.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"4294967298.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6822,7 +6822,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[270]: "8589934590" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934590",
 
 	10,	/* length of original JSON floating point string */
@@ -6846,7 +6846,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[271]: "8589934590.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934590.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6870,7 +6870,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[272]: "8589934590.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934590.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6894,7 +6894,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[273]: "8589934591" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934591",
 
 	10,	/* length of original JSON floating point string */
@@ -6918,7 +6918,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[274]: "8589934591.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934591.1",
 
 	12,	/* length of original JSON floating point string */
@@ -6942,7 +6942,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[275]: "8589934591.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934591.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -6966,7 +6966,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[276]: "8589934592" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934592",
 
 	10,	/* length of original JSON floating point string */
@@ -6990,7 +6990,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[277]: "8589934592.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934592.1",
 
 	12,	/* length of original JSON floating point string */
@@ -7014,7 +7014,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[278]: "8589934592.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934592.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -7038,7 +7038,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[279]: "8589934593" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934593",
 
 	10,	/* length of original JSON floating point string */
@@ -7062,7 +7062,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[280]: "8589934593.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934593.1",
 
 	12,	/* length of original JSON floating point string */
@@ -7086,7 +7086,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[281]: "8589934593.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934593.2e0",
 
 	14,	/* length of original JSON floating point string */
@@ -7110,7 +7110,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[282]: "8589934594" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934594",
 
 	10,	/* length of original JSON floating point string */
@@ -7134,7 +7134,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[283]: "8589934594.1" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934594.1",
 
 	12,	/* length of original JSON floating point string */
@@ -7158,7 +7158,7 @@ struct json_floating test_result[TEST_COUNT] = {
 
     /* test_result[284]: "8589934594.2e0" */
     {
-	/* malloced JSON floating point string, whitespace trimmed if needed */
+	/* allocated JSON floating point string, whitespace trimmed if needed */
 	"8589934594.2e0",
 
 	14,	/* length of original JSON floating point string */

--- a/jint.c
+++ b/jint.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
     bool error = false;		/* true ==> JSON integer conversion test suite error */
     bool test_mode = false;	/* true ==> perform JSON integer conversion test suite */
     bool strict = false;	/* true ==> strict testing for all struct integer element, implies -t -q */
-    struct json *node = NULL;	/* malloced JSON parser tree node */
+    struct json *node = NULL;	/* allocated JSON parser tree node */
     struct json_integer *item = NULL;	/* integer element in JSON parser tree node */
     int arg_cnt = 0;		/* number of args to process */
 #if defined(JINT_TEST_ENABLED)
@@ -416,7 +416,7 @@ main(int argc, char *argv[])
 	    /*
 	     * print JSON string
 	     */
-	    print("\t\"%s\",\t/* malloced JSON integer string, whitespace trimmed if needed */\n\n",
+	    print("\t\"%s\",\t/* allocated JSON integer string, whitespace trimmed if needed */\n\n",
 		  item->as_str);
 
 	    /*

--- a/jint.test.c
+++ b/jint.test.c
@@ -122,7 +122,7 @@ char *test_set[TEST_COUNT+1] = {
 struct json_integer test_result[TEST_COUNT] = {
     /* test_result[0]: "-131074" */
     {
-	"-131074",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-131074",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	7,	/* length of original JSON integer string */
 	7,	/* length of as_str */
@@ -191,7 +191,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[1]: "-131073" */
     {
-	"-131073",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-131073",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	7,	/* length of original JSON integer string */
 	7,	/* length of as_str */
@@ -260,7 +260,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[2]: "-131072" */
     {
-	"-131072",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-131072",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	7,	/* length of original JSON integer string */
 	7,	/* length of as_str */
@@ -329,7 +329,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[3]: "-131071" */
     {
-	"-131071",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-131071",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	7,	/* length of original JSON integer string */
 	7,	/* length of as_str */
@@ -398,7 +398,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[4]: "-131070" */
     {
-	"-131070",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-131070",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	7,	/* length of original JSON integer string */
 	7,	/* length of as_str */
@@ -467,7 +467,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[5]: "-65538" */
     {
-	"-65538",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-65538",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -536,7 +536,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[6]: "-65537" */
     {
-	"-65537",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-65537",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -605,7 +605,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[7]: "-65536" */
     {
-	"-65536",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-65536",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -674,7 +674,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[8]: "-65535" */
     {
-	"-65535",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-65535",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -743,7 +743,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[9]: "-65534" */
     {
-	"-65534",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-65534",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -812,7 +812,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[10]: "-32770" */
     {
-	"-32770",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-32770",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -881,7 +881,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[11]: "-32769" */
     {
-	"-32769",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-32769",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -950,7 +950,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[12]: "-32768" */
     {
-	"-32768",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-32768",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -1019,7 +1019,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[13]: "-32767" */
     {
-	"-32767",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-32767",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -1088,7 +1088,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[14]: "-32766" */
     {
-	"-32766",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-32766",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -1157,7 +1157,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[15]: "-514" */
     {
-	"-514",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-514",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1226,7 +1226,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[16]: "-513" */
     {
-	"-513",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-513",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1295,7 +1295,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[17]: "-512" */
     {
-	"-512",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-512",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1364,7 +1364,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[18]: "-511" */
     {
-	"-511",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-511",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1433,7 +1433,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[19]: "-510" */
     {
-	"-510",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-510",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1502,7 +1502,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[20]: "-258" */
     {
-	"-258",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-258",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1571,7 +1571,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[21]: "-257" */
     {
-	"-257",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-257",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1640,7 +1640,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[22]: "-256" */
     {
-	"-256",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-256",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1709,7 +1709,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[23]: "-255" */
     {
-	"-255",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-255",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1778,7 +1778,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[24]: "-254" */
     {
-	"-254",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-254",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1847,7 +1847,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[25]: "-130" */
     {
-	"-130",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-130",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1916,7 +1916,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[26]: "-129" */
     {
-	"-129",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-129",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -1985,7 +1985,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[27]: "-128" */
     {
-	"-128",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-128",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -2054,7 +2054,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[28]: "-127" */
     {
-	"-127",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-127",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -2123,7 +2123,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[29]: "-126" */
     {
-	"-126",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-126",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	4,	/* length of original JSON integer string */
 	4,	/* length of as_str */
@@ -2192,7 +2192,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[30]: "-2" */
     {
-	"-2",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-2",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	2,	/* length of original JSON integer string */
 	2,	/* length of as_str */
@@ -2261,7 +2261,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[31]: "-1" */
     {
-	"-1",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"-1",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	2,	/* length of original JSON integer string */
 	2,	/* length of as_str */
@@ -2330,7 +2330,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[32]: "0" */
     {
-	"0",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"0",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	1,	/* length of original JSON integer string */
 	1,	/* length of as_str */
@@ -2399,7 +2399,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[33]: "1" */
     {
-	"1",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"1",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	1,	/* length of original JSON integer string */
 	1,	/* length of as_str */
@@ -2468,7 +2468,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[34]: "2" */
     {
-	"2",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"2",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	1,	/* length of original JSON integer string */
 	1,	/* length of as_str */
@@ -2537,7 +2537,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[35]: "126" */
     {
-	"126",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"126",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2606,7 +2606,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[36]: "127" */
     {
-	"127",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"127",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2675,7 +2675,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[37]: "128" */
     {
-	"128",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"128",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2744,7 +2744,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[38]: "129" */
     {
-	"129",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"129",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2813,7 +2813,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[39]: "130" */
     {
-	"130",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"130",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2882,7 +2882,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[40]: "254" */
     {
-	"254",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"254",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -2951,7 +2951,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[41]: "255" */
     {
-	"255",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"255",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3020,7 +3020,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[42]: "256" */
     {
-	"256",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"256",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3089,7 +3089,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[43]: "257" */
     {
-	"257",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"257",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3158,7 +3158,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[44]: "258" */
     {
-	"258",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"258",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3227,7 +3227,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[45]: "510" */
     {
-	"510",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"510",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3296,7 +3296,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[46]: "511" */
     {
-	"511",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"511",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3365,7 +3365,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[47]: "512" */
     {
-	"512",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"512",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3434,7 +3434,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[48]: "513" */
     {
-	"513",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"513",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3503,7 +3503,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[49]: "514" */
     {
-	"514",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"514",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	3,	/* length of original JSON integer string */
 	3,	/* length of as_str */
@@ -3572,7 +3572,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[50]: "32766" */
     {
-	"32766",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"32766",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3641,7 +3641,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[51]: "32767" */
     {
-	"32767",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"32767",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3710,7 +3710,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[52]: "32768" */
     {
-	"32768",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"32768",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3779,7 +3779,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[53]: "32769" */
     {
-	"32769",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"32769",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3848,7 +3848,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[54]: "32770" */
     {
-	"32770",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"32770",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3917,7 +3917,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[55]: "65534" */
     {
-	"65534",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"65534",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -3986,7 +3986,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[56]: "65535" */
     {
-	"65535",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"65535",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -4055,7 +4055,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[57]: "65536" */
     {
-	"65536",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"65536",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -4124,7 +4124,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[58]: "65537" */
     {
-	"65537",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"65537",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -4193,7 +4193,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[59]: "65538" */
     {
-	"65538",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"65538",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	5,	/* length of original JSON integer string */
 	5,	/* length of as_str */
@@ -4262,7 +4262,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[60]: "131070" */
     {
-	"131070",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"131070",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -4331,7 +4331,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[61]: "131071" */
     {
-	"131071",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"131071",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -4400,7 +4400,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[62]: "131072" */
     {
-	"131072",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"131072",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -4469,7 +4469,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[63]: "131073" */
     {
-	"131073",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"131073",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */
@@ -4538,7 +4538,7 @@ struct json_integer test_result[TEST_COUNT] = {
 
     /* test_result[64]: "131074" */
     {
-	"131074",	/* malloced JSON integer string, whitespace trimmed if needed */
+	"131074",	/* allocated JSON integer string, whitespace trimmed if needed */
 
 	6,	/* length of original JSON integer string */
 	6,	/* length of as_str */

--- a/jparse.l
+++ b/jparse.l
@@ -60,8 +60,10 @@ YY_BUFFER_STATE bs;
  */
 
 /*
- * XXX JTYPE_WHITESPACE might not be needed but until this is determined I'm
- * keeping it in. For now when whitespace is encountered we print the string:
+ * XXX JTYPE_WHITESPACE is not needed but for testing I have the whitespace here
+ * and below in the actions print out that it is whitespace and what characters
+ * (though newlines and other non-printable whitespace chars are not translated
+ * to escape sequences). The text looks like:
  *
  *	whitespace: '<whitespace chars>'
  *

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -632,8 +632,10 @@ YY_BUFFER_STATE bs;
  * if there aren't any other errors.
  */
 /*
- * XXX JTYPE_WHITESPACE might not be needed but until this is determined I'm
- * keeping it in. For now when whitespace is encountered we print the string:
+ * XXX JTYPE_WHITESPACE is not needed but for testing I have the whitespace here
+ * and below in the actions print out that it is whitespace and what characters
+ * (though newlines and other non-printable whitespace chars are not translated
+ * to escape sequences). The text looks like:
  *
  *	whitespace: '<whitespace chars>'
  *
@@ -672,7 +674,7 @@ YY_BUFFER_STATE bs;
  *
  * For now we just print the type and value and then return the type.
  */
-#line 633 "jparse.c"
+#line 635 "jparse.c"
 
 #define INITIAL 0
 
@@ -889,9 +891,9 @@ YY_DECL
 		}
 
 	{
-#line 124 "jparse.l"
+#line 126 "jparse.l"
 
-#line 852 "jparse.c"
+#line 854 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -961,75 +963,75 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 125 "jparse.l"
+#line 127 "jparse.l"
 { printf("\nwhitespace: '%s'\n", yytext); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 126 "jparse.l"
+#line 128 "jparse.l"
 { printf("\nstring: '%s'\n", yytext); return JTYPE_STRING; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 127 "jparse.l"
+#line 129 "jparse.l"
 { printf("\nuintmax: '%s'\n", yytext); return JTYPE_UINTMAX; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 128 "jparse.l"
+#line 130 "jparse.l"
 { printf("\nintmax: '%s'\n", yytext); return JTYPE_INTMAX; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 129 "jparse.l"
+#line 131 "jparse.l"
 { printf("\nlong double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 130 "jparse.l"
+#line 132 "jparse.l"
 { printf("\nnull: '%s'\n", yytext); return JTYPE_NULL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 131 "jparse.l"
+#line 133 "jparse.l"
 { printf("\nboolean: '%s'\n", yytext); return JTYPE_BOOLEAN; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 132 "jparse.l"
+#line 134 "jparse.l"
 { printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 133 "jparse.l"
+#line 135 "jparse.l"
 { printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 134 "jparse.l"
+#line 136 "jparse.l"
 { printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 135 "jparse.l"
+#line 137 "jparse.l"
 { printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JTYPE_CLOSE_BRACKET; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 136 "jparse.l"
+#line 138 "jparse.l"
 { printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JTYPE_COLON; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 137 "jparse.l"
+#line 139 "jparse.l"
 { printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JTYPE_COMMA; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 138 "jparse.l"
+#line 140 "jparse.l"
 ECHO;
 	YY_BREAK
-#line 990 "jparse.c"
+#line 992 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2046,7 +2048,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 138 "jparse.l"
+#line 140 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/json.c
+++ b/json.c
@@ -404,18 +404,18 @@ static void expand_json_code_ignore_set(void);
  * given:
  *	ptr	start of memory block to encode
  *	len	length of block to encode in bytes
- *	retlen	address of where to store malloced length, if retlen != NULL
+ *	retlen	address of where to store allocated length, if retlen != NULL
  *
  * returns:
- *	malloced JSON encoding of a block, or NULL ==> error
+ *	allocated JSON encoding of a block, or NULL ==> error
  *	NOTE: retlen, if non-NULL, is set to 0 on error
  */
 char *
 json_encode(char const *ptr, size_t len, size_t *retlen)
 {
-    char *ret = NULL;	    /* malloced encoding string or NULL */
-    char *beyond = NULL;    /* beyond the end of the malloced encoding string */
-    size_t mlen = 0;	    /* length of malloced encoded string */
+    char *ret = NULL;	    /* allocated encoding string or NULL */
+    char *beyond = NULL;    /* beyond the end of the allocated encoding string */
+    size_t mlen = 0;	    /* length of allocated encoded string */
     char *p;		    /* next place to encode */
     size_t i;
 
@@ -423,7 +423,7 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
      * firewall
      */
     if (ptr == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -431,7 +431,7 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
 	return NULL;
     }
     if (len <= 0) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -440,7 +440,7 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
     }
 
     /*
-     * count the bytes that will be in the encoded malloced string
+     * count the bytes that will be in the encoded allocated string
      */
     for (i=0; i < len; ++i) {
 	mlen += jenc[(uint8_t)(ptr[i])].len;
@@ -451,7 +451,7 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
      */
     ret = malloc(mlen + 1 + 1);
     if (ret == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -467,11 +467,11 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
      */
     for (i=0, p=ret; i < len; ++i) {
 	if (p+jenc[(uint8_t)(ptr[i])].len > beyond) {
-	    /* error - clear malloced length */
+	    /* error - clear allocated length */
 	    if (retlen != NULL) {
 		*retlen = 0;
 	    }
-	    warn(__func__, "encoding ran beyond end of malloced encoded string");
+	    warn(__func__, "encoding ran beyond end of allocated encoded string");
 	    return NULL;
 	}
 	strcpy(p, jenc[(uint8_t)(ptr[i])].enc);
@@ -497,23 +497,23 @@ json_encode(char const *ptr, size_t len, size_t *retlen)
  *
  * given:
  *	str	a string to encode
- *	retlen	address of where to store malloced length, if retlen != NULL
+ *	retlen	address of where to store allocated length, if retlen != NULL
  *
  * returns:
- *	malloced JSON encoding of a block, or NULL ==> error
+ *	allocated JSON encoding of a block, or NULL ==> error
  *	NOTE: retlen, if non-NULL, is set to 0 on error
  */
 char *
 json_encode_str(char const *str, size_t *retlen)
 {
-    void *ret = NULL;	    /* malloced encoding string or NULL */
+    void *ret = NULL;	    /* allocated encoding string or NULL */
     size_t len = 0;	    /* length of string to encode */
 
     /*
      * firewall
      */
     if (str == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -522,7 +522,7 @@ json_encode_str(char const *str, size_t *retlen)
     }
     len = strlen(str);
     if (len <= 0) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -563,10 +563,10 @@ jencchk(void)
     char const *encstr;	/* encoding string */
     int ret;		/* libc function return value */
     char str[2];	/* character string to encode */
-    char *mstr = NULL;	/* malloced encoding string */
-    size_t mlen = 0;	/* length of malloced encoding string */
-    char *mstr2 = NULL;	/* malloced decoding string */
-    size_t mlen2 = 0;	/* length of malloced decoding string */
+    char *mstr = NULL;	/* allocated encoding string */
+    size_t mlen = 0;	/* length of allocated encoding string */
+    char *mstr2 = NULL;	/* allocated decoding string */
+    size_t mlen2 = 0;	/* length of allocated decoding string */
     unsigned int i;
 
     /*
@@ -998,7 +998,7 @@ jencchk(void)
 			   (uintmax_t)mlen, jenc[0].enc);
 	not_reached();
     }
-    /* free the malloced encoded string */
+    /* free the allocated encoded string */
     if (mstr != NULL) {
 	free(mstr);
 	mstr = NULL;
@@ -1057,7 +1057,7 @@ jencchk(void)
 	    not_reached();
 	}
 
-	/* free the malloced encoded string */
+	/* free the allocated encoded string */
 	if (mstr != NULL) {
 	    free(mstr);
 	    mstr = NULL;
@@ -1118,18 +1118,18 @@ json_putc(uint8_t const c, FILE *stream)
  * given:
  *	ptr	start of memory block to decode
  *	len	length of block to decode in bytes
- *	retlen	address of where to store malloced length, if retlen != NULL
+ *	retlen	address of where to store allocated length, if retlen != NULL
  *
  * returns:
- *	malloced JSON decoding of a block, or NULL ==> error
+ *	allocated JSON decoding of a block, or NULL ==> error
  *	NOTE: retlen, if non-NULL, is set to 0 on error
  */
 char *
 json_decode(char const *ptr, size_t len, size_t *retlen)
 {
-    char *ret = NULL;	    /* malloced encoding string or NULL */
-    char *beyond = NULL;    /* beyond the end of the malloced encoding string */
-    size_t mlen = 0;	    /* length of malloced encoded string */
+    char *ret = NULL;	    /* allocated encoding string or NULL */
+    char *beyond = NULL;    /* beyond the end of the allocated encoding string */
+    size_t mlen = 0;	    /* length of allocated encoded string */
     char *p = NULL;	    /* next place to encode */
     char n = 0;		    /* next character beyond a \\ */
     char a = 0;		    /* first hex character after \u */
@@ -1146,7 +1146,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
      * firewall
      */
     if (ptr == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -1154,7 +1154,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	return NULL;
     }
     if (len <= 0) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -1163,7 +1163,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
     }
 
     /*
-     * count the bytes that will be in the decoded malloced string
+     * count the bytes that will be in the decoded allocated string
      */
     for (i=0; i < len; ++i) {
 
@@ -1186,7 +1186,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	    case '\n':  /*fallthrough*/
 	    case '\f':  /*fallthrough*/
 	    case '\r':
-		/* error - clear malloced length */
+		/* error - clear allocated length */
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
@@ -1196,7 +1196,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	    case '"':   /*fallthrough*/
 	    case '/':   /*fallthrough*/
 	    case '\\':
-		/* error - clear malloced length */
+		/* error - clear allocated length */
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
@@ -1221,7 +1221,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	     * there must be at least one more character beyond \
 	     */
 	    if (i+1 >= len) {
-		/* error - clear malloced length */
+		/* error - clear allocated length */
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
@@ -1262,7 +1262,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 		 * there must be at least five more characters beyond \
 		 */
 		if (i+5 >= len) {
-		    /* error - clear malloced length */
+		    /* error - clear allocated length */
 		    if (retlen != NULL) {
 			*retlen = 0;
 		    }
@@ -1308,7 +1308,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	     * found invalid JSON \-escape character
 	     */
 	    default:
-		/* error - clear malloced length */
+		/* error - clear allocated length */
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
@@ -1319,11 +1319,11 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
     }
 
     /*
-     * malloced decoded string
+     * allocated decoded string
      */
     ret = malloc(mlen + 1 + 1);
     if (ret == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -1351,7 +1351,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	 * paranoia
 	 */
 	if (p >= beyond) {
-	    /* error - clear malloced length */
+	    /* error - clear allocated length */
 	    if (retlen != NULL) {
 		*retlen = 0;
 	    }
@@ -1428,7 +1428,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 		 * there must be at least five more characters beyond \
 		 */
 		if (i+5 >= len) {
-		    /* error - clear malloced length */
+		    /* error - clear allocated length */
 		    if (retlen != NULL) {
 			*retlen = 0;
 		    }
@@ -1457,7 +1457,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 		     * paranoia
 		     */
 		    if (p+1 >= beyond) {
-			/* error - clear malloced length */
+			/* error - clear allocated length */
 			if (retlen != NULL) {
 			    *retlen = 0;
 			}
@@ -1475,7 +1475,7 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 	     * unknown \c escaped pairs
 	     */
 	    default:
-		/* error - clear malloced length */
+		/* error - clear allocated length */
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
@@ -1504,10 +1504,10 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
  *
  * given:
  *	str	a string to decode
- *	retlen	address of where to store malloced length, if retlen != NULL
+ *	retlen	address of where to store allocated length, if retlen != NULL
  *
  * returns:
- *	malloced JSON decoding of a block, or NULL ==> error
+ *	allocated JSON decoding of a block, or NULL ==> error
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *
@@ -1521,14 +1521,14 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 char *
 json_decode_str(char const *str, size_t *retlen)
 {
-    void *ret = NULL;	    /* malloced decoding string or NULL */
+    void *ret = NULL;	    /* allocated decoding string or NULL */
     size_t len = 0;	    /* length of string to decode */
 
     /*
      * firewall
      */
     if (str == NULL) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -1537,7 +1537,7 @@ json_decode_str(char const *str, size_t *retlen)
     }
     len = strlen(str);
     if (len <= 0) {
-	/* error - clear malloced length */
+	/* error - clear allocated length */
 	if (retlen != NULL) {
 	    *retlen = 0;
 	}
@@ -3634,10 +3634,10 @@ ignore_json_code(int code)
  *	len	length, starting at str, of the JSON string
  *
  * returns:
- *	malloced JSON parser tree node converted JSON integer
+ *	allocated JSON parser tree node converted JSON integer
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
@@ -4060,10 +4060,10 @@ json_conv_int(char const *str, size_t len)
  *	retlen	address of where to store length of str, if retlen != NULL
  *
  * returns:
- *	malloced JSON parser tree node converted JSON integer
+ *	allocated JSON parser tree node converted JSON integer
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *
@@ -4118,10 +4118,10 @@ json_conv_int_str(char const *str, size_t *retlen)
  *	len	length, starting at str, of the JSON string
  *
  * returns:
- *	malloced JSON parser tree node converted JSON floating point string
+ *	allocated JSON parser tree node converted JSON floating point string
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
@@ -4303,10 +4303,10 @@ json_conv_float(char const *str, size_t len)
  *	retlen	address of where to store length of str, if retlen != NULL
  *
  * returns:
- *	malloced JSON parser tree node converted JSON JSON floating point string
+ *	allocated JSON parser tree node converted JSON JSON floating point string
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *
@@ -4363,10 +4363,10 @@ json_conv_float_str(char const *str, size_t *retlen)
  *		false ==> the entire str is to be converted
  *
  * returns:
- *	malloced JSON parser tree node converted JSON encoded string
+ *	allocated JSON parser tree node converted JSON encoded string
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
@@ -4507,10 +4507,10 @@ json_conv_string(char const *str, size_t len, bool quote)
  *		false ==> the entire str is to be converted
  *
  * returns:
- *	malloced JSON parser tree node converted JSON string
+ *	allocated JSON parser tree node converted JSON string
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *
@@ -4565,10 +4565,10 @@ json_conv_string_str(char const *str, size_t *retlen, bool quote)
  *	len	length, starting at str, of the JSON boolean
  *
  * returns:
- *	malloced JSON parser tree node converted JSON encoded boolean
+ *	allocated JSON parser tree node converted JSON encoded boolean
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
@@ -4577,7 +4577,7 @@ struct json *
 json_conv_bool(char const *str, size_t len)
 {
     struct json *ret = NULL;		    /* JSON parser tree node to return */
-    struct json_boolean *item = NULL;	    /* malloced decoding string or NULL */
+    struct json_boolean *item = NULL;	    /* allocated decoding string or NULL */
 
     /*
      * allocate the JSON parse tree element
@@ -4665,10 +4665,10 @@ json_conv_bool(char const *str, size_t len)
  *	retlen	address of where to store length of str, if retlen != NULL
  *
  * returns:
- *	malloced JSON parser tree node converted JSON boolean
+ *	allocated JSON parser tree node converted JSON boolean
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *
@@ -4723,10 +4723,10 @@ json_conv_bool_str(char const *str, size_t *retlen)
  *	len	length, starting at str, of the JSON null
  *
  * returns:
- *	malloced JSON parser tree node converted JSON encoded null
+ *	allocated JSON parser tree node converted JSON encoded null
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
@@ -4735,7 +4735,7 @@ struct json *
 json_conv_null(char const *str, size_t len)
 {
     struct json *ret = NULL;		    /* JSON parser tree node to return */
-    struct json_null *item = NULL;	    /* malloced decoding string or NULL */
+    struct json_null *item = NULL;	    /* allocated decoding string or NULL */
 
     /*
      * allocate the JSON parse tree element
@@ -4819,10 +4819,10 @@ json_conv_null(char const *str, size_t len)
  *	retlen	address of where to store length of str, if retlen != NULL
  *
  * returns:
- *	malloced JSON parser tree node converted JSON null
+ *	allocated JSON parser tree node converted JSON null
  *
  * NOTE: It is the responsibility of the calling function to link this
- *	 malloced JSON parser tree node into the JSON parse tree.
+ *	 allocated JSON parser tree node into the JSON parse tree.
  *
  * NOTE: retlen, if non-NULL, is set to 0 on error
  *

--- a/json.h
+++ b/json.h
@@ -149,7 +149,7 @@ extern struct ignore_json_code *ignore_json_code_set;
  */
 struct json_integer
 {
-    char *as_str;		/* malloced JSON integer string, whitespace trimmed if needed */
+    char *as_str;		/* allocated JSON integer string, whitespace trimmed if needed */
 
     size_t orig_len;		/* length of original JSON integer string */
     size_t as_str_len;		/* length of as_str */
@@ -231,7 +231,7 @@ struct json_integer
  */
 struct json_floating
 {
-    char *as_str;		/* malloced JSON floating point string, whitespace trimmed if needed */
+    char *as_str;		/* allocated JSON floating point string, whitespace trimmed if needed */
 
     size_t orig_len;		/* length of original JSON floating point string */
     size_t as_str_len;		/* length of as_str */
@@ -258,8 +258,8 @@ struct json_floating
  */
 struct json_string
 {
-    char *as_str;		/* malloced non-decoded JSON string, NUL terminated (perhaps sans JSON "s) */
-    char *str;			/* malloced decoded JSON string, NUL terminated */
+    char *as_str;		/* allocated non-decoded JSON string, NUL terminated (perhaps sans JSON "s) */
+    char *str;			/* allocated decoded JSON string, NUL terminated */
 
     size_t as_str_len;		/* length of as_str, not including final NUL */
     size_t str_len;		/* length of str, not including final NUL */
@@ -282,7 +282,7 @@ struct json_string
  */
 struct json_boolean
 {
-    char *as_str;		/* malloced JSON floating point string, whitespace trimmed if needed */
+    char *as_str;		/* allocated JSON floating point string, whitespace trimmed if needed */
     size_t as_str_len;		/* length of as_str */
 
     bool converted;		/* true ==> able to decode JSON boolean, false ==> as_str is invalid or not decoded */
@@ -295,7 +295,7 @@ struct json_boolean
  */
 struct json_null
 {
-    char *as_str;		/* malloced JSON floating point string, whitespace trimmed if needed */
+    char *as_str;		/* allocated JSON floating point string, whitespace trimmed if needed */
     size_t as_str_len;		/* length of as_str */
 
     bool converted;		/* true ==> able to decode JSON null, false ==> as_str is invalid or not decoded */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1272,7 +1272,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
  *
  *
  * returns:
- *      malloced input string with newline and trailing whitespace removed
+ *      allocated input string with newline and trailing whitespace removed
  *	if lenp != NULL, *lenp will be set to the length of the response
  *
  * NOTE: This function will NOT return NULL.
@@ -1285,7 +1285,7 @@ prompt(char const *str, size_t *lenp)
     char *linep = NULL;		/* readline_dup line buffer */
     int ret;			/* libc function return value */
     size_t len;			/* length of input */
-    char *buf;			/* malloced input string */
+    char *buf;			/* allocated input string */
 
     /*
      * firewall
@@ -1370,7 +1370,7 @@ prompt(char const *str, size_t *lenp)
     }
 
     /*
-     * return malloced input buffer
+     * return allocated input buffer
      */
     return buf;
 }
@@ -1380,7 +1380,7 @@ prompt(char const *str, size_t *lenp)
  * get IOCCC ID or test
  *
  * This function will prompt the user for a contest ID, validate it and return it
- * as a malloced string.  If the contest ID is the special value "test", then
+ * as a allocated string.  If the contest ID is the special value "test", then
  * *testp will be set to true, otherwise it will be set to false.
  *
  * given:
@@ -1388,7 +1388,7 @@ prompt(char const *str, size_t *lenp)
  *      testp   - pointer to boolean for test mode
  *
  * returns:
- *      malloced contest ID string
+ *      allocated contest ID string
  *      *testp ==> contest ID is "test", else contest ID is a UUID.
  *
  * This function does not return on error or if the contest ID is malformed.
@@ -1396,7 +1396,7 @@ prompt(char const *str, size_t *lenp)
 static char *
 get_contest_id(bool *testp, bool *read_answers_flag_used)
 {
-    char *malloc_ret;		/* malloced return string */
+    char *malloc_ret;		/* allocated return string */
     size_t len;			/* input string length */
     int ret;			/* libc function return */
     unsigned int a, b, c, d, e, f;	/* parts of the UUID string */
@@ -1668,7 +1668,7 @@ get_entry_num(struct info *infop)
  *      work_dir        - working directory under which the entry directory is formed
  *      ioccc_id        - IOCCC entry ID (or test)
  *      entry_num       - entry number
- *      tarball_path    - pointer to the malloced path to where the compressed tarball will be formed
+ *      tarball_path    - pointer to the allocated path to where the compressed tarball will be formed
  *      tstamp          - now as a timestamp
  *
  * returns:
@@ -1681,7 +1681,7 @@ mk_entry_dir(char const *work_dir, char const *ioccc_id, int entry_num, char **t
 {
     size_t entry_dir_len;	/* length of entry directory */
     size_t tarball_len;		/* length of the compressed tarball path */
-    char *entry_dir = NULL;	/* malloced entry directory path */
+    char *entry_dir = NULL;	/* allocated entry directory path */
     int ret;			/* libc function return */
 
     /*
@@ -3229,13 +3229,13 @@ yes_or_no(char const *question)
  * get_title - get the title of the entry
  *
  * Ask the user for an entry title, validate the response
- * and return the malloced title.
+ * and return the allocated title.
  *
  * given:
  *      infop   - pointer to info structure
  *
  * returns:
- *      malloced and validated title
+ *      allocated and validated title
  *
  * This function does not return on error.
  */
@@ -3370,7 +3370,7 @@ get_title(struct info *infop)
 
 
     /*
-     * returned malloced title
+     * returned allocated title
      */
     return title;
 }
@@ -3380,13 +3380,13 @@ get_title(struct info *infop)
  * get_abstract - get the abstract of the entry
  *
  * Ask the user for an entry abstract, validate the response
- * and return the malloced abstract.
+ * and return the allocated abstract.
  *
  * given:
  *      infop           - pointer to info structure
  *
  * returns:
- *      malloced and validated abstract
+ *      allocated and validated abstract
  *
  * This function does not return on error.
  */
@@ -3478,7 +3478,7 @@ get_abstract(struct info *infop)
     } while (abstract == NULL);
 
     /*
-     * returned malloced abstract
+     * returned allocated abstract
      */
     return abstract;
 }

--- a/prep.sh
+++ b/prep.sh
@@ -183,7 +183,7 @@ if [[ $EXIT_CODE -eq 0 ]]; then
     echo "=-=-=-=-= PASS: $0 =-=-=-=-="
     echo
 else
-    echo "=-=-=-=-= FALL: $0 =-=-=-=-="
+    echo "=-=-=-=-= FAIL: $0 =-=-=-=-="
     echo
     echo "=-=-=-=-= Will exit: $EXIT_CODE =-=-=-=-="
     echo

--- a/utf8_posix_map.c
+++ b/utf8_posix_map.c
@@ -1638,7 +1638,7 @@ check_utf8_posix_map(void)
  * will be returned.  If the translation results in a string that would
  * be too long, the string will be truncated.
  *
- * In all cases the return will be a non-NULL malloced string that
+ * In all cases the return will be a non-NULL allocated string that
  * is NUL terminated, not empty, and consisting of only POSIX portable
  * filename and + chars.
  *
@@ -1646,7 +1646,7 @@ check_utf8_posix_map(void)
  *	name		- name of the author
  *
  * returns:
- *	malloced default handle
+ *	allocated default handle
  *
  * Does not return on error nor NULL pointers nor invalid args.
  */
@@ -1739,7 +1739,7 @@ default_handle(char const *name)
      * case: estimated default handle is empty
      *
      * If the hmap[] translation of name would be empty, then
-     * for a malloced string of hex characters our of 3 calls random().
+     * for a allocated string of hex characters our of 3 calls random().
      */
     if (def_len <= 0) {
 
@@ -1873,10 +1873,10 @@ default_handle(char const *name)
 		if (m->posix_str_len > 0) {
 
 		    /*
-		     * firewall - do not copy beyond end of malloced buffer
+		     * firewall - do not copy beyond end of allocated buffer
 		     */
 		    if (cur_len + m->posix_str_len > def_len) {
-			err(22, __func__, "attempt to copy to buf[%ju] %ju bytes: would go beyond malloced len: %ju",
+			err(22, __func__, "attempt to copy to buf[%ju] %ju bytes: would go beyond allocated len: %ju",
 					   (uintmax_t)cur_len, (uintmax_t)m->posix_str_len, (uintmax_t)def_len);
 			not_reached();
 		    }

--- a/util.c
+++ b/util.c
@@ -70,7 +70,7 @@
  *      path    - path to form the basename from
  *
  * returns:
- *      malloced basename
+ *      allocated basename
  *
  * This function does not return on error.
  */
@@ -531,7 +531,7 @@ file_size(char const *path)
  *      ...    - args to give after the format
  *
  * returns:
- *	malloced shell command line, or
+ *	allocated shell command line, or
  *	NULL ==> error
  */
 char *
@@ -582,7 +582,7 @@ cmdprintf(char const *format, ...)
  *      ap     - va_list of arguments for format
  *
  * returns:
- *	malloced shell command line, or
+ *	allocated shell command line, or
  *	NULL ==> error
  *
  * NOTE: This code is based on an enhancement request by GitHub user @ilyakurdyukov:
@@ -828,7 +828,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -851,7 +851,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -874,7 +874,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     exit_code = system(cmd);
     if (exit_code < 0) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -893,7 +893,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
      * case: exit code 127 usually means the fork/exec was unable to invoke the shell
      */
     } else if (exit_code == 127) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -910,7 +910,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
     }
 
     /*
-     * free malloced command storage
+     * free allocated command storage
      */
     if (cmd != NULL) {
 	free(cmd);
@@ -1013,7 +1013,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stdout);
     if (ret < 0) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -1036,7 +1036,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fflush(stderr);
     if (ret < 0) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -1059,7 +1059,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     errno = 0;			/* pre-clear errno for errp() */
     stream = popen(cmd, "r");
     if (stream == NULL) {
-	/* free malloced command storage */
+	/* free allocated command storage */
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
@@ -1085,7 +1085,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     }
 
     /*
-     * free malloced command storage
+     * free allocated command storage
      */
     if (cmd != NULL) {
 	free(cmd);
@@ -1508,7 +1508,7 @@ pr(char const *name, char const *fmt, ...)
  * buffer as needed.  Remove the trailing newline that was read.
  *
  * given:
- *      linep   - malloced line buffer (may be realloced) or ptr to NULL
+ *      linep   - allocated line buffer (may be realloced) or ptr to NULL
  *                NULL ==> getline() will malloc() the linep buffer
  *                else ==> getline() might realloc() the linep buffer
  *      stream - file stream to read from
@@ -1590,20 +1590,20 @@ readline(char **linep, FILE * stream)
 
 
 /*
- * readline_dup - read a line from a stream and duplicate to a malloced buffer.
+ * readline_dup - read a line from a stream and duplicate to a allocated buffer.
  *
  * given:
- *      linep   - malloced line buffer (may be realloced) or ptr to NULL
+ *      linep   - allocated line buffer (may be realloced) or ptr to NULL
  *                NULL ==> getline() will malloc() the linep buffer
  *                else ==> getline() might realloc() the linep buffer
  *      strip   - true ==> remove trailing whitespace,
  *                false ==> only remove the trailing newline
- *      lenp    - != NULL ==> pointer to length of final length of line malloced,
+ *      lenp    - != NULL ==> pointer to length of final length of line allocated,
  *                NULL ==> do not return length of line
  *      stream - file stream to read from
  *
  * returns:
- *      malloced buffer containing the input without a trailing newline,
+ *      allocated buffer containing the input without a trailing newline,
  *      and if strip == true, without trailing whitespace,
  *      or NULL ==> EOF
  *
@@ -1613,7 +1613,7 @@ char *
 readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
 {
     ssize_t len;		/* getline return and our modified size return */
-    char *ret;			/* malloced input */
+    char *ret;			/* allocated input */
     ssize_t i;
 
     /*
@@ -1670,7 +1670,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
     }
 
     /*
-     * return the malloced string
+     * return the allocated string
      */
     return ret;
 }
@@ -1805,14 +1805,14 @@ round_to_multiple(off_t num, off_t multiple)
  * This function will update *psize, if it was non-NULL, to indicate
  * the amount of data that was read from stream before EOF.
  *
- * The malloced buffer may be larger than the amount of data read.
+ * The allocated buffer may be larger than the amount of data read.
  * In this case *psize (if psize != NULL) will contain the exact
  * amount of data read, ignoring any extra allocated data.
- * Any extra unused space in the malloced buffer will be zeroized
+ * Any extra unused space in the allocated buffer will be zeroized
  * before returning.
  *
  * This function will always add at least one extra byte of allocated
- * data to the end of the malloced buffer (zeroized as mentioned above).
+ * data to the end of the allocated buffer (zeroized as mentioned above).
  * These extra bytes(s) WILL be set to NUL.  Thus, a file or stream
  * without a NUL byte will return a NUL terminated C-style string.
  *
@@ -1835,7 +1835,7 @@ round_to_multiple(off_t num, off_t multiple)
  }	}
  *
  * Because files can contain NUL bytes, the strlen() function on
- * the malloced buffer may return a different length than the
+ * the allocated buffer may return a different length than the
  * amount of data read from stream.  This is also why the function
  * returns a pointer to void.
  *
@@ -1975,7 +1975,7 @@ read_all(FILE *stream, size_t *psize)
     }
 
     /*
-     * return the malloced buffer
+     * return the allocated buffer
      */
     ret = dyn_array_addr(array, uint8_t, 0);
     return ret;

--- a/verge.c
+++ b/verge.c
@@ -62,8 +62,8 @@ main(int argc, char *argv[])
     char *ver2 = NULL;		/* second version string */
     int ver1_levels = 0;	/* number of version levels for first version string */
     int ver2_levels = 0;	/* number of version levels for second version string */
-    long *vlevel1 = NULL;	/* malloced version levels from first version string */
-    long *vlevel2 = NULL;	/* malloced version levels from second version string */
+    long *vlevel1 = NULL;	/* allocated version levels from first version string */
+    long *vlevel2 = NULL;	/* allocated version levels from second version string */
     int i;
 
     /*
@@ -222,23 +222,23 @@ main(int argc, char *argv[])
 
 
 /*
- * malloc_vers - convert version string into a malloced array or version numbers
+ * malloc_vers - convert version string into a allocated array or version numbers
  *
  * given:
  *	ver	version string
- *	pvers	pointer to malloced array of versions
+ *	pvers	pointer to allocated array of versions
  *
  * returns:
- *	> 0  ==> number of version integers in malloced array of versions
+ *	> 0  ==> number of version integers in allocated array of versions
  *	0 <= ==> string was not a valid version string,
- *		 array of versions not malloced
+ *		 array of versions not allocated
  *
  * NOTE: This function does not return on malloc failure or arg error.
  */
 static size_t
 malloc_vers(char *str, long **pvers)
 {
-    char *wstr = NULL;		/* working malloced copy of orig_str */
+    char *wstr = NULL;		/* working allocated copy of orig_str */
     size_t len;			/* length of version string */
     bool dot = false;		/* true ==> previous character was dot */
     size_t dot_count = 0;	/* number of .'s in version string */


### PR DESCRIPTION
As for commit https://github.com/ioccc-src/mkiocccentry/commit/45d9d324d6a910f88eb128b5d47b484af9958862 I am pointing out the log here for those who need a laugh and who are easily amused:

```
Typo fix in prep.sh

Not to criticise (atefr all, we all mkae tpyos :) ) but just point it out
out because it's an ironic and funny typo: FALL -> FAIL which was a FAIL
itself :)
```

And yes: there are several intentional typos in the commit log! Bonus points to those who can find them all.