### PR TITLE
txzchk fixes + several JSON updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ dbg: dbg.c Makefile
 fnamchk: fnamchk.c dbg.o util.o dyn_array.o Makefile
 	${CC} ${CFLAGS} fnamchk.c dbg.o util.o dyn_array.o -o $@
 
-txzchk: txzchk.c rule_count.o dbg.o util.o dyn_array.o location.o json.o json_chk.o json_util.o \
+txzchk: txzchk.c txzchk.h rule_count.o dbg.o util.o dyn_array.o location.o json.o json_chk.o json_util.o \
 	utf8_posix_map.o sanity.o Makefile
 	${CC} ${CFLAGS} txzchk.c rule_count.o dbg.o util.o dyn_array.o location.o json.o \
 	    json_chk.o json_util.o utf8_posix_map.o sanity.o -o $@
@@ -892,27 +892,27 @@ depend: all
 utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dyn_array.h \
   dbg.h limit_ioccc.h version.h
 jparse.o: jparse.c jparse.h dbg.h util.h dyn_array.h json.h sanity.h \
-  location.h utf8_posix_map.h json_chk.h limit_ioccc.h version.h \
-  jparse.tab.h
-jparse.tab.o: jparse.tab.c jparse.h dbg.h util.h dyn_array.h json.h \
-  sanity.h location.h utf8_posix_map.h json_chk.h limit_ioccc.h \
+  location.h utf8_posix_map.h json_chk.h json_util.h limit_ioccc.h \
   version.h jparse.tab.h
+jparse.tab.o: jparse.tab.c jparse.h dbg.h util.h dyn_array.h json.h \
+  sanity.h location.h utf8_posix_map.h json_chk.h json_util.h \
+  limit_ioccc.h version.h jparse.tab.h
 dbg.o: dbg.c dbg.h
 util.o: util.c dbg.h util.h dyn_array.h limit_ioccc.h version.h
 mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h dyn_array.h dbg.h \
   json_entry.h location.h utf8_posix_map.h sanity.h json.h json_chk.h \
-  limit_ioccc.h version.h iocccsize.h
+  json_util.h limit_ioccc.h version.h iocccsize.h
 iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
 fnamchk.o: fnamchk.c fnamchk.h dbg.h util.h dyn_array.h limit_ioccc.h \
   version.h utf8_posix_map.h
 txzchk.o: txzchk.c txzchk.h util.h dyn_array.h dbg.h sanity.h location.h \
-  utf8_posix_map.h json.h json_chk.h limit_ioccc.h version.h
+  utf8_posix_map.h json.h json_chk.h json_util.h limit_ioccc.h version.h
 jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h dyn_array.h json.h \
-  sanity.h location.h utf8_posix_map.h json_chk.h limit_ioccc.h \
-  version.h
+  json_entry.h json_util.h sanity.h location.h utf8_posix_map.h \
+  json_chk.h limit_ioccc.h version.h
 jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h dyn_array.h json.h \
-  json_entry.h sanity.h location.h utf8_posix_map.h json_chk.h \
-  limit_ioccc.h version.h
+  json_entry.h json_util.h sanity.h location.h utf8_posix_map.h \
+  json_chk.h limit_ioccc.h version.h
 json.o: json.c dbg.h util.h dyn_array.h limit_ioccc.h version.h json.h
 jstrencode.o: jstrencode.c jstrencode.h dbg.h util.h dyn_array.h json.h \
   limit_ioccc.h version.h
@@ -921,7 +921,7 @@ jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h dyn_array.h json.h \
 rule_count.o: rule_count.c iocccsize_err.h iocccsize.h
 location.o: location.c location.h util.h dyn_array.h dbg.h
 sanity.o: sanity.c sanity.h util.h dyn_array.h dbg.h location.h \
-  utf8_posix_map.h json.h json_chk.h limit_ioccc.h version.h
+  utf8_posix_map.h json.h json_chk.h json_util.h limit_ioccc.h version.h
 utf8_test.o: utf8_test.c utf8_posix_map.h util.h dyn_array.h dbg.h \
   limit_ioccc.h version.h
 jint.o: jint.c jint.h dbg.h util.h dyn_array.h json.h limit_ioccc.h \
@@ -933,6 +933,6 @@ jfloat.test.o: jfloat.test.c json.h
 verge.o: verge.c verge.h dbg.h util.h dyn_array.h limit_ioccc.h version.h
 dyn_array.o: dyn_array.c dyn_array.h util.h dbg.h
 dyn_test.o: dyn_test.c dyn_test.h util.h dyn_array.h dbg.h version.h
-json_chk.o: json_chk.c json_chk.h util.h dyn_array.h dbg.h \
-  json.h limit_ioccc.h version.h
+json_chk.o: json_chk.c json_chk.h util.h dyn_array.h dbg.h json.h \
+  json_util.h limit_ioccc.h version.h
 json_entry.o: json_entry.c dbg.h util.h dyn_array.h json.h json_entry.h

--- a/Makefile
+++ b/Makefile
@@ -431,8 +431,8 @@ jparse.tab.c jparse.tab.h: jparse.y bfok.sh limit_ioccc.sh verge jparse.tab.ref.
 		echo "${CP} -f -v jparse.tab.ref.h jparse.tab.h"; \
 		${CP} -f -v jparse.tab.ref.h jparse.tab.h; \
 	    else \
-		echo "$$BISON_PATH -d jparse.y"; \
-		"$$BISON_PATH" -d jparse.y; \
+		echo "$$BISON_PATH -d -Wyacc -Dparse.error=verbose -Dparse.lac=full jparse.y"; \
+		"$$BISON_PATH" -d -Wyacc -Dparse.error=verbose -Dparse.lac=full jparse.y; \
 		status="$$?"; \
 		if [[ $$status -eq 0 && -s jparse.tab.c && -s jparse.tab.h ]]; then \
 		    echo '# prepending comment and line number reset to jparse.tab.c'; \

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -442,8 +442,8 @@ check_author_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (author_field && author_field->can_be_empty);
-	    is_json_string = (common_field && common_field->field_type == JSON_STRING) ||
-			     (author_field && (author_field->field_type == JSON_STRING));
+	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
+			     (author_field && (author_field->field_type == JTYPE_STRING));
 	    /*
 	     * If the field type is a string we have to remove a single '"' and
 	     * from the beginning and end of the value.
@@ -770,7 +770,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 	     * valid values.
 	     */
 	    switch (author_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       author_field->name, json_filename, val);
@@ -780,7 +780,7 @@ check_found_author_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "%s is a bool", val);
 		    }
 		    break;
-		case JSON_INT:
+		case JTYPE_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       author_field->name, json_filename, val);

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -503,7 +503,7 @@ check_info_json(char const *file, char const *fnamchk)
 
 		/* only some array fields can have empty values (null string) */
 		can_be_empty = array_info_field && array_info_field->can_be_empty;
-		is_json_string = array_info_field && array_info_field->field_type == JSON_STRING;
+		is_json_string = array_info_field && array_info_field->field_type == JTYPE_STRING;
 
 
 		array_val = strtok_r(NULL, ":,", &array_saveptr);
@@ -682,8 +682,8 @@ check_info_json(char const *file, char const *fnamchk)
 		break;
 
 	    can_be_empty = (common_field && common_field->can_be_empty) || (info_field && info_field->can_be_empty);
-	    is_json_string = (common_field && common_field->field_type == JSON_STRING) ||
-			     (info_field && info_field->field_type == JSON_STRING);
+	    is_json_string = (common_field && common_field->field_type == JTYPE_STRING) ||
+			     (info_field && info_field->field_type == JTYPE_STRING);
 
 	    /*
 	     * If the field type is a string we have to remove a single '"' from
@@ -1240,7 +1240,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 	     * name individually.
 	     */
 	    switch (info_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       info_field->name, json_filename, val);
@@ -1250,7 +1250,7 @@ check_found_info_json_fields(char const *json_filename, bool test)
 			dbg(DBG_VHIGH, "... %s is a bool", val);
 		    }
 		    break;
-		case JSON_INT:
+		case JTYPE_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       info_field->name, json_filename, val);

--- a/jparse.l
+++ b/jparse.l
@@ -9,7 +9,7 @@
  * there might be some grammar that's not correct. Not all actions are complete
  * and some that have been added do not yet check for errors.
  *
- * The JTYPE_STRING action that uses strdup() will be changed to use struct
+ * The JSON_STRING action that uses strdup() will be changed to use struct
  * string at a later date (sometime after struct json_string is finished). Similar
  * will be done for the numbers: struct integer and struct json_floating. These
  * structs are finished but will not be integrated until later on.
@@ -54,13 +54,13 @@ YY_BUFFER_STATE bs;
 /*
  * Section 2: Patterns (regular expressions) and actions.
  *
- * NOTE: I'm aware of at least one error here (the JTYPE_STRING regex is
+ * NOTE: I'm aware of at least one error here (the JSON_STRING regex is
  * incorrect), it's likely that the list incomplete as well and I'd be surprised
  * if there aren't any other errors.
  */
 
 /*
- * XXX JTYPE_WHITESPACE is not needed but for testing I have the whitespace here
+ * XXX JSON_WHITESPACE is not needed but for testing I have the whitespace here
  * and below in the actions print out that it is whitespace and what characters
  * (though newlines and other non-printable whitespace chars are not translated
  * to escape sequences). The text looks like:
@@ -69,10 +69,10 @@ YY_BUFFER_STATE bs;
  *
  * to help distinguish it from other patterns.
  */
