### PR TITLE
JSON parser updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ makefile.local
 
 # temporary files
 *.tmp
+
+# parser logs
+jparse.output

--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ limit_ioccc.sh: limit_ioccc.h version.h Makefile
 #
 jparse.tab.c jparse.tab.h: jparse.y jparse.h sorry.tm.ca.h run_bison.sh limit_ioccc.sh verge \
 	jparse.tab.ref.c jparse.tab.ref.h Makefile
-	./run_bison.sh -b ${BISON_BASENAME} ${BISON_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- -d
+	./run_bison.sh -b ${BISON_BASENAME} ${BISON_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- --report all -d
 
 # How to create jparse.c
 #
@@ -692,7 +692,7 @@ clean_generated_obj:
 prep_clobber:
 	${RM} -f ${TARGETS} ${TEST_TARGETS}
 	${RM} -f ${GENERATED_CSRC} ${GENERATED_HSRC}
-	${RM} -f answers.txt j-test.out j-test2.out json-test.log
+	${RM} -f answers.txt j-test.out j-test2.out json-test.log jparse.output
 	${RM} -rf test-iocccsize test_src test_work tags dbg.out
 	${RM} -f dbg_test.c
 	${RM} -rf dyn_test.dSYM

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ iocccsize.o: iocccsize.c Makefile
 iocccsize: iocccsize.o rule_count.o dbg.o Makefile
 	${CC} ${CFLAGS} iocccsize.o rule_count.o dbg.o -o $@
 
-dbg.o: dbg.c Makefile
+dbg.o: dbg.c dbg.h Makefile
 	${CC} ${CFLAGS} dbg.c -c
 
 dbg_test.c: dbg.c Makefile
@@ -364,13 +364,13 @@ dbg_test.o: dbg_test.c Makefile
 dbg: dbg_test.o Makefile
 	${CC} ${CFLAGS} dbg_test.o -o $@
 
-fnamchk.o: fnamchk.c Makefile
+fnamchk.o: fnamchk.c fnamchk.h Makefile
 	${CC} ${CFLAGS} fnamchk.c -c
 
 fnamchk: fnamchk.o dbg.o util.o dyn_array.o Makefile
 	${CC} ${CFLAGS} fnamchk.o dbg.o util.o dyn_array.o -o $@
 
-txzchk.o: txzchk.c Makefile
+txzchk.o: txzchk.c txzchk.h Makefile
 	${CC} ${CFLAGS} txzchk.c -c
 
 txzchk: txzchk.o rule_count.o dbg.o util.o dyn_array.o location.o json.o json_chk.o json_util.o \
@@ -378,7 +378,7 @@ txzchk: txzchk.o rule_count.o dbg.o util.o dyn_array.o location.o json.o json_ch
 	${CC} ${CFLAGS} txzchk.o rule_count.o dbg.o util.o dyn_array.o location.o json.o \
 	    json_chk.o json_util.o utf8_posix_map.o sanity.o -o $@
 
-jauthchk.o: jauthchk.c Makefile
+jauthchk.o: jauthchk.c jauthchk.h json_util.h Makefile
 	${CC} ${CFLAGS} jauthchk.c -c
 
 jauthchk: jauthchk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
@@ -386,7 +386,7 @@ jauthchk: jauthchk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
 	${CC} ${CFLAGS} jauthchk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
 	    dyn_array.o sanity.o json_chk.o location.o utf8_posix_map.o -o $@
 
-jinfochk.o: jinfochk.c Makefile
+jinfochk.o: jinfochk.c jinfochk.h json_util.h Makefile
 	${CC} ${CFLAGS} jinfochk.c -c
 
 jinfochk: jinfochk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
@@ -394,40 +394,40 @@ jinfochk: jinfochk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
 	${CC} ${CFLAGS} jinfochk.o rule_count.o json.o json_entry.o dbg.o util.o json_util.o \
 	    dyn_array.o sanity.o json_chk.o location.o utf8_posix_map.o -o $@
 
-jstrencode.o: jstrencode.c Makefile
-	${CC} ${CFLAGS} jstrencode.c -c
+jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c Makefile
+	${CC} ${CFLAGS} jstrencode.c json_util.o -c
 
-jstrencode: jstrencode.o dbg.o json.o util.o dyn_array.o Makefile
-	${CC} ${CFLAGS} jstrencode.o dbg.o json.o util.o dyn_array.o -o $@
+jstrencode: jstrencode.o dbg.o json.o json_util.o util.o dyn_array.o Makefile
+	${CC} ${CFLAGS} jstrencode.o dbg.o json.o json_util.o util.o dyn_array.o -o $@
 
-jstrdecode.o: jstrdecode.c Makefile
+jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json.h Makefile
 	${CC} ${CFLAGS} jstrdecode.c -c
 
-jstrdecode: jstrdecode.o dbg.o json.o util.o dyn_array.o Makefile
-	${CC} ${CFLAGS} jstrdecode.o dbg.o json.o util.o dyn_array.o -o $@
+jstrdecode: jstrdecode.o dbg.o json.o json_util.o util.o dyn_array.o Makefile
+	${CC} ${CFLAGS} jstrdecode.o dbg.o json.o json_util.o util.o dyn_array.o -o $@
 
 jnum_test.o: jnum_test.c Makefile
 	${CC} ${CFLAGS} jnum_test.c -c
 
-jnum_chk.o: jnum_chk.c Makefile
+jnum_chk.o: jnum_chk.c jnum_chk.h Makefile
 	${CC} ${CFLAGS} jnum_chk.c -c
 
-jnum_chk: jnum_chk.o dbg.o json.o util.o dyn_array.o jnum_test.o Makefile
-	${CC} ${CFLAGS} jnum_chk.o dbg.o json.o util.o dyn_array.o jnum_test.o -o $@
+jnum_chk: jnum_chk.o dbg.o json.o json_util.o util.o dyn_array.o jnum_test.o Makefile
+	${CC} ${CFLAGS} jnum_chk.o dbg.o json.o json_util.o util.o dyn_array.o jnum_test.o -o $@
 
-jnum_gen.o: jnum_gen.c Makefile
+jnum_gen.o: jnum_gen.c jnum_gen.h Makefile
 	${CC} ${CFLAGS} jnum_gen.c -c
 
-jnum_gen: jnum_gen.o dbg.o json.o util.o dyn_array.o Makefile
-	${CC} ${CFLAGS} jnum_gen.o dbg.o json.o util.o dyn_array.o -o $@
+jnum_gen: jnum_gen.o dbg.o json.o json_util.o util.o dyn_array.o Makefile
+	${CC} ${CFLAGS} jnum_gen.o dbg.o json.o json_util.o util.o dyn_array.o -o $@
 
-jparse.o: jparse.c Makefile
+jparse.o: jparse.c jparse.h Makefile
 	${CC} ${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration jparse.c -c
 
-json_chk.o: json_chk.c Makefile
+json_chk.o: json_chk.c json_chk.h Makefile
 	${CC} ${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration json_chk.c -c
 
-json_util.o: json_util.c Makefile
+json_util.o: json_util.c json_util.h Makefile
 	${CC} ${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration json_util.c -c
 
 json_entry.o: json_entry.c Makefile
@@ -441,19 +441,19 @@ jparse: jparse.o jparse.tab.o util.o dyn_array.o dbg.o sanity.o json.o json_entr
 	${CC} ${CFLAGS} jparse.o jparse.tab.o util.o dyn_array.o dbg.o sanity.o \
 	    json.o json_entry.o json_chk.o json_util.o utf8_posix_map.o location.o -o $@
 
-utf8_test.o: utf8_test.c Makefile
+utf8_test.o: utf8_test.c utf8_posix_map.h Makefile
 	${CC} ${CFLAGS} utf8_test.c -c
 
 utf8_test: utf8_test.o utf8_posix_map.o dbg.o util.o dyn_array.o Makefile
 	${CC} ${CFLAGS} utf8_test.o utf8_posix_map.o dbg.o util.o dyn_array.o -o $@
 
-verge.o: verge.c Makefile
+verge.o: verge.c verge.h Makefile
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o dbg.o util.o dyn_array.o Makefile
 	${CC} ${CFLAGS} verge.o dbg.o util.o dyn_array.o -o $@
 
-dyn_array.o: dyn_array.c Makefile
+dyn_array.o: dyn_array.c dyn_array.h Makefile
 	${CC} ${CFLAGS} dyn_array.c -c
 
 dyn_test: dbg.o util.o dyn_array.o Makefile
@@ -757,37 +757,38 @@ depend: all
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 utf8_posix_map.o: utf8_posix_map.c utf8_posix_map.h util.h dyn_array.h \
   dbg.h limit_ioccc.h version.h
-jparse.o: jparse.c jparse.h dbg.h util.h dyn_array.h json.h sanity.h \
-  location.h utf8_posix_map.h json_chk.h json_util.h limit_ioccc.h \
+jparse.o: jparse.c jparse.h json_util.h dbg.h util.h dyn_array.h json.h \
+  sanity.h location.h utf8_posix_map.h json_chk.h limit_ioccc.h \
   version.h jparse.tab.h
-jparse.tab.o: jparse.tab.c jparse.h dbg.h util.h dyn_array.h json.h \
-  sanity.h location.h utf8_posix_map.h json_chk.h json_util.h \
-  limit_ioccc.h version.h jparse.tab.h
+jparse.tab.o: jparse.tab.c jparse.h json_util.h dbg.h util.h dyn_array.h \
+  json.h sanity.h location.h utf8_posix_map.h json_chk.h limit_ioccc.h \
+  version.h jparse.tab.h
 dbg.o: dbg.c dbg.h
 util.o: util.c dbg.h util.h dyn_array.h limit_ioccc.h version.h
 mkiocccentry.o: mkiocccentry.c mkiocccentry.h util.h dyn_array.h dbg.h \
-  json_entry.h location.h utf8_posix_map.h sanity.h json.h json_chk.h \
-  json_util.h limit_ioccc.h version.h iocccsize.h
+  json_entry.h location.h utf8_posix_map.h sanity.h json.h json_util.h \
+  json_chk.h limit_ioccc.h version.h iocccsize.h
 iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
 fnamchk.o: fnamchk.c fnamchk.h dbg.h util.h dyn_array.h limit_ioccc.h \
   version.h utf8_posix_map.h
 txzchk.o: txzchk.c txzchk.h util.h dyn_array.h dbg.h sanity.h location.h \
-  utf8_posix_map.h json.h json_chk.h json_util.h limit_ioccc.h version.h
+  utf8_posix_map.h json.h json_util.h json_chk.h limit_ioccc.h version.h
 jauthchk.o: jauthchk.c jauthchk.h dbg.h util.h dyn_array.h json.h \
-  json_entry.h json_util.h sanity.h location.h utf8_posix_map.h \
+  json_util.h json_entry.h sanity.h location.h utf8_posix_map.h \
   json_chk.h limit_ioccc.h version.h
 jinfochk.o: jinfochk.c jinfochk.h dbg.h util.h dyn_array.h json.h \
-  json_entry.h json_util.h sanity.h location.h utf8_posix_map.h \
+  json_util.h json_entry.h sanity.h location.h utf8_posix_map.h \
   json_chk.h limit_ioccc.h version.h
-json.o: json.c dbg.h util.h dyn_array.h limit_ioccc.h version.h json.h
+json.o: json.c dbg.h util.h dyn_array.h limit_ioccc.h version.h json.h \
+  json_util.h
 jstrencode.o: jstrencode.c jstrencode.h dbg.h util.h dyn_array.h json.h \
-  limit_ioccc.h version.h
+  json_util.h limit_ioccc.h version.h
 jstrdecode.o: jstrdecode.c jstrdecode.h dbg.h util.h dyn_array.h json.h \
-  limit_ioccc.h version.h
+  json_util.h limit_ioccc.h version.h
 rule_count.o: rule_count.c iocccsize_err.h iocccsize.h
 location.o: location.c location.h util.h dyn_array.h dbg.h
 sanity.o: sanity.c sanity.h util.h dyn_array.h dbg.h location.h \
-  utf8_posix_map.h json.h json_chk.h json_util.h limit_ioccc.h version.h
+  utf8_posix_map.h json.h json_util.h json_chk.h limit_ioccc.h version.h
 utf8_test.o: utf8_test.c utf8_posix_map.h util.h dyn_array.h dbg.h \
   limit_ioccc.h version.h
 verge.o: verge.c verge.h dbg.h util.h dyn_array.h limit_ioccc.h version.h
@@ -795,11 +796,12 @@ dyn_array.o: dyn_array.c dyn_array.h util.h dbg.h
 dyn_test.o: dyn_test.c dyn_test.h util.h dyn_array.h dbg.h version.h
 json_chk.o: json_chk.c json_chk.h util.h dyn_array.h dbg.h json.h \
   json_util.h limit_ioccc.h version.h
-json_entry.o: json_entry.c dbg.h util.h dyn_array.h json.h json_entry.h
+json_entry.o: json_entry.c dbg.h util.h dyn_array.h json.h json_util.h \
+  json_entry.h
 dbg_test.o: dbg_test.c dbg.h
 jnum_chk.o: jnum_chk.c jnum_chk.h dbg.h util.h dyn_array.h json.h \
-  limit_ioccc.h version.h
+  json_util.h limit_ioccc.h version.h
 jnum_gen.o: jnum_gen.c jnum_gen.h dbg.h util.h dyn_array.h json.h \
-  limit_ioccc.h version.h
-jnum_test.o: jnum_test.c json.h
+  json_util.h limit_ioccc.h version.h
+jnum_test.o: jnum_test.c json.h json_util.h dbg.h
 json_util.o: json_util.c json_util.h dbg.h

--- a/jparse.1
+++ b/jparse.1
@@ -2,9 +2,9 @@
 .SH NAME
 jparse \- IOCCC JSON parser
 .SH SYNOPSIS
-\fBjparse [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [\-s string] file ...
+\fBjparse [\-h] [\-v level] [\-J level] [\-q] [\-V] [\-t] [\-n] [\-s string] file ...
 .SH DESCRIPTION
-\fBjparse\fP will parse a block of JSON text either from a file or a string passed into the command line.
+\fBjparse\fP will parse a block of JSON text either from a file (\fB\-\fP means \fBstdin\fP) or a string passed to the program via the \fB\-s\fP option.
 .PP
 .SH OPTIONS
 .PP
@@ -14,6 +14,10 @@ Show help and exit.
 \fB\-v\fP
 Set verbosity level.
 .PP
+\fB\-J\fP
+Set JSON verbosity level.
+Note that you need to specify this option prior to \fB\-s\fP because \fP\-s\fP is processed immediately.
+.PP
 \fB\-q\fP
 Suppresses some of the output (def: not quiet).
 .PP
@@ -22,7 +26,7 @@ Show version and exit 0.
 .PP
 \fB\-s\fP
 Parse as a string.
-Anything after the last option is to be considered a file.
+Anything after the last option is considered a file.
 .PP
 \fB\-n\fP
 Do not output a newline after the decode function.

--- a/jparse.1
+++ b/jparse.1
@@ -60,12 +60,11 @@ Parse the JSON string \fB{ "test_mode" : false }\fP:
 .RE
 .PP
 .nf
-Parse input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, twice, to parse):
+Parse input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to parse):
 .RS
 \fB
  ./jparse -
  []
- ^D
  ^D
 .fi
 .RE

--- a/jparse.h
+++ b/jparse.h
@@ -35,7 +35,7 @@
 
 /* NOTE: UGLY_DEBUG MUST be defined prior to #including jparse.tab.h! */
 #define UGLY_DEBUG 1
-
+#define UGLY__BUFFER_STATE YY_BUFFER_STATE /* see comments in jparse.l as to why we do this here */
 
 /*
  * dbg - debug, warning and error reporting facility

--- a/jparse.h
+++ b/jparse.h
@@ -131,6 +131,6 @@ struct json *parse_json_number(char const *string, struct json *ast);
 struct json *parse_json_bool(char const *string, struct json *ast);
 struct json *parse_json_null(char const *string, struct json *ast);
 struct json *parse_json_array(char const *string, struct json *ast);
-struct json *parse_json_member(char const *string, struct json *ast);
+struct json *parse_json_member(struct json *name, struct json *value, struct json *ast);
 
 #endif /* INCLUDE_JPARSE_H */

--- a/jparse.h
+++ b/jparse.h
@@ -80,16 +80,18 @@
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-s string] [file ...]\n"
+    "usage: %s [-h] [-v level] [-J level] [-q] [-V] [-s string] [file ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit 0\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
+    "\t-J level\tset JSON verbosity level (def level: %d)\n"
+    "\t\t\tNOTE: You must specify this option before -s as -s is processed immediately\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit 0\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-s\t\tread arg as a string\n"
     "\n"
-    "\t[file]\t\tread and parse file (def: parse stdin)\n"
+    "\t[file]\t\tread and parse file\n"
     "\t\t\tNOTE: - means read from stdin\n"
     "\n"
     "jparse version: %s\n";

--- a/jparse.h
+++ b/jparse.h
@@ -25,6 +25,11 @@
 #include <stdio.h>
 
 /*
+ * json_util - utility functions for json
+ */
+#include "json_util.h"
+
+/*
  * definitions
  */
 
@@ -113,7 +118,7 @@ int ugly_lex(void);
 /*
  * parser specific functions
  *
- * XXX - these are incomplete and subject to change - XXX
+ * XXX - these are all incomplete and subject to change - XXX
  */
 void ugly_error(char const *format, ...);
 void parse_json_file(char const *filename); /* parse a file as JSON */

--- a/jparse.l
+++ b/jparse.l
@@ -401,6 +401,10 @@ parse_json_file(char const *filename)
     free(data);
     data = NULL;
 
+    /*
+     * we cannot use clearerr_or_fclose() here as it's possible that ugly_in
+     * will be NULL and so we do it manually instead.
+     */
     if (is_stdin)
 	clearerr(stdin);
     else if (ugly_in != NULL) {

--- a/jparse.l
+++ b/jparse.l
@@ -111,9 +111,10 @@ YY_BUFFER_STATE bs;
  * XXX JSON_WHITESPACE is not needed but for testing I have the whitespace here
  * and below in the actions I print out that it is whitespace and what
  * characters (though newlines and other non-printable whitespace chars are not
- * translated to escape sequences). The text looks like:
+ * translated to escape sequences). The text looks like one of:
  *
- *	whitespace: '<whitespace chars>'
+ *	ignoring 1 whitespace
+ *	ignoring [2-9]+ whitespaces
  *
  * to help distinguish it from other patterns matched.
  */
@@ -154,87 +155,87 @@ JSON_COMMA		","
 			     * Not needed but included for now for debugging
 			     * purposes.
 			     */
-			    printf("\nwhitespace: '%s'\n", ugly_text);
+			    printf("\nignoring %ju whitespace%s\n", strlen(ugly_text), strlen(ugly_text)==1?"":"s");
 			}
 
 {JSON_STRING}		{
 			    /* string */
-			    printf("\nstring: '%s'\n", ugly_text);
+			    printf("\nstring: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_STRING;
 			    return JSON_STRING;
 			}
 
 {JSON_NUMBER}		{
 			    /* number */
-			    printf("\nnumber: '%s'\n", ugly_text);
+			    printf("\nnumber: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_NUMBER;
 			    return JSON_NUMBER;
 			}
 
 {JSON_NULL}		{
 			    /* null object */
-			    printf("\nnull: '%s'\n", ugly_text);
+			    printf("\nnull: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_NULL;
 			    return JSON_NULL;
 			}
 
 {JSON_TRUE}		{
 			    /* boolean: true */
-			    printf("\ntrue: '%s'\n", ugly_text);
+			    printf("\ntrue: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_BOOL;
 			    return JSON_TRUE;
 			}
 {JSON_FALSE}		{
 			    /* boolean: false */
-			    printf("\nfalse: '%s'\n", ugly_text);
+			    printf("\nfalse: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_BOOL;
 			    return JSON_FALSE;
 			}
 
 {JSON_OPEN_BRACE}	{
 			    /* start of object */
-			    printf("\nstart of object: '%c'\n", *ugly_text);
+			    printf("\nstart of object: <%c>\n", *ugly_text);
 			    ugly_lval.type = JTYPE_OBJECT;
 			    return JSON_OPEN_BRACE;
 			}
 {JSON_CLOSE_BRACE}	{
 			    /* end of object */
-			    printf("\nend of object: '%c'\n", *ugly_text);
+			    printf("\nend of object: <%c>\n", *ugly_text);
 			    token = '}';
 			    return JSON_CLOSE_BRACE;
 			}
 
 {JSON_OPEN_BRACKET}	{
 			    /* start of array */
-			    printf("\nstart of array: '%c'\n", *ugly_text);
+			    printf("\nstart of array: <%c>\n", *ugly_text);
 			    ugly_lval.type = JTYPE_ARRAY;
 			    token = '[';
 			    return JSON_OPEN_BRACKET;
 			}
 {JSON_CLOSE_BRACKET}	{
 			    /* end of array */
-			    printf("\nend of array: '%c'\n", *ugly_text);
+			    printf("\nend of array: <%c>\n", *ugly_text);
 			    token = ']';
 			    return JSON_CLOSE_BRACKET;
 			}
 
 {JSON_COLON}		{
 			    /* colon or 'equals' */
-			    printf("\ncolon (or 'equals' ): '%c'\n", *ugly_text);
+			    printf("\ncolon (or 'equals' ): <%c>\n", *ugly_text);
 			    token = ':';
 			    return JSON_COLON;
 			}
 
 {JSON_COMMA}		{
 			    /* comma: name/value pair separator */
-			    printf("\ncomma: '%c'\n", *ugly_text);
+			    printf("\ncomma: <%c>\n", *ugly_text);
 			    token = ',';
 			    return JSON_COMMA;
 			}
 
 .			{
 			    /* invalid token: any other character */
-			    ugly_error("\ninvalid token: '%c'\n", *ugly_text);
+			    ugly_error("\ninvalid token: <%c>\n", *ugly_text);
 			    return JSON_INVALID_TOKEN;
 			}
 
@@ -291,14 +292,14 @@ parse_json_block(char const *string)
 	++num_errors;
 	return;
     }
-    dbg(DBG_NONE, "*** BEGIN PARSE:\n'\n%s\n'", string);
+    json_dbg(JSON_DBG_LEVEL, __func__, "*** BEGIN PARSE:\n<\n%s\n>\n", string);
 
     ugly_parse();
 
     ugly__delete_buffer(bs);
     bs = NULL;
 
-    dbg(DBG_NONE, "*** END PARSE");
+    json_dbg(JSON_DBG_LEVEL, __func__, "*** END PARSE");
     print_newline(output_newline);
 }
 
@@ -335,6 +336,7 @@ parse_json_file(char const *filename)
     bool is_stdin = false;	/* true if reading from stdin (filename == "-") */
     char *data = NULL;		/* used to determine if there are NUL bytes in the file */
     size_t len = 0;		/* length of data read */
+    int ret;
 
     /*
      * firewall
@@ -393,21 +395,22 @@ parse_json_file(char const *filename)
 	return;
     }
 
-    dbg(DBG_NONE, "*** BEGIN PARSE:\n'\n%s\n'", data);
+    parse_json_block(data);
 
     /* free data */
     free(data);
     data = NULL;
 
-    /* now parse the file */
-    rewind(ugly_in);
-    ugly_restart(ugly_in);
-    ugly_lineno = 1;
-    ugly_parse();
+    if (is_stdin)
+	clearerr(stdin);
+    else if (ugly_in != NULL) {
+	errno = 0;
+	ret = fclose(ugly_in);
+	if (ret != 0) {
+	    warnp(__func__, "error in fclose on file %s", filename);
+	}
+	ugly_in = NULL;
+    }
 
-    clearerr_or_fclose(filename, ugly_in);
-    ugly_in = NULL;
-    dbg(DBG_NONE, "*** END PARSE");
     print_newline(output_newline);
-
 }

--- a/jparse.l
+++ b/jparse.l
@@ -155,7 +155,7 @@ JSON_COMMA		","
 			     * Not needed but included for now for debugging
 			     * purposes.
 			     */
-			    printf("\nignoring %ju whitespace%s\n", strlen(ugly_text), strlen(ugly_text)==1?"":"s");
+			    printf("\nignoring %ju whitespace%s\n", (uintmax_t)ugly_leng, yyleng==1?"":"s");
 			}
 
 {JSON_STRING}		{
@@ -235,7 +235,7 @@ JSON_COMMA		","
 
 .			{
 			    /* invalid token: any other character */
-			    ugly_error("\ninvalid token: <%c>\n", *ugly_text);
+			    ugly_error("\ninvalid token: %c\n", *ugly_text);
 			    return JSON_INVALID_TOKEN;
 			}
 

--- a/jparse.l
+++ b/jparse.l
@@ -100,7 +100,12 @@
 /* our header file - #includes what we need */
 #include "jparse.h"
 
-YY_BUFFER_STATE bs;
+/*
+ * An exception where the prefix does not change YY to UGLY_ is YY_BUFFER_STATE
+ * but because it IS ugly we have done it for them in jparse.h so that where one
+ * sees UGLY__BUFFER_STATE it's actually YY_BUFFER_STATE.
+ */
+UGLY__BUFFER_STATE bs;
 %}
 
 /*

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2851,6 +2851,10 @@ parse_json_file(char const *filename)
     free(data);
     data = NULL;
 
+    /*
+     * we cannot use clearerr_or_fclose() here as it's possible that ugly_in
+     * will be NULL and so we do it manually instead.
+     */
     if (is_stdin)
 	clearerr(stdin);
     else if (ugly_in != NULL) {

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -1400,7 +1400,7 @@ YY_RULE_SETUP
 			     * Not needed but included for now for debugging
 			     * purposes.
 			     */
-			    printf("\nignoring %ju whitespace%s\n", strlen(ugly_text), strlen(ugly_text)==1?"":"s");
+			    printf("\nignoring %ju whitespace%s\n", (uintmax_t)ugly_leng, yyleng==1?"":"s");
 			}
 	YY_BREAK
 case 2:
@@ -1519,7 +1519,7 @@ YY_RULE_SETUP
 #line 236 "jparse.l"
 {
 			    /* invalid token: any other character */
-			    ugly_error("\ninvalid token: <%c>\n", *ugly_text);
+			    ugly_error("\ninvalid token: %c\n", *ugly_text);
 			    return JSON_INVALID_TOKEN;
 			}
 	YY_BREAK

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -881,8 +881,8 @@ int yy_flex_debug = 1;
 
 static const flex_int16_t yy_rule_linenum[14] =
     {   0,
-      150,  160,  167,  174,  181,  187,  194,  200,  207,  214,
-      221,  228,  235
+      151,  161,  168,  175,  182,  188,  195,  201,  208,  215,
+      222,  229,  236
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -998,9 +998,10 @@ YY_BUFFER_STATE bs;
  * XXX JSON_WHITESPACE is not needed but for testing I have the whitespace here
  * and below in the actions I print out that it is whitespace and what
  * characters (though newlines and other non-printable whitespace chars are not
- * translated to escape sequences). The text looks like:
+ * translated to escape sequences). The text looks like one of:
  *
- *	whitespace: '<whitespace chars>'
+ *	ignoring 1 whitespace
+ *	ignoring [2-9]+ whitespaces
  *
  * to help distinguish it from other patterns matched.
  */
@@ -1016,7 +1017,7 @@ YY_BUFFER_STATE bs;
  * TODO: We have to do more than just assigning the token type (by which we mean
  * ugly_lval.type). These things will be done later.
  */
-#line 968 "jparse.c"
+#line 969 "jparse.c"
 
 #define INITIAL 0
 
@@ -1296,9 +1297,9 @@ YY_DECL
 
 	{
 /* %% [7.0] user's declarations go here */
-#line 149 "jparse.l"
+#line 150 "jparse.l"
 
-#line 1250 "jparse.c"
+#line 1251 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1391,7 +1392,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 150 "jparse.l"
+#line 151 "jparse.l"
 {
 			    /*
 			     * Whitespace
@@ -1399,85 +1400,85 @@ YY_RULE_SETUP
 			     * Not needed but included for now for debugging
 			     * purposes.
 			     */
-			    printf("\nwhitespace: '%s'\n", ugly_text);
+			    printf("\nignoring %ju whitespace%s\n", strlen(ugly_text), strlen(ugly_text)==1?"":"s");
 			}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 160 "jparse.l"
+#line 161 "jparse.l"
 {
 			    /* string */
-			    printf("\nstring: '%s'\n", ugly_text);
+			    printf("\nstring: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_STRING;
 			    return JSON_STRING;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 167 "jparse.l"
+#line 168 "jparse.l"
 {
 			    /* number */
-			    printf("\nnumber: '%s'\n", ugly_text);
+			    printf("\nnumber: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_NUMBER;
 			    return JSON_NUMBER;
 			}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 174 "jparse.l"
+#line 175 "jparse.l"
 {
 			    /* null object */
-			    printf("\nnull: '%s'\n", ugly_text);
+			    printf("\nnull: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_NULL;
 			    return JSON_NULL;
 			}
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 181 "jparse.l"
+#line 182 "jparse.l"
 {
 			    /* boolean: true */
-			    printf("\ntrue: '%s'\n", ugly_text);
+			    printf("\ntrue: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_BOOL;
 			    return JSON_TRUE;
 			}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 187 "jparse.l"
+#line 188 "jparse.l"
 {
 			    /* boolean: false */
-			    printf("\nfalse: '%s'\n", ugly_text);
+			    printf("\nfalse: <%s>\n", ugly_text);
 			    ugly_lval.type = JTYPE_BOOL;
 			    return JSON_FALSE;
 			}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 194 "jparse.l"
+#line 195 "jparse.l"
 {
 			    /* start of object */
-			    printf("\nstart of object: '%c'\n", *ugly_text);
+			    printf("\nstart of object: <%c>\n", *ugly_text);
 			    ugly_lval.type = JTYPE_OBJECT;
 			    return JSON_OPEN_BRACE;
 			}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 200 "jparse.l"
+#line 201 "jparse.l"
 {
 			    /* end of object */
-			    printf("\nend of object: '%c'\n", *ugly_text);
+			    printf("\nend of object: <%c>\n", *ugly_text);
 			    token = '}';
 			    return JSON_CLOSE_BRACE;
 			}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 207 "jparse.l"
+#line 208 "jparse.l"
 {
 			    /* start of array */
-			    printf("\nstart of array: '%c'\n", *ugly_text);
+			    printf("\nstart of array: <%c>\n", *ugly_text);
 			    ugly_lval.type = JTYPE_ARRAY;
 			    token = '[';
 			    return JSON_OPEN_BRACKET;
@@ -1485,49 +1486,49 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 214 "jparse.l"
+#line 215 "jparse.l"
 {
 			    /* end of array */
-			    printf("\nend of array: '%c'\n", *ugly_text);
+			    printf("\nend of array: <%c>\n", *ugly_text);
 			    token = ']';
 			    return JSON_CLOSE_BRACKET;
 			}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 221 "jparse.l"
+#line 222 "jparse.l"
 {
 			    /* colon or 'equals' */
-			    printf("\ncolon (or 'equals' ): '%c'\n", *ugly_text);
+			    printf("\ncolon (or 'equals' ): <%c>\n", *ugly_text);
 			    token = ':';
 			    return JSON_COLON;
 			}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 228 "jparse.l"
+#line 229 "jparse.l"
 {
 			    /* comma: name/value pair separator */
-			    printf("\ncomma: '%c'\n", *ugly_text);
+			    printf("\ncomma: <%c>\n", *ugly_text);
 			    token = ',';
 			    return JSON_COMMA;
 			}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 235 "jparse.l"
+#line 236 "jparse.l"
 {
 			    /* invalid token: any other character */
-			    ugly_error("\ninvalid token: '%c'\n", *ugly_text);
+			    ugly_error("\ninvalid token: <%c>\n", *ugly_text);
 			    return JSON_INVALID_TOKEN;
 			}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 241 "jparse.l"
+#line 242 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1479 "jparse.c"
+#line 1480 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2687,7 +2688,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 241 "jparse.l"
+#line 242 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */
@@ -2741,14 +2742,14 @@ parse_json_block(char const *string)
 	++num_errors;
 	return;
     }
-    dbg(DBG_NONE, "*** BEGIN PARSE:\n'\n%s\n'", string);
+    json_dbg(JSON_DBG_LEVEL, __func__, "*** BEGIN PARSE:\n<\n%s\n>\n", string);
 
     ugly_parse();
 
     ugly__delete_buffer(bs);
     bs = NULL;
 
-    dbg(DBG_NONE, "*** END PARSE");
+    json_dbg(JSON_DBG_LEVEL, __func__, "*** END PARSE");
     print_newline(output_newline);
 }
 
@@ -2785,6 +2786,7 @@ parse_json_file(char const *filename)
     bool is_stdin = false;	/* true if reading from stdin (filename == "-") */
     char *data = NULL;		/* used to determine if there are NUL bytes in the file */
     size_t len = 0;		/* length of data read */
+    int ret;
 
     /*
      * firewall
@@ -2843,22 +2845,23 @@ parse_json_file(char const *filename)
 	return;
     }
 
-    dbg(DBG_NONE, "*** BEGIN PARSE:\n'\n%s\n'", data);
+    parse_json_block(data);
 
     /* free data */
     free(data);
     data = NULL;
 
-    /* now parse the file */
-    rewind(ugly_in);
-    ugly_restart(ugly_in);
-    ugly_lineno = 1;
-    ugly_parse();
+    if (is_stdin)
+	clearerr(stdin);
+    else if (ugly_in != NULL) {
+	errno = 0;
+	ret = fclose(ugly_in);
+	if (ret != 0) {
+	    warnp(__func__, "error in fclose on file %s", filename);
+	}
+	ugly_in = NULL;
+    }
 
-    clearerr_or_fclose(filename, ugly_in);
-    ugly_in = NULL;
-    dbg(DBG_NONE, "*** END PARSE");
     print_newline(output_newline);
-
 }
 

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -881,8 +881,8 @@ int yy_flex_debug = 1;
 
 static const flex_int16_t yy_rule_linenum[14] =
     {   0,
-      151,  161,  168,  175,  182,  188,  195,  201,  208,  215,
-      222,  229,  236
+      156,  166,  173,  180,  187,  193,  200,  206,  213,  220,
+      227,  234,  241
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -989,8 +989,13 @@ char *yytext;
 /* our header file - #includes what we need */
 #include "jparse.h"
 
-YY_BUFFER_STATE bs;
-#line 942 "jparse.c"
+/*
+ * An exception where the prefix does not change YY to UGLY_ is YY_BUFFER_STATE
+ * but because it IS ugly we have done it for them in jparse.h so that where one
+ * sees UGLY__BUFFER_STATE it's actually YY_BUFFER_STATE.
+ */
+UGLY__BUFFER_STATE bs;
+#line 947 "jparse.c"
 /*
  * Section 2: Patterns (regular expressions) and actions.
  */
@@ -1017,7 +1022,7 @@ YY_BUFFER_STATE bs;
  * TODO: We have to do more than just assigning the token type (by which we mean
  * ugly_lval.type). These things will be done later.
  */
-#line 969 "jparse.c"
+#line 974 "jparse.c"
 
 #define INITIAL 0
 
@@ -1297,9 +1302,9 @@ YY_DECL
 
 	{
 /* %% [7.0] user's declarations go here */
-#line 150 "jparse.l"
+#line 155 "jparse.l"
 
-#line 1251 "jparse.c"
+#line 1256 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1392,7 +1397,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 151 "jparse.l"
+#line 156 "jparse.l"
 {
 			    /*
 			     * Whitespace
@@ -1405,7 +1410,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 161 "jparse.l"
+#line 166 "jparse.l"
 {
 			    /* string */
 			    printf("\nstring: <%s>\n", ugly_text);
@@ -1415,7 +1420,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 168 "jparse.l"
+#line 173 "jparse.l"
 {
 			    /* number */
 			    printf("\nnumber: <%s>\n", ugly_text);
@@ -1425,7 +1430,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 175 "jparse.l"
+#line 180 "jparse.l"
 {
 			    /* null object */
 			    printf("\nnull: <%s>\n", ugly_text);
@@ -1435,7 +1440,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 182 "jparse.l"
+#line 187 "jparse.l"
 {
 			    /* boolean: true */
 			    printf("\ntrue: <%s>\n", ugly_text);
@@ -1445,7 +1450,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 188 "jparse.l"
+#line 193 "jparse.l"
 {
 			    /* boolean: false */
 			    printf("\nfalse: <%s>\n", ugly_text);
@@ -1455,7 +1460,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 195 "jparse.l"
+#line 200 "jparse.l"
 {
 			    /* start of object */
 			    printf("\nstart of object: <%c>\n", *ugly_text);
@@ -1465,7 +1470,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 201 "jparse.l"
+#line 206 "jparse.l"
 {
 			    /* end of object */
 			    printf("\nend of object: <%c>\n", *ugly_text);
@@ -1475,7 +1480,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 208 "jparse.l"
+#line 213 "jparse.l"
 {
 			    /* start of array */
 			    printf("\nstart of array: <%c>\n", *ugly_text);
@@ -1486,7 +1491,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 215 "jparse.l"
+#line 220 "jparse.l"
 {
 			    /* end of array */
 			    printf("\nend of array: <%c>\n", *ugly_text);
@@ -1496,7 +1501,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 222 "jparse.l"
+#line 227 "jparse.l"
 {
 			    /* colon or 'equals' */
 			    printf("\ncolon (or 'equals' ): <%c>\n", *ugly_text);
@@ -1506,7 +1511,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 229 "jparse.l"
+#line 234 "jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    printf("\ncomma: <%c>\n", *ugly_text);
@@ -1516,7 +1521,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 236 "jparse.l"
+#line 241 "jparse.l"
 {
 			    /* invalid token: any other character */
 			    ugly_error("\ninvalid token: %c\n", *ugly_text);
@@ -1525,10 +1530,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 242 "jparse.l"
+#line 247 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1480 "jparse.c"
+#line 1485 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2688,7 +2693,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 242 "jparse.l"
+#line 247 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1962,23 +1962,37 @@ main(int argc, char **argv)
     int i;
 
 
-    /* XXX for development purposes we override initial verbosity_level to
-     * DBG_MED which we have the JSON_DBG_LEVEL set to. I'd actually like it to
-     * be DBG_LOW because it means I wouldn't have to see as much information.
-     * The thought I had of making a json debug function is good except it has
-     * the same problem as before: it makes the other tools too chatty. On the
-     * other hand though it might be that we could have a boolean (maybe it's
-     * already there) that if false it does not show this debug function output;
-     * if true (which we'd have in jparse) it would show it. That's probably the
-     * best option but it'll come at a later time. For now we simply override
-     * the initial verbosity_level. We can always do the other at another time.
+    /*
+     * XXX for development purposes we override the initial json_verbosity_level
+     * to JSON_DBG_LEVEL. This is used in json_vdbg() which is called by
+     * json_dbg().
+     *
+     * This variable is used because it means we don't have to see debug
+     * information unrelated to json if we don't want to - and it also prevents
+     * the problem of other tools having this information printed if they don't
+     * want it.
+     *
+     * On the other hand it also prevents other tools from seeing this
+     * information until an option is added to set this level. I chose -J as
+     * this seems like a good choice: with the exception of mkiocccentry no
+     * other tool uses -j or -J and -J is a good letter for JSON specific
+     * options. If mkiocccentry ever will need this option (which I can imagine
+     * might well happen) another letter will have to be decided upon possibly
+     * for all the tools.
+     *
+     * NOTE: This debug information is outside of the parser so until debugging
+     * information in the parser is disabled you'll still see that upon using
+     * jparse.
+     *
+     * NOTE: Because -s string parses the string at the time of seeing it one
+     * must specify -J prior to -s if they want to change the debug level.
      */
-    verbosity_level = DBG_MED;
+    json_verbosity_level = JSON_DBG_LEVEL;
     /*
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, "hv:qVns:")) != -1) {
+    while ((i = getopt(argc, argv, "hv:qVns:J:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, "-h help mode", program); /*ooo*/
@@ -1989,6 +2003,12 @@ main(int argc, char **argv)
 	     * parse verbosity
 	     */
 	    verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'J': /* -J json_verbosity_level */
+	    /*
+	     * parse json verbosity level
+	     */
+	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'q':
 	    msg_warn_silent = true;
@@ -2014,11 +2034,11 @@ main(int argc, char **argv)
 	    string_flag_used = true;
 
 	    json_dbg(JSON_DBG_LEVEL, __func__, "Calling parse_json_block(\"%s\"):", optarg);
-	    /* parse arg as a string */
+	    /* parse arg as a block of json input */
 	    parse_json_block(optarg);
 	    break;
 	default:
-	    usage(2, "invalid -flag", program); /*ooo*/
+	    usage(2, "invalid -flag or missing option argument", program); /*ooo*/
 	    not_reached();
 	}
     }
@@ -2040,7 +2060,7 @@ main(int argc, char **argv)
 	}
 
     } else if (!string_flag_used) {
-	usage(2, "-s string was not used and file specified", program); /*ooo*/
+	usage(2, "-s string was not used and no file specified", program); /*ooo*/
 	not_reached();
     }
 
@@ -2432,7 +2452,7 @@ usage(int exitcode, char const *str, char const *prog)
      * print the formatted usage stream
      */
     fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JPARSE_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_LEVEL, JPARSE_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1992,6 +1992,7 @@ main(int argc, char **argv)
 	    break;
 	case 'q':
 	    msg_warn_silent = true;
+	    ugly_debug = 0;
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */
@@ -2012,7 +2013,7 @@ main(int argc, char **argv)
 	     */
 	    string_flag_used = true;
 
-	    dbg(DBG_NONE, "Calling parse_json_block(\"%s\"):", optarg);
+	    json_dbg(JSON_DBG_LEVEL, __func__, "Calling parse_json_block(\"%s\"):", optarg);
 	    /* parse arg as a string */
 	    parse_json_block(optarg);
 	    break;
@@ -2034,7 +2035,7 @@ main(int argc, char **argv)
 	 * process each argument in order
 	 */
 	for (i=optind; i < argc; ++i) {
-	    dbg(DBG_NONE, "Calling parse_json_file(\"%s\"):", argv[i]);
+	    json_dbg(JSON_DBG_LEVEL, __func__, "Calling parse_json_file(\"%s\"):", argv[i]);
 	    parse_json_file(argv[i]);
 	}
 
@@ -2083,7 +2084,6 @@ ugly_error(char const *format, ...)
 /*
  * XXX - the parse_json_() functions don't yet link the structs into the tree - XXX
  * XXX - the parameters might or might not have to change - XXX
- * XXX - these functions don't belong in this file - XXX
  */
 
 
@@ -2114,7 +2114,7 @@ parse_json_string(char const *string, struct json *ast)
 	not_reached();
     }
 
-    dbg(JSON_DBG_LEVEL, "%s: about to parse string: <%s>", __func__, string);
+    json_dbg(JSON_DBG_LEVEL, __func__, "about to parse string: <%s>", string);
     /*
      * we say that quote == true because the pattern in the lexer will include
      * the '"'s.
@@ -2133,7 +2133,7 @@ parse_json_string(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't decode string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded string: <%s>", __func__, item->str);
+        json_dbg(JSON_DBG_LEVEL, __func__, "decoded string: <%s>", item->str);
     }
 
     /* XXX Are there any other checks that have to be done ? */
@@ -2195,7 +2195,7 @@ parse_json_bool(char const *string, struct json *ast)
 	err(41, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else {
-	dbg(JSON_DBG_LEVEL, "%s: <%s> -> %s", __func__, string, bool_to_string(item->value));
+	json_dbg(JSON_DBG_LEVEL, __func__, "<%s> -> %s", string, bool_to_string(item->value));
     }
 
     /* TODO add to parse tree */
@@ -2248,7 +2248,7 @@ parse_json_null(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert null: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert null: <%s> -> null", __func__, string);
+        json_dbg(JSON_DBG_LEVEL, __func__, "convert null: <%s> -> null", string);
     }
 
 
@@ -2300,7 +2300,7 @@ parse_json_number(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert number string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert number string: <%s>", __func__, item->as_str);
+        json_dbg(JSON_DBG_LEVEL, __func__, "convert number string: <%s>", item->as_str);
     }
 
     return number;
@@ -2388,7 +2388,7 @@ parse_json_member(struct json *name, struct json *value, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert member");
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert member", __func__);
+        json_dbg(JSON_DBG_LEVEL, __func__, "converted member");
     }
 
 

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -188,13 +188,14 @@ enum yysymbol_kind_t
   YYSYMBOL_YYACCEPT = 15,                  /* $accept  */
   YYSYMBOL_json = 16,                      /* json  */
   YYSYMBOL_json_value = 17,                /* json_value  */
-  YYSYMBOL_json_number = 18,               /* json_number  */
-  YYSYMBOL_json_object = 19,               /* json_object  */
-  YYSYMBOL_json_members = 20,              /* json_members  */
-  YYSYMBOL_json_member = 21,               /* json_member  */
-  YYSYMBOL_json_array = 22,                /* json_array  */
-  YYSYMBOL_json_elements = 23,             /* json_elements  */
-  YYSYMBOL_json_element = 24               /* json_element  */
+  YYSYMBOL_json_string = 18,               /* json_string  */
+  YYSYMBOL_json_number = 19,               /* json_number  */
+  YYSYMBOL_json_object = 20,               /* json_object  */
+  YYSYMBOL_json_members = 21,              /* json_members  */
+  YYSYMBOL_json_member = 22,               /* json_member  */
+  YYSYMBOL_json_array = 23,                /* json_array  */
+  YYSYMBOL_json_elements = 24,             /* json_elements  */
+  YYSYMBOL_json_element = 25               /* json_element  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -497,18 +498,18 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  23
+#define YYFINAL  24
 /* YYLAST -- Last index in YYTABLE.  */
 #define YYLAST   38
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  15
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  10
+#define YYNNTS  11
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  21
+#define YYNRULES  22
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  32
+#define YYNSTATES  33
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   269
@@ -559,8 +560,8 @@ static const yytype_int8 yytranslate[] =
 static const yytype_uint8 yyrline[] =
 {
        0,   151,   151,   152,   153,   154,   157,   158,   159,   160,
-     161,   162,   163,   166,   169,   172,   173,   176,   179,   182,
-     183,   186
+     161,   162,   163,   166,   168,   171,   174,   175,   178,   181,
+     184,   185,   188
 };
 #endif
 
@@ -579,8 +580,9 @@ static const char *const yytname[] =
   "\"end of file\"", "error", "\"invalid token\"", "\"{\"", "\"}\"",
   "\"[\"", "\"]\"", "\",\"", "\":\"", "\"null\"", "\"true\"", "\"false\"",
   "JSON_STRING", "JSON_NUMBER", "JSON_INVALID_TOKEN", "$accept", "json",
-  "json_value", "json_number", "json_object", "json_members",
-  "json_member", "json_array", "json_elements", "json_element", YY_NULLPTR
+  "json_value", "json_string", "json_number", "json_object",
+  "json_members", "json_member", "json_array", "json_elements",
+  "json_element", YY_NULLPTR
 };
 
 static const char *
@@ -590,7 +592,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-3)
+#define YYPACT_NINF (-7)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -604,10 +606,10 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-       9,     1,    -2,    -3,    -3,    -3,    -3,    -3,     2,    -3,
-      -3,    -3,    -3,    -3,    -3,     7,    12,    -1,     5,    20,
-      -3,    21,    19,    -3,    20,    -3,     5,    -3,    20,    -3,
-      -3,    -3
+      10,    12,    -2,    -7,    -7,    -7,    -7,    -7,     5,    -7,
+      -7,    -7,    -7,    -7,    -7,    -7,     4,    13,     7,    -6,
+      25,    -7,    19,    22,    -7,    25,    -7,    -6,    -7,    25,
+      -7,    -7,    -7
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -615,22 +617,24 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     0,    12,    10,    11,     8,    13,     0,    21,
-       9,     6,     7,     3,     4,     0,     0,    15,     0,     0,
-       5,     0,    19,     1,     0,    14,     0,    18,     0,    17,
-      16,    20
+       2,     0,     0,    12,    10,    11,    13,    14,     0,    22,
+       8,     9,     6,     7,     3,     4,     0,     0,    16,     0,
+       0,     5,     0,    20,     1,     0,    15,     0,    19,     0,
+      18,    17,    21
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-      -3,    -3,    -3,    -3,    -3,     8,    -3,    -3,    10,     0
+      -7,    -7,    -7,    -1,    -7,    -7,     6,    -7,    -7,     3,
+       2
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,     8,     9,    10,    11,    16,    17,    12,    21,    22
+       0,     8,     9,    10,    11,    12,    17,    18,    13,    22,
+      23
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -638,18 +642,18 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      13,    18,    23,    19,    20,    14,    26,     3,     4,     5,
-       6,     7,     1,    15,     2,    24,    25,    15,     3,     4,
-       5,     6,     7,    18,    29,    19,    28,    27,     0,     3,
-       4,     5,     6,     7,    30,     0,     0,     0,    31
+      16,    19,    14,    20,    21,    24,     6,     3,     4,     5,
+       6,     7,    25,     1,    27,     2,    15,    26,    16,     3,
+       4,     5,     6,     7,     6,    28,    16,    30,    19,    29,
+      20,     0,    32,    31,     3,     4,     5,     6,     7
 };
 
 static const yytype_int8 yycheck[] =
 {
-       0,     3,     0,     5,     6,     4,     7,     9,    10,    11,
-      12,    13,     3,    12,     5,     8,     4,    12,     9,    10,
-      11,    12,    13,     3,    24,     5,     7,     6,    -1,     9,
-      10,    11,    12,    13,    26,    -1,    -1,    -1,    28
+       1,     3,     0,     5,     6,     0,    12,     9,    10,    11,
+      12,    13,     8,     3,     7,     5,     4,     4,    19,     9,
+      10,    11,    12,    13,    12,     6,    27,    25,     3,     7,
+       5,    -1,    29,    27,     9,    10,    11,    12,    13
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -657,25 +661,25 @@ static const yytype_int8 yycheck[] =
 static const yytype_int8 yystos[] =
 {
        0,     3,     5,     9,    10,    11,    12,    13,    16,    17,
-      18,    19,    22,    24,     4,    12,    20,    21,     3,     5,
-       6,    23,    24,     0,     8,     4,     7,     6,     7,    24,
-      20,    23
+      18,    19,    20,    23,    25,     4,    18,    21,    22,     3,
+       5,     6,    24,    25,     0,     8,     4,     7,     6,     7,
+      25,    21,    24
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
        0,    15,    16,    16,    16,    16,    17,    17,    17,    17,
-      17,    17,    17,    18,    19,    20,    20,    21,    22,    23,
-      23,    24
+      17,    17,    17,    18,    19,    20,    21,    21,    22,    23,
+      24,    24,    25
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     2,     2,     1,     1,     1,     1,
-       1,     1,     1,     1,     3,     1,     3,     3,     3,     1,
-       3,     1
+       1,     1,     1,     1,     1,     3,     1,     3,     3,     3,
+       1,     3,     1
 };
 
 
@@ -1668,44 +1672,44 @@ yyreduce:
     int yychar_backup = yychar;
     switch (yyn)
       {
-  case 8: /* json_value: JSON_STRING  */
-#line 159 "jparse.y"
-                              { yyval = *parse_json_string(ugly_text, &tree); }
-#line 1624 "jparse.tab.c"
-    break;
-
   case 10: /* json_value: "true"  */
 #line 161 "jparse.y"
                             { yyval = *parse_json_bool(ugly_text, &tree); }
-#line 1630 "jparse.tab.c"
+#line 1628 "jparse.tab.c"
     break;
 
   case 11: /* json_value: "false"  */
 #line 162 "jparse.y"
                              { yyval = *parse_json_bool(ugly_text, &tree); }
-#line 1636 "jparse.tab.c"
+#line 1634 "jparse.tab.c"
     break;
 
   case 12: /* json_value: "null"  */
 #line 163 "jparse.y"
                             { yyval = *parse_json_null(ugly_text, &tree); }
-#line 1642 "jparse.tab.c"
+#line 1640 "jparse.tab.c"
     break;
 
-  case 13: /* json_number: JSON_NUMBER  */
+  case 13: /* json_string: JSON_STRING  */
 #line 166 "jparse.y"
+                            { yyval = *parse_json_string(ugly_text, &tree); }
+#line 1646 "jparse.tab.c"
+    break;
+
+  case 14: /* json_number: JSON_NUMBER  */
+#line 168 "jparse.y"
                             { yyval = *parse_json_number(ugly_text, &tree); }
-#line 1648 "jparse.tab.c"
+#line 1652 "jparse.tab.c"
     break;
 
-  case 17: /* json_member: JSON_STRING ":" json_element  */
-#line 176 "jparse.y"
+  case 18: /* json_member: json_string ":" json_element  */
+#line 178 "jparse.y"
                                                     { yyval = *parse_json_member(&yyvsp[-2], &yyvsp[0], &tree); }
-#line 1654 "jparse.tab.c"
+#line 1658 "jparse.tab.c"
     break;
 
 
-#line 1658 "jparse.tab.c"
+#line 1662 "jparse.tab.c"
 
         default: break;
       }
@@ -1940,7 +1944,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 189 "jparse.y"
+#line 191 "jparse.y"
 
 /* Section 3: C code */
 
@@ -2163,17 +2167,17 @@ parse_json_bool(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(37, __func__, "passed NULL string and/or ast");
+	err(38, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
 
     boolean = json_conv_bool_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (boolean == NULL) {
-	err(38, __func__, "converting JSON bool returned NULL: <%s>", string);
+	err(39, __func__, "converting JSON bool returned NULL: <%s>", string);
 	not_reached();
     } else if (boolean->type != JTYPE_BOOL) {
-        err(37, __func__, "expected JTYPE_BOOL, found type: %s", json_element_type_name(boolean->type));
+        err(40, __func__, "expected JTYPE_BOOL, found type: %s", json_element_type_name(boolean->type));
         not_reached();
     }
     item = &(boolean->element.boolean);
@@ -2188,7 +2192,7 @@ parse_json_bool(char const *string, struct json *ast)
 	 * If it's not we will abort as there's a serious mismatch between the
 	 * scanner and the parser.
 	 */
-	err(39, __func__, "called on non-boolean string: <%s>", string);
+	err(41, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else {
 	dbg(JSON_DBG_LEVEL, "%s: <%s> -> %s", __func__, string, bool_to_string(item->value));
@@ -2223,7 +2227,7 @@ parse_json_null(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(40, __func__, "passed NULL string and/or ast");
+	err(42, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
 
@@ -2233,18 +2237,18 @@ parse_json_null(char const *string, struct json *ast)
      * null should not be NULL :-)
      */
     if (null == NULL) {
-	err(41, __func__, "null ironically should not be NULL but it is :-)");
+	err(43, __func__, "null ironically should not be NULL but it is :-)");
 	not_reached();
     } else if (null->type != JTYPE_NULL) {
-        err(37, __func__, "expected JTYPE_NULL, found type: %s", json_element_type_name(null->type));
+        err(44, __func__, "expected JTYPE_NULL, found type: %s", json_element_type_name(null->type));
         not_reached();
     }
     item = &(null->element.null);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode null: <%s>", string);
+	warn(__func__, "couldn't convert null: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded null: <%s> -> null", __func__, string);
+        dbg(JSON_DBG_LEVEL, "%s: convert null: <%s> -> null", __func__, string);
     }
 
 
@@ -2279,24 +2283,24 @@ parse_json_number(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(43, __func__, "passed NULL string and/or ast");
+	err(45, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
     number = json_conv_number_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (number == NULL) {
-	err(44, __func__, "converting JSON number returned NULL: <%s>", string);
+	err(46, __func__, "converting JSON number returned NULL: <%s>", string);
         not_reached();
     } else if (number->type != JTYPE_NUMBER) {
-        err(37, __func__, "expected JTYPE_NUMBER, found type: %s", json_element_type_name(number->type));
+        err(47, __func__, "expected JTYPE_NUMBER, found type: %s", json_element_type_name(number->type));
         not_reached();
     }
     item = &(number->element.number);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode number string: <%s>", string);
+	warn(__func__, "couldn't convert number string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded number string: <%s>", __func__, item->as_str);
+        dbg(JSON_DBG_LEVEL, "%s: convert number string: <%s>", __func__, item->as_str);
     }
 
     return number;
@@ -2331,7 +2335,7 @@ parse_json_array(char const *string, struct json *ast)
      * firewall
      */
     if (string == NULL || ast == NULL) {
-	err(45, __func__, "passed NULL string and/or ast");
+	err(48, __func__, "passed NULL string and/or ast");
 	not_reached();
     }
 
@@ -2366,25 +2370,25 @@ parse_json_member(struct json *name, struct json *value, struct json *ast)
      * firewall
      */
     if (name == NULL || value == NULL || ast == NULL) {
-	err(46, __func__, "passed NULL pointer(s)");
+	err(49, __func__, "passed NULL pointer(s)");
 	not_reached();
     }
 
     member = json_conv_member(name, value);
     /* paranoia - these tests should never result in an error */
     if (member == NULL) {
-	err(47, __func__, "converting JSON member returned NULL");
+	err(50, __func__, "converting JSON member returned NULL");
 	not_reached();
     } else if (member->type != JTYPE_MEMBER) {
-        err(37, __func__, "expected JTYPE_MEMBER, found type: %s", json_element_type_name(member->type));
+        err(51, __func__, "expected JTYPE_MEMBER, found type: %s", json_element_type_name(member->type));
         not_reached();
     }
     item = &(member->element.member);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode member");
+	warn(__func__, "couldn't convert member");
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded member", __func__);
+        dbg(JSON_DBG_LEVEL, "%s: convert member", __func__);
     }
 
 

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2100,6 +2100,7 @@ struct json *
 parse_json_string(char const *string, struct json *ast)
 {
     struct json *str = NULL;
+    struct json_string *item = NULL;
 
     /*
      * firewall
@@ -2115,19 +2116,23 @@ parse_json_string(char const *string, struct json *ast)
      * the '"'s.
      */
     str = json_conv_string_str(string, NULL, true);
+    /* paranoia - these tests should never result in an error */
     if (str == NULL) {
-	err(36, __func__, "converting JSON string returned NULL: <%s>", string);
-	not_reached();
+        err(36, __func__, "converting JSON string returned NULL: <%s>", string);
+        not_reached();
+    } else if (str->type != JTYPE_STRING) {
+        err(37, __func__, "expected JTYPE_STRING, found type: %s", json_element_type_name(str->type));
+        not_reached();
     }
-
-    if (!str->element.string.converted) {
+    item = &(str->element.string);
+    if (!item->converted) {
+	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't decode string: <%s>", string);
     } else {
-	dbg(JSON_DBG_LEVEL, "%s: decoded string: <%s>", __func__, str->element.string.str);
+        dbg(JSON_DBG_LEVEL, "%s: decoded string: <%s>", __func__, item->str);
     }
 
-    /* XXX decide what tests should be done on the returned string other than
-     * conversion success */
+    /* XXX Are there any other checks that have to be done ? */
 
     /* TODO add to parse tree */
 
@@ -2152,6 +2157,7 @@ struct json *
 parse_json_bool(char const *string, struct json *ast)
 {
     struct json *boolean = NULL;
+    struct json_boolean *item = NULL;
 
     /*
      * firewall
@@ -2162,26 +2168,30 @@ parse_json_bool(char const *string, struct json *ast)
     }
 
     boolean = json_conv_bool_str(string, NULL);
+    /* paranoia - these tests should never result in an error */
     if (boolean == NULL) {
 	err(38, __func__, "converting JSON bool returned NULL: <%s>", string);
 	not_reached();
+    } else if (boolean->type != JTYPE_BOOL) {
+        err(37, __func__, "expected JTYPE_BOOL, found type: %s", json_element_type_name(boolean->type));
+        not_reached();
     }
-
-    /*
-     * XXX json_conv_bool_str() calls json_conv_bool() which will warn if the
-     * boolean is neither true nor false. We know that this function should never
-     * be called on anything but the strings "true" or "false" and since the
-     * function will abort if NULL is returned we should check if
-     * boolean->converted == true.
-     *
-     * If it's not we will abort as there's a serious mismatch between the
-     * scanner and the parser.
-     */
-    if (!boolean->element.boolean.converted) {
+    item = &(boolean->element.boolean);
+    if (!item->converted) {
+	/*
+	 * XXX json_conv_bool_str() calls json_conv_bool() which will warn if the
+	 * boolean is neither true nor false. We know that this function should never
+	 * be called on anything but the strings "true" or "false" and since the
+	 * function will abort if NULL is returned we should check if
+	 * boolean->converted == true.
+	 *
+	 * If it's not we will abort as there's a serious mismatch between the
+	 * scanner and the parser.
+	 */
 	err(39, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else {
-	dbg(JSON_DBG_LEVEL, "%s: <%s> -> %s", __func__, string, bool_to_string(boolean->element.boolean.value));
+	dbg(JSON_DBG_LEVEL, "%s: <%s> -> %s", __func__, string, bool_to_string(item->value));
     }
 
     /* TODO add to parse tree */
@@ -2207,6 +2217,7 @@ struct json *
 parse_json_null(char const *string, struct json *ast)
 {
     struct json *null = NULL;
+    struct json_null *item = NULL;
 
     /*
      * firewall
@@ -2224,12 +2235,16 @@ parse_json_null(char const *string, struct json *ast)
     if (null == NULL) {
 	err(41, __func__, "null ironically should not be NULL but it is :-)");
 	not_reached();
+    } else if (null->type != JTYPE_NULL) {
+        err(37, __func__, "expected JTYPE_NULL, found type: %s", json_element_type_name(null->type));
+        not_reached();
     }
-    if (!null->element.null.converted) {
-	err(42, __func__, "unable to convert null: <%s>", string);
-	not_reached();
+    item = &(null->element.null);
+    if (!item->converted) {
+	/* XXX should this be a fatal error ? */
+	warn(__func__, "couldn't decode null: <%s>", string);
     } else {
-	dbg(JSON_DBG_LEVEL, "%s: converted null", __func__);
+        dbg(JSON_DBG_LEVEL, "%s: decoded null: <%s> -> null", __func__, string);
     }
 
 
@@ -2258,6 +2273,7 @@ struct json *
 parse_json_number(char const *string, struct json *ast)
 {
     struct json *number = NULL;
+    struct json_number *item = NULL;
 
     /*
      * firewall
@@ -2267,12 +2283,22 @@ parse_json_number(char const *string, struct json *ast)
 	not_reached();
     }
     number = json_conv_number_str(string, NULL);
+    /* paranoia - these tests should never result in an error */
     if (number == NULL) {
 	err(44, __func__, "converting JSON number returned NULL: <%s>", string);
-	not_reached();
+        not_reached();
+    } else if (number->type != JTYPE_NUMBER) {
+        err(37, __func__, "expected JTYPE_NUMBER, found type: %s", json_element_type_name(number->type));
+        not_reached();
+    }
+    item = &(number->element.number);
+    if (!item->converted) {
+	/* XXX should this be a fatal error ? */
+	warn(__func__, "couldn't decode number string: <%s>", string);
+    } else {
+        dbg(JSON_DBG_LEVEL, "%s: decoded number string: <%s>", __func__, item->as_str);
     }
 
-    /* XXX - decide what tests should be done on the returned number - XXX */
     return number;
 }
 
@@ -2334,6 +2360,7 @@ struct json *
 parse_json_member(struct json *name, struct json *value, struct json *ast)
 {
     struct json *member = NULL;
+    struct json_member *item = NULL;
 
     /*
      * firewall
@@ -2344,10 +2371,22 @@ parse_json_member(struct json *name, struct json *value, struct json *ast)
     }
 
     member = json_conv_member(name, value);
+    /* paranoia - these tests should never result in an error */
     if (member == NULL) {
 	err(47, __func__, "converting JSON member returned NULL");
 	not_reached();
+    } else if (member->type != JTYPE_MEMBER) {
+        err(37, __func__, "expected JTYPE_MEMBER, found type: %s", json_element_type_name(member->type));
+        not_reached();
     }
+    item = &(member->element.member);
+    if (!item->converted) {
+	/* XXX should this be a fatal error ? */
+	warn(__func__, "couldn't decode member");
+    } else {
+        dbg(JSON_DBG_LEVEL, "%s: decoded member", __func__);
+    }
+
 
     return member;
 }

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -498,9 +498,9 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  24
+#define YYFINAL  22
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   38
+#define YYLAST   31
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  15
@@ -509,7 +509,7 @@ union yyalloc
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  22
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  33
+#define YYNSTATES  31
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   269
@@ -559,8 +559,8 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   151,   151,   152,   153,   154,   157,   158,   159,   160,
-     161,   162,   163,   166,   168,   171,   174,   175,   178,   181,
+       0,   151,   151,   152,   155,   156,   157,   158,   159,   160,
+     161,   164,   166,   169,   170,   173,   174,   177,   180,   181,
      184,   185,   188
 };
 #endif
@@ -592,7 +592,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-7)
+#define YYPACT_NINF (-3)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -606,10 +606,10 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      10,    12,    -2,    -7,    -7,    -7,    -7,    -7,     5,    -7,
-      -7,    -7,    -7,    -7,    -7,    -7,     4,    13,     7,    -6,
-      25,    -7,    19,    22,    -7,    25,    -7,    -6,    -7,    25,
-      -7,    -7,    -7
+       9,     1,    -2,    -3,    -3,    -3,    -3,    -3,     6,    -3,
+      -3,    -3,    -3,    -3,    -3,    -3,     7,    12,    10,    -3,
+      17,    19,    -3,     9,    -3,    15,    -3,     9,    -3,    -3,
+      -3
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -617,24 +617,24 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     0,    12,    10,    11,    13,    14,     0,    22,
-       8,     9,     6,     7,     3,     4,     0,     0,    16,     0,
-       0,     5,     0,    20,     1,     0,    15,     0,    19,     0,
-      18,    17,    21
+       2,     0,     0,    10,     8,     9,    11,    12,     0,    22,
+       6,     7,     4,     5,     3,    14,     0,     0,    15,    19,
+       0,    20,     1,     0,    13,     0,    18,     0,    17,    16,
+      21
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-      -7,    -7,    -7,    -1,    -7,    -7,     6,    -7,    -7,     3,
+      -3,    -3,    -3,    -1,    -3,    -3,     3,    -3,    -3,     4,
        2
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,     8,     9,    10,    11,    12,    17,    18,    13,    22,
-      23
+       0,     8,     9,    10,    11,    12,    17,    18,    13,    20,
+      21
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -642,18 +642,18 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      16,    19,    14,    20,    21,    24,     6,     3,     4,     5,
-       6,     7,    25,     1,    27,     2,    15,    26,    16,     3,
-       4,     5,     6,     7,     6,    28,    16,    30,    19,    29,
-      20,     0,    32,    31,     3,     4,     5,     6,     7
+      16,     1,    14,     2,    19,    15,    22,     3,     4,     5,
+       6,     7,     1,     6,     2,    23,    24,    25,     3,     4,
+       5,     6,     7,    26,    16,    28,    27,     6,    29,     0,
+       0,    30
 };
 
 static const yytype_int8 yycheck[] =
 {
-       1,     3,     0,     5,     6,     0,    12,     9,    10,    11,
-      12,    13,     8,     3,     7,     5,     4,     4,    19,     9,
-      10,    11,    12,    13,    12,     6,    27,    25,     3,     7,
-       5,    -1,    29,    27,     9,    10,    11,    12,    13
+       1,     3,     0,     5,     6,     4,     0,     9,    10,    11,
+      12,    13,     3,    12,     5,     8,     4,     7,     9,    10,
+      11,    12,    13,     6,    25,    23,     7,    12,    25,    -1,
+      -1,    27
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -661,24 +661,24 @@ static const yytype_int8 yycheck[] =
 static const yytype_int8 yystos[] =
 {
        0,     3,     5,     9,    10,    11,    12,    13,    16,    17,
-      18,    19,    20,    23,    25,     4,    18,    21,    22,     3,
-       5,     6,    24,    25,     0,     8,     4,     7,     6,     7,
-      25,    21,    24
+      18,    19,    20,    23,    25,     4,    18,    21,    22,     6,
+      24,    25,     0,     8,     4,     7,     6,     7,    25,    21,
+      24
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    15,    16,    16,    16,    16,    17,    17,    17,    17,
-      17,    17,    17,    18,    19,    20,    21,    21,    22,    23,
+       0,    15,    16,    16,    17,    17,    17,    17,    17,    17,
+      17,    18,    19,    20,    20,    21,    21,    22,    23,    23,
       24,    24,    25
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
-       0,     2,     0,     1,     2,     2,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     3,     1,     3,     3,     3,
+       0,     2,     0,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     3,     2,     1,     3,     3,     3,     2,
        1,     3,     1
 };
 
@@ -1672,44 +1672,56 @@ yyreduce:
     int yychar_backup = yychar;
     switch (yyn)
       {
-  case 10: /* json_value: "true"  */
-#line 161 "jparse.y"
+  case 8: /* json_value: "true"  */
+#line 159 "jparse.y"
                             { yyval = *parse_json_bool(ugly_text, &tree); }
 #line 1628 "jparse.tab.c"
     break;
 
-  case 11: /* json_value: "false"  */
-#line 162 "jparse.y"
+  case 9: /* json_value: "false"  */
+#line 160 "jparse.y"
                              { yyval = *parse_json_bool(ugly_text, &tree); }
 #line 1634 "jparse.tab.c"
     break;
 
-  case 12: /* json_value: "null"  */
-#line 163 "jparse.y"
+  case 10: /* json_value: "null"  */
+#line 161 "jparse.y"
                             { yyval = *parse_json_null(ugly_text, &tree); }
 #line 1640 "jparse.tab.c"
     break;
 
-  case 13: /* json_string: JSON_STRING  */
-#line 166 "jparse.y"
+  case 11: /* json_string: JSON_STRING  */
+#line 164 "jparse.y"
                             { yyval = *parse_json_string(ugly_text, &tree); }
 #line 1646 "jparse.tab.c"
     break;
 
-  case 14: /* json_number: JSON_NUMBER  */
-#line 168 "jparse.y"
+  case 12: /* json_number: JSON_NUMBER  */
+#line 166 "jparse.y"
                             { yyval = *parse_json_number(ugly_text, &tree); }
 #line 1652 "jparse.tab.c"
     break;
 
-  case 18: /* json_member: json_string ":" json_element  */
-#line 178 "jparse.y"
-                                                    { yyval = *parse_json_member(&yyvsp[-2], &yyvsp[0], &tree); }
+  case 14: /* json_object: "{" "}"  */
+#line 170 "jparse.y"
+                                                   { yyval = *json_create_object(); }
 #line 1658 "jparse.tab.c"
     break;
 
+  case 17: /* json_member: json_string ":" json_element  */
+#line 177 "jparse.y"
+                                                    { yyval = *parse_json_member(&yyvsp[-2], &yyvsp[0], &tree); }
+#line 1664 "jparse.tab.c"
+    break;
 
-#line 1662 "jparse.tab.c"
+  case 19: /* json_array: "[" "]"  */
+#line 181 "jparse.y"
+                                                       { yyval = *json_create_array(); }
+#line 1670 "jparse.tab.c"
+    break;
+
+
+#line 1674 "jparse.tab.c"
 
         default: break;
       }

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1944,7 +1944,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 191 "jparse.y"
+#line 192 "jparse.y"
 
 /* Section 3: C code */
 

--- a/jparse.y
+++ b/jparse.y
@@ -156,12 +156,14 @@ json:		/* empty */
 
 json_value:	  json_object
 		| json_array
-		| JSON_STRING { $$ = *parse_json_string(ugly_text, &tree); }
+		| json_string
 		| json_number
 		| JSON_TRUE { $$ = *parse_json_bool(ugly_text, &tree); }
 		| JSON_FALSE { $$ = *parse_json_bool(ugly_text, &tree); }
 		| JSON_NULL { $$ = *parse_json_null(ugly_text, &tree); }
 		;
+
+json_string:	JSON_STRING { $$ = *parse_json_string(ugly_text, &tree); }
 
 json_number:	JSON_NUMBER { $$ = *parse_json_number(ugly_text, &tree); }
 		;
@@ -173,7 +175,7 @@ json_members:	json_member
 		| json_member JSON_COMMA json_members
 		;
 
-json_member:	JSON_STRING JSON_COLON json_element { $$ = *parse_json_member(&$1, &$3, &tree); }
+json_member:	json_string JSON_COLON json_element { $$ = *parse_json_member(&$1, &$3, &tree); }
 		;
 
 json_array:	JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET
@@ -487,9 +489,9 @@ parse_json_null(char const *string, struct json *ast)
     item = &(null->element.null);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode null: <%s>", string);
+	warn(__func__, "couldn't convert null: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded null: <%s> -> null", __func__, string);
+        dbg(JSON_DBG_LEVEL, "%s: convert null: <%s> -> null", __func__, string);
     }
 
 
@@ -539,9 +541,9 @@ parse_json_number(char const *string, struct json *ast)
     item = &(number->element.number);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode number string: <%s>", string);
+	warn(__func__, "couldn't convert number string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded number string: <%s>", __func__, item->as_str);
+        dbg(JSON_DBG_LEVEL, "%s: convert number string: <%s>", __func__, item->as_str);
     }
 
     return number;
@@ -627,9 +629,9 @@ parse_json_member(struct json *name, struct json *value, struct json *ast)
     item = &(member->element.member);
     if (!item->converted) {
 	/* XXX should this be a fatal error ? */
-	warn(__func__, "couldn't decode member");
+	warn(__func__, "couldn't convert member");
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded member", __func__);
+        dbg(JSON_DBG_LEVEL, "%s: convert member", __func__);
     }
 
 

--- a/jparse.y
+++ b/jparse.y
@@ -235,6 +235,7 @@ main(int argc, char **argv)
 	    break;
 	case 'q':
 	    msg_warn_silent = true;
+	    ugly_debug = 0;
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    errno = 0;		/* pre-clear errno for warnp() */
@@ -255,7 +256,7 @@ main(int argc, char **argv)
 	     */
 	    string_flag_used = true;
 
-	    dbg(DBG_NONE, "Calling parse_json_block(\"%s\"):", optarg);
+	    json_dbg(JSON_DBG_LEVEL, __func__, "Calling parse_json_block(\"%s\"):", optarg);
 	    /* parse arg as a string */
 	    parse_json_block(optarg);
 	    break;
@@ -277,7 +278,7 @@ main(int argc, char **argv)
 	 * process each argument in order
 	 */
 	for (i=optind; i < argc; ++i) {
-	    dbg(DBG_NONE, "Calling parse_json_file(\"%s\"):", argv[i]);
+	    json_dbg(JSON_DBG_LEVEL, __func__, "Calling parse_json_file(\"%s\"):", argv[i]);
 	    parse_json_file(argv[i]);
 	}
 
@@ -326,7 +327,6 @@ ugly_error(char const *format, ...)
 /*
  * XXX - the parse_json_() functions don't yet link the structs into the tree - XXX
  * XXX - the parameters might or might not have to change - XXX
- * XXX - these functions don't belong in this file - XXX
  */
 
 
@@ -357,7 +357,7 @@ parse_json_string(char const *string, struct json *ast)
 	not_reached();
     }
 
-    dbg(JSON_DBG_LEVEL, "%s: about to parse string: <%s>", __func__, string);
+    json_dbg(JSON_DBG_LEVEL, __func__, "about to parse string: <%s>", string);
     /*
      * we say that quote == true because the pattern in the lexer will include
      * the '"'s.
@@ -376,7 +376,7 @@ parse_json_string(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't decode string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: decoded string: <%s>", __func__, item->str);
+        json_dbg(JSON_DBG_LEVEL, __func__, "decoded string: <%s>", item->str);
     }
 
     /* XXX Are there any other checks that have to be done ? */
@@ -438,7 +438,7 @@ parse_json_bool(char const *string, struct json *ast)
 	err(41, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else {
-	dbg(JSON_DBG_LEVEL, "%s: <%s> -> %s", __func__, string, bool_to_string(item->value));
+	json_dbg(JSON_DBG_LEVEL, __func__, "<%s> -> %s", string, bool_to_string(item->value));
     }
 
     /* TODO add to parse tree */
@@ -491,7 +491,7 @@ parse_json_null(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert null: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert null: <%s> -> null", __func__, string);
+        json_dbg(JSON_DBG_LEVEL, __func__, "convert null: <%s> -> null", string);
     }
 
 
@@ -543,7 +543,7 @@ parse_json_number(char const *string, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert number string: <%s>", string);
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert number string: <%s>", __func__, item->as_str);
+        json_dbg(JSON_DBG_LEVEL, __func__, "convert number string: <%s>", item->as_str);
     }
 
     return number;
@@ -631,7 +631,7 @@ parse_json_member(struct json *name, struct json *value, struct json *ast)
 	/* XXX should this be a fatal error ? */
 	warn(__func__, "couldn't convert member");
     } else {
-        dbg(JSON_DBG_LEVEL, "%s: convert member", __func__);
+        json_dbg(JSON_DBG_LEVEL, __func__, "converted member");
     }
 
 

--- a/jparse.y
+++ b/jparse.y
@@ -186,6 +186,7 @@ json_elements:	json_element
 		;
 
 json_element:	json_value
+		;
 
 
 %%

--- a/jparse.y
+++ b/jparse.y
@@ -150,8 +150,6 @@ int token = 0;
 %%
 json:		/* empty */
 		| json_element
-		| JSON_OPEN_BRACE JSON_CLOSE_BRACE
-		| JSON_OPEN_BRACKET JSON_CLOSE_BRACKET
 		;
 
 json_value:	  json_object
@@ -169,6 +167,7 @@ json_number:	JSON_NUMBER { $$ = *parse_json_number(ugly_text, &tree); }
 		;
 
 json_object:	JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE
+		| JSON_OPEN_BRACE JSON_CLOSE_BRACE { $$ = *json_create_object(); }
 		;
 
 json_members:	json_member
@@ -179,6 +178,7 @@ json_member:	json_string JSON_COLON json_element { $$ = *parse_json_member(&$1, 
 		;
 
 json_array:	JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET
+		| JSON_OPEN_BRACKET JSON_CLOSE_BRACKET { $$ = *json_create_array(); }
 		;
 
 json_elements:	json_element

--- a/json.c
+++ b/json.c
@@ -3169,35 +3169,35 @@ json_array_add_value(struct json *obj, struct json *value)
 char const *
 json_element_type_name(enum element_type json_type)
 {
-    char const *name = "unset";
+    char const *name = "JTYPE_UNSET";
 
     switch (json_type) {
     case JTYPE_UNSET:
-	name = "unset";
+	name = "JTYPE_UNSET";
 	break;
     case JTYPE_NUMBER:
-	name = "number";
+	name = "JTYPE_NUMBER";
 	break;
     case JTYPE_STRING:
-	name = "string";
+	name = "JTYPE_STRING";
 	break;
     case JTYPE_BOOL:
-	name = "boolean";
+	name = "JTYPE_BOOL";
 	break;
     case JTYPE_NULL:
-	name = "null";
+	name = "JTYPE_NULL";
 	break;
     case JTYPE_MEMBER:
-	name = "member";
+	name = "JTYPE_MEMBER";
 	break;
     case JTYPE_OBJECT:
-	name = "object";
+	name = "JTYPE_OBJECT";
 	break;
     case JTYPE_ARRAY:
-	name = "array";
+	name = "JTYPE_ARRAY";
 	break;
     default:
-	name = "UNKNOWN";
+	name = "((JTYPE_UNKNOWN))";
 	warn(__func__, "called with unknown JSON type: %d", json_type);
 	break;
     }

--- a/json.c
+++ b/json.c
@@ -2143,7 +2143,7 @@ json_conv_number(char const *ptr, size_t len)
     }
 
 
-    dbg(JSON_DBG_LEVEL, "JSON return type: %s", json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "JSON return type: %s", json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -2346,7 +2346,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
      */
     posix_safe_chk(item->str, item->str_len, &item->slash, &item->posix_safe, &item->first_alphanum, &item->upper);
 
-    dbg(JSON_DBG_LEVEL, "JSON return type: %s", json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "JSON return type: %s", json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -2505,7 +2505,7 @@ json_conv_bool(char const *ptr, size_t len)
 	warn(__func__, "JSON boolean string neither true nor false: <%s>", item->as_str);
     }
 
-    dbg(JSON_DBG_LEVEL, "JSON return type: %s", json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "JSON return type: %s", json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -2657,7 +2657,7 @@ json_conv_null(char const *ptr, size_t len)
 	warn(__func__, "JSON null string is not null: <%s>", item->as_str);
     }
 
-    dbg(JSON_DBG_LEVEL, "JSON return type: %s", json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "JSON return type: %s", json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -2806,8 +2806,8 @@ json_conv_member(struct json *name, struct json *value)
     case JTYPE_MEMBER:
     case JTYPE_OBJECT:
     case JTYPE_ARRAY:
-	dbg(JSON_DBG_LEVEL, "%s: JSON name type: %s", __func__, json_element_type_name(name->type));
-	dbg(JSON_DBG_LEVEL, "%s: JSON value type: %s", __func__, json_element_type_name(value->type));
+	json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON name type: %s", __func__, json_element_type_name(name->type));
+	json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON value type: %s", __func__, json_element_type_name(value->type));
 	break;
     default:
 	warn(__func__, "expected JSON object, array, string, number, boolean or null, found type: %d", value->type);
@@ -2899,7 +2899,7 @@ json_create_object(void)
     item->set = dyn_array_addr(item->s, struct json *, 0);
     item->converted = true;
 
-    dbg(JSON_DBG_LEVEL, "%s: JSON return type: %s", __func__, json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON return type: %s", __func__, json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -2961,8 +2961,8 @@ json_object_add_member(struct json *obj, struct json *member)
 	return false;
     }
 
-    dbg(JSON_DBG_LEVEL, "%s: JSON object type: %s", __func__, json_element_type_name(obj->type));
-    dbg(JSON_DBG_LEVEL, "%s: JSON member type: %s", __func__, json_element_type_name(member->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON object type: %s", __func__, json_element_type_name(obj->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON member type: %s", __func__, json_element_type_name(member->type));
 
     item = &(ret->element.object);
     if (item->s == NULL) {
@@ -3057,7 +3057,7 @@ json_create_array(void)
     item->set = dyn_array_addr(item->s, struct json *, 0);
     item->converted = true;
 
-    dbg(JSON_DBG_LEVEL, "%s: JSON return type: %s", __func__, json_element_type_name(ret->type));
+    json_dbg(JSON_DBG_LEVEL, __func__, "%s: JSON return type: %s", __func__, json_element_type_name(ret->type));
 
     /*
      * return the JSON parse tree element
@@ -3120,8 +3120,8 @@ json_array_add_value(struct json *obj, struct json *value)
     case JTYPE_MEMBER:
     case JTYPE_OBJECT:
     case JTYPE_ARRAY:
-	dbg(JSON_DBG_LEVEL, "%s: JSON value type: %s", __func__, json_element_type_name(value->type));
-	dbg(JSON_DBG_LEVEL, "%s: JSON object type: %s", __func__, json_element_type_name(obj->type));
+	json_dbg(JSON_DBG_LEVEL, __func__, "JSON value type: %s", json_element_type_name(value->type));
+	json_dbg(JSON_DBG_LEVEL, __func__, "JSON object type: %s", json_element_type_name(obj->type));
 	break;
     default:
 	warn(__func__, "expected JSON object, array, string, number, boolean or null, found type: %d", value->type);

--- a/json.c
+++ b/json.c
@@ -2305,7 +2305,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
     }
 
     /*
-     * duplicate the JSON integer string
+     * duplicate the JSON string
      */
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));

--- a/json.h
+++ b/json.h
@@ -47,12 +47,15 @@
 #include "json_util.h"
 
 /*
+ * globals
+ */
+extern int json_verbosity_level;	/* print json debug messages <= json_verbosity_level in json_dbg(), json_vdbg() */
+/*
  * JSON defines
  *
  * JSON parser related definitions and structures
  */
-#define JSON_CHUNK (16)			/* number of pointers to allocate at a time */
-#define JSON_DBG_LEVEL (DBG_MED)	/* default JSON debugging level */
+#define JSON_CHUNK (16)			/* number of pointers to allocate at a time in dynamic array */
 
 
 /*

--- a/json.h
+++ b/json.h
@@ -41,6 +41,10 @@
 #include <time.h>
 #include <stdint.h>
 
+/*
+ * json_util - utility functions related to json
+ */
+#include "json_util.h"
 
 /*
  * JSON defines

--- a/json.h
+++ b/json.h
@@ -48,7 +48,7 @@
  * JSON parser related definitions and structures
  */
 #define JSON_CHUNK (16)			/* number of pointers to allocate at a time */
-#define JSON_DBG_LEVEL (DBG_HIGH)	/* fault JSON debugging level */
+#define JSON_DBG_LEVEL (DBG_MED)	/* default JSON debugging level */
 
 
 /*

--- a/json_chk.c
+++ b/json_chk.c
@@ -1310,5 +1310,3 @@ free_json_field(struct json_field *field)
     free(field);
     field = NULL;
 }
-
-

--- a/json_chk.c
+++ b/json_chk.c
@@ -222,17 +222,17 @@ find_json_field_in_table(struct json_field *table, char const *name, size_t *loc
 void
 check_json_fields_tables(void)
 {
-    dbg(DBG_MED, "Running sanity checks on common_json_fields table ...");
+    dbg(DBG_VVHIGH, "Running sanity checks on common_json_fields table ...");
     check_common_json_fields_table();
-    dbg(DBG_MED, "... all OK.");
+    dbg(DBG_VVHIGH, "... all OK.");
 
-    dbg(DBG_MED, "Running sanity checks on info_json_fields table ...");
+    dbg(DBG_VVHIGH, "Running sanity checks on info_json_fields table ...");
     check_info_json_fields_table();
-    dbg(DBG_MED, "... all OK.");
+    dbg(DBG_VVHIGH, "... all OK.");
 
-    dbg(DBG_MED, "Running sanity checks on author_json_fields table ...");
+    dbg(DBG_VVHIGH, "Running sanity checks on author_json_fields table ...");
     check_author_json_fields_table();
-    dbg(DBG_MED, "... all OK.");
+    dbg(DBG_VVHIGH, "... all OK.");
 }
 
 

--- a/json_util.c
+++ b/json_util.c
@@ -38,6 +38,11 @@ static int cmp_codes(const void *a, const void *b);
 static void expand_json_code_ignore_set(void);
 static struct ignore_json_code *ignore_json_code_set;
 
+/*
+ * globals
+ */
+
+int json_verbosity_level = JSON_DBG_NONE;	/* json debug level set by -J in jparse */
 
 /*
  * JSON warn (NOT error) codes to ignore
@@ -926,7 +931,7 @@ json_vdbg(int level, char const *name, char const *fmt, va_list ap)
      * print the debug message if allowed and allowed by the verbosity level
      */
     if (dbg_output_allowed) {
-	if (level <= verbosity_level) {
+	if (level <= json_verbosity_level) {
 	    errno = 0;
 	    ret = fprintf(stderr, "JSON DEBUG[%d]: ", level);
 	    if (ret < 0) {

--- a/json_util.c
+++ b/json_util.c
@@ -820,3 +820,146 @@ ignore_json_code(int code)
     dbg(DBG_VHIGH, "code %d added to ignore_json_code_set[]", code);
     return;
 }
+
+/*
+ * json_dbg - print JSON debug message if we are verbose enough
+ *
+ * given:
+ *	level	    print message if >= verbosity level
+ *	program	    program name
+ *	name	    function name
+ *	fmt	    printf format
+ *	...
+ *
+ * Example:
+ *
+ *	json_dbg(1, __func__, "foobar information: %d", value);
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *	 Normally one should NOT include newlines in warn messages.
+ */
+void
+json_dbg(int level, char const *name, char const *fmt, ...)
+{
+    va_list ap;		/* argument pointer */
+    int saved_errno;	/* errno at function start */
+
+    /*
+     * save errno so we can restore it before returning
+     */
+    saved_errno = errno;
+
+    /*
+     * start the var arg setup and fetch our first arg
+     */
+    va_start(ap, fmt);
+
+    /*
+     * firewall
+     */
+    if (name == NULL) {
+	name = "((NULL name))";
+	warn(__func__, "\nin json_dbg(%d, ...): NULL name, forcing use of: %s\n", level, name);
+    }
+    if (fmt == NULL) {
+	fmt = "((NULL fmt))";
+	warn(__func__, "\nin json_dbg(%d, ...): NULL fmt, forcing use of: %s\n", level, fmt);
+    }
+
+    /*
+     * print the debug message if allowed and allowed by the verbosity level
+     */
+    json_vdbg(level, name, fmt, ap);
+
+    /*
+     * clean up stdarg stuff
+     */
+    va_end(ap);
+
+    /*
+     * restore previous errno value
+     */
+    errno = saved_errno;
+    return;
+}
+
+
+/*
+ * json_vdbg - print debug message if we are verbose enough
+ *
+ * given:
+ *	level	    print message if >= verbosity level
+ *	name	    function name
+ *	ap	    va_list
+ *
+ * Example:
+ *
+ *	json_vdbg(1, "jparse", __func__, "foobar information: %d", ap);
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *	 Normally one should NOT include newlines in warn messages.
+ */
+void
+json_vdbg(int level, char const *name, char const *fmt, va_list ap)
+{
+    int ret;		/* libc function return code */
+    int saved_errno;	/* errno at function start */
+
+    /*
+     * save errno so we can restore it before returning
+     */
+    saved_errno = errno;
+
+    /*
+     * firewall
+     */
+    if (name == NULL) {
+	name = "((NULL name))";
+	warn(__func__, "\nin json_vdbg(%d, ...): NULL name, forcing use of: %s\n", level, name);
+    }
+    if (fmt == NULL) {
+	fmt = "((NULL fmt))";
+	warn(__func__, "\nin json_vdbg(%d, ...): NULL fmt, forcing use of: %s\n", level, fmt);
+    }
+
+    /*
+     * print the debug message if allowed and allowed by the verbosity level
+     */
+    if (dbg_output_allowed) {
+	if (level <= verbosity_level) {
+	    errno = 0;
+	    ret = fprintf(stderr, "JSON DEBUG[%d]: ", level);
+	    if (ret < 0) {
+		warn(__func__, "\nin json_vdbg(%d, %s, %s ...): fprintf returned error: %s\n",
+			       level, name, fmt, strerror(errno));
+	    }
+
+	    errno = 0;
+	    ret = vfprintf(stderr, fmt, ap);
+	    if (ret < 0) {
+		warn(__func__, "\nin json_vdbg(%d, %s, %s ...): vfprintf returned error: %s\n",
+			       level, name, fmt, strerror(errno));
+	    }
+
+	    errno = 0;
+	    ret = fputc('\n', stderr);
+	    if (ret != '\n') {
+		warn(__func__, "\nin json_vdbg(%d, %s ...): fputc returned error: %s\n",
+			       level, fmt, strerror(errno));
+	    }
+
+	    errno = 0;
+	    ret = fflush(stderr);
+	    if (ret < 0) {
+		warn(__func__, "\nin json_vdbg(%d, %s, %s ...): fflush returned error: %s\n",
+			       level, name, fmt, strerror(errno));
+	    }
+	}
+    }
+
+    /*
+     * restore previous errno value
+     */
+    errno = saved_errno;
+    return;
+}

--- a/json_util.c
+++ b/json_util.c
@@ -894,7 +894,7 @@ json_dbg(int level, char const *name, char const *fmt, ...)
  *
  * Example:
  *
- *	json_vdbg(1, "jparse", __func__, "foobar information: %d", ap);
+ *	json_vdbg(1, __func__, "foobar information: %d", ap);
  *
  * NOTE: We warn with extra newlines to help internal fault messages stand out.
  *	 Normally one should NOT include newlines in warn messages.

--- a/json_util.h
+++ b/json_util.h
@@ -25,7 +25,13 @@
  * dbg - debug, warning and error reporting facility
  */
 #include "dbg.h"
-
+/*
+ * JSON debug levels
+ */
+#define JSON_DBG_NONE	(DBG_NONE)	/* no JSON debugging information outside of the parser */
+#define JSON_DBG_LOW	(DBG_LOW)	/* minimal JSON debugging information outside of parser */
+#define JSON_DBG_MED	(DBG_MED)	/* somewhat more JSON debugging information outside of parser */
+#define JSON_DBG_LEVEL	(JSON_DBG_LOW)	/* default JSON debugging level json_verbosity_level */
 
 /*
  * JSON warn / error codes

--- a/json_util.h
+++ b/json_util.h
@@ -96,6 +96,7 @@ extern bool show_full_json_warnings;
 /*
  * function prototypes
  */
+
 /* warning and error specific functions */
 extern void jwarn(int code, const char *program, char const *name, char const *filename, char const *line,
 		  int line_num, const char *fmt, ...) \
@@ -109,10 +110,12 @@ extern void jerr(int exitcode, char const *program, const char *name, char const
 extern void jerrp(int exitcode, char const *program, const char *name, char const *filename, char const *line,
 		  int line_num, const char *fmt, ...) \
 	__attribute__((noreturn)) __attribute__((format(printf, 7, 8))); /* 7=format 8=params */
-
 /* ignored warnings via the -W option in jinfochk and jauthchk */
 extern bool is_json_code_ignored(int code);
 extern void ignore_json_code(int code);
-
+/* JSON specific debug functions */
+extern void json_dbg(int level, char const *name, const char *fmt, ...) \
+	__attribute__((format(printf, 3, 4)));		/* 3=format 4=params */
+extern void json_vdbg(int level, char const *name, const char *fmt, va_list ap);
 
 #endif /* INCLUDE_JSON_UTIL_H */

--- a/run_bison.sh
+++ b/run_bison.sh
@@ -475,14 +475,14 @@ use_bison_backup() {
     cp -f -v "$BISON_BACKUP_C" "$BISON_C"
     status="$?"
     if [[ $status -ne 0 ]]; then
-	ech0 "$0: ERROR: failed to copy $BISON_BACKUP_C to $BISON_C exit code: $status" 1>&2
+	echo "$0: ERROR: failed to copy $BISON_BACKUP_C to $BISON_C exit code: $status" 1>&2
 	exit 5
     fi
     echo "cp -f -v $BISON_BACKUP_H $BISON_H"
     cp -f -v "$BISON_BACKUP_H" "$BISON_H"
     status="$?"
     if [[ $status -ne 0 ]]; then
-	ech0 "$0: ERROR: failed to copy $BISON_BACKUP_H to $BISON_H exit code: $status" 1>&2
+	echo "$0: ERROR: failed to copy $BISON_BACKUP_H to $BISON_H exit code: $status" 1>&2
 	exit 5
     fi
 

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -450,7 +450,7 @@ use_flex_backup() {
     cp -f -v "$FLEX_BACKUP_C" "$FLEX_C"
     status="$?"
     if [[ $status -ne 0 ]]; then
-	ech0 "$0: ERROR: failed to copy $FLEX_BACKUP_C to $FLEX_C exit code: $status" 1>&2
+	echo "$0: ERROR: failed to copy $FLEX_BACKUP_C to $FLEX_C exit code: $status" 1>&2
 	exit 5
     fi
 

--- a/sanity.c
+++ b/sanity.c
@@ -36,17 +36,17 @@ ioccc_sanity_chks(void)
      * elements and that the final element is in fact NULL. It also sets up the
      * length of the source and target strings.
      */
-    dbg(DBG_MED, "Running sanity checks on UTF-8 POSIX map ...");
+    dbg(DBG_VVHIGH, "Running sanity checks on UTF-8 POSIX map ...");
     check_utf8_posix_map();
-    dbg(DBG_MED, "... all OK.");
+    dbg(DBG_VVHIGH, "... all OK.");
 
     /*
      * Check that the location table is sane: that there are no embedded NULL
      * elements and that the final element is in fact NULL.
      */
-    dbg(DBG_MED, "Running sanity checks on location table ...");
+    dbg(DBG_VVHIGH, "Running sanity checks on location table ...");
     check_location_table();
-    dbg(DBG_MED, "... all OK.");
+    dbg(DBG_VVHIGH, "... all OK.");
 
     /*
      * Check that the JSON fields tables are sane: that there are no

--- a/util.c
+++ b/util.c
@@ -64,9 +64,9 @@
 
 
 /*
- * hexval - concert ASCII character to hex value
+ * hexval - convert ASCII character to hex value
  *
- * NOTE: -1 means the ASCII character is not a value hex character
+ * NOTE: -1 means the ASCII character is not a valid hex character
  */
 int const hexval[BYTE_VALUES] = {
     /* \x00 - \x0f */


### PR DESCRIPTION
The json_member action now uses json_conv_member(). This means that the
parse_json_member() now is:

    struct json *parse_json_member(struct json *name, struct json *value, struct json *ast);

and the action looks like:

    +json_member:	JSON_STRING JSON_COLON json_element { $$ = *parse_json_member(&$1, &$3, &tree); }

which in the generated code is:

    { yyval = *parse_json_member(&yyvsp[-2], &yyvsp[0], &tree); }

Override default debug level in jparse to be DBG_MED and change
JSON_DBG_LEVEL to DBG_MED. I have the idea that a json debug function
could be added that is prefixed with JSON instead of dbg and which might
take a different variable which would mean that the other tools won't be
chatty but jparse can be. However for now this is not done. I made it
DBG_MED as I don't want too much information as there already is a lot
of information.

Updated some comments and remove duplicate XXX comments (some anyway).
There were comment fixes as well - the functions (except of the one for
arrays) do not return NULL pointers as of some commits ago.

TODO:

* The conversion routines should print better debug information. Right
now it only shows the type but it could also display the value - at
least for ones that have a value that's easy to define (strings being
the most obvious example).

* Add safer handling of union checking in struct json in the parse
functions. This will most likely be done in one of the next few commits
but it's possible it won't be today. But if it's not today it'll be in
the next few days.

* Write the parsing of arrays and verify that everything looks good.
After that we can start thinking about the parse tree and linking the
structs into it.

* Decide if the tree should be a global variable or not. I made it a
global variable yesterday to quickly get it in as I had to get going but
I was making use of the parse_json_() functions so I felt I should pass
in a tree.