### PR TITLE
Various updates and fixes (including typos)

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -95,8 +95,8 @@ extern bool output_newline;		/* true ==> -n not specified, output new line after
 extern unsigned num_errors;		/* > 0 number of errors encountered */
 /* lexer and parser specific variables */
 extern int ugly_lineno;			/* line number in lexer */
-extern char *yytext;			/* current text */
-extern FILE *yyin;			/* input file lexer/parser reads from */
+extern char *ugly_text;			/* current text */
+extern FILE *ugly_in;			/* input file lexer/parser reads from */
 extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern bool output_newline;		/* true ==> -n not specified, output new line after each arg processed */
 extern int token_type;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' and so on */
@@ -106,7 +106,7 @@ extern int token_type;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' a
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 /* lexer specific */
-int yylex(void);
+int ugly_lex(void);
 /* parser specific */
 void parse_json_file(char const *filename);
 void parse_json_string(char const *string);

--- a/jparse.l
+++ b/jparse.l
@@ -24,7 +24,7 @@
  * problems. Another way is to provide 'int yywrap() { return 1; }' but this is
  * unnecessary.
  */
-%option noyywrap yylineno nodefault
+%option noyywrap yylineno nodefault 8bit
 
 /*
  * As we utterly object to the hideous code that bison and flex generate we
@@ -57,7 +57,21 @@
  * Thus as much as we find the specification objectionable we rather feel sorry
  * for those poor lost souls who are indeed in the JSON Barmy Army and we
  * apologise to them in a light and fun way and with hope that they're not
- * terribly humour impaired.
+ * terribly humour impaired. :-)
+ *
+ * BTW: If you want to see all the symbols (re?)defined to something ugly run:
+ *
+ *	grep -i 'define[[:space:]].*ugly_' *.c
+ *
+ * after generating the files; and if you want to see only what was changed from
+ * yy or YY to refer to ugly_ or UGLY_:
+ *
+ *	grep -i '#[[:space:]]*define yy.*ugly_' *.c
+ *
+ * This will help you find the right symbols should you need them. If (as is
+ * likely to happen) the parser is split into another repo for a json parser by
+ * itself I will possibly remove this prefix: this is as satire for the IOCCC
+ * (though we all believe that the generated code is in fact ugly).
  */
 %option prefix="ugly_"
 
@@ -120,19 +134,19 @@ JSON_COMMA		","
  * ugly_lval.type). These things will be done later.
  */
 %%
