### PR TITLE
JSON (and other) updates (including man pages)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,9 @@ CFLAGS= ${STD_SRC} ${COPT} -pedantic ${WARN_FLAGS} ${LDFLAGS}
 #
 MANDIR = /usr/local/share/man/man1
 DESTDIR= /usr/local/bin
-TARGETS= mkiocccentry iocccsize dbg limit_ioccc.sh fnamchk txzchk jauthchk jinfochk \
+TARGETS= mkiocccentry iocccsize dbg fnamchk txzchk jauthchk jinfochk \
 	jstrencode jstrdecode utf8_test jparse verge jnumber
+SH_TARGETS=limit_ioccc.sh
 
 # man pages
 #
@@ -732,7 +733,7 @@ clobber: clean prep_clobber
 distclean nuke: clobber
 
 install: all
-	${INSTALL} -v -m 0555 ${TARGETS} ${DESTDIR}
+	${INSTALL} -v -m 0555 ${TARGETS} ${SH_TARGETS} ${DESTDIR}
 	${INSTALL} -v -m 0644 ${MANPAGES} ${MANDIR} 2>/dev/null
 
 tags: ${ALL_CSRC} ${H_FILES}

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ FLEX_DIRS= \
 #
 # The - before include means it's not an error if the file does not exist.
 #
-# We put this directive just before the 1st all rule so that you may override
+# We put this directive just before the first all rule so that you may override
 # or modify any of the above Makefile variables.  To override a value, use := symbols.
 # For example:
 #

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ TARGETS= mkiocccentry iocccsize dbg limit_ioccc.sh fnamchk txzchk jauthchk jinfo
 # page is written the MAN_TARGETS should have the tool name (without any
 # extension) added to it.  Eventually MAN_TARGETS can be removed entirely and
 # MANPAGES will act on TARGETS.
-MAN_TARGETS = mkiocccentry txzchk fnamchk iocccsize jinfochk jauthchk
+MAN_TARGETS = mkiocccentry txzchk fnamchk iocccsize jinfochk jauthchk jstrdecode jstrencode
 MANPAGES= $(MAN_TARGETS:=.1)
 
 TEST_TARGETS= dbg utf8_test dyn_test

--- a/jstrdecode.1
+++ b/jstrdecode.1
@@ -1,0 +1,74 @@
+.TH jstrdecode 1 "28 April 2022" "jstrdecode" "IOCCC tools"
+.SH NAME
+jstrdecode \- decode JSON encoded strings
+.SH SYNOPSIS
+\fBjstrdecode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [string ...]
+.SH DESCRIPTION
+\fBjstrdecode\fP decodes JSON encoded strings given on the command line.
+If given the \fB\-t\fP option it performs a test on the JSON decode and encode functions.
+.PP
+By default the program reads from \fBstdin\fP.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-q\fP
+Suppresses some of the output (def: not quiet).
+.PP
+\fB\-V\fP
+Show version and exit.
+.PP
+\fB\-t\fP
+Run tests on the JSON decode/encode functions.
+.PP
+\fB\-n\fP
+Do not output a newline after the decode function.
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 1 for errors or issues found; 0 for success.
+.SH FILES
+\fIjstrdecode.c\fP
+.RS
+Source file of the \fBjstrdecode\fP tool.
+.RE
+\fIjstrdecode.h\fP
+.RS
+Header file of the \fBjstrdecode\fP tool.
+.RE
+.SH BUGS
+.PP
+If you have an issue with the tool you can report it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+.SH EXAMPLES
+.PP
+.nf
+Decode the JSON string \fB{ "test_mode" : false }\fP:
+.RS
+\fB
+ ./jstrdecode { "test_mode" : false }\fP
+.fi
+.RE
+.PP
+.nf
+Decode input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to decode):
+.RS
+\fB
+ ./jstrdecode
+ -5
+ ^D
+.fi
+.RE
+.PP
+.nf
+Decode just a negative number:
+.RS
+\fB
+ ./jstrdecode -- -5
+.fi
+.RE
+.SH SEE ALSO
+.PP
+For the encode counterpart, see \fBjstrencode(1)\fP.

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -70,10 +70,11 @@ static const char * const usage_msg =
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit 0\n"
-    "\t-t\t\tperform jencchk test on code JSON decode/decode functions\n"
+    "\t-t\t\tperform jencchk test on code JSON decode/encode functions\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\n"
     "\t[string ...]\tdecode strings on command line (def: read stdin)\n"
