### PR TITLE
JSON parser now allows NUL bytes - resolve #208

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -110,6 +110,7 @@ extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern bool output_newline;		/* true ==> -n not specified, output new line after each arg processed */
 extern int token;			/* for braces, brackets etc.: '{', '}', '[', ']', ':' and so on */
 extern struct json tree;		/* the parse tree */
+extern int ugly_length;			/* for regex length: needed in some cases in parser (where ugly_leng does not exist) */
 
 /*
  * function prototypes
@@ -133,7 +134,7 @@ void parse_json_block(char const *string, size_t len);  /* parse a string as a J
  *
  * XXX - these are subject to change and some are incomplete as well - XXX
  */
-struct json *parse_json_string(char const *string);
+struct json *parse_json_string(char const *string, size_t len);
 struct json *parse_json_number(char const *string);
 struct json *parse_json_bool(char const *string);
 struct json *parse_json_null(char const *string);

--- a/jparse.l
+++ b/jparse.l
@@ -101,6 +101,8 @@
 /* our header file - #includes what we need */
 #include "jparse.h"
 
+int ugly_length = 0;
+
 /*
  * An exception where the prefix does not change YY to UGLY_ is YY_BUFFER_STATE
  * but because it IS ugly we have done it for them in jparse.h so that where one
@@ -161,6 +163,7 @@ JSON_COMMA		","
 
 {JSON_STRING}		{
 			    /* string */