-{JSON_WHITESPACE}	    { printf("\nwhitespace: '%s'\n", yytext); }
-{JSON_STRING}		    { printf("\nstring: '%s'\n", yytext); ugly_lval.type = JTYPE_STRING; return JSON_STRING; }
-{JSON_NUMBER}		    { printf("\nnumber: '%s'\n", yytext); ugly_lval.type = JTYPE_NUMBER; return JSON_NUMBER; }
-{JSON_NULL}		    { printf("\nnull: '%s'\n", yytext); ugly_lval.type = JTYPE_NULL; return JSON_NULL; }
-{JSON_TRUE}		    { printf("\ntrue: '%s'\n", yytext); ugly_lval.type = JTYPE_BOOL; return JSON_TRUE; }
-{JSON_FALSE}		    { printf("\nfalse: '%s'\n", yytext); ugly_lval.type = JTYPE_BOOL; return JSON_FALSE; }
-{JSON_OPEN_BRACE}	    { printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
-{JSON_CLOSE_BRACE}	    { printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
-{JSON_OPEN_BRACKET}	    { printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
-{JSON_CLOSE_BRACKET}	    { printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
-{JSON_COLON}		    { printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
-{JSON_COMMA}		    { printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
-.			    { ugly_error("invalid input: %s\n", yytext); return JSON_INVALID_TOKEN; }
+{JSON_WHITESPACE}	    { printf("\nwhitespace: '%s'\n", ugly_text); }
+{JSON_STRING}		    { printf("\nstring: '%s'\n", ugly_text); ugly_lval.type = JTYPE_STRING; return JSON_STRING; }
+{JSON_NUMBER}		    { printf("\nnumber: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NUMBER; return JSON_NUMBER; }
+{JSON_NULL}		    { printf("\nnull: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NULL; return JSON_NULL; }
+{JSON_TRUE}		    { printf("\ntrue: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_TRUE; }
+{JSON_FALSE}		    { printf("\nfalse: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_FALSE; }
+{JSON_OPEN_BRACE}	    { printf("\nopen brace: '%c'\n", *ugly_text); token_type = '{'; return JSON_OPEN_BRACE; }
+{JSON_CLOSE_BRACE}	    { printf("\nclose brace: '%c'\n", *ugly_text); token_type = '}'; return JSON_CLOSE_BRACE;}
+{JSON_OPEN_BRACKET}	    { printf("\nopen bracket: '%c'\n", *ugly_text); token_type = '['; return JSON_OPEN_BRACKET; }
+{JSON_CLOSE_BRACKET}	    { printf("\nclose bracket: '%c'\n", *ugly_text); token_type = ']'; return JSON_CLOSE_BRACKET; }
+{JSON_COLON}		    { printf("\nequals/colon: '%c'\n", *ugly_text); token_type = ':'; return JSON_COLON; }
+{JSON_COMMA}		    { printf("\ncomma: '%c'\n", *ugly_text); token_type = ','; return JSON_COMMA; }
+.			    { ugly_error("invalid input: %s\n", ugly_text); return JSON_INVALID_TOKEN; }
 %%
 
 /* Section 3: Code that's copied to the generated scanner */
@@ -178,7 +192,7 @@ parse_json_string(char const *string)
     }
 
     ugly_lineno = 1;
-    bs = yy_scan_string(string);
+    bs = ugly__scan_string(string);
     if (bs == NULL) {
 	warn(__func__, "unable to scan string");
 	++num_errors;
@@ -188,7 +202,7 @@ parse_json_string(char const *string)
 
     ugly_parse();
 
-    yy_delete_buffer(bs);
+    ugly__delete_buffer(bs);
     bs = NULL;
 
     dbg(DBG_NONE, "*** END PARSE");
@@ -253,30 +267,30 @@ parse_json_file(char const *filename)
     }
 
     errno = 0;
-    yyin = is_stdin ? stdin : fopen(filename, "r");
-    if (yyin == NULL) {
+    ugly_in = is_stdin ? stdin : fopen(filename, "r");
+    if (ugly_in == NULL) {
 	warnp(__func__, "couldn't open file %s, ignoring", filename);
 	++num_errors;
 	return;
     }
 
-    data = read_all(yyin, &len);
+    data = read_all(ugly_in, &len);
     if (data == NULL) {
 	warn(__func__, "couldn't read in %s", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     }
     else if (len <= 0) {
 	warn(__func__, "%s is empty", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     }
     else if (!is_string(data, len + 1)) {
 	warn(__func__, "found embedded NUL byte in %s", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     } else if (is_all_whitespace_str(data)) {
 	warn(__func__, "file has only whitespace");
@@ -291,13 +305,13 @@ parse_json_file(char const *filename)
     data = NULL;
 
     /* now parse the file */
-    rewind(yyin);
-    yyrestart(yyin);
+    rewind(ugly_in);
+    ugly_restart(ugly_in);
     ugly_lineno = 1;
     ugly_parse();
 
-    clearerr_or_fclose(filename, yyin);
-    yyin = NULL;
+    clearerr_or_fclose(filename, ugly_in);
+    ugly_in = NULL;
     dbg(DBG_NONE, "*** END PARSE");
     print_newline(output_newline);
 

--- a/jparse.l
+++ b/jparse.l
@@ -61,12 +61,12 @@
  *
  * BTW: If you want to see all the symbols (re?)defined to something ugly run:
  *
- *	grep -i 'define[[:space:]].*ugly_' *.c
+ *	grep -i '#[[:space:]]*define[[:space:]].*ugly_' *.c
  *
  * after generating the files; and if you want to see only what was changed from
  * yy or YY to refer to ugly_ or UGLY_:
  *
- *	grep -i '#[[:space:]]*define yy.*ugly_' *.c
+ *	grep -i '#[[:space:]]*define[[:space:]]*yy.*ugly_' *.c
  *
  * This will help you find the right symbols should you need them. If (as is
  * likely to happen) the parser is split into another repo for a json parser by

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -1366,67 +1366,67 @@ case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
 #line 123 "jparse.l"
-{ printf("\nwhitespace: '%s'\n", yytext); }
+{ printf("\nwhitespace: '%s'\n", ugly_text); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
 #line 124 "jparse.l"
-{ printf("\nstring: '%s'\n", yytext); ugly_lval.type = JTYPE_STRING; return JSON_STRING; }
+{ printf("\nstring: '%s'\n", ugly_text); ugly_lval.type = JTYPE_STRING; return JSON_STRING; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
 #line 125 "jparse.l"
-{ printf("\nnumber: '%s'\n", yytext); ugly_lval.type = JTYPE_NUMBER; return JSON_NUMBER; }
+{ printf("\nnumber: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NUMBER; return JSON_NUMBER; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
 #line 126 "jparse.l"
-{ printf("\nnull: '%s'\n", yytext); ugly_lval.type = JTYPE_NULL; return JSON_NULL; }
+{ printf("\nnull: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NULL; return JSON_NULL; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
 #line 127 "jparse.l"
-{ printf("\ntrue: '%s'\n", yytext); ugly_lval.type = JTYPE_BOOL; return JSON_TRUE; }
+{ printf("\ntrue: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_TRUE; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
 #line 128 "jparse.l"
-{ printf("\nfalse: '%s'\n", yytext); ugly_lval.type = JTYPE_BOOL; return JSON_FALSE; }
+{ printf("\nfalse: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_FALSE; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
 #line 129 "jparse.l"
-{ printf("\nopen brace: '%c'\n", *yytext); token_type = '{'; return JSON_OPEN_BRACE; }
+{ printf("\nopen brace: '%c'\n", *ugly_text); token_type = '{'; return JSON_OPEN_BRACE; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
 #line 130 "jparse.l"
-{ printf("\nclose brace: '%c'\n", *yytext); token_type = '}'; return JSON_CLOSE_BRACE;}
+{ printf("\nclose brace: '%c'\n", *ugly_text); token_type = '}'; return JSON_CLOSE_BRACE;}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
 #line 131 "jparse.l"
-{ printf("\nopen bracket: '%c'\n", *yytext); token_type = '['; return JSON_OPEN_BRACKET; }
+{ printf("\nopen bracket: '%c'\n", *ugly_text); token_type = '['; return JSON_OPEN_BRACKET; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
 #line 132 "jparse.l"
-{ printf("\nclose bracket: '%c'\n", *yytext); token_type = ']'; return JSON_CLOSE_BRACKET; }
+{ printf("\nclose bracket: '%c'\n", *ugly_text); token_type = ']'; return JSON_CLOSE_BRACKET; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
 #line 133 "jparse.l"
-{ printf("\nequals/colon: '%c'\n", *yytext); token_type = ':'; return JSON_COLON; }
+{ printf("\nequals/colon: '%c'\n", *ugly_text); token_type = ':'; return JSON_COLON; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
 #line 134 "jparse.l"
-{ printf("\ncomma: '%c'\n", *yytext); token_type = ','; return JSON_COMMA; }
+{ printf("\ncomma: '%c'\n", *ugly_text); token_type = ','; return JSON_COMMA; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
 #line 135 "jparse.l"
-{ ugly_error("invalid input: %s\n", yytext); return JSON_INVALID_TOKEN; }
+{ ugly_error("invalid input: %s\n", ugly_text); return JSON_INVALID_TOKEN; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
@@ -2714,30 +2714,30 @@ parse_json_file(char const *filename)
     }
 
     errno = 0;
-    yyin = is_stdin ? stdin : fopen(filename, "r");
-    if (yyin == NULL) {
+    ugly_in = is_stdin ? stdin : fopen(filename, "r");
+    if (ugly_in == NULL) {
 	warnp(__func__, "couldn't open file %s, ignoring", filename);
 	++num_errors;
 	return;
     }
 
-    data = read_all(yyin, &len);
+    data = read_all(ugly_in, &len);
     if (data == NULL) {
 	warn(__func__, "couldn't read in %s", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     }
     else if (len <= 0) {
 	warn(__func__, "%s is empty", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     }
     else if (!is_string(data, len + 1)) {
 	warn(__func__, "found embedded NUL byte in %s", is_stdin?"stdin":filename);
 	++num_errors;
-	clearerr_or_fclose(filename, yyin);
+	clearerr_or_fclose(filename, ugly_in);
 	return;
     } else if (is_all_whitespace_str(data)) {
 	warn(__func__, "file has only whitespace");
@@ -2752,13 +2752,13 @@ parse_json_file(char const *filename)
     data = NULL;
 
     /* now parse the file */
-    rewind(yyin);
-    yyrestart(yyin);
+    rewind(ugly_in);
+    yyrestart(ugly_in);
     ugly_lineno = 1;
     ugly_parse();
 
-    clearerr_or_fclose(filename, yyin);
-    yyin = NULL;
+    clearerr_or_fclose(filename, ugly_in);
+    ugly_in = NULL;
     dbg(DBG_NONE, "*** END PARSE");
     print_newline(output_newline);
 

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -881,8 +881,8 @@ int yy_flex_debug = 1;
 
 static const flex_int16_t yy_rule_linenum[14] =
     {   0,
-      123,  124,  125,  126,  127,  128,  129,  130,  131,  132,
-      133,  134,  135
+      137,  138,  139,  140,  141,  142,  143,  144,  145,  146,
+      147,  148,  149
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -949,9 +949,23 @@ char *yytext;
  * Thus as much as we find the specification objectionable we rather feel sorry
  * for those poor lost souls who are indeed in the JSON Barmy Army and we
  * apologise to them in a light and fun way and with hope that they're not
- * terribly humour impaired.
+ * terribly humour impaired. :-)
+ *
+ * BTW: If you want to see all the symbols (re?)defined to something ugly run:
+ *
+ *	grep -i '#[[:space:]]*define[[:space:]].*ugly_' *.c
+ *
+ * after generating the files; and if you want to see only what was changed from
+ * yy or YY to refer to ugly_ or UGLY_:
+ *
+ *	grep -i '#[[:space:]]*define[[:space:]]*yy.*ugly_' *.c
+ *
+ * This will help you find the right symbols should you need them. If (as is
+ * likely to happen) the parser is split into another repo for a json parser by
+ * itself I will possibly remove this prefix: this is as satire for the IOCCC
+ * (though we all believe that the generated code is in fact ugly).
  */
-#line 65 "jparse.l"
+#line 79 "jparse.l"
 /* Declarations etc. go here.
  *
  * Code is copied verbatim near the top of the generated code.
@@ -964,7 +978,7 @@ char *yytext;
 
 YY_BUFFER_STATE bs;
 void ugly_error(char const *format, ...);
-#line 916 "jparse.c"
+#line 930 "jparse.c"
 /*
  * Section 2: Patterns (regular expressions) and actions.
  */
@@ -990,7 +1004,7 @@ void ugly_error(char const *format, ...);
  * TODO: We have to do more than just assigning the token type (by which we mean
  * ugly_lval.type). These things will be done later.
  */
-#line 942 "jparse.c"
+#line 956 "jparse.c"
 
 #define INITIAL 0
 
@@ -1270,9 +1284,9 @@ YY_DECL
 
 	{
 /* %% [7.0] user's declarations go here */
-#line 122 "jparse.l"
+#line 136 "jparse.l"
 
-#line 1224 "jparse.c"
+#line 1238 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1365,75 +1379,75 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 123 "jparse.l"
+#line 137 "jparse.l"
 { printf("\nwhitespace: '%s'\n", ugly_text); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 124 "jparse.l"
+#line 138 "jparse.l"
 { printf("\nstring: '%s'\n", ugly_text); ugly_lval.type = JTYPE_STRING; return JSON_STRING; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 125 "jparse.l"
+#line 139 "jparse.l"
 { printf("\nnumber: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NUMBER; return JSON_NUMBER; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 126 "jparse.l"
+#line 140 "jparse.l"
 { printf("\nnull: '%s'\n", ugly_text); ugly_lval.type = JTYPE_NULL; return JSON_NULL; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 127 "jparse.l"
+#line 141 "jparse.l"
 { printf("\ntrue: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_TRUE; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 128 "jparse.l"
+#line 142 "jparse.l"
 { printf("\nfalse: '%s'\n", ugly_text); ugly_lval.type = JTYPE_BOOL; return JSON_FALSE; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 129 "jparse.l"
+#line 143 "jparse.l"
 { printf("\nopen brace: '%c'\n", *ugly_text); token_type = '{'; return JSON_OPEN_BRACE; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 130 "jparse.l"
+#line 144 "jparse.l"
 { printf("\nclose brace: '%c'\n", *ugly_text); token_type = '}'; return JSON_CLOSE_BRACE;}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 131 "jparse.l"
+#line 145 "jparse.l"
 { printf("\nopen bracket: '%c'\n", *ugly_text); token_type = '['; return JSON_OPEN_BRACKET; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 132 "jparse.l"
+#line 146 "jparse.l"
 { printf("\nclose bracket: '%c'\n", *ugly_text); token_type = ']'; return JSON_CLOSE_BRACKET; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 133 "jparse.l"
+#line 147 "jparse.l"
 { printf("\nequals/colon: '%c'\n", *ugly_text); token_type = ':'; return JSON_COLON; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 134 "jparse.l"
+#line 148 "jparse.l"
 { printf("\ncomma: '%c'\n", *ugly_text); token_type = ','; return JSON_COMMA; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 135 "jparse.l"
+#line 149 "jparse.l"
 { ugly_error("invalid input: %s\n", ugly_text); return JSON_INVALID_TOKEN; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 136 "jparse.l"
+#line 150 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1385 "jparse.c"
+#line 1399 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2593,7 +2607,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 136 "jparse.l"
+#line 150 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */
@@ -2639,7 +2653,7 @@ parse_json_string(char const *string)
     }
 
     ugly_lineno = 1;
-    bs = yy_scan_string(string);
+    bs = ugly__scan_string(string);
     if (bs == NULL) {
 	warn(__func__, "unable to scan string");
 	++num_errors;
@@ -2649,7 +2663,7 @@ parse_json_string(char const *string)
 
     ugly_parse();
 
-    yy_delete_buffer(bs);
+    ugly__delete_buffer(bs);
     bs = NULL;
 
     dbg(DBG_NONE, "*** END PARSE");
@@ -2753,7 +2767,7 @@ parse_json_file(char const *filename)
 
     /* now parse the file */
     rewind(ugly_in);
-    yyrestart(ugly_in);
+    ugly_restart(ugly_in);
     ugly_lineno = 1;
     ugly_parse();
 

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -126,7 +126,7 @@
 #define yychar          ugly_char
 
 /* First part of user prologue.  */
-#line 72 "jparse.y"
+#line 89 "jparse.y"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -138,7 +138,7 @@ unsigned num_errors = 0;		/* > 0 number of errors encountered */
 
 
 /* debug information during development */
-int yydebug = 1;
+int ugly_debug = 1;
 
 int token_type = 0;
 
@@ -558,9 +558,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   115,   115,   116,   117,   118,   121,   122,   123,   124,
-     125,   126,   127,   130,   132,   135,   136,   139,   142,   145,
-     146,   149
+       0,   132,   132,   133,   134,   135,   138,   139,   140,   141,
+     142,   143,   144,   147,   149,   152,   153,   156,   159,   162,
+     163,   166
 };
 #endif
 
@@ -1904,7 +1904,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 152 "jparse.y"
+#line 169 "jparse.y"
 
 /* Section 3: C code */
 int

--- a/jparse.y
+++ b/jparse.y
@@ -29,15 +29,17 @@
  * We enable lookahead correction parser for improved errors
  */
 %define parse.lac full
-/*
- * As we utterly object to the hideous code that bison and flex generate we
- * point it out in an ironic way by changing the prefix yy to ugly_.
- */
-%define api.prefix {ugly_}
+
 
 /*
  * We use our struct json (see json.h for its definition) instead of bison
  * %union.
+ */
+%define api.value.type {struct json}
+
+/*
+ * As we utterly object to the hideous code that bison and flex generate we
+ * point it out in an ironic way by changing the prefix yy to ugly_.
  *
  * This means that to access the struct json's union type in the lexer we can do
  * (because the prefix is ugly_ as described above):
@@ -66,9 +68,24 @@
  * Thus as much as we find the specification objectionable we rather feel sorry
  * for those poor lost souls who are indeed in the JSON Barmy Army and we
  * apologise to them in a light and fun way and with hope that they're not
- * terribly humour impaired.
+ * terribly humour impaired. :-)
+ *
+ * BTW: If you want to see all the symbols (re?)defined to something ugly run:
+ *
+ *	grep -i 'define[[:space:]].*ugly_' *.c
+ *
+ * after generating the files; and if you want to see only what was changed from
+ * yy or YY to refer to ugly_ or UGLY_:
+ *
+ *	grep -i '#[[:space:]]*define yy.*ugly_' *.c
+ *
+ * This will help you find the right symbols should you need them. If (as is
+ * likely to happen) the parser is split into another repo for a json parser by
+ * itself I will possibly remove this prefix: this is as satire for the IOCCC
+ * (though we all believe that the generated code is in fact ugly).
  */
-%define api.value.type {struct json}
+%define api.prefix {ugly_}
+
 %{
 #include <inttypes.h>
 #include <stdio.h>
@@ -80,7 +97,7 @@ unsigned num_errors = 0;		/* > 0 number of errors encountered */
 
 
 /* debug information during development */
-int yydebug = 1;
+int ugly_debug = 1;
 
 int token_type = 0;
 %}

--- a/jparse.y
+++ b/jparse.y
@@ -72,12 +72,12 @@
  *
  * BTW: If you want to see all the symbols (re?)defined to something ugly run:
  *
- *	grep -i 'define[[:space:]].*ugly_' *.c
+ *	grep -i '#[[:space:]]*define[[:space:]].*ugly_' *.c
  *
  * after generating the files; and if you want to see only what was changed from
  * yy or YY to refer to ugly_ or UGLY_:
  *
- *	grep -i '#[[:space:]]*define yy.*ugly_' *.c
+ *	grep -i '#[[:space:]]*define[[:space:]]*yy.*ugly_' *.c
  *
  * This will help you find the right symbols should you need them. If (as is
  * likely to happen) the parser is split into another repo for a json parser by

--- a/reset_tstamp.sh
+++ b/reset_tstamp.sh
@@ -137,14 +137,14 @@ export HAVE_RPL
 HAVE_RPL="$(command -v rpl)"
 if [[ -z "$HAVE_RPL" ]]; then
     echo "$0: ERROR: rpl not found" 1>&2
-    echo "$0: ERROR: If do no thave the rpl tool, then you may not perform this actiob." 1>&2
+    echo "$0: ERROR: If do not have the rpl tool, then you may not perform this action." 1>&2
     exit 1
 fi
 
 # Phase 0 of verification
 #
 echo
-echo 'Yes, we make it very hard to run this rule for good reasson.'
+echo 'Yes, we make it very hard to run this rule for good reason.'
 echo 'Only IOCCC judges can perform the ALL the steps needed to complete this action.'
 echo
 echo 'WARNING: This rule will invalidate all timestamps prior to now.'
@@ -237,7 +237,7 @@ echo "%0: notice: You still need to:"
 echo
 echo '    make clobber all test'
 echo
-echo "%0: notice: And if all is well, commit and push the change to the GitHib repo!"
+echo "%0: notice: And if all is well, commit and push the change to the GitHub repo!"
 echo
 
 # All Done!!! -- Jessica Noll, Age 2

--- a/run_bison.sh
+++ b/run_bison.sh
@@ -508,7 +508,7 @@ add_sorry() {
     TMP_FILE=$(mktemp -t "$FILE.XXXXXXXX")
     status="$?"
     if [[ $status -ne 0 ]]; then
-	echo "$0: ERROR: mktemp -r $FILE exit code: $status" 1>&2
+	echo "$0: ERROR: mktemp -t $FILE exit code: $status" 1>&2
 	exit 14
     fi
     if [[ ! -e $TMP_FILE ]]; then

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -476,7 +476,7 @@ add_sorry() {
     TMP_FILE=$(mktemp -t "$FILE.XXXXXXXX")
     status="$?"
     if [[ $status -ne 0 ]]; then
-	echo "$0: ERROR: mktemp -r $FILE exit code: $status" 1>&2
+	echo "$0: ERROR: mktemp -t $FILE exit code: $status" 1>&2
 	exit 14
     fi
     if [[ ! -e $TMP_FILE ]]; then

--- a/txzchk.c
+++ b/txzchk.c
@@ -87,7 +87,7 @@ main(int argc, char **argv)
 	default:
 	    usage(1, "invalid -flag", program); /*ooo*/
 	    not_reached();
-	 }
+	}
     }
     /* must have the exact required number of args */
     if (argc - optind != REQUIRED_ARGS) {

--- a/util.c
+++ b/util.c
@@ -689,12 +689,12 @@ vcmdprintf(char const *format, va_list ap)
     size += (size_t)(f - format);
 
     /*
-     * malloc storage or return NULL
+     * calloc storage or return NULL
      */
-    errno = 0;			/* pre-clear errno for warnp() */
-    cmd = (char *)malloc(size);	/* trailing zero included in size */
+    errno = 0;			    /* pre-clear errno for warnp() */
+    cmd = (char *)calloc(1, size);  /* NOTE: the trailing NUL byte is included in size */
     if (cmd == NULL) {
-	warnp(__func__, "malloc from vcmdprintf of %ju bytes failed", (uintmax_t)size);
+	warnp(__func__, "calloc from vcmdprintf of %ju bytes failed", (uintmax_t)size);
 	return NULL;
     }
 
@@ -786,7 +786,7 @@ vcmdprintf(char const *format, va_list ap)
  * given:
  *	name		- name of the calling function
  *	abort_on_error	- false ==> return exit code if able to successfully call system(), or
- *			    return MALLOC_FAILED_EXIT malloc() failure,
+ *			    return CALLOC_FAILED_EXIT malloc() failure,
  *			    return FLUSH_FAILED_EXIT on fflush failure,
  *			    return SYSTEM_FAILED_EXIT if system() failed,
  *			    return NULL_ARGS_EXIT if NULL pointers were passed
@@ -852,13 +852,13 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
     if (cmd == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(112, name, "malloc failed in vcmdprintf()");
+	    errp(112, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called from %s: malloc failed in vcmdprintf(): %s, returning: %d < 0",
-			 name, strerror(errno), MALLOC_FAILED_EXIT);
+	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s, returning: %d < 0",
+			 name, strerror(errno), CALLOC_FAILED_EXIT);
 	    va_end(ap);
-	    return MALLOC_FAILED_EXIT;
+	    return CALLOC_FAILED_EXIT;
 	}
     }
 
@@ -1037,11 +1037,11 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     if (cmd == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    errp(119, name, "malloc failed in vcmdprintf()");
+	    errp(119, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called from %s: malloc failed in vcmdprintf(): %s returning: %d < 0",
-			 name, strerror(errno), MALLOC_FAILED_EXIT);
+	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s returning: %d < 0",
+			 name, strerror(errno), CALLOC_FAILED_EXIT);
 	    va_end(ap);
 	    return NULL;
 	}

--- a/util.c
+++ b/util.c
@@ -1059,7 +1059,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
 	    free(cmd);
 	    cmd = NULL;
 	}
-	/* exit or error return depending on abort */
+	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
 	    errp(120, name, "fflush(stdout): error code: %d", ret);
 	    not_reached();

--- a/util.h
+++ b/util.h
@@ -131,7 +131,7 @@ typedef unsigned char bool;
 /*
  * invalid exit codes (values < 0): that may be returned by shell_cmd()
  */
-#define MALLOC_FAILED_EXIT (-2)		/* invalid exit code - malloc() failure */
+#define CALLOC_FAILED_EXIT (-2)		/* invalid exit code - calloc() failure */
 #define SYSTEM_FAILED_EXIT (-3)		/* invalid exit code - system() failed - returned exit 127 */
 #define FLUSH_FAILED_EXIT (-4)		/* invalid exit code - fflush() failed */
 #define NULL_ARGS_EXIT (-5)		/* invalid exit code - function called with a NULL arg */


### PR DESCRIPTION
As for commit https://github.com/ioccc-src/mkiocccentry/pull/184/commits/231c53e7e58f4ded5a1751d18dcd8ddce7938b21:


```
    Noted that the ugly_ prefix is a satire for the IOCCC and if it's moved
    to a new repo for a JSON parser (as was suggested to me) after the IOCCC
    has used it I might well remove the prefix even though we all think the
    generated code by flex and bison is in fact ugly. Perhaps this should be
    moved further up in the comment but this can come at another time.
```

I think that should be noted here so all can see. 

I don't plan on doing any more today but am sure to do more tomorrow.