### PR TITLE
JSON parser Makefile updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ makefile.local
 
 # parser logs
 jparse.output
+jparse.html


### PR DESCRIPTION
Add new variable BISON_FLAGS:

    # Additional flags to pass to bison
    #
    # For --report all it will generate upon execution (if bison successfully
    # generates the code) the file jparse.output. With --report all --html it will
    # generate a html file which is easier to follow but I'm not sure how portable
    # this is; under CentOS (which does not have the right version but actually
    # normally generates code fine) the error:
    #
    #   jparse.y: error: xsltproc failed with status 127
    #
    # is thrown and since this could happen on other systems even with the
    # appropriate version I have not enabled this.
    #
    # For the -Wcounterexamples it gives counter examples if there are ever
    # shift/reduce conflicts in the grammar. The other warnings are of use as well.
    #
    # NOTE: We include required flags like -d here but we explicitly include them in
    # the run_bison.sh call as well. This is to make sure that they're there and not
    # disabled via a user override or because of a mistake here.
    #
    BISON_FLAGS = -Werror --report all -Wcounterexamples -Wmidrule-values \
		  -Wprecedence -Wdeprecated -d

This enables some additional warnings and turns them into errors. Note
that -d is also in the call to run_bison.sh after the BISON_FLAGS is
referenced because it's possible to override the BISON_FLAGS in
makefile.local (as I do in fact on the macOS for html output).

Add new variable FLEX_FLAGS:

    # flags to pass to flex
    #
    # NOTE: We include required flags like -d -8 here but we explicitly include them
    # in the run_flex.sh call as well. This is to make sure that they're there and
    # not disabled via a user override or because of a mistake here.
    FLEX_FLAGS = -d -8

Add jparse.html to be deleted in make clobber.

Add jparse.html to .gitignore.