### PR TITLE
run_{flex,bison}: mktemp: too few X's in template

### DIFF
--- a/run_bison.sh
+++ b/run_bison.sh
@@ -495,7 +495,7 @@ add_sorry() {
 
     # obtain a temporary filename
     #
-    TMP_FILE=$(mktemp -t "$FILE")
+    TMP_FILE=$(mktemp -t "$FILE.XXXXXXXX")
     status="$?"
     if [[ $status -ne 0 ]]; then
 	echo "$0: ERROR: mktemp -r $FILE exit code: $status" 1>&2

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -464,7 +464,7 @@ add_sorry() {
 
     # obtain a temporary filename
     #
-    TMP_FILE=$(mktemp -t "$FILE")
+    TMP_FILE=$(mktemp -t "$FILE.XXXXXXXX")
     status="$?"
     if [[ $status -ne 0 ]]; then
 	echo "$0: ERROR: mktemp -r $FILE exit code: $status" 1>&2


### PR DESCRIPTION
Under linux (at least CentOS 7) I got the following error (after changing the version of bison temporarily - which is NOT being committed! - to the version that CentOS 7 has):

    mktemp: too few X's in template 'jparse.tab.c'
    ./run_bison.sh: ERROR: mktemp -r jparse.tab.c exit code: 1

This also happened for flex. Thus the following diff was added to both run_flex.sh and run_bison.sh:

    -    TMP_FILE=$(mktemp -t "$FILE")
    +    TMP_FILE=$(mktemp -t "$FILE.XXXXXXXX")

This works under linux as well as macOS.

Some words about required versions of flex and bison. After a recent
commit I made the default flex and bison versions under CentOS 7 (flex
2.5.37 and bison 3.0.4) do actually work. But in order to make sure that
I don't inadvertently introduce an incompatibility when developing (for
development I use the most recent versions under macOS) I have not
changed the required version. When everything is in order I will then
test if older versions work and only then will I change the required
versions.

Now I did install under CentOS bison 3.8 and tried it and it appeared
okay after updating the version. However for flex there's a missing tool
by default under CentOS and I wanted to work on other things (I had
worked out several issues already) so I kind of cheated: I changed the
required version of a tool in the configure script (or a configuration
related script) and then compiled. This allowed the run_flex.sh to
generate the proper files but there were compilation errors. Now nobody
would normally do this but it's worth pointing out because if there are
any problems with the tools you cannot expect the correct results so if
you use a system that does not have bison >= BISON_VERSION and/or 
flex >= FLEX_VERSION you should expect valid results just to be safe (whether
there will be any problems or not is another matter entirely).

Finally as a reminder: /usr/local/bin is searched before /usr/bin and
/bin (whichever order it is in your PATH environment var) so if you have
a flex or bison installed in this directory and it works it'll be fine
but if there's a problem with them (e.g. because you did something like
I did above for testing purposes) you might run into compilation issues
or other problems.