+    "\t\t\tNOTE: - means read from stdin\n"
     "\n"
     "jstrdecode version: %s\n";
 
@@ -86,6 +87,7 @@ static const char * const usage_msg =
 /*
  * function prototypes
  */
+static bool jstrdecode_stdin(void);
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 
 

--- a/jstrencode.1
+++ b/jstrencode.1
@@ -1,0 +1,74 @@
+.TH jstrencode 1 "28 April 2022" "jstrencode" "IOCCC tools"
+.SH NAME
+jstrencode \- encode JSON encoded strings
+.SH SYNOPSIS
+\fBjstrencode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [string ...]
+.SH DESCRIPTION
+\fBjstrencode\fP encodes JSON encoded strings given on the command line.
+If given the \fB\-t\fP option it performs a test on the JSON encode and encode functions.
+.PP
+By default the program reads from \fBstdin\fP.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level.
+.PP
+\fB\-q\fP
+Suppresses some of the output (def: not quiet).
+.PP
+\fB\-V\fP
+Show version and exit.
+.PP
+\fB\-t\fP
+Run tests on the JSON encode/encode functions.
+.PP
+\fB\-n\fP
+Do not output a newline after the encode function.
+.SH EXIT STATUS
+.PP
+\fBmain()\fP returns 1 for errors or issues found; 0 for success.
+.SH FILES
+\fIjstrencode.c\fP
+.RS
+Source file of the \fBjstrencode\fP tool.
+.RE
+\fIjstrencode.h\fP
+.RS
+Header file of the \fBjstrencode\fP tool.
+.RE
+.SH BUGS
+.PP
+If you have an issue with the tool you can report it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+.SH EXAMPLES
+.PP
+.nf
+Encode the JSON string \fB{ "test_mode" : false }\fP:
+.RS
+\fB
+ ./jstrencode { "test_mode" : false }\fP
+.fi
+.RE
+.PP
+.nf
+Encode a string containing an escaped \fB"\fP from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to encode):
+.RS
+\fB
+ ./jstrencode
+ {"test\\"ing":false}
+ ^D
+.fi
+.RE
+.PP
+.nf
+Encode just a negative number:
+.RS
+\fB
+ ./jstrencode -- -5
+.fi
+.RE
+.SH SEE ALSO
+.PP
+For the decode counterpart, see \fBjstrdecode(1)\fP.

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -75,6 +75,7 @@ static const char * const usage_msg =
     "\t-n\t\tdo not output newline after encode output\n"
     "\n"
     "\t[string ...]\tencode strings on command line (def: read stdin)\n"
+    "\t\t\tNOTE: - means read from stdin\n"
     "\n"
     "jstrencode version: %s\n";
 
@@ -88,6 +89,7 @@ static const char * const usage_msg =
 /*
  * forward declarations
  */
+static bool jstrencode_stdin(void);
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 
 

--- a/prep.sh
+++ b/prep.sh
@@ -34,7 +34,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-e] [-o] [-m make] [-M Makefile]
     -v level        flag ignored
     -V              print version and exit 5
 
-    -e		    exit in 1st make action error (def: exit only at end)
+    -e		    exit in first make action error (def: exit only at end)
     -o		    do NOT use backup files, fail if bison cannot be used (def: use)
     -m make	    make command (def: make)
     -M Makefile	    path to Makefile (def: ./Makefile)

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -48,7 +48,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-o] [-f flex] [-l limit_ioccc.sh]
 			NOTE:		prefix.c
 			NOTE:
     -s sorry.h	    File to prepend to C output (def: sorry.tm.ca.h)
-    -F dir          1st look for flex in dir (def: look just along \$PATH)
+    -F dir          first look for flex in dir (def: look just along \$PATH)
 		        NOTE: Multiple -B dir are allowed.
 		        NOTE: Search is performed in dir order before the \$PATH path.
 			NOTE: If dir is missing or not searchable, dir is ignored.


### PR DESCRIPTION
The tools now will parse `-` at the command line as `stdin`. NOTE: exactly `-`: doing `-5` still counts as a string though of course one would have to first pass `--`.

Added man pages for these two tools and updated Makefile to install these (added to the man page targets variable).