-JTYPE_WHITESPACE	[ \t\r\n]+
+JSON_WHITESPACE	[ \t\r\n]+
 
 /*
- * XXX JTYPE_STRING is NOT correct! It does capture basic strings but it does
+ * XXX JSON_STRING is NOT correct! It does capture basic strings but it does
  * not address everything correctly.
  *
  * Now one might ask questions about the tighter restrictions on JSON strings
@@ -81,21 +81,22 @@ JTYPE_WHITESPACE	[ \t\r\n]+
  * let the conversion routines do the actual JSON checks: this way it keeps the
  * regex simple and we don't have to worry about any complexities.
  */
-JTYPE_STRING           \"[^"\n]*\"
-JTYPE_DIGIT		[0-9]
-JTYPE_DIGITS		{JTYPE_DIGIT}+
-JTYPE_EXPONENT		[Ee][-+]?[0-9]+
-JTYPE_INTMAX		-?{JTYPE_DIGITS}
-JTYPE_UINTMAX		{JTYPE_DIGITS}
-JTYPE_LONG_DOUBLE	-?{JTYPE_DIGITS}"."{JTYPE_DIGITS}{JTYPE_EXPONENT}?
-JTYPE_BOOLEAN		"true"|"false"
-JTYPE_NULL		"null"
-JTYPE_OPEN_BRACE	"{"
-JTYPE_CLOSE_BRACE	"}"
-JTYPE_OPEN_BRACKET	"["
-JTYPE_CLOSE_BRACKET	"]"
-JTYPE_COLON		":"
-JTYPE_COMMA		","
+JSON_STRING           \"[^"\n]*\"
+JSON_DIGIT		[0-9]
+JSON_DIGITS		{JSON_DIGIT}+
+JSON_EXPONENT		[Ee][-+]?[0-9]+
+JSON_INTMAX		-?{JSON_DIGITS}
+JSON_UINTMAX		{JSON_DIGITS}
+JSON_LONG_DOUBLE	-?{JSON_DIGITS}"."{JSON_DIGITS}{JSON_EXPONENT}?
+JSON_TRUE		"true"
+JSON_FALSE		"false"
+JSON_NULL		"null"
+JSON_OPEN_BRACE	"{"
+JSON_CLOSE_BRACE	"}"
+JSON_OPEN_BRACKET	"["
+JSON_CLOSE_BRACKET	"]"
+JSON_COLON		":"
+JSON_COMMA		","
 
 /* Actions.
  *
@@ -109,19 +110,20 @@ JTYPE_COMMA		","
  * For now we just print the type and value and then return the type.
  */
 %%
