### PR TITLE
Various updates

### DIFF
--- a/jparse.l
+++ b/jparse.l
@@ -352,7 +352,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid, FILE *dbg_stream)
     ugly_parse();
 
     /*
-     * scan and parse cleanup
+     * scan and parse clean up
      */
     ugly__delete_buffer(bs);
     bs = NULL;
@@ -548,7 +548,7 @@ parse_json_file(char const *filename, bool *is_valid, FILE *dbg_stream)
     }
     if (len <= 0) {
 
-	/* warn about emptuy file */
+	/* warn about empty file */
 	warn(__func__, "%s is empty", is_stdin?"stdin":filename);
 	++num_errors;
 	clearerr_or_fclose(filename, ugly_in);

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2803,7 +2803,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid, FILE *dbg_stream)
     ugly_parse();
 
     /*
-     * scan and parse cleanup
+     * scan and parse clean up
      */
     ugly__delete_buffer(bs);
     bs = NULL;
@@ -2999,7 +2999,7 @@ parse_json_file(char const *filename, bool *is_valid, FILE *dbg_stream)
     }
     if (len <= 0) {
 
-	/* warn about emptuy file */
+	/* warn about empty file */
 	warn(__func__, "%s is empty", is_stdin?"stdin":filename);
 	++num_errors;
 	clearerr_or_fclose(filename, ugly_in);

--- a/jparse_test.sh
+++ b/jparse_test.sh
@@ -217,11 +217,9 @@ else
 
 	# process all lines in test file
 	#
-	# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-	# shellcheck disable=SC2002
-	cat "$JSON_TEST_FILE" | while read -r JSON_DOC; do
+	while read -r JSON_DOC; do
 	    run_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC"
-	done
+	done < "$JSON_TEST_FILE"
 
     done
 fi

--- a/jparse_test.sh
+++ b/jparse_test.sh
@@ -97,7 +97,7 @@ if [[ ! -f "${LOGFILE}" ]]; then
     exit 5
 fi
 if [[ ! -w "${LOGFILE}" ]]; then
-    echo "$0: ERROR: log file not writeable" 1>&2
+    echo "$0: ERROR: log file not writable" 1>&2
     exit 5
 fi
 

--- a/json_parse.c
+++ b/json_parse.c
@@ -1,36 +1,28 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * json_parse - JSON parse tree supporting functions
- *
- * JSON related functions to support formation of .info.json files
- * and .author.json files, their related check tools, test code,
- * and string encoding/decoding tools.
+ * json_parse - JSON parser support code
  *
  * "Because JSON embodies a commitment to original design flaws." :-)
  *
- * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
+ * JSON parser support code for the eventual jinfochk and jauthchk tools to
+ * verify the .info.json and .author.json files created by mkiocccentry. This
+ * file has the parse functions as well as functions that these functions use to
+ * construct the parse tree etc.
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ * This is currently being worked on by:
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * and
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
  *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * Share and enjoy! :-)
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
+ * well as json_util.c and json_util.h.
+ *
  */
 
 

--- a/json_parse.h
+++ b/json_parse.h
@@ -34,8 +34,8 @@
  */
 
 
-#if !defined(INCLUDE_JSON_H)
-#    define  INCLUDE_JSON_H
+#if !defined(INCLUDE_JSON_PARSE_H)
+#    define  INCLUDE_JSON_PARSE_H
 
 
 #include <time.h>
@@ -466,4 +466,4 @@ extern struct json *parse_json_array(char const *string, struct json *ast);
 extern struct json *parse_json_member(struct json *name, struct json *value, struct json *ast);
 
 
-#endif /* INCLUDE_JSON_H */
+#endif /* INCLUDE_JSON_PARSE_H */

--- a/json_parse.h
+++ b/json_parse.h
@@ -1,36 +1,28 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * json_parse - JSON functions supporting mkiocccentry code
- *
- * JSON related functions to support formation of .info.json files
- * and .author.json files, their related check tools, test code,
- * and string encoding/decoding tools.
+ * json_parse - JSON parser support code
  *
  * "Because JSON embodies a commitment to original design flaws." :-)
  *
- * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
+ * JSON parser support code for the eventual jinfochk and jauthchk tools to
+ * verify the .info.json and .author.json files created by mkiocccentry. This
+ * file has the parse functions as well as functions that these functions use to
+ * construct the parse tree etc.
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ * This is currently being worked on by:
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * and
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
  *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * Share and enjoy! :-)
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
+ * well as json_util.c and json_util.h.
+ *
  */
 
 

--- a/json_test.sh
+++ b/json_test.sh
@@ -121,7 +121,7 @@ if [[ ! -f "${LOGFILE}" ]]; then
     exit 5
 fi
 if [[ ! -w "${LOGFILE}" ]]; then
-    echo "$0: ERROR: log file not writeable" 1>&2
+    echo "$0: ERROR: log file not writable" 1>&2
     exit 5
 fi
 

--- a/json_util.c
+++ b/json_util.c
@@ -2,21 +2,22 @@
 /*
  * json_util - general JSON parser utility support functions
  *
- * "Because sometimes even the IOCCC Judges need some help." :-)
+ * "Because JSON embodies a commitment to original design flaws." :-)
  *
  * This is currently being worked on by:
+ *
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * and
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
  *
- * and
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * This is very much a work in progress!
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
+ * well as json_util.c and json_util.h.
  */
-
 
 #include <stdio.h>
 #include <string.h>

--- a/json_util.h
+++ b/json_util.h
@@ -2,19 +2,21 @@
 /*
  * json_util - general JSON parser utility support functions
  *
- * "Because sometimes even the IOCCC Judges need some help." :-)
+ * "Because JSON embodies a commitment to original design flaws." :-)
  *
  * This is currently being worked on by:
+ *
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * and
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
  *
- * and
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * This is very much a work in progress!
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
+ * well as json_util.c and json_util.h.
  */
 
 


### PR DESCRIPTION
Contrary to what vim thinks the word is 'writable' is not a regional
spelling for 'writeable'. The word is 'writable' full stop. That
/usr/share/dict/words has it in under linux and macOS does not change
the fact it's both incorrect and not even a word so spelt (iOS also has
both, interestingly) even if it might make more sense (to some people).
The thing is spelling often does not make sense. For an amusing and
ironic example: short is longer than long. Possibly it's modelled after
other words like uniteable (alternative spelling for unitable though vim
does not recognise either word and neither do some other dictionaries
but both mean some things/people that can be united). But I've digressed
well beyond the point due to my love of words. The point is writable is
the correct spelling.