### PR TITLE
Various bug fixes and updates to do with json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ jauthchk.o: jauthchk.c jauthchk.h json_util.h Makefile
 	${CC} ${CFLAGS} jauthchk.c -c
 
 jauthchk: jauthchk.o rule_count.o json_parse.o json_entry.o dbg.o util.o json_util.o \
-	dyn_array.o sanity.o location.o utf8_posix_map.o Makefile
+	dyn_array.o sanity.o location.o utf8_posix_map.o json_chk.o Makefile
 	${CC} ${CFLAGS} jauthchk.o rule_count.o json_parse.o json_entry.o dbg.o util.o json_util.o \
 	    dyn_array.o sanity.o json_chk.o location.o utf8_posix_map.o -o $@
 
@@ -421,7 +421,7 @@ jinfochk.o: jinfochk.c jinfochk.h json_util.h Makefile
 	${CC} ${CFLAGS} jinfochk.c -c
 
 jinfochk: jinfochk.o rule_count.o json_parse.o json_entry.o dbg.o util.o json_util.o \
-	dyn_array.o sanity.o location.o utf8_posix_map.o Makefile
+	dyn_array.o sanity.o location.o utf8_posix_map.o json_chk.o Makefile
 	${CC} ${CFLAGS} jinfochk.o rule_count.o json_parse.o json_entry.o dbg.o util.o json_util.o \
 	    dyn_array.o sanity.o json_chk.o location.o utf8_posix_map.o -o $@
 

--- a/jauthchk.c
+++ b/jauthchk.c
@@ -833,6 +833,16 @@ check_found_author_json_fields(char const *json_filename, bool test)
 		 * NOTE: Don't increment issues because this doesn't mean
 		 * there's anything wrong with the .author.json file but rather
 		 * that the field isn't verified.
+		 *
+		 * XXX On the other hand it can result in a false positive of a
+		 * valid test so this has to be carefully considered. However
+		 * since the jinfochk and jauthchk tools will change
+		 * dramatically this function might not even exist (or if it
+		 * does it'll be very different). Either the idea that an
+		 * unhandled field is not an issue with the file could be
+		 * reassessed even if an unhandled field is actually a problem
+		 * with the tools themselves. This same logic applies to the
+		 * .info.json and common fields check functions.
 		 */
 	    }
 	}

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -1436,6 +1436,16 @@ check_found_info_json_fields(char const *json_filename, bool test)
 		 * NOTE: Don't increment issues because this doesn't mean
 		 * there's anything wrong with the .info.json file but rather
 		 * that the field isn't verified.
+		 *
+		 * XXX On the other hand it can result in a false positive of a
+		 * valid test so this has to be carefully considered. However
+		 * since the jinfochk and jauthchk tools will change
+		 * dramatically this function might not even exist (or if it
+		 * does it'll be very different). Either the idea that an
+		 * unhandled field is not an issue with the file could be
+		 * reassessed even if an unhandled field is actually a problem
+		 * with the tools themselves. This same logic applies to the
+		 * .author.json and common fields check functions.
 		 */
 	    }
 	}
@@ -1697,7 +1707,7 @@ main(int argc, char **argv)
     /* free any allocated memory in our info struct */
     free_info(&info);
 
-    if (issues != 0 && !test) {
+    if (issues != 0) {
 	dbg(DBG_LOW, "%s is invalid", file);
     }
     /*

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2136,7 +2136,7 @@ yyreduce:
 					 "json_elements: json_elements JSON_COMMA json_element");
 	json_dbg(JSON_DBG_MED, __func__, "under json_elements: $1 ($json_elements) type: %s",
 					 json_element_type_name(yyvsp[-2]));
-	json_dbg(JSON_DBG_MED, __func__, "under json_element: $3 ($json_element) type: %s",
+	json_dbg(JSON_DBG_MED, __func__, "under json_elements: $3 ($json_element) type: %s",
 					 json_element_type_name(yyvsp[0]));
 	json_dbg(JSON_DBG_MED, __func__, "under json_elements: about to perform: "
 					 "XXX - need more code here - XXX");

--- a/jparse.y
+++ b/jparse.y
@@ -604,7 +604,7 @@ json_elements:
 					 "json_elements: json_elements JSON_COMMA json_element");
 	json_dbg(JSON_DBG_MED, __func__, "under json_elements: $1 ($json_elements) type: %s",
 					 json_element_type_name($1));
-	json_dbg(JSON_DBG_MED, __func__, "under json_element: $3 ($json_element) type: %s",
+	json_dbg(JSON_DBG_MED, __func__, "under json_elements: $3 ($json_element) type: %s",
 					 json_element_type_name($3));
 	json_dbg(JSON_DBG_MED, __func__, "under json_elements: about to perform: "
 					 "XXX - need more code here - XXX");

--- a/json_chk.c
+++ b/json_chk.c
@@ -987,6 +987,13 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 		    test_mode = strtobool(val);
 		    dbg(DBG_LOW, "set test_mode to %s", test_mode?"true":"false");
 		}
+	    } else if (!strcmp(field->name, JSON_PARSING_DIRECTIVE_NAME)) {
+		if (strcmp(val, JSON_PARSING_DIRECTIVE_VALUE)) {
+		    warn(__func__, "%s != \"%s\" in file %s: \"%s\"",
+				   JSON_PARSING_DIRECTIVE_NAME, JSON_PARSING_DIRECTIVE_VALUE,
+				   json_filename, val);
+		    ++issues;
+		}
 
 	    } else {
 		/*
@@ -1000,6 +1007,16 @@ check_found_common_json_fields(char const *program, char const *json_filename, c
 		 * NOTE: Don't increment issues because this doesn't mean
 		 * there's anything wrong with the json file but rather that the
 		 * field isn't verified.
+		 *
+		 * XXX On the other hand it can result in a false positive of a
+		 * valid test so this has to be carefully considered. However
+		 * since the jinfochk and jauthchk tools will change
+		 * dramatically this function might not even exist (or if it
+		 * does it'll be very different). Either the idea that an
+		 * unhandled field is not an issue with the file could be
+		 * reassessed even if an unhandled field is actually a problem
+		 * with the tools themselves. This same logic applies to the
+		 * .info.json and .author.json fields check functions.
 		 */
 	    }
 


### PR DESCRIPTION
Primarily an unhandled field was added to the check function (the no-comment one). There was also a problem in that the Makefile did not have for jinfochk and jauthchk the dependency `json_chk.o` so updating `json_chk.c` would not result in recompilation of those tools. 

Those are the bugs I refer to but perhaps JSON should itself be called a bug or maybe a virus. Probably not as I don't know that I would call it efficient (but I might be a tad bit biased). Well ... just something to think about maybe.