### PR TITLE
Minor fixes (typos) and updates in jparse.1

### DIFF
--- a/jparse.1
+++ b/jparse.1
@@ -31,11 +31,11 @@ Do not output a newline after the decode function.
 .SH FILES
 \fIjparse.y\fP
 .RS
-\fbbison(1)\fP source file for the \fBjparse\fP tool.
+\fBbison(1)\fP source file for the \fBjparse\fP tool.
 .RE
 \fIjparse.l\fP
 .RS
-\fbflex(1)\fP source file for the \fBjparse\fP tool.
+\fBflex(1)\fP source file for the \fBjparse\fP tool.
 .RE
 \fIjparse.h\fP
 .RS
@@ -86,4 +86,4 @@ Parse .info.json file:
 .RE
 .SH SEE ALSO
 .PP
-\fBjinfochk(1)\fP and \fBjauthchk(1)\fP.
+\fBjinfochk(1)\fP, \fBjauthchk(1)\fP, \fBflex(1)\fP and \fBbison(1)\fP.


### PR DESCRIPTION
Had \fb instead of \fB for flex(1) and bison(1).

In SEE ALSO section add reference to flex(1) and bison(1) as well.