-{JTYPE_WHITESPACE}	    { printf("\nwhitespace: '%s'\n", yytext); }
-{JTYPE_STRING}		    { printf("\nstring: '%s'\n", yytext); return JTYPE_STRING; }
-{JTYPE_UINTMAX}		    { printf("\nuintmax: '%s'\n", yytext); return JTYPE_UINTMAX; }
-{JTYPE_INTMAX}		    { printf("\nintmax: '%s'\n", yytext); return JTYPE_INTMAX; }
-{JTYPE_LONG_DOUBLE}	    { printf("\nlong double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
-{JTYPE_NULL}		    { printf("\nnull: '%s'\n", yytext); return JTYPE_NULL; }
-{JTYPE_BOOLEAN}		    { printf("\nboolean: '%s'\n", yytext); return JTYPE_BOOLEAN; }
-{JTYPE_OPEN_BRACE}	    { printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
-{JTYPE_CLOSE_BRACE}	    { printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
-{JTYPE_OPEN_BRACKET}	    { printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }
-{JTYPE_CLOSE_BRACKET}	    { printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JTYPE_CLOSE_BRACKET; }
-{JTYPE_COLON}		    { printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JTYPE_COLON; }
-{JTYPE_COMMA}		    { printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JTYPE_COMMA; }
+{JSON_WHITESPACE}	    { printf("\nwhitespace: '%s'\n", yytext); }
+{JSON_STRING}		    { printf("\nstring: '%s'\n", yytext); return JSON_STRING; }
+{JSON_UINTMAX}		    { printf("\nuintmax: '%s'\n", yytext); return JSON_UINTMAX; }
+{JSON_INTMAX}		    { printf("\nintmax: '%s'\n", yytext); return JSON_INTMAX; }
+{JSON_LONG_DOUBLE}	    { printf("\nlong double: '%s'\n", yytext); return JSON_LONG_DOUBLE; }
+{JSON_NULL}		    { printf("\nnull: '%s'\n", yytext); return JSON_NULL; }
+{JSON_TRUE}		    { printf("\ntrue: '%s'\n", yytext); return JSON_TRUE; }
+{JSON_FALSE}		    { printf("\nfalse: '%s'\n", yytext); return JSON_FALSE; }
+{JSON_OPEN_BRACE}	    { printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
+{JSON_CLOSE_BRACE}	    { printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
+{JSON_OPEN_BRACKET}	    { printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
+{JSON_CLOSE_BRACKET}	    { printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
+{JSON_COLON}		    { printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
+{JSON_COMMA}		    { printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
 %%
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -416,8 +416,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 14
-#define YY_END_OF_BUFFER 15
+#define YY_NUM_RULES 15
+#define YY_END_OF_BUFFER 16
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -425,12 +425,12 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[38] =
+static const flex_int16_t yy_accept[39] =
     {   0,
-        0,    0,   15,   14,    1,   14,   13,   14,    3,   12,
-       10,   11,   14,   14,   14,    8,    9,    1,    0,    2,
+        0,    0,   16,   15,    1,   15,   14,   15,    3,   13,
+       11,   12,   15,   15,   15,    9,   10,    1,    0,    2,
         4,    0,    3,    0,    0,    0,    5,    0,    0,    0,
-        0,    0,    6,    7,    0,    5,    0
+        0,    0,    6,    7,    0,    5,    8,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -472,20 +472,20 @@ static const YY_CHAR yy_meta[25] =
         1,    1,    1,    1
     } ;
 
-static const flex_int16_t yy_base[39] =
+static const flex_int16_t yy_base[40] =
     {   0,
         0,    0,   58,   59,   23,   53,   59,   47,   19,   59,
        59,   59,   41,   32,   34,   59,   59,   27,   48,   59,
        23,   42,   25,   33,   32,   26,   26,   27,   29,   30,
-       31,   29,   59,   59,   34,   33,   59,   38
+       31,   29,   59,   59,   34,   33,   59,   59,   38
     } ;
 
-static const flex_int16_t yy_def[39] =
+static const flex_int16_t yy_def[40] =
     {   0,
-       37,    1,   37,   37,   37,   38,   37,   37,   37,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   38,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   37,   37,
-       37,   37,   37,   37,   37,   37,    0,   37
+       38,    1,   38,   38,   38,   39,   38,   38,   38,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   39,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   38,   38,
+       38,   38,   38,   38,   38,   38,   38,    0,   38
     } ;
 
 static const flex_int16_t yy_nxt[84] =
@@ -494,11 +494,11 @@ static const flex_int16_t yy_nxt[84] =
         4,   11,   12,    4,    4,   13,    4,   14,    4,    4,
        15,    4,   16,   17,   18,   18,   22,   23,   18,   18,
        22,   21,   22,   23,   27,   35,   31,   35,   19,   36,
-       31,   36,   36,   34,   34,   33,   32,   30,   29,   28,
-       27,   20,   26,   25,   24,   21,   20,   37,    3,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   37,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   37,   37,
-       37,   37,   37
+       31,   36,   36,   37,   34,   33,   32,   30,   29,   28,
+       27,   20,   26,   25,   24,   21,   20,   38,    3,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   38,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   38,   38,
+       38,   38,   38
     } ;
 
 static const flex_int16_t yy_chk[84] =
@@ -506,18 +506,18 @@ static const flex_int16_t yy_chk[84] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    5,    5,    9,    9,   18,   18,
-       21,   21,   23,   23,   27,   31,   27,   31,   38,   31,
+       21,   21,   23,   23,   27,   31,   27,   31,   39,   31,
        27,   36,   35,   32,   30,   29,   28,   26,   25,   24,
-       22,   19,   15,   14,   13,    8,    6,    3,   37,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   37,   37,
-       37,   37,   37,   37,   37,   37,   37,   37,   37,   37,
-       37,   37,   37
+       22,   19,   15,   14,   13,    8,    6,    3,   38,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   38,   38,
+       38,   38,   38,   38,   38,   38,   38,   38,   38,   38,
+       38,   38,   38
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static const flex_int32_t yy_rule_can_match_eol[15] =
+static const flex_int32_t yy_rule_can_match_eol[16] =
     {   0,
-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,     };
+1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,     };
 
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
@@ -545,7 +545,7 @@ char *yytext;
  * there might be some grammar that's not correct. Not all actions are complete
  * and some that have been added do not yet check for errors.
  *
- * The JTYPE_STRING action that uses strdup() will be changed to use struct
+ * The JSON_STRING action that uses strdup() will be changed to use struct
  * string at a later date (sometime after struct json_string is finished). Similar
  * will be done for the numbers: struct integer and struct json_floating. These
  * structs are finished but will not be integrated until later on.
@@ -584,12 +584,12 @@ YY_BUFFER_STATE bs;
 /*
  * Section 2: Patterns (regular expressions) and actions.
  *
- * NOTE: I'm aware of at least one error here (the JTYPE_STRING regex is
+ * NOTE: I'm aware of at least one error here (the JSON_STRING regex is
  * incorrect), it's likely that the list incomplete as well and I'd be surprised
  * if there aren't any other errors.
  */
 /*
- * XXX JTYPE_WHITESPACE is not needed but for testing I have the whitespace here
+ * XXX JSON_WHITESPACE is not needed but for testing I have the whitespace here
  * and below in the actions print out that it is whitespace and what characters
  * (though newlines and other non-printable whitespace chars are not translated
  * to escape sequences). The text looks like:
@@ -599,7 +599,7 @@ YY_BUFFER_STATE bs;
  * to help distinguish it from other patterns.
  */
 /*
- * XXX JTYPE_STRING is NOT correct! It does capture basic strings but it does
+ * XXX JSON_STRING is NOT correct! It does capture basic strings but it does
  * not address everything correctly.
  *
  * Now one might ask questions about the tighter restrictions on JSON strings
@@ -836,7 +836,7 @@ YY_DECL
 		}
 
 	{
-#line 111 "jparse.l"
+#line 112 "jparse.l"
 
 #line 799 "jparse.c"
 
@@ -865,7 +865,7 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 38 )
+				if ( yy_current_state >= 39 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -908,75 +908,80 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 112 "jparse.l"
+#line 113 "jparse.l"
 { printf("\nwhitespace: '%s'\n", yytext); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 113 "jparse.l"
-{ printf("\nstring: '%s'\n", yytext); return JTYPE_STRING; }
+#line 114 "jparse.l"
+{ printf("\nstring: '%s'\n", yytext); return JSON_STRING; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 114 "jparse.l"
-{ printf("\nuintmax: '%s'\n", yytext); return JTYPE_UINTMAX; }
+#line 115 "jparse.l"
+{ printf("\nuintmax: '%s'\n", yytext); return JSON_UINTMAX; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 115 "jparse.l"
-{ printf("\nintmax: '%s'\n", yytext); return JTYPE_INTMAX; }
+#line 116 "jparse.l"
+{ printf("\nintmax: '%s'\n", yytext); return JSON_INTMAX; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 116 "jparse.l"
-{ printf("\nlong double: '%s'\n", yytext); return JTYPE_LONG_DOUBLE; }
+#line 117 "jparse.l"
+{ printf("\nlong double: '%s'\n", yytext); return JSON_LONG_DOUBLE; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 117 "jparse.l"
-{ printf("\nnull: '%s'\n", yytext); return JTYPE_NULL; }
+#line 118 "jparse.l"
+{ printf("\nnull: '%s'\n", yytext); return JSON_NULL; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 118 "jparse.l"
-{ printf("\nboolean: '%s'\n", yytext); return JTYPE_BOOLEAN; }
+#line 119 "jparse.l"
+{ printf("\ntrue: '%s'\n", yytext); return JSON_TRUE; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 119 "jparse.l"
-{ printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JTYPE_OPEN_BRACE; }
+#line 120 "jparse.l"
+{ printf("\nfalse: '%s'\n", yytext); return JSON_FALSE; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 120 "jparse.l"
-{ printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JTYPE_CLOSE_BRACE;}
+#line 121 "jparse.l"
+{ printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 121 "jparse.l"
-{ printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JTYPE_OPEN_BRACKET; }
+#line 122 "jparse.l"
+{ printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 122 "jparse.l"
-{ printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JTYPE_CLOSE_BRACKET; }
+#line 123 "jparse.l"
+{ printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 123 "jparse.l"
-{ printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JTYPE_COLON; }
+#line 124 "jparse.l"
+{ printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 124 "jparse.l"
-{ printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JTYPE_COMMA; }
+#line 125 "jparse.l"
+{ printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 125 "jparse.l"
+#line 126 "jparse.l"
+{ printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
+	YY_BREAK
+case 15:
+YY_RULE_SETUP
+#line 127 "jparse.l"
 ECHO;
 	YY_BREAK
-#line 937 "jparse.c"
+#line 942 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1273,7 +1278,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 38 )
+			if ( yy_current_state >= 39 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1301,11 +1306,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 38 )
+		if ( yy_current_state >= 39 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 37);
+	yy_is_jam = (yy_current_state == 38);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1993,7 +1998,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 125 "jparse.l"
+#line 127 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -172,12 +172,13 @@ enum yysymbol_kind_t
   YYSYMBOL_YYACCEPT = 16,                  /* $accept  */
   YYSYMBOL_json = 17,                      /* json  */
   YYSYMBOL_json_value = 18,                /* json_value  */
-  YYSYMBOL_json_object = 19,               /* json_object  */
-  YYSYMBOL_json_members = 20,              /* json_members  */
-  YYSYMBOL_json_member = 21,               /* json_member  */
-  YYSYMBOL_json_array = 22,                /* json_array  */
-  YYSYMBOL_json_elements = 23,             /* json_elements  */
-  YYSYMBOL_json_element = 24               /* json_element  */
+  YYSYMBOL_json_number = 19,               /* json_number  */
+  YYSYMBOL_json_object = 20,               /* json_object  */
+  YYSYMBOL_json_members = 21,              /* json_members  */
+  YYSYMBOL_json_member = 22,               /* json_member  */
+  YYSYMBOL_json_array = 23,                /* json_array  */
+  YYSYMBOL_json_elements = 24,             /* json_elements  */
+  YYSYMBOL_json_element = 25               /* json_element  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -480,18 +481,18 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  24
+#define YYFINAL  25
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   45
+#define YYLAST   46
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  16
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  9
+#define YYNNTS  10
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  22
+#define YYNRULES  23
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  33
+#define YYNSTATES  34
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   270
@@ -542,9 +543,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   102,   102,   103,   104,   105,   108,   109,   110,   111,
-     112,   113,   114,   115,   116,   119,   122,   123,   126,   129,
-     132,   133,   136
+       0,   106,   106,   107,   108,   109,   112,   113,   114,   115,
+     116,   117,   118,   121,   122,   123,   125,   128,   129,   132,
+     135,   138,   139,   142
 };
 #endif
 
@@ -564,8 +565,8 @@ static const char *const yytname[] =
   "JSON_CLOSE_BRACE", "JSON_OPEN_BRACKET", "JSON_CLOSE_BRACKET",
   "JSON_COMMA", "JSON_COLON", "JSON_NULL", "JSON_STRING", "JSON_UINTMAX",
   "JSON_INTMAX", "JSON_LONG_DOUBLE", "JSON_TRUE", "JSON_FALSE", "$accept",
-  "json", "json_value", "json_object", "json_members", "json_member",
-  "json_array", "json_elements", "json_element", YY_NULLPTR
+  "json", "json_value", "json_number", "json_object", "json_members",
+  "json_member", "json_array", "json_elements", "json_element", YY_NULLPTR
 };
 
 static const char *
@@ -575,7 +576,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-11)
+#define YYPACT_NINF (-12)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -589,10 +590,10 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      17,    11,    -2,   -11,   -11,   -11,   -11,   -11,   -11,   -11,
-       2,   -11,   -11,   -11,   -11,   -11,    -3,    10,    -1,     6,
-      30,   -11,    12,    16,   -11,    30,   -11,     6,   -11,    30,
-     -11,   -11,   -11
+      18,    10,    -2,   -12,   -12,   -12,   -12,   -12,   -12,   -12,
+       2,   -12,   -12,   -12,   -12,   -12,   -12,    -3,    11,    -1,
+       6,    31,   -12,    12,    15,   -12,    31,   -12,     6,   -12,
+      31,   -12,   -12,   -12
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -600,22 +601,22 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     0,    14,     8,    10,     9,    11,    12,    13,
-       0,    22,     6,     7,     3,     4,     0,     0,    16,     0,
-       0,     5,     0,    20,     1,     0,    15,     0,    19,     0,
-      18,    17,    21
+       2,     0,     0,    12,     8,    14,    13,    15,    10,    11,
+       0,    23,     9,     6,     7,     3,     4,     0,     0,    17,
+       0,     0,     5,     0,    21,     1,     0,    16,     0,    20,
+       0,    19,    18,    22
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -11,   -11,   -11,   -11,   -10,   -11,   -11,    -5,     0
+     -12,   -12,   -12,   -12,   -12,   -11,   -12,   -12,    -6,     0
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,    10,    11,    12,    17,    18,    13,    22,    23
+       0,    10,    11,    12,    13,    18,    19,    14,    23,    24
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -623,20 +624,20 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      14,    19,    24,    20,    21,    25,    27,     3,     4,     5,
-       6,     7,     8,     9,    26,    15,    16,    31,    28,     0,
-       1,    16,     2,    29,    32,    30,     3,     4,     5,     6,
-       7,     8,     9,    19,     0,    20,     0,     0,     0,     3,
-       4,     5,     6,     7,     8,     9
+      15,    20,    25,    21,    22,    26,    28,     3,     4,     5,
+       6,     7,     8,     9,    16,    27,    17,    32,    29,     0,
+      17,     1,    30,     2,    33,     0,    31,     3,     4,     5,
+       6,     7,     8,     9,    20,     0,    21,     0,     0,     0,
+       3,     4,     5,     6,     7,     8,     9
 };
 
 static const yytype_int8 yycheck[] =
 {
        0,     3,     0,     5,     6,     8,     7,     9,    10,    11,
-      12,    13,    14,    15,     4,     4,    10,    27,     6,    -1,
-       3,    10,     5,     7,    29,    25,     9,    10,    11,    12,
-      13,    14,    15,     3,    -1,     5,    -1,    -1,    -1,     9,
-      10,    11,    12,    13,    14,    15
+      12,    13,    14,    15,     4,     4,    10,    28,     6,    -1,
+      10,     3,     7,     5,    30,    -1,    26,     9,    10,    11,
+      12,    13,    14,    15,     3,    -1,     5,    -1,    -1,    -1,
+       9,    10,    11,    12,    13,    14,    15
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -644,25 +645,25 @@ static const yytype_int8 yycheck[] =
 static const yytype_int8 yystos[] =
 {
        0,     3,     5,     9,    10,    11,    12,    13,    14,    15,
-      17,    18,    19,    22,    24,     4,    10,    20,    21,     3,
-       5,     6,    23,    24,     0,     8,     4,     7,     6,     7,
-      24,    20,    23
+      17,    18,    19,    20,    23,    25,     4,    10,    21,    22,
+       3,     5,     6,    24,    25,     0,     8,     4,     7,     6,
+       7,    25,    21,    24
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    16,    17,    17,    17,    17,    18,    18,    18,    18,
-      18,    18,    18,    18,    18,    19,    20,    20,    21,    22,
-      23,    23,    24
+      18,    18,    18,    19,    19,    19,    20,    21,    21,    22,
+      23,    24,    24,    25
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     2,     2,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     3,     1,     3,     3,     3,
-       1,     3,     1
+       1,     1,     1,     1,     1,     1,     3,     1,     3,     3,
+       3,     1,     3,     1
 };
 
 
@@ -1656,7 +1657,7 @@ yyreduce:
     switch (yyn)
       {
 
-#line 1618 "jparse.tab.c"
+#line 1619 "jparse.tab.c"
 
         default: break;
       }
@@ -1891,7 +1892,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 139 "jparse.y"
+#line 145 "jparse.y"
 
 /* Section 3: C code */
 int

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -556,19 +556,22 @@ static const yytype_uint8 yyrline[] =
    YYSYMBOL.  No bounds checking.  */
 static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
 
-static const char *
-yysymbol_name (yysymbol_kind_t yysymbol)
+/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
+   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
+static const char *const yytname[] =
 {
-  static const char *const yy_sname[] =
-  {
-  "end of file", "error", "invalid token", "JSON_OPEN_BRACE",
+  "\"end of file\"", "error", "\"invalid token\"", "JSON_OPEN_BRACE",
   "JSON_CLOSE_BRACE", "JSON_OPEN_BRACKET", "JSON_CLOSE_BRACKET",
   "JSON_COMMA", "JSON_COLON", "JSON_NULL", "JSON_STRING", "JSON_UINTMAX",
   "JSON_INTMAX", "JSON_LONG_DOUBLE", "JSON_TRUE", "JSON_FALSE", "$accept",
   "json", "json_value", "json_object", "json_members", "json_member",
   "json_array", "json_elements", "json_element", YY_NULLPTR
-  };
-  return yy_sname[yysymbol];
+};
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
 }
 #endif
 
@@ -1173,6 +1176,55 @@ yystpcpy (char *yydest, const char *yysrc)
 # endif
 #endif
 
+#ifndef yytnamerr
+/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
+   quotes and backslashes, so that it's suitable for yyerror.  The
+   heuristic is that double-quoting is unnecessary unless the string
+   contains an apostrophe, a comma, or backslash (other than
+   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
+   null, do not copy; instead, return the length of what the result
+   would have been.  */
+static YYPTRDIFF_T
+yytnamerr (char *yyres, const char *yystr)
+{
+  if (*yystr == '"')
+    {
+      YYPTRDIFF_T yyn = 0;
+      char const *yyp = yystr;
+      for (;;)
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
+
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            else
+              goto append;
+
+          append:
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
+
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
+    do_not_strip_quotes: ;
+    }
+
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
+    return yystrlen (yystr);
+}
+#endif
 
 
 static int
@@ -1272,7 +1324,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     for (yyi = 0; yyi < yycount; ++yyi)
       {
         YYPTRDIFF_T yysize1
-          = yysize + yystrlen (yysymbol_name (yyarg[yyi]));
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
         if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
           yysize = yysize1;
         else
@@ -1298,7 +1350,7 @@ yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
     while ((*yyp = *yyformat) != '\0')
       if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
         {
-          yyp = yystpcpy (yyp, yysymbol_name (yyarg[yyi++]));
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
           yyformat += 2;
         }
       else
@@ -1604,7 +1656,7 @@ yyreduce:
     switch (yyn)
       {
 
-#line 1566 "jparse.tab.c"
+#line 1618 "jparse.tab.c"
 
         default: break;
       }

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -156,27 +156,28 @@ enum yysymbol_kind_t
   YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
   YYSYMBOL_YYerror = 1,                    /* error  */
   YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
-  YYSYMBOL_JTYPE_OPEN_BRACE = 3,           /* JTYPE_OPEN_BRACE  */
-  YYSYMBOL_JTYPE_CLOSE_BRACE = 4,          /* JTYPE_CLOSE_BRACE  */
-  YYSYMBOL_JTYPE_OPEN_BRACKET = 5,         /* JTYPE_OPEN_BRACKET  */
-  YYSYMBOL_JTYPE_CLOSE_BRACKET = 6,        /* JTYPE_CLOSE_BRACKET  */
-  YYSYMBOL_JTYPE_COMMA = 7,                /* JTYPE_COMMA  */
-  YYSYMBOL_JTYPE_COLON = 8,                /* JTYPE_COLON  */
-  YYSYMBOL_JTYPE_NULL = 9,                 /* JTYPE_NULL  */
-  YYSYMBOL_JTYPE_STRING = 10,              /* JTYPE_STRING  */
-  YYSYMBOL_JTYPE_UINTMAX = 11,             /* JTYPE_UINTMAX  */
-  YYSYMBOL_JTYPE_INTMAX = 12,              /* JTYPE_INTMAX  */
-  YYSYMBOL_JTYPE_LONG_DOUBLE = 13,         /* JTYPE_LONG_DOUBLE  */
-  YYSYMBOL_JTYPE_BOOLEAN = 14,             /* JTYPE_BOOLEAN  */
-  YYSYMBOL_YYACCEPT = 15,                  /* $accept  */
-  YYSYMBOL_json = 16,                      /* json  */
-  YYSYMBOL_json_value = 17,                /* json_value  */
-  YYSYMBOL_json_object = 18,               /* json_object  */
-  YYSYMBOL_json_members = 19,              /* json_members  */
-  YYSYMBOL_json_member = 20,               /* json_member  */
-  YYSYMBOL_json_array = 21,                /* json_array  */
-  YYSYMBOL_json_elements = 22,             /* json_elements  */
-  YYSYMBOL_json_element = 23               /* json_element  */
+  YYSYMBOL_JSON_OPEN_BRACE = 3,            /* JSON_OPEN_BRACE  */
+  YYSYMBOL_JSON_CLOSE_BRACE = 4,           /* JSON_CLOSE_BRACE  */
+  YYSYMBOL_JSON_OPEN_BRACKET = 5,          /* JSON_OPEN_BRACKET  */
+  YYSYMBOL_JSON_CLOSE_BRACKET = 6,         /* JSON_CLOSE_BRACKET  */
+  YYSYMBOL_JSON_COMMA = 7,                 /* JSON_COMMA  */
+  YYSYMBOL_JSON_COLON = 8,                 /* JSON_COLON  */
+  YYSYMBOL_JSON_NULL = 9,                  /* JSON_NULL  */
+  YYSYMBOL_JSON_STRING = 10,               /* JSON_STRING  */
+  YYSYMBOL_JSON_UINTMAX = 11,              /* JSON_UINTMAX  */
+  YYSYMBOL_JSON_INTMAX = 12,               /* JSON_INTMAX  */
+  YYSYMBOL_JSON_LONG_DOUBLE = 13,          /* JSON_LONG_DOUBLE  */
+  YYSYMBOL_JSON_TRUE = 14,                 /* JSON_TRUE  */
+  YYSYMBOL_JSON_FALSE = 15,                /* JSON_FALSE  */
+  YYSYMBOL_YYACCEPT = 16,                  /* $accept  */
+  YYSYMBOL_json = 17,                      /* json  */
+  YYSYMBOL_json_value = 18,                /* json_value  */
+  YYSYMBOL_json_object = 19,               /* json_object  */
+  YYSYMBOL_json_members = 20,              /* json_members  */
+  YYSYMBOL_json_member = 21,               /* json_member  */
+  YYSYMBOL_json_array = 22,                /* json_array  */
+  YYSYMBOL_json_elements = 23,             /* json_elements  */
+  YYSYMBOL_json_element = 24               /* json_element  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -479,21 +480,21 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  23
+#define YYFINAL  24
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   42
+#define YYLAST   45
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  15
+#define YYNTOKENS  16
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  9
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  21
+#define YYNRULES  22
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  32
+#define YYNSTATES  33
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   269
+#define YYMAXUTOK   270
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -533,7 +534,8 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
-       5,     6,     7,     8,     9,    10,    11,    12,    13,    14
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
+      15
 };
 
 #if YYDEBUG
@@ -541,8 +543,8 @@ static const yytype_int8 yytranslate[] =
 static const yytype_uint8 yyrline[] =
 {
        0,   102,   102,   103,   104,   105,   108,   109,   110,   111,
-     112,   113,   114,   115,   118,   121,   122,   125,   128,   131,
-     132,   135
+     112,   113,   114,   115,   116,   119,   122,   123,   126,   129,
+     132,   133,   136
 };
 #endif
 
@@ -559,12 +561,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 {
   static const char *const yy_sname[] =
   {
-  "end of file", "error", "invalid token", "JTYPE_OPEN_BRACE",
-  "JTYPE_CLOSE_BRACE", "JTYPE_OPEN_BRACKET", "JTYPE_CLOSE_BRACKET",
-  "JTYPE_COMMA", "JTYPE_COLON", "JTYPE_NULL", "JTYPE_STRING",
-  "JTYPE_UINTMAX", "JTYPE_INTMAX", "JTYPE_LONG_DOUBLE", "JTYPE_BOOLEAN",
-  "$accept", "json", "json_value", "json_object", "json_members",
-  "json_member", "json_array", "json_elements", "json_element", YY_NULLPTR
+  "end of file", "error", "invalid token", "JSON_OPEN_BRACE",
+  "JSON_CLOSE_BRACE", "JSON_OPEN_BRACKET", "JSON_CLOSE_BRACKET",
+  "JSON_COMMA", "JSON_COLON", "JSON_NULL", "JSON_STRING", "JSON_UINTMAX",
+  "JSON_INTMAX", "JSON_LONG_DOUBLE", "JSON_TRUE", "JSON_FALSE", "$accept",
+  "json", "json_value", "json_object", "json_members", "json_member",
+  "json_array", "json_elements", "json_element", YY_NULLPTR
   };
   return yy_sname[yysymbol];
 }
@@ -584,10 +586,10 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      16,    10,    -2,   -11,   -11,   -11,   -11,   -11,   -11,     2,
-     -11,   -11,   -11,   -11,   -11,    -3,     9,    -1,     5,    28,
-     -11,    11,    15,   -11,    28,   -11,     5,   -11,    28,   -11,
-     -11,   -11
+      17,    11,    -2,   -11,   -11,   -11,   -11,   -11,   -11,   -11,
+       2,   -11,   -11,   -11,   -11,   -11,    -3,    10,    -1,     6,
+      30,   -11,    12,    16,   -11,    30,   -11,     6,   -11,    30,
+     -11,   -11,   -11
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -595,10 +597,10 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     0,    13,     8,    10,     9,    11,    12,     0,
-      21,     6,     7,     3,     4,     0,     0,    15,     0,     0,
-       5,     0,    19,     1,     0,    14,     0,    18,     0,    17,
-      16,    20
+       2,     0,     0,    14,     8,    10,     9,    11,    12,    13,
+       0,    22,     6,     7,     3,     4,     0,     0,    16,     0,
+       0,     5,     0,    20,     1,     0,    15,     0,    19,     0,
+      18,    17,    21
 };
 
 /* YYPGOTO[NTERM-NUM].  */
@@ -610,7 +612,7 @@ static const yytype_int8 yypgoto[] =
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,     9,    10,    11,    16,    17,    12,    21,    22
+       0,    10,    11,    12,    17,    18,    13,    22,    23
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -618,46 +620,46 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      13,    18,    23,    19,    20,    24,    26,     3,     4,     5,
-       6,     7,     8,    25,    14,    15,    30,    27,     0,     1,
-      15,     2,    28,    31,    29,     3,     4,     5,     6,     7,
-       8,    18,     0,    19,     0,     0,     0,     3,     4,     5,
-       6,     7,     8
+      14,    19,    24,    20,    21,    25,    27,     3,     4,     5,
+       6,     7,     8,     9,    26,    15,    16,    31,    28,     0,
+       1,    16,     2,    29,    32,    30,     3,     4,     5,     6,
+       7,     8,     9,    19,     0,    20,     0,     0,     0,     3,
+       4,     5,     6,     7,     8,     9
 };
 
 static const yytype_int8 yycheck[] =
 {
        0,     3,     0,     5,     6,     8,     7,     9,    10,    11,
-      12,    13,    14,     4,     4,    10,    26,     6,    -1,     3,
-      10,     5,     7,    28,    24,     9,    10,    11,    12,    13,
-      14,     3,    -1,     5,    -1,    -1,    -1,     9,    10,    11,
-      12,    13,    14
+      12,    13,    14,    15,     4,     4,    10,    27,     6,    -1,
+       3,    10,     5,     7,    29,    25,     9,    10,    11,    12,
+      13,    14,    15,     3,    -1,     5,    -1,    -1,    -1,     9,
+      10,    11,    12,    13,    14,    15
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,     3,     5,     9,    10,    11,    12,    13,    14,    16,
-      17,    18,    21,    23,     4,    10,    19,    20,     3,     5,
-       6,    22,    23,     0,     8,     4,     7,     6,     7,    23,
-      19,    22
+       0,     3,     5,     9,    10,    11,    12,    13,    14,    15,
+      17,    18,    19,    22,    24,     4,    10,    20,    21,     3,
+       5,     6,    23,    24,     0,     8,     4,     7,     6,     7,
+      24,    20,    23
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    15,    16,    16,    16,    16,    17,    17,    17,    17,
-      17,    17,    17,    17,    18,    19,    19,    20,    21,    22,
-      22,    23
+       0,    16,    17,    17,    17,    17,    18,    18,    18,    18,
+      18,    18,    18,    18,    18,    19,    20,    20,    21,    22,
+      23,    23,    24
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     2,     2,     1,     1,     1,     1,
-       1,     1,     1,     1,     3,     1,     3,     3,     3,     1,
-       3,     1
+       1,     1,     1,     1,     1,     3,     1,     3,     3,     3,
+       1,     3,     1
 };
 
 
@@ -1602,7 +1604,7 @@ yyreduce:
     switch (yyn)
       {
 
-#line 1564 "jparse.tab.c"
+#line 1566 "jparse.tab.c"
 
         default: break;
       }
@@ -1837,7 +1839,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 138 "jparse.y"
+#line 139 "jparse.y"
 
 /* Section 3: C code */
 int

--- a/jparse.tab.ref.h
+++ b/jparse.tab.ref.h
@@ -96,18 +96,19 @@ extern int yydebug;
     YYEOF = 0,                     /* "end of file"  */
     YYerror = 256,                 /* error  */
     YYUNDEF = 257,                 /* "invalid token"  */
-    JTYPE_OPEN_BRACE = 258,        /* JTYPE_OPEN_BRACE  */
-    JTYPE_CLOSE_BRACE = 259,       /* JTYPE_CLOSE_BRACE  */
-    JTYPE_OPEN_BRACKET = 260,      /* JTYPE_OPEN_BRACKET  */
-    JTYPE_CLOSE_BRACKET = 261,     /* JTYPE_CLOSE_BRACKET  */
-    JTYPE_COMMA = 262,             /* JTYPE_COMMA  */
-    JTYPE_COLON = 263,             /* JTYPE_COLON  */
-    JTYPE_NULL = 264,              /* JTYPE_NULL  */
-    JTYPE_STRING = 265,            /* JTYPE_STRING  */
-    JTYPE_UINTMAX = 266,           /* JTYPE_UINTMAX  */
-    JTYPE_INTMAX = 267,            /* JTYPE_INTMAX  */
-    JTYPE_LONG_DOUBLE = 268,       /* JTYPE_LONG_DOUBLE  */
-    JTYPE_BOOLEAN = 269            /* JTYPE_BOOLEAN  */
+    JSON_OPEN_BRACE = 258,         /* JSON_OPEN_BRACE  */
+    JSON_CLOSE_BRACE = 259,        /* JSON_CLOSE_BRACE  */
+    JSON_OPEN_BRACKET = 260,       /* JSON_OPEN_BRACKET  */
+    JSON_CLOSE_BRACKET = 261,      /* JSON_CLOSE_BRACKET  */
+    JSON_COMMA = 262,              /* JSON_COMMA  */
+    JSON_COLON = 263,              /* JSON_COLON  */
+    JSON_NULL = 264,               /* JSON_NULL  */
+    JSON_STRING = 265,             /* JSON_STRING  */
+    JSON_UINTMAX = 266,            /* JSON_UINTMAX  */
+    JSON_INTMAX = 267,             /* JSON_INTMAX  */
+    JSON_LONG_DOUBLE = 268,        /* JSON_LONG_DOUBLE  */
+    JSON_TRUE = 269,               /* JSON_TRUE  */
+    JSON_FALSE = 270               /* JSON_FALSE  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -121,7 +122,7 @@ union json_type
 
     struct json json;
 
-#line 83 "jparse.tab.h"
+#line 84 "jparse.tab.h"
 
 };
 #line 88 "jparse.y"

--- a/jparse.y
+++ b/jparse.y
@@ -25,13 +25,13 @@
 /* Section 1: Declarations */
 
 /*
- * More detailed error reporting.
+ * More detailed error reporting is enabled via the -D option as POSIX Yacc does
+ * not support the %define directive:
  *
- * NOTE: This is very verbose and will be removed when things are finished.
+ *	-Dparse.error=verbose -Dparse.lac=full
+ *
+ * NOTE: It's very verbose and will be removed when things are finished.
  */
-%define parse.error detailed
-%define parse.lac full
-
 %{
 #include <inttypes.h>
 #include <stdio.h>
@@ -99,7 +99,7 @@ int token_type = 0;
  * there are also possibly errors!
  */
 %%
-json:		%empty
+json:		/* empty */
 		| json_element
 		| JSON_OPEN_BRACE JSON_CLOSE_BRACE
 		| JSON_OPEN_BRACKET JSON_CLOSE_BRACKET

--- a/jparse.y
+++ b/jparse.y
@@ -92,11 +92,15 @@ int token_type = 0;
 %token JSON_COMMA JSON_COLON JSON_NULL JSON_STRING
 %token JSON_UINTMAX JSON_INTMAX JSON_LONG_DOUBLE JSON_TRUE JSON_FALSE
 
+
 /* Section 2: Rules
  *
- * XXX Not all rules are here and no actions are defined yet. As well some of
- * the rules are probably wrong. Again this is (possibly very) incomplete and
- * there are also possibly errors!
+ * XXX I believe all the rules are here but there are no actions. However the
+ * json_number should be simplified to e.g. JSON_INTEGER | JSON_FLOAT or
+ * something like that. This will require a regex change in the flex grammar
+ * which will happen later.
+ *
+ * There are no actions here so this is incomplete in that way too.
  */
 %%
 json:		/* empty */
@@ -105,16 +109,18 @@ json:		/* empty */
 		| JSON_OPEN_BRACKET JSON_CLOSE_BRACKET
 		;
 
-json_value:	json_object
+json_value:	  json_object
 		| json_array
 		| JSON_STRING
-		| JSON_INTMAX
-		| JSON_UINTMAX
-		| JSON_LONG_DOUBLE
+		| json_number
 		| JSON_TRUE
 		| JSON_FALSE
 		| JSON_NULL
 		;
+
+json_number:	JSON_INTMAX
+		| JSON_UINTMAX
+		| JSON_LONG_DOUBLE ;
 
 json_object:	JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE
 		;

--- a/jparse.y
+++ b/jparse.y
@@ -12,7 +12,7 @@
  * There are no actions yet. I'm not sure when I will be adding the actions and
  * it's very likely that I won't add all at once.
  *
- * The memory returned by strdup() (json_parser.l action for JTYPE_STRING) will
+ * The memory returned by strdup() (json_parser.l action for JSON_STRING) will
  * not yet be freed but since the parser doesn't do anything but just finishes
  * until a parse error or EOF (or end of string) this is not a problem. Actually
  * struct json_string will be used in this case so the way strings are handled will
@@ -58,7 +58,7 @@ int token_type = 0;
 /* This union is not complete and will need to be fixed in one or more ways as
  * well.
  *
- * For example it might (not sure) be better if there was JTYPE_NUMBER but
+ * For example it might (not sure) be better if there was JSON_NUMBER but
  * depending on a type variable the proper member in the union would be
  * addressd, thereby simplifying the rules below. Perhaps this will be the int
  * token_type above (I am not yet entirely sure of the use of that but it might
@@ -88,9 +88,9 @@ int token_type = 0;
 %union json_type {
     struct json json;
 }
-%token JTYPE_OPEN_BRACE JTYPE_CLOSE_BRACE JTYPE_OPEN_BRACKET JTYPE_CLOSE_BRACKET
-%token JTYPE_COMMA JTYPE_COLON JTYPE_NULL JTYPE_STRING
-%token JTYPE_UINTMAX JTYPE_INTMAX JTYPE_LONG_DOUBLE JTYPE_BOOLEAN
+%token JSON_OPEN_BRACE JSON_CLOSE_BRACE JSON_OPEN_BRACKET JSON_CLOSE_BRACKET
+%token JSON_COMMA JSON_COLON JSON_NULL JSON_STRING
+%token JSON_UINTMAX JSON_INTMAX JSON_LONG_DOUBLE JSON_TRUE JSON_FALSE
 
 /* Section 2: Rules
  *
@@ -99,37 +99,38 @@ int token_type = 0;
  * there are also possibly errors!
  */
 %%
-json:		%empty |
-		json_element |
-		JTYPE_OPEN_BRACE JTYPE_CLOSE_BRACE |
-		JTYPE_OPEN_BRACKET JTYPE_CLOSE_BRACKET
+json:		%empty
+		| json_element
+		| JSON_OPEN_BRACE JSON_CLOSE_BRACE
+		| JSON_OPEN_BRACKET JSON_CLOSE_BRACKET
 		;
 
-json_value:	json_object |
-		json_array  |
-		JTYPE_STRING |
-		JTYPE_INTMAX |
-		JTYPE_UINTMAX |
-		JTYPE_LONG_DOUBLE |
-		JTYPE_BOOLEAN   |
-		JTYPE_NULL
+json_value:	json_object
+		| json_array
+		| JSON_STRING
+		| JSON_INTMAX
+		| JSON_UINTMAX
+		| JSON_LONG_DOUBLE
+		| JSON_TRUE
+		| JSON_FALSE
+		| JSON_NULL
 		;
 
-json_object:	JTYPE_OPEN_BRACE json_members JTYPE_CLOSE_BRACE
+json_object:	JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE
 		;
 
-json_members:	json_member |
-		json_member JTYPE_COMMA json_members
+json_members:	json_member
+		| json_member JSON_COMMA json_members
 		;
 
-json_member:	JTYPE_STRING JTYPE_COLON json_element
+json_member:	JSON_STRING JSON_COLON json_element
 		;
 
-json_array:	JTYPE_OPEN_BRACKET json_elements JTYPE_CLOSE_BRACKET
+json_array:	JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET
 		;
 
-json_elements:	json_element |
-		json_element JTYPE_COMMA json_elements
+json_elements:	json_element
+		| json_element JSON_COMMA json_elements
 		;
 
 json_element:	json_value

--- a/json.c
+++ b/json.c
@@ -1383,29 +1383,29 @@ json_conv_free(struct json *node)
      */
     switch (node->type) {
 
-    case JSON_EOT:	/* special end of the table value */
+    case JTYPE_EOT:	/* special end of the table value */
 	/* nothing to free */
 	break;
 
-    case JSON_UNSET:	/* JSON element has not been set - must be the value 0 */
+    case JTYPE_UNSET:	/* JSON element has not been set - must be the value 0 */
 	/* nothing to free */
 	break;
 
-    case JSON_INT:	/* JSON element is an integer - see struct json_integer */
+    case JTYPE_INT:	/* JSON element is an integer - see struct json_integer */
 	if (node->element.integer.as_str != NULL) {
 	    free(node->element.integer.as_str);
 	    node->element.integer.as_str = NULL;
 	}
 	break;
 
-    case JSON_FLOAT:	/* JSON element is a float - see struct json_floating */
+    case JTYPE_FLOAT:	/* JSON element is a float - see struct json_floating */
 	if (node->element.floating.as_str != NULL) {
 	    free(node->element.floating.as_str);
 	    node->element.floating.as_str = NULL;
 	}
 	break;
 
-    case JSON_STRING:	/* JSON element is a string - see struct json_string */
+    case JTYPE_STRING:	/* JSON element is a string - see struct json_string */
 	if (node->element.string.as_str != NULL) {
 	    free(node->element.string.as_str);
 	    node->element.string.as_str = NULL;
@@ -1416,29 +1416,29 @@ json_conv_free(struct json *node)
 	}
 	break;
 
-    case JSON_BOOL:	/* JSON element is a boolean - see struct json_boolean */
+    case JTYPE_BOOL:	/* JSON element is a boolean - see struct json_boolean */
 	if (node->element.boolean.as_str != NULL) {
 	    free(node->element.boolean.as_str);
 	    node->element.boolean.as_str = NULL;
 	}
 	break;
 
-    case JSON_NULL:	/* JSON element is a null - see struct json_null */
+    case JTYPE_NULL:	/* JSON element is a null - see struct json_null */
 	if (node->element.null.as_str != NULL) {
 	    free(node->element.null.as_str);
 	    node->element.null.as_str = NULL;
 	}
 	break;
 
-    case JSON_OBJECT:	/* JSON element is a { members } */
+    case JTYPE_OBJECT:	/* JSON element is a { members } */
 	/* XXX - update when struct json_object is defined - XXX */
 	break;
 
-    case JSON_MEMBER:	/* JSON element is a member */
+    case JTYPE_MEMBER:	/* JSON element is a member */
 	/* XXX - update when struct json_member is defined - XXX */
 	break;
 
-    case JSON_ARRAY:	/* JSON element is a [ elements ] */
+    case JTYPE_ARRAY:	/* JSON element is a [ elements ] */
 	/* XXX - update when struct json_array is defined - XXX */
 	break;
 
@@ -1489,7 +1489,7 @@ json_conv_int(char const *str, size_t len)
     /*
      * initialize the JSON parse tree element
      */
-    ret->type = JSON_INT;
+    ret->type = JTYPE_INT;
     ret->parent = NULL;
     ret->prev = NULL;
     ret->next = NULL;
@@ -1981,7 +1981,7 @@ json_conv_float(char const *str, size_t len)
     /*
      * initialize the JSON parse tree element
      */
-    ret->type = JSON_FLOAT;
+    ret->type = JTYPE_FLOAT;
     ret->parent = NULL;
     ret->prev = NULL;
     ret->next = NULL;
@@ -2390,7 +2390,7 @@ json_conv_string(char const *str, size_t len, bool quote)
     /*
      * initialize the JSON parse tree element
      */
-    ret->type = JSON_STRING;
+    ret->type = JTYPE_STRING;
     ret->parent = NULL;
     ret->prev = NULL;
     ret->next = NULL;
@@ -2592,7 +2592,7 @@ json_conv_bool(char const *str, size_t len)
     /*
      * initialize the JSON parse tree element
      */
-    ret->type = JSON_BOOL;
+    ret->type = JTYPE_BOOL;
     ret->parent = NULL;
     ret->prev = NULL;
     ret->next = NULL;
@@ -2750,7 +2750,7 @@ json_conv_null(char const *str, size_t len)
     /*
      * initialize the JSON parse tree element
      */
-    ret->type = JSON_NULL;
+    ret->type = JTYPE_NULL;
     ret->parent = NULL;
     ret->prev = NULL;
     ret->next = NULL;

--- a/json.h
+++ b/json.h
@@ -290,16 +290,16 @@ struct json_array
  * element_type - JSON element type - an enum for each union element member in struct json
  */
 enum element_type {
-    JSON_EOT	    = -1,   /* special end of the table value */
-    JSON_UNSET	    = 0,    /* JSON element has not been set - must be the value 0 */
-    JSON_INT,		    /* JSON element is an integer - see struct json_integer */
-    JSON_FLOAT,		    /* JSON element is a float - see struct json_floating */
-    JSON_STRING,	    /* JSON element is a string - see struct json_string */
-    JSON_BOOL,		    /* JSON element is a boolean - see struct json_boolean */
-    JSON_NULL,		    /* JSON element is a null - see struct json_null */
-    JSON_OBJECT,	    /* JSON element is a { members } */
-    JSON_MEMBER,	    /* JSON element is a member */
-    JSON_ARRAY,		    /* JSON element is a [ elements ] */
+    JTYPE_EOT	    = -1,   /* special end of the table value */
+    JTYPE_UNSET	    = 0,    /* JSON element has not been set - must be the value 0 */
+    JTYPE_INT,		    /* JSON element is an integer - see struct json_integer */
+    JTYPE_FLOAT,		    /* JSON element is a float - see struct json_floating */
+    JTYPE_STRING,	    /* JSON element is a string - see struct json_string */
+    JTYPE_BOOL,		    /* JSON element is a boolean - see struct json_boolean */
+    JTYPE_NULL,		    /* JSON element is a null - see struct json_null */
+    JTYPE_OBJECT,	    /* JSON element is a { members } */
+    JTYPE_MEMBER,	    /* JSON element is a member */
+    JTYPE_ARRAY,		    /* JSON element is a [ elements ] */
 };
 
 /*
@@ -311,14 +311,14 @@ struct json
 {
     enum element_type type;		/* union element specifier */
     union json_union {
-	struct json_integer integer;	/* JSON_INT - value is either a signed or unsigned integer */
-	struct json_floating floating;	/* JSON_FLOAT - value is a floating point */
-	struct json_string string;	/* JSON_STRING - value is a string */
-	struct json_boolean boolean;	/* JSON_BOOL - value is a JSON boolean */
-	struct json_null null;		/* JSON_NULL - value is a JSON null value */
-	struct json_object object;	/* JSON_OBJECT - value is a JSON { members } */
-	struct json_member member;	/* JSON_MEMBER - value is a JSON member: name : value */
-	struct json_array array;	/* JSON_ARRAY - value is a JSON [ elements ] */
+	struct json_integer integer;	/* JTYPE_INT - value is either a signed or unsigned integer */
+	struct json_floating floating;	/* JTYPE_FLOAT - value is a floating point */
+	struct json_string string;	/* JTYPE_STRING - value is a string */
+	struct json_boolean boolean;	/* JTYPE_BOOL - value is a JSON boolean */
+	struct json_null null;		/* JTYPE_NULL - value is a JSON null value */
+	struct json_object object;	/* JTYPE_OBJECT - value is a JSON { members } */
+	struct json_member member;	/* JTYPE_MEMBER - value is a JSON member: name : value */
+	struct json_array array;	/* JTYPE_ARRAY - value is a JSON [ elements ] */
     } element;
 
     /*

--- a/json_chk.c
+++ b/json_chk.c
@@ -37,20 +37,20 @@
  */
 struct json_field common_json_fields[] =
 {
-    { "ioccc_contest",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "ioccc_year",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
-    { "mkiocccentry_version",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "fnamchk_version",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "IOCCC_contest_id",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "entry_num",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
-    { "tarball",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "formed_timestamp",	    NULL, 0, 1, false, JSON_INT,	false, NULL },
-    { "formed_timestamp_usec",	    NULL, 0, 1, false, JSON_INT,	false, NULL },
-    { "timestamp_epoch",	    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "min_timestamp",		    NULL, 0, 1, false, JSON_INT,	false, NULL },
-    { "formed_UTC",		    NULL, 0, 1, false, JSON_STRING,	false, NULL },
-    { "test_mode",		    NULL, 0, 1, false, JSON_BOOL,	false, NULL },
-    { NULL,			    NULL, 0, 0, false, JSON_EOT,	false, NULL } /* this **MUST** be last! */
+    { "ioccc_contest",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "ioccc_year",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "mkiocccentry_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "fnamchk_version",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "IOCCC_contest_id",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "entry_num",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "tarball",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "formed_timestamp",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "formed_timestamp_usec",	    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "timestamp_epoch",	    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "min_timestamp",		    NULL, 0, 1, false, JTYPE_INT,	false, NULL },
+    { "formed_UTC",		    NULL, 0, 1, false, JTYPE_STRING,	false, NULL },
+    { "test_mode",		    NULL, 0, 1, false, JTYPE_BOOL,	false, NULL },
+    { NULL,			    NULL, 0, 0, false, JTYPE_EOT,	false, NULL } /* this **MUST** be last! */
 };
 size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
 
@@ -63,37 +63,37 @@ size_t SIZEOF_COMMON_JSON_FIELDS_TABLE = TBLLEN(common_json_fields);
  */
 struct json_field info_json_fields[] =
 {
-    { "IOCCC_info_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "jinfochk_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "iocccsize_version",	NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "txzchk_version",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "title",			NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "abstract",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "rule_2a_size",		NULL, 0, 1, false, JSON_INT,	    false,  NULL },
-    { "rule_2b_size",		NULL, 0, 1, false, JSON_INT,	    false,  NULL },
-    { "empty_override",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "rule_2a_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "rule_2a_mismatch",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "rule_2b_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "highbit_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "nul_warning",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "trigraph_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "wordbuf_warning",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "ungetc_warning",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "Makefile_override",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "first_rule_is_all",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "found_all_rule",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "found_clean_rule",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "found_clobber_rule",	NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "found_try_rule",		NULL, 0, 1, false, JSON_BOOL,	    false,  NULL },
-    { "manifest",		NULL, 0, 1, false, JSON_ARRAY,	    false,  NULL },
-    { "info_JSON",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "author_JSON",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "c_src",			NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "Makefile",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "remarks",		NULL, 0, 1, false, JSON_STRING,    false,  NULL },
-    { "extra_file",		NULL, 0, 0, false, JSON_STRING,    false,  NULL },
-    { NULL,			NULL, 0, 0, false, JSON_EOT,	    false,  NULL } /* this **MUST** be last */
+    { "IOCCC_info_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "jinfochk_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "iocccsize_version",	NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "txzchk_version",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "title",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "abstract",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "rule_2a_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
+    { "rule_2b_size",		NULL, 0, 1, false, JTYPE_INT,	    false,  NULL },
+    { "empty_override",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2a_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2a_mismatch",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "rule_2b_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "highbit_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "nul_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "trigraph_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "wordbuf_warning",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "ungetc_warning",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "Makefile_override",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "first_rule_is_all",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_all_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_clean_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_clobber_rule",	NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "found_try_rule",		NULL, 0, 1, false, JTYPE_BOOL,	    false,  NULL },
+    { "manifest",		NULL, 0, 1, false, JTYPE_ARRAY,	    false,  NULL },
+    { "info_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "author_JSON",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "c_src",			NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "Makefile",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "remarks",		NULL, 0, 1, false, JTYPE_STRING,    false,  NULL },
+    { "extra_file",		NULL, 0, 0, false, JTYPE_STRING,    false,  NULL },
+    { NULL,			NULL, 0, 0, false, JTYPE_EOT,	    false,  NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
 
@@ -112,22 +112,22 @@ size_t SIZEOF_INFO_JSON_FIELDS_TABLE = TBLLEN(info_json_fields);
  */
 struct json_field author_json_fields[] =
 {
-    { "IOCCC_author_version",	NULL, 0, 1, false, JSON_STRING,		false,	NULL },
-    { "jauthchk_version",	NULL, 0, 1, false, JSON_STRING,		false,	NULL },
-    { "author_count",		NULL, 0, 1, false, JSON_INT,		false,  NULL },
-    { "authors",		NULL, 0, 1, false, JSON_ARRAY,		false,	NULL },
-    { "name",			NULL, 0, 5, false, JSON_STRING,	false,  NULL },
-    { "location_code",		NULL, 0, 5, false, JSON_STRING,	false,	NULL },
-    { "email",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "url",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "twitter",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "github",			NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "affiliation",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "past_winner",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
-    { "default_handle",		NULL, 0, 1, false, JSON_BOOL,		true,	NULL },
-    { "author_handle",		NULL, 0, 5, false, JSON_STRING,	true,	NULL },
-    { "author_number",		NULL, 0, 5, false, JSON_INT,	false,	NULL },
-    { NULL,			NULL, 0, 0, false, JSON_EOT,		false,	NULL } /* this **MUST** be last */
+    { "IOCCC_author_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
+    { "jauthchk_version",	NULL, 0, 1, false, JTYPE_STRING,		false,	NULL },
+    { "author_count",		NULL, 0, 1, false, JTYPE_INT,		false,  NULL },
+    { "authors",		NULL, 0, 1, false, JTYPE_ARRAY,		false,	NULL },
+    { "name",			NULL, 0, 5, false, JTYPE_STRING,	false,  NULL },
+    { "location_code",		NULL, 0, 5, false, JTYPE_STRING,	false,	NULL },
+    { "email",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "url",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "twitter",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "github",			NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "affiliation",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "past_winner",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
+    { "default_handle",		NULL, 0, 1, false, JTYPE_BOOL,		true,	NULL },
+    { "author_handle",		NULL, 0, 5, false, JTYPE_STRING,	true,	NULL },
+    { "author_number",		NULL, 0, 5, false, JTYPE_INT,	false,	NULL },
+    { NULL,			NULL, 0, 0, false, JTYPE_EOT,		false,	NULL } /* this **MUST** be last */
 };
 size_t SIZEOF_AUTHOR_JSON_FIELDS_TABLE = TBLLEN(author_json_fields);
 
@@ -203,7 +203,7 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
  * check_info_json_fields_table() and check_author_json_fields_table() to make
  * sure that they're all sane.
  *
- * This means that the only element with the JSON_EOT type is the last element,
+ * This means that the only element with the JTYPE_EOT type is the last element,
  * that the field types are valid (see json.h), that there are no embedded NULL
  * elements (name == NULL) and that the final element _IS_ NULL.
  *
@@ -230,7 +230,7 @@ check_json_fields_tables(void)
 /*
  * check_common_json_fields_table - perform some sanity checks on the common_json_fields table
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -252,20 +252,20 @@ check_common_json_fields_table(void)
 
     for (i = 0; i < max-1 && common_json_fields[i].name != NULL; ++i) {
 	switch (common_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (common_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in common_json_fields table; fix table and recompile",
                             common_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_INT:
-	    case JSON_FLOAT:
-	    case JSON_BOOL:
-	    case JSON_STRING:
-	    case JSON_ARRAY:
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -294,7 +294,7 @@ check_common_json_fields_table(void)
 /*
  * check_info_json_fields_table	 - sanity check info_json_fields table
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid. Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -321,20 +321,20 @@ check_info_json_fields_table(void)
 	}
 
 	switch (info_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (info_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in info_json_fields table; fix table and recompile",
 			    info_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_INT:
-	    case JSON_FLOAT:
-	    case JSON_BOOL:
-	    case JSON_STRING:
-	    case JSON_ARRAY:
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -370,7 +370,7 @@ check_info_json_fields_table(void)
 /*
  * check_author_json_fields_table - perform author_json_fields table sanity checks
  *
- * This function checks if JSON_EOT is used on any field other than the NULL
+ * This function checks if JTYPE_EOT is used on any field other than the NULL
  * field. It also makes sure that each field_type is valid.  Additionally it
  * makes sure that there are no NULL elements before the final element and that
  * the final element _IS_ NULL. It also makes sure the table is not empty.
@@ -397,20 +397,20 @@ check_author_json_fields_table(void)
 	}
 
 	switch (author_json_fields[i].field_type) {
-	    case JSON_EOT:
+	    case JTYPE_EOT:
 		if (author_json_fields[i].name != NULL) {
 		    jerr(JSON_CODE_RESERVED(1), NULL, __func__, __FILE__, NULL, __LINE__,
-						"found JSON_EOT element with non NULL name '%s' location %ju "
+						"found JTYPE_EOT element with non NULL name '%s' location %ju "
 						"in author_json_fields table; fix table and recompile",
                             author_json_fields[i].name, (uintmax_t)i);
 		    not_reached();
 		}
 		break;
-	    case JSON_INT:
-	    case JSON_FLOAT:
-	    case JSON_BOOL:
-	    case JSON_STRING:
-	    case JSON_ARRAY:
+	    case JTYPE_INT:
+	    case JTYPE_FLOAT:
+	    case JTYPE_BOOL:
+	    case JTYPE_STRING:
+	    case JTYPE_ARRAY:
 		/* these are all the valid types */
 		break;
 	    default:
@@ -829,7 +829,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 	    }
 	    /* first we do checks on the field type */
 	    switch (common_field->field_type) {
-		case JSON_BOOL:
+		case JTYPE_BOOL:
 		    if (strcmp(val, "false") && strcmp(val, "true")) {
 			warn(__func__, "bool field '%s' has non boolean value in file %s: '%s'",
 				       common_field->name, json_filename, val);
@@ -837,7 +837,7 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 			continue;
 		    }
 		    break;
-		case JSON_INT:
+		case JTYPE_INT:
 		    if (!is_integer(val)) {
 			warn(__func__, "number field '%s' has non-number value in file %s: '%s'",
 				       common_field->name, json_filename, val);

--- a/json_chk.h
+++ b/json_chk.h
@@ -111,8 +111,8 @@ struct json_field
      * valid and parsing in that certain data types have to be parsed
      * differently.
      *
-     * Data type: one of JSON_NUM, JSON_BOOL, JSON_CHARS or
-     * JSON_ARRAY_ equivalents.
+     * Data type: one of JSON_NUM, JTYPE_BOOL, JSON_CHARS or
+     * JTYPE_ARRAY_ equivalents.
      */
     int field_type;
     /*
@@ -160,8 +160,6 @@ extern struct json_field *new_json_field(char const *json_filename, char const *
 extern struct json_value *add_json_value(char const *json_filename, struct json_field *field, char const *val, int line_num);
 
 /* warning and error specific functions */
-
-
 extern void jwarn(int code, const char *program, char const *name, char const *filename, char const *line,
 		  int line_num, const char *fmt, ...) \
 	__attribute__((format(printf, 7, 8)));		/* 7=format 8=params */

--- a/sanity.c
+++ b/sanity.c
@@ -50,7 +50,7 @@ ioccc_sanity_chks(void)
 
     /*
      * Check that the JSON fields tables are sane: that there are no
-     * embedded NULL elements, that the only JSON_NULL type is the final
+     * embedded NULL elements, that the only JTYPE_NULL type is the final
      * element, that the other elements have valid field types and that the
      * final element is in fact NULL. As well it makes sure the tables are not
      * empty.


### PR DESCRIPTION
I'd like in particular to point out commit 1f4dd7687a69fc:

```
    Older bison and POSIX Yacc compatibility
    
    Change parse.error 'detailed' to 'verbose' to support older versions of
    bison. Now bison version 3.0.4 will work which means CentOS 7 bison can
    actually generate the file. The change in verbosity does not seem to
    make a difference for me so this is a worthwhile change. Please note the
    version has not yet been updated in version.h.
    
    Now passes -Wyacc which has been added to the Makefile. This is done by
    making a couple changes described below.
    
    POSIX Yacc does not support the %empty directive so we use /* empty */
    instead.
    
    POSIX Yacc does not support the %define directive but it does support
    the -D option. Thus instead of having in jparse.y (where detailed is now
    verbose as described above):
    
        %define parse.error detailed
        %define parse.lac full
    
    we have in the Makefile:
    
        echo "$$BISON_PATH -d -Wyacc -Dparse.error=verbose -Dparse.lac=full jparse.y"; \
        "$$BISON_PATH" -d -Wyacc -Dparse.error=verbose -Dparse.lac=full jparse.y; \

```

I did try updating the version in `version.h` but for some reason running `make` did not let CentOS bison work though using `./bfok.sh` directly reported the correct exit code (I think I did that). Would you like to change this? I'm not sure if older versions of flex will work but I'll test that: perhaps in a bit as I need to go afk for now.