### PR TITLE
Fix memory leak in verge.c

### DIFF
--- a/verge.c
+++ b/verge.c
@@ -281,9 +281,11 @@ allocate_vers(char *str, long **pvers)
     if (i == len) {
 	/* report invalid version string */
 	dbg(DBG_MED, "version string contained no digits: <%s>", wstr);
-	/* free strdup()d string */
-	free(wstr);
-	wstr = NULL;
+	/* free strdup()d string if != NULL */
+	if (wstr != NULL) {
+	    free(wstr);
+	    wstr = NULL;
+	}
 	return 0;
     }
     wstr += i;
@@ -326,9 +328,11 @@ allocate_vers(char *str, long **pvers)
 	    if (dot == true) {
 		/* report invalid version string */
 		dbg(DBG_MED, "trimmed version string contains 2 dots in a row: <%s>", wstr);
-		/* free strdup()d string */
-		free(wstr);
-		wstr = NULL;
+		/* free strdup()d string if != NULL */
+		if (wstr != NULL) {
+		    free(wstr);
+		    wstr = NULL;
+		}
 		return 0;
 	    }
 	    dot = true;
@@ -337,9 +341,11 @@ allocate_vers(char *str, long **pvers)
 	    /* report invalid version string */
 	    dbg(DBG_MED, "trimmed version string contains non-version character: wstr[%ju] = <%c>: <%s>",
 			 (uintmax_t)i, wstr[i], wstr);
-	    /* free strdup()d string */
-	    free(wstr);
-	    wstr = NULL;
+	    /* free strdup()d string if != NULL */
+	    if (wstr != NULL) {
+		free(wstr);
+		wstr = NULL;
+	    }
 	    return 0;
 	}
     }
@@ -371,8 +377,10 @@ allocate_vers(char *str, long **pvers)
     }
 
     /* we no longer need the duplicated string */
-    free(wstr);
-    wstr = NULL;
+    if (wstr != NULL) {
+	free(wstr);
+	wstr = NULL;
+    }
 
     /*
      * return number of version levels

--- a/verge.c
+++ b/verge.c
@@ -361,6 +361,10 @@ allocate_vers(char *str, long **pvers)
 	dbg(DBG_VHIGH, "version level %ju: %ld", (uintmax_t)i, (*pvers)[i]);
     }
 
+    /* we no longer need the duplicated string */
+    free(wstr);
+    wstr = NULL;
+
     /*
      * return number of version levels
      */

--- a/verge.c
+++ b/verge.c
@@ -281,6 +281,9 @@ allocate_vers(char *str, long **pvers)
     if (i == len) {
 	/* report invalid version string */
 	dbg(DBG_MED, "version string contained no digits: <%s>", wstr);
+	/* free strdup()d string */
+	free(wstr);
+	wstr = NULL;
 	return 0;
     }
     wstr += i;
@@ -323,6 +326,9 @@ allocate_vers(char *str, long **pvers)
 	    if (dot == true) {
 		/* report invalid version string */
 		dbg(DBG_MED, "trimmed version string contains 2 dots in a row: <%s>", wstr);
+		/* free strdup()d string */
+		free(wstr);
+		wstr = NULL;
 		return 0;
 	    }
 	    dot = true;
@@ -331,6 +337,9 @@ allocate_vers(char *str, long **pvers)
 	    /* report invalid version string */
 	    dbg(DBG_MED, "trimmed version string contains non-version character: wstr[%ju] = <%c>: <%s>",
 			 (uintmax_t)i, wstr[i], wstr);
+	    /* free strdup()d string */
+	    free(wstr);
+	    wstr = NULL;
 	    return 0;
 	}
     }


### PR DESCRIPTION
In allocate_vers() a string was strdup()d but prior to returning the
copy was not freed.