### PR TITLE
Bug fix and add JSON parser actions + JSON tree

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -102,6 +102,7 @@ extern FILE *ugly_in;			/* input file lexer/parser reads from */
 extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern bool output_newline;		/* true ==> -n not specified, output new line after each arg processed */
 extern int token;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' and so on */
+extern struct json tree;		/* the parse tree */
 
 /*
  * function prototypes
@@ -125,7 +126,6 @@ void parse_json_block(char const *string);  /* parse a string as a JSON block */
  *
  * XXX - these are subject to change and are very incomplete as well - XXX
  */
-struct json *parse_json_name(char const *string, struct json *ast);
 struct json *parse_json_string(char const *string, struct json *ast);
 struct json *parse_json_number(char const *string, struct json *ast);
 struct json *parse_json_bool(char const *string, struct json *ast);

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2229,7 +2229,7 @@ parse_json_null(char const *string, struct json *ast)
 	not_reached();
     }
     if (!null->element.null.converted) {
-	err(39, __func__, "unable to convert null: <%s>", string);
+	err(42, __func__, "unable to convert null: <%s>", string);
 	not_reached();
     } else {
 	dbg(JSON_DBG_LEVEL, "%s: converted null", __func__);
@@ -2273,12 +2273,12 @@ parse_json_number(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(42, __func__, "passed NULL string and/or ast");
+	err(43, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
     number = json_conv_number_str(string, NULL);
     if (number == NULL) {
-	err(43, __func__, "converting JSON number returned NULL: <%s>", string);
+	err(44, __func__, "converting JSON number returned NULL: <%s>", string);
 	not_reached();
     }
 
@@ -2319,7 +2319,7 @@ parse_json_array(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(44, __func__, "passed NULL string and/or ast");
+	err(45, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
 
@@ -2361,7 +2361,7 @@ parse_json_member(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(45, __func__, "passed NULL string and/or ast");
+	err(46, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
 

--- a/json.c
+++ b/json.c
@@ -3158,7 +3158,7 @@ json_array_add_value(struct json *obj, struct json *value)
  *	json_type   one of the values of the JTYPE_ enum
  *
  * returns:
- *	A constant (read-only) string that names the the JTYPE_ enum.
+ *	A constant (read-only) string that names the JTYPE_ enum.
  *
  * NOTE: This string returned is read only: It's not allocated on the stack.
  */

--- a/util.c
+++ b/util.c
@@ -2688,6 +2688,25 @@ string_to_bool(char const *str)
     return !strcmp(str, "true");
 }
 
+/* bool_to_string
+ *
+ * Return string "true" or "false" depending on value of boolean.
+ *
+ * given:
+ *
+ *	boolean	    bool to convert to a string
+ *
+ * Returns "true" if boolean is true; else "false".
+ */
+char const *
+bool_to_string(bool boolean)
+{
+    if (boolean) {
+	return "true";
+    } else {
+	return "false";
+    }
+}
 
 /*
  * posix_plus_safe - if string is a valid POSIX portable safe plus + chars

--- a/util.h
+++ b/util.h
@@ -207,6 +207,7 @@ extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_decimal(char const *ptr, size_t len);
 extern bool is_decimal_str(char const *str, size_t *retlen);
 extern bool string_to_bool(char const *str);
+extern char const *bool_to_string(bool boolean);
 extern bool posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first);
 extern void posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe,
 			   bool *first_alphanum, bool *upper);


### PR DESCRIPTION
In the parse_json_bool() function I accidentally had checked the
converted bool of 'null' in the union. This has been fixed.

Add several more actions to the parser. In particular:


    json_value:       json_object
		    | json_array
		    | JSON_STRING { $$ = *parse_json_string(ugly_text, &tree); }
		    | json_number
		    | JSON_TRUE { $$ = *parse_json_bool(ugly_text, &tree); }
		    | JSON_FALSE { $$ = *parse_json_bool(ugly_text, &tree); }
		    | JSON_NULL { $$ = *parse_json_null(ugly_text, &tree); }
		    ;

    json_number:    JSON_NUMBER { $$ = *parse_json_number(ugly_text, &tree); }
		    ;

In parse_json_null() check if converted is true. If not it's an error;
else print a debug statement saying it was converted.

In parse_json_number() it still does not print the number or check for
conversion. Part of this is there's more to check and I have to head off
for the day.

In parse_json_bool() there also was no change except for the bug fix as
above. However the function is now called when encountering JSON_TRUE or
JSON_FALSE.

The parse_json_member() function is not used yet and it's probable that
it'll have to change definition as well, taking a struct json *member.

JSON_OBJECT might be in a way mostly accounted for via the json_members
but not all is handled there and nothing is linked into the tree yet.
What this means is I believe (I might be wrong) is that except for
JSON_OBJECT and JSON_ARRAY conversion is done. What's not done is all
the checks on these and also linking it into the parse tree.

Added 'struct json tree' which is zero initialised. Right now the
parse_json_() functions are passed &tree but it's not used except to
check for NULL pointer. At a later commit at a later tree will be used.

There was a typo fix ('the the' by accident in json.c).

I hope that I documented everything here: there was a lot and I have to
stop working on this.