+			    ugly_length = ugly_leng;
 			    printf("\nstring: <%s>\n", ugly_text);
 			    return JSON_STRING;
 			}

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -881,8 +881,8 @@ int yy_flex_debug = 1;
 
 static const flex_int16_t yy_rule_linenum[14] =
     {   0,
-      152,  162,  168,  174,  180,  185,  191,  196,  203,  209,
-      216,  223,  230
+      154,  164,  171,  177,  183,  188,  194,  199,  206,  212,
+      219,  226,  233
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -991,13 +991,15 @@ char *yytext;
 /* our header file - #includes what we need */
 #include "jparse.h"
 
+int ugly_length = 0;
+
 /*
  * An exception where the prefix does not change YY to UGLY_ is YY_BUFFER_STATE
  * but because it IS ugly we have done it for them in jparse.h so that where one
  * sees UGLY__BUFFER_STATE it's actually YY_BUFFER_STATE.
  */
 UGLY__BUFFER_STATE bs;
-#line 949 "jparse.c"
+#line 951 "jparse.c"
 /*
  * Section 2: Patterns (regular expressions) and actions.
  */
@@ -1019,7 +1021,7 @@ UGLY__BUFFER_STATE bs;
  * don't have to worry about complicating the parser unnecessarily.
  */
 /* Actions. */
-#line 971 "jparse.c"
+#line 973 "jparse.c"
 
 #define INITIAL 0
 
@@ -1299,9 +1301,9 @@ YY_DECL
 
 	{
 /* %% [7.0] user's declarations go here */
-#line 151 "jparse.l"
+#line 153 "jparse.l"
 
-#line 1253 "jparse.c"
+#line 1255 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1394,7 +1396,7 @@ do_action:	/* This label is used only to access EOF actions. */
 case 1:
 /* rule 1 can match eol */
 YY_RULE_SETUP
-#line 152 "jparse.l"
+#line 154 "jparse.l"
 {
 			    /*
 			     * Whitespace
@@ -1407,16 +1409,17 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 162 "jparse.l"
+#line 164 "jparse.l"
 {
 			    /* string */
+			    ugly_length = ugly_leng;
 			    printf("\nstring: <%s>\n", ugly_text);
 			    return JSON_STRING;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 168 "jparse.l"
+#line 171 "jparse.l"
 {
 			    /* number */
 			    printf("\nnumber: <%s>\n", ugly_text);
@@ -1425,7 +1428,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 174 "jparse.l"
+#line 177 "jparse.l"
 {
 			    /* null object */
 			    printf("\nnull: <%s>\n", ugly_text);
@@ -1434,7 +1437,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 180 "jparse.l"
+#line 183 "jparse.l"
 {
 			    /* boolean: true */
 			    printf("\ntrue: <%s>\n", ugly_text);
@@ -1443,7 +1446,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 185 "jparse.l"
+#line 188 "jparse.l"
 {
 			    /* boolean: false */
 			    printf("\nfalse: <%s>\n", ugly_text);
@@ -1452,7 +1455,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 191 "jparse.l"
+#line 194 "jparse.l"
 {
 			    /* start of object */
 			    printf("\nstart of object: <%c>\n", *ugly_text);
@@ -1461,7 +1464,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 196 "jparse.l"
+#line 199 "jparse.l"
 {
 			    /* end of object */
 			    printf("\nend of object: <%c>\n", *ugly_text);
@@ -1471,7 +1474,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 203 "jparse.l"
+#line 206 "jparse.l"
 {
 			    /* start of array */
 			    printf("\nstart of array: <%c>\n", *ugly_text);
@@ -1481,7 +1484,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 209 "jparse.l"
+#line 212 "jparse.l"
 {
 			    /* end of array */
 			    printf("\nend of array: <%c>\n", *ugly_text);
@@ -1491,7 +1494,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 216 "jparse.l"
+#line 219 "jparse.l"
 {
 			    /* colon or 'equals' */
 			    printf("\ncolon (or 'equals'): <%c>\n", *ugly_text);
@@ -1501,7 +1504,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 223 "jparse.l"
+#line 226 "jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    printf("\ncomma: <%c>\n", *ugly_text);
@@ -1511,7 +1514,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 230 "jparse.l"
+#line 233 "jparse.l"
 {
 			    /* invalid token: any other character */
 			    ugly_error("\ninvalid token: 0x%02x = <%c>\n", *ugly_text, *ugly_text);
@@ -1520,10 +1523,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 236 "jparse.l"
+#line 239 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1475 "jparse.c"
+#line 1478 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2683,7 +2686,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 236 "jparse.l"
+#line 239 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2368,7 +2368,7 @@ ugly_error(char const *format, ...)
 }
 
 /*
- * XXX - these functions are incomplete and subject to change - XXX
+ * XXX - some of these functions are incomplete and subject to change - XXX
  */
 
 
@@ -2383,7 +2383,7 @@ ugly_error(char const *format, ...)
  *
  * NOTE: The len is important for strings that have NUL bytes: without it we
  * would rely on strlen() which would mean that the first NUL byte would be the
- * end of the string.
+ * end of the string. If len <= 0 this function uses strlen() on the string.
  *
  * NOTE: This function does not return if passed a NULL string or if conversion
  * fails.

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1956,7 +1956,7 @@ yyreduce:
   case 32: /* json_string: JSON_STRING  */
 #line 337 "jparse.y"
                         {
-			    yyval = parse_json_string(ugly_text);
+			    yyval = parse_json_string(ugly_text, ugly_length);
 			    json_dbg(JSON_DBG_MED, __func__, "under json_string: after JSON_STRING returning type: %s",
 						   json_element_type_name(yyval));
 			    json_dbg(JSON_DBG_LOW, __func__, "under json_string: after JSON_STRING before ;");
@@ -2377,14 +2377,19 @@ ugly_error(char const *format, ...)
  * given:
  *
  *	string	    - the text that triggered the action
+ *	len	    - length of the string to convert (important for NUL bytes)
  *
  * Returns a pointer to a struct json with the converted string.
+ *
+ * NOTE: The len is important for strings that have NUL bytes: without it we
+ * would rely on strlen() which would mean that the first NUL byte would be the
+ * end of the string.
  *
  * NOTE: This function does not return if passed a NULL string or if conversion
  * fails.
  */
 struct json *
-parse_json_string(char const *string)
+parse_json_string(char const *string, size_t len)
 {
     struct json *str = NULL;
     struct json_string *item = NULL;
@@ -2397,12 +2402,16 @@ parse_json_string(char const *string)
 	not_reached();
     }
 
-    json_dbg(json_verbosity_level, __func__, "about to parse string: <%s>", string);
+    /* obtain length if necessary */
+    if (len <= 0)
+	len = strlen(string);
+
+    json_dbg(json_verbosity_level, __func__, "about to parse string of length %ju: <%s>", (uintmax_t)len, string);
     /*
      * we say that quote == true because the pattern in the lexer will include
      * the '"'s.
      */
-    str = json_conv_string_str(string, NULL, true);
+    str = json_conv_string(string, len, true);
     /* paranoia - these tests should never result in an error */
     if (str == NULL) {
         err(41, __func__, "converting JSON string returned NULL: <%s>", string);

--- a/jparse.y
+++ b/jparse.y
@@ -335,7 +335,7 @@ json_element:	    json_value
 
 json_string:	    JSON_STRING
 			{
-			    $$ = parse_json_string(ugly_text);
+			    $$ = parse_json_string(ugly_text, ugly_length);
 			    json_dbg(JSON_DBG_MED, __func__, "under json_string: after JSON_STRING returning type: %s",
 						   json_element_type_name($$));
 			    json_dbg(JSON_DBG_LOW, __func__, "under json_string: after JSON_STRING before ;");
@@ -510,7 +510,7 @@ ugly_error(char const *format, ...)
 }
 
 /*
- * XXX - these functions are incomplete and subject to change - XXX
+ * XXX - some of these functions are incomplete and subject to change - XXX
  */
 
 
@@ -519,14 +519,19 @@ ugly_error(char const *format, ...)
  * given:
  *
  *	string	    - the text that triggered the action
+ *	len	    - length of the string to convert (important for NUL bytes)
  *
  * Returns a pointer to a struct json with the converted string.
+ *
+ * NOTE: The len is important for strings that have NUL bytes: without it we
+ * would rely on strlen() which would mean that the first NUL byte would be the
+ * end of the string. If len <= 0 this function uses strlen() on the string.
  *
  * NOTE: This function does not return if passed a NULL string or if conversion
  * fails.
  */
 struct json *
-parse_json_string(char const *string)
+parse_json_string(char const *string, size_t len)
 {
     struct json *str = NULL;
     struct json_string *item = NULL;
@@ -539,12 +544,16 @@ parse_json_string(char const *string)
 	not_reached();
     }
 
-    json_dbg(json_verbosity_level, __func__, "about to parse string: <%s>", string);
+    /* obtain length if necessary */
+    if (len <= 0)
+	len = strlen(string);
+
+    json_dbg(json_verbosity_level, __func__, "about to parse string of length %ju: <%s>", (uintmax_t)len, string);
     /*
      * we say that quote == true because the pattern in the lexer will include
      * the '"'s.
      */
-    str = json_conv_string_str(string, NULL, true);
+    str = json_conv_string(string, len, true);
     /* paranoia - these tests should never result in an error */
     if (str == NULL) {
         err(41, __func__, "converting JSON string returned NULL: <%s>", string);

--- a/jstrdecode.1
+++ b/jstrdecode.1
@@ -1,8 +1,8 @@
-.TH jstrdecode 1 "28 April 2022" "jstrdecode" "IOCCC tools"
+.TH jstrdecode 1 "18 May 2022" "jstrdecode" "IOCCC tools"
 .SH NAME
 jstrdecode \- decode JSON encoded strings
 .SH SYNOPSIS
-\fBjstrdecode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [string ...]
+\fBjstrdecode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [\-Q] [string ...]
 .SH DESCRIPTION
 \fBjstrdecode\fP decodes JSON encoded strings given on the command line.
 If given the \fB\-t\fP option it performs a test on the JSON decode and encode functions.
@@ -27,6 +27,9 @@ Run tests on the JSON decode/encode functions.
 .PP
 \fB\-n\fP
 Do not output a newline after the decode function.
+.PP
+\fB\-Q\fP
+Enclose output in quotes (def: do not).
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 1 for errors or issues found; 0 for success.

--- a/jstrencode.1
+++ b/jstrencode.1
@@ -1,8 +1,8 @@
-.TH jstrencode 1 "28 April 2022" "jstrencode" "IOCCC tools"
+.TH jstrencode 1 "18 May 2022" "jstrencode" "IOCCC tools"
 .SH NAME
 jstrencode \- encode JSON encoded strings
 .SH SYNOPSIS
-\fBjstrencode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [string ...]
+\fBjstrencode [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [\-Q] [string ...]
 .SH DESCRIPTION
 \fBjstrencode\fP encodes JSON encoded strings given on the command line.
 If given the \fB\-t\fP option it performs a test on the JSON encode and encode functions.
@@ -27,6 +27,9 @@ Run tests on the JSON encode/encode functions.
 .PP
 \fB\-n\fP
 Do not output a newline after the encode function.
+.PP
+\fB\-Q\fP
+Enclose output in quotes (def: do not).
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 1 for errors or issues found; 0 for success.


### PR DESCRIPTION
If a string (or a file) has a NUL byte not within a string it is a
syntax error in the parser and parsing will not continue. If however a
NUL byte is in a string it will be accepted.

The way this works is quite simple. The string regex already allowed for
NUL bytes and the default rule (that we define later) in the lexer does
not allow for NUL bytes. Now in the lexer we have the length of each
pattern that matched in ugly_leng. This variable does not exist in bison
though so for each string matched we set ugly_length to ugly_leng
(perhaps this should always be done?). Now the parse_json_string()
function has changed to be:

    /* parse_json_string - parse a json string
     *
     * given:
     *
     *	string	    - the text that triggered the action
     *	len	    - length of the string to convert (important for NUL bytes)
     *
     * Returns a pointer to a struct json with the converted string.
     *
     * NOTE: The len is important for strings that have NUL bytes: without it we
     * would rely on strlen() which would mean that the first NUL byte would be the
     * end of the string. If len <= 0 this function uses strlen() on the string.
     *
     * NOTE: This function does not return if passed a NULL string or if conversion
     * fails.
     */
    struct json *
    parse_json_string(char const *string, size_t len)
    {
    }

Then in the bison grammar rule for string the action looks like:

    json_string: JSON_STRING
		    {
			$$ = parse_json_string(ugly_text, ugly_length);
			json_dbg(JSON_DBG_MED, __func__, "under json_string: after JSON_STRING returning type: %s",
					   json_element_type_name($$));
			json_dbg(JSON_DBG_LOW, __func__, "under json_string: after JSON_STRING before ;");
		    }
		    ;

The important line is the one that calls parse_json_string():

    $$ = parse_json_string(ugly_text, ugly_length);

An important thing to note is that when the debug functions show what is
about to be parsed has a NUL byte it will stop at the first NUL so that
for a file that has a NUL byte between two "s you would see:

    JSON DEBUG[1]: Calling parse_json_block(""", 4):
    JSON DEBUG[1]: *** BEGIN PARSE:
    <
    "
    >

because the NUL byte after the first '"' makes the debug function think
it's reached the end of the string. There are a few ways to go about
solving this which I'm going to bring up on the GitHub issue as this is
already much too long.

In any case this resolves issue #208 for both files with NUL bytes as
well as strings on the command line with NUL bytes.