### PR TITLE
Makefile dependency updates for flex and bison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ limit_ioccc.sh: limit_ioccc.h version.h Makefile
 # if bison is found and has a recent enough version, otherwise
 # use a pre-built reference copies stored in jparse.tab.ref.h and jparse.tab.ref.c.
 #
-jparse.tab.c jparse.tab.h: jparse.y run_bison.sh limit_ioccc.sh verge jparse.tab.ref.c jparse.tab.ref.h Makefile
+jparse.tab.c jparse.tab.h: jparse.y jparse.h sorry.tm.ca.h run_bison.sh limit_ioccc.sh verge jparse.tab.ref.c jparse.tab.ref.h Makefile
 	./run_bison.sh ${BISON_DIRS} -p jparse -v 1 -- -d
 
 # How to create jparse.c
@@ -440,7 +440,7 @@ jparse.tab.c jparse.tab.h: jparse.y run_bison.sh limit_ioccc.sh verge jparse.tab
 # if flex found and has a recent enough version, otherwise
 # use a pre-built reference copy stored in jparse.ref.c
 #
-jparse.c: jparse.l jparse.tab.h run_flex.sh limit_ioccc.sh verge jparse.ref.c Makefile
+jparse.c: jparse.l jparse.h sorry.tm.ca.h jparse.tab.h run_flex.sh limit_ioccc.sh verge jparse.ref.c Makefile
 	./run_flex.sh ${FLEX_DIRS} -p jparse -v 1 -- -d -8 -o jparse.c
 
 

--- a/jparse.h
+++ b/jparse.h
@@ -73,13 +73,12 @@
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-T] [-s string] [file ...]\n"
+    "usage: %s [-h] [-v level] [-q] [-V] [-s string] [file ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit 0\n"
-    "\t-T\t\tshow IOCCC toolkit release repository tag\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-s\t\tread arg as a string\n"
     "\n"


### PR DESCRIPTION
If sorry.tm.ca.h or jparse.h is updated both flex and bison will
regenerate the files. This is because if jparse.h is updated it might be
a change in prototypes (or new functions or variables or something else)
and if sorry.tm.ca.h is updated we want the updated apology to be
injected into the files again.