### PR TITLE
Update JSON parser including one action added

### DIFF
--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -558,9 +558,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   147,   147,   148,   149,   150,   153,   154,   155,   156,
-     157,   158,   159,   162,   164,   167,   168,   171,   174,   177,
-     178,   181
+       0,   148,   148,   149,   150,   151,   154,   155,   156,   157,
+     158,   159,   160,   163,   166,   169,   170,   173,   176,   179,
+     180,   183
 };
 #endif
 
@@ -1668,8 +1668,14 @@ yyreduce:
     int yychar_backup = yychar;
     switch (yyn)
       {
+  case 17: /* json_member: JSON_STRING ":" json_element  */
+#line 173 "jparse.y"
+                                                    { yyval = *json_conv_member(&yyvsp[-2], &yyvsp[0]); }
+#line 1624 "jparse.tab.c"
+    break;
 
-#line 1622 "jparse.tab.c"
+
+#line 1628 "jparse.tab.c"
 
         default: break;
       }
@@ -1904,7 +1910,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 184 "jparse.y"
+#line 186 "jparse.y"
 
 /* Section 3: C code */
 
@@ -2027,6 +2033,12 @@ ugly_error(char const *format, ...)
 
     va_end(ap);
 }
+
+/*
+ * XXX The concept of the below parse_json_() functions might be invalid as the
+ * value of $$ variables in the bison actions is of type struct json * and these
+ * functions take a char const *.
+ */
 
 /* parse_json_name - parse a json string as a name
  *

--- a/jparse.y
+++ b/jparse.y
@@ -141,7 +141,8 @@ int token = 0;
 
 /* Section 2: Rules
  *
- * XXX I believe all the rules are here but there are no actions yet.
+ * XXX All the rules should be here but there's only one action (json_member) as
+ * of 07 May 2022.
  */
 %%
 json:		/* empty */
@@ -159,7 +160,8 @@ json_value:	  json_object
 		| JSON_NULL
 		;
 
-json_number:	JSON_NUMBER ;
+json_number:	JSON_NUMBER
+		;
 
 json_object:	JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE
 		;
@@ -168,7 +170,7 @@ json_members:	json_member
 		| json_member JSON_COMMA json_members
 		;
 
-json_member:	JSON_STRING JSON_COLON json_element
+json_member:	JSON_STRING JSON_COLON json_element { $$ = *json_conv_member(&$1, &$3); }
 		;
 
 json_array:	JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET
@@ -303,6 +305,12 @@ ugly_error(char const *format, ...)
 
     va_end(ap);
 }
+
+/*
+ * XXX The concept of the below parse_json_() functions might be invalid as the
+ * value of $$ variables in the bison actions is of type struct json * and these
+ * functions take a char const *.
+ */
 
 /* parse_json_name - parse a json string as a name
  *

--- a/json.h
+++ b/json.h
@@ -49,9 +49,13 @@
 
 
 /*
- * JSON parser related structures
+ * JSON parser related definitions and structures
  */
 
+/*
+ * definitions
+ */
+#define JSON_DBG_LEVEL (DBG_NONE)
 
 /*
  * JSON encoding of an octet in a JSON string
@@ -438,6 +442,8 @@ extern struct json *json_create_object(void);
 extern bool json_object_add_member(struct json *obj, struct json *member);
 extern struct json *json_create_array(void);
 extern bool json_array_add_value(struct json *obj, struct json *value);
+/* print the type of json element in the struct json */
+extern char const *json_element_name(enum element_type json_type);
 /* JSON parse node free storage */
 extern void json_free(struct json *node);
 


### PR DESCRIPTION
Add function 'char const *json_element_name(enum element_type
json_type)' to print the element type by name rather than a number.

Add to the conversion functions a call (in some cases more than one
call) to dbg() with new debug value (#defined in json.h as DBG_NONE)
JSON_DBG_LEVEL so that I can see the type in each call to the conversion
functions. The reason I named it JSON_DBG_LEVEL is so that it's easy to
remove once this is no longer needed (alternatively it could be changed
to some other debug value if it's worth keeping).

Add action to json_member so that it actually parses a member (it does
NOT add to the parse tree as currently there is no parse tree) or a list
of members. The diff in jparse.y looks like:

    -json_member:	JSON_STRING JSON_COLON json_element
    +json_member:	JSON_STRING JSON_COLON json_element { $$ = *json_conv_member(&$1, &$3); }
		    ;

Removing the debug information from the lexer and parser themselves
here's an example output:

    $ ./jparse -s '{ "test": true, "complete": false, "number": -555 }' 2>&1 |grep debug
    debug[0]: Calling parse_json_block("{ "test": true, "complete": false, "number": -555 }"):
    debug[0]: *** BEGIN PARSE:
    debug[0]: json_conv_member: JSON name type: string
    debug[0]: json_conv_member: JSON value type: boolean
    debug[0]: json_conv_member: JSON name type: string
    debug[0]: json_conv_member: JSON value type: boolean
    debug[0]: json_conv_member: JSON name type: string
    debug[0]: json_conv_member: JSON value type: number
    debug[0]: *** END PARSE

Perhaps the actual value of each type itself should be printed as well
but this is a good start.

NOTE: The concept of the parse_json_() functions from commits cc3173e
and b0b426c084 might actually be invalid which I noted in jparse.y:

    /*
    * XXX The concept of the below parse_json_() functions might be invalid as the
    * value of $$ variables in the bison actions is of type struct json * and these
    * functions take a char const *.
    */