### PR TITLE
Add hack for better json error messages + minor comment updates

### DIFF
--- a/jparse.l
+++ b/jparse.l
@@ -154,8 +154,12 @@ JSON_COMMA		","
 			    /*
 			     * Whitespace
 			     *
-			     * Not needed but included for now for debugging
-			     * purposes.
+			     * NOTE: We have to include this action as otherwise
+			     * the action '.' will return an invalid token to
+			     * the parser.
+			     *
+			     * We don't need the below message but for debugging
+			     * purposes we have it printed for now.
 			     */
 			    fprintf(stderr, "\nignoring %ju whitespace%s\n", (uintmax_t)ugly_leng, yyleng==1?"":"s");
 			}
@@ -215,7 +219,31 @@ JSON_COMMA		","
 .			{
 			    /* invalid token: any other character */
 			    ugly_error(NULL, "\ninvalid token: 0x%02x = <%c>\n", *ugly_text, *ugly_text);
-			    return JSON_INVALID_TOKEN;
+			    /*
+			     * This is a hack for better error messages with
+			     * invalid tokens. Bison syntax error messages are
+			     * in the form of:
+			     *
+			     *	    syntax error, unexpected <token name>
+			     *	    syntax error, unexpected <token name>, expecting } or JSON_STRING
+			     *
+			     * etc. where <token name> is whatever we return
+			     * here in the lexer actions (e.g.  JSON_STRING or
+			     * in this case literally token) to the parser. But
+			     * the problem is what do we call an invalid token
+			     * without knowing what what the token actually is?
+			     * Thus we call it token so that it will read
+			     * literally as 'unexpected token' which removes any
+			     * ambiguity (it could be read as 'it's unexpected
+			     * in this place but it is valid in other contexts'
+			     * but it's never actually valid: it's a catch all
+			     * for anything that's not valid.
+			     *
+			     * In jparse.y there are some features that would be
+			     * nice to have that would make this much less a
+			     * problem but if they exist I'm unaware of them.
+			     */
+			    return token;
 			}
 
 %%

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -881,8 +881,8 @@ int yy_flex_debug = 1;
 
 static const flex_int16_t yy_rule_linenum[14] =
     {   0,
-      153,  163,  168,  173,  178,  182,  187,  191,  196,  200,
-      205,  210,  215
+      153,  167,  172,  177,  182,  186,  191,  195,  200,  204,
+      209,  214,  219
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -1400,15 +1400,19 @@ YY_RULE_SETUP
 			    /*
 			     * Whitespace
 			     *
-			     * Not needed but included for now for debugging
-			     * purposes.
+			     * NOTE: We have to include this action as otherwise
+			     * the action '.' will return an invalid token to
+			     * the parser.
+			     *
+			     * We don't need the below message but for debugging
+			     * purposes we have it printed for now.
 			     */
 			    fprintf(stderr, "\nignoring %ju whitespace%s\n", (uintmax_t)ugly_leng, yyleng==1?"":"s");
 			}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 163 "jparse.l"
+#line 167 "jparse.l"
 {
 			    /* string */
 			    return JSON_STRING;
@@ -1416,7 +1420,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 168 "jparse.l"
+#line 172 "jparse.l"
 {
 			    /* number */
 			    return JSON_NUMBER;
@@ -1424,7 +1428,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 173 "jparse.l"
+#line 177 "jparse.l"
 {
 			    /* null object */
 			    return JSON_NULL;
@@ -1432,7 +1436,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 178 "jparse.l"
+#line 182 "jparse.l"
 {
 			    /* boolean: true */
 			    return JSON_TRUE;
@@ -1440,7 +1444,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 182 "jparse.l"
+#line 186 "jparse.l"
 {
 			    /* boolean: false */
 			    return JSON_FALSE;
@@ -1448,7 +1452,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 187 "jparse.l"
+#line 191 "jparse.l"
 {
 			    /* start of object */
 			    return JSON_OPEN_BRACE;
@@ -1456,7 +1460,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 191 "jparse.l"
+#line 195 "jparse.l"
 {
 			    /* end of object */
 			    return JSON_CLOSE_BRACE;
@@ -1464,7 +1468,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 196 "jparse.l"
+#line 200 "jparse.l"
 {
 			    /* start of array */
 			    return JSON_OPEN_BRACKET;
@@ -1472,7 +1476,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 200 "jparse.l"
+#line 204 "jparse.l"
 {
 			    /* end of array */
 			    return JSON_CLOSE_BRACKET;
@@ -1480,7 +1484,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 205 "jparse.l"
+#line 209 "jparse.l"
 {
 			    /* colon or 'equals' */
 			    return JSON_COLON;
@@ -1488,7 +1492,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 210 "jparse.l"
+#line 214 "jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    return JSON_COMMA;
@@ -1496,19 +1500,43 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 215 "jparse.l"
+#line 219 "jparse.l"
 {
 			    /* invalid token: any other character */
 			    ugly_error(NULL, "\ninvalid token: 0x%02x = <%c>\n", *ugly_text, *ugly_text);
-			    return JSON_INVALID_TOKEN;
+			    /*
+			     * This is a hack for better error messages with
+			     * invalid tokens. Bison syntax error messages are
+			     * in the form of:
+			     *
+			     *	    syntax error, unexpected <token name>
+			     *	    syntax error, unexpected <token name>, expecting } or JSON_STRING
+			     *
+			     * etc. where <token name> is whatever we return
+			     * here in the lexer actions (e.g.  JSON_STRING or
+			     * in this case literally token) to the parser. But
+			     * the problem is what do we call an invalid token
+			     * without knowing what what the token actually is?
+			     * Thus we call it token so that it will read
+			     * literally as 'unexpected token' which removes any
+			     * ambiguity (it could be read as 'it's unexpected
+			     * in this place but it is valid in other contexts'
+			     * but it's never actually valid: it's a catch all
+			     * for anything that's not valid.
+			     *
+			     * In jparse.y there are some features that would be
+			     * nice to have that would make this much less a
+			     * problem but if they exist I'm unaware of them.
+			     */
+			    return token;
 			}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 221 "jparse.l"
+#line 249 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1460 "jparse.c"
+#line 1488 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2668,7 +2696,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 221 "jparse.l"
+#line 249 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -182,7 +182,7 @@ enum yysymbol_kind_t
   YYSYMBOL_JSON_FALSE = 11,                /* "false"  */
   YYSYMBOL_JSON_STRING = 12,               /* JSON_STRING  */
   YYSYMBOL_JSON_NUMBER = 13,               /* JSON_NUMBER  */
-  YYSYMBOL_JSON_INVALID_TOKEN = 14,        /* JSON_INVALID_TOKEN  */
+  YYSYMBOL_token = 14,                     /* token  */
   YYSYMBOL_YYACCEPT = 15,                  /* $accept  */
   YYSYMBOL_json = 16,                      /* json  */
   YYSYMBOL_json_value = 17,                /* json_value  */
@@ -496,18 +496,18 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  23
+#define YYFINAL  22
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   32
+#define YYLAST   30
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  15
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  11
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  22
+#define YYNRULES  21
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  32
+#define YYNSTATES  31
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   269
@@ -557,9 +557,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   163,   163,   191,   217,   243,   269,   295,   320,   345,
-     372,   398,   423,   449,   483,   514,   540,   565,   591,   624,
-     649,   657,   684
+       0,   185,   185,   213,   239,   265,   291,   317,   342,   367,
+     394,   420,   445,   471,   505,   536,   562,   587,   613,   646,
+     674,   701
 };
 #endif
 
@@ -577,8 +577,8 @@ static const char *const yytname[] =
 {
   "\"end of file\"", "error", "\"invalid token\"", "\"{\"", "\"}\"",
   "\"[\"", "\"]\"", "\",\"", "\":\"", "\"null\"", "\"true\"", "\"false\"",
-  "JSON_STRING", "JSON_NUMBER", "JSON_INVALID_TOKEN", "$accept", "json",
-  "json_value", "json_object", "json_members", "json_member", "json_array",
+  "JSON_STRING", "JSON_NUMBER", "token", "$accept", "json", "json_value",
+  "json_object", "json_members", "json_member", "json_array",
   "json_elements", "json_element", "json_string", "json_number", YY_NULLPTR
 };
 
@@ -589,7 +589,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-7)
+#define YYPACT_NINF (-6)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -603,10 +603,10 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      18,     2,    -1,    -7,    -7,    -7,    -7,    -7,    -7,     3,
-      -7,    -7,    -7,    -7,    -7,    -7,    -7,    11,    -7,    12,
-      -7,    10,    -7,    -7,    -7,    -5,    18,    -7,    18,    -7,
-      -7,    -7
+      17,     2,    -1,    -6,    -6,    -6,    -6,    -6,     3,    -6,
+      -6,    -6,    -6,    -6,    -6,    -6,     9,    -6,     7,    -6,
+      11,    -6,    -6,    -6,    -5,    17,    -6,    17,    -6,    -6,
+      -6
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -614,24 +614,24 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       0,     0,     0,     9,     7,     8,    21,    22,    20,     0,
-      19,     3,     4,     2,     5,     6,    11,     0,    12,     0,
-      16,     0,    17,     1,    10,     0,     0,    15,     0,    13,
-      14,    18
+       0,     0,     0,     9,     7,     8,    20,    21,     0,    19,
+       3,     4,     2,     5,     6,    11,     0,    12,     0,    16,
+       0,    17,     1,    10,     0,     0,    15,     0,    13,    14,
+      18
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-      -7,    -7,    -7,    -7,    -7,    -6,    -7,    -7,    -2,     0,
-      -7
+      -6,    -6,    -6,    -6,    -6,    -3,    -6,    -6,    -2,     0,
+      -6
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,     9,    10,    11,    17,    18,    12,    21,    13,    14,
-      15
+       0,     8,     9,    10,    16,    17,    11,    20,    12,    13,
+      14
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -639,28 +639,28 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      22,    19,     1,    23,     2,    20,    16,     6,     3,     4,
-       5,     6,     7,     8,     6,    24,    27,    28,    25,    29,
-      26,     1,     0,     2,    30,    19,    31,     3,     4,     5,
-       6,     7,     8
+      21,    18,     1,    22,     2,    19,    15,     6,     3,     4,
+       5,     6,     7,    23,     6,    25,    24,    26,    27,     0,
+       1,    28,     2,    29,    18,    30,     3,     4,     5,     6,
+       7
 };
 
 static const yytype_int8 yycheck[] =
 {
        2,     1,     3,     0,     5,     6,     4,    12,     9,    10,
-      11,    12,    13,    14,    12,     4,     6,     7,     7,    25,
-       8,     3,    -1,     5,    26,    25,    28,     9,    10,    11,
-      12,    13,    14
+      11,    12,    13,     4,    12,     8,     7,     6,     7,    -1,
+       3,    24,     5,    25,    24,    27,     9,    10,    11,    12,
+      13
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,     3,     5,     9,    10,    11,    12,    13,    14,    16,
-      17,    18,    21,    23,    24,    25,     4,    19,    20,    24,
-       6,    22,    23,     0,     4,     7,     8,     6,     7,    20,
-      23,    23
+       0,     3,     5,     9,    10,    11,    12,    13,    16,    17,
+      18,    21,    23,    24,    25,     4,    19,    20,    24,     6,
+      22,    23,     0,     4,     7,     8,     6,     7,    20,    23,
+      23
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
@@ -668,7 +668,7 @@ static const yytype_int8 yyr1[] =
 {
        0,    15,    16,    17,    17,    17,    17,    17,    17,    17,
       18,    18,    19,    19,    20,    21,    21,    22,    22,    23,
-      23,    24,    25
+      24,    25
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -676,7 +676,7 @@ static const yytype_int8 yyr2[] =
 {
        0,     2,     1,     1,     1,     1,     1,     1,     1,     1,
        3,     2,     1,     3,     3,     3,     2,     1,     3,     1,
-       1,     1,     1
+       1,     1
 };
 
 
@@ -1672,7 +1672,7 @@ yyreduce:
     switch (yyn)
       {
   case 2: /* json: json_element  */
-#line 164 "jparse.y"
+#line 186 "jparse.y"
     {
 	/*
 	 * $$ = $json
@@ -1700,7 +1700,7 @@ yyreduce:
     break;
 
   case 3: /* json_value: json_object  */
-#line 192 "jparse.y"
+#line 214 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1728,7 +1728,7 @@ yyreduce:
     break;
 
   case 4: /* json_value: json_array  */
-#line 218 "jparse.y"
+#line 240 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1756,7 +1756,7 @@ yyreduce:
     break;
 
   case 5: /* json_value: json_string  */
-#line 244 "jparse.y"
+#line 266 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1784,7 +1784,7 @@ yyreduce:
     break;
 
   case 6: /* json_value: json_number  */
-#line 270 "jparse.y"
+#line 292 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1812,7 +1812,7 @@ yyreduce:
     break;
 
   case 7: /* json_value: "true"  */
-#line 296 "jparse.y"
+#line 318 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1839,7 +1839,7 @@ yyreduce:
     break;
 
   case 8: /* json_value: "false"  */
-#line 321 "jparse.y"
+#line 343 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1866,7 +1866,7 @@ yyreduce:
     break;
 
   case 9: /* json_value: "null"  */
-#line 346 "jparse.y"
+#line 368 "jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1893,7 +1893,7 @@ yyreduce:
     break;
 
   case 10: /* json_object: "{" json_members "}"  */
-#line 373 "jparse.y"
+#line 395 "jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1921,7 +1921,7 @@ yyreduce:
     break;
 
   case 11: /* json_object: "{" "}"  */
-#line 399 "jparse.y"
+#line 421 "jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1946,7 +1946,7 @@ yyreduce:
     break;
 
   case 12: /* json_members: json_member  */
-#line 424 "jparse.y"
+#line 446 "jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -1974,7 +1974,7 @@ yyreduce:
     break;
 
   case 13: /* json_members: json_members "," json_member  */
-#line 450 "jparse.y"
+#line 472 "jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -2008,7 +2008,7 @@ yyreduce:
     break;
 
   case 14: /* json_member: json_string ":" json_element  */
-#line 484 "jparse.y"
+#line 506 "jparse.y"
     {
 	/*
 	 * $$ = $json_member
@@ -2039,7 +2039,7 @@ yyreduce:
     break;
 
   case 15: /* json_array: "[" json_elements "]"  */
-#line 515 "jparse.y"
+#line 537 "jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2067,7 +2067,7 @@ yyreduce:
     break;
 
   case 16: /* json_array: "[" "]"  */
-#line 541 "jparse.y"
+#line 563 "jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2092,7 +2092,7 @@ yyreduce:
     break;
 
   case 17: /* json_elements: json_element  */
-#line 566 "jparse.y"
+#line 588 "jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2120,7 +2120,7 @@ yyreduce:
     break;
 
   case 18: /* json_elements: json_elements "," json_element  */
-#line 592 "jparse.y"
+#line 614 "jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2153,7 +2153,7 @@ yyreduce:
     break;
 
   case 19: /* json_element: json_value  */
-#line 625 "jparse.y"
+#line 647 "jparse.y"
     {
 	/*
 	 * $$ = $json_element
@@ -2180,16 +2180,8 @@ yyreduce:
 #line 2130 "jparse.tab.c"
     break;
 
-  case 20: /* json_element: JSON_INVALID_TOKEN  */
-#line 650 "jparse.y"
-    {
-	UGLY_ABORT;
-    }
-#line 2138 "jparse.tab.c"
-    break;
-
-  case 21: /* json_string: JSON_STRING  */
-#line 658 "jparse.y"
+  case 20: /* json_string: JSON_STRING  */
+#line 675 "jparse.y"
     {
 	/*
 	 * $$ = $json_string
@@ -2212,11 +2204,11 @@ yyreduce:
 	json_dbg(JSON_DBG_LOW, __func__, "under json_string: ending: "
 					 "json_string: JSON_STRING");
     }
-#line 2165 "jparse.tab.c"
+#line 2157 "jparse.tab.c"
     break;
 
-  case 22: /* json_number: JSON_NUMBER  */
-#line 685 "jparse.y"
+  case 21: /* json_number: JSON_NUMBER  */
+#line 702 "jparse.y"
     {
 	/*
 	 * $$ = $json_number
@@ -2239,11 +2231,11 @@ yyreduce:
 	json_dbg(JSON_DBG_LOW, __func__, "under json_number: ending: "
 					 "json_number: JSON_NUMBER");
     }
-#line 2192 "jparse.tab.c"
+#line 2184 "jparse.tab.c"
     break;
 
 
-#line 2196 "jparse.tab.c"
+#line 2188 "jparse.tab.c"
 
         default: break;
       }
@@ -2478,7 +2470,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 710 "jparse.y"
+#line 727 "jparse.y"
 
 
 

--- a/jparse.tab.ref.h
+++ b/jparse.tab.ref.h
@@ -124,7 +124,7 @@ extern int ugly_debug;
     JSON_FALSE = 266,              /* "false"  */
     JSON_STRING = 267,             /* JSON_STRING  */
     JSON_NUMBER = 268,             /* JSON_NUMBER  */
-    JSON_INVALID_TOKEN = 269       /* JSON_INVALID_TOKEN  */
+    token = 269                    /* token  */
   };
   typedef enum ugly_tokentype ugly_token_kind_t;
 #endif

--- a/json_parse.c
+++ b/json_parse.c
@@ -1672,6 +1672,9 @@ parse_json_member(struct json *name, struct json *value)
 	err(190, __func__, "couldn't convert member");
 	not_reached();
     } else {
+	/*
+	 * XXX show what the member name is
+	 */
         json_dbg(json_verbosity_level, __func__, "converted member");
     }
 

--- a/json_parse.h
+++ b/json_parse.h
@@ -199,6 +199,10 @@ struct json_number
  * A JSON string is of the form:
  *
  *	"([^\n"]|\\")*"
+ *
+ * NOTE: We let the conversion function decide whether the string is actually
+ * invalid according to the JSON standard so the regex above is for the parser
+ * even if it allows things in the string that JSON does not allow.
  */
 struct json_string
 {

--- a/json_util.c
+++ b/json_util.c
@@ -2463,8 +2463,8 @@ json_conv_number_str(char const *str, size_t *retlen)
  * given:
  *	ptr	pointer to buffer containing a JSON encoded string
  *	len	length, starting at ptr, of the JSON encoded string
- *	quote	true ==> ignore JSON double quotes, both ptr[0] & ptr[len-1]
- *		must be '"'
+ *	quote	true ==>  ignore JSON double quotes: both ptr[0] & ptr[len-1]
+ *			  must be '"'
  *		false ==> the entire ptr is to be converted
  *
  * returns:
@@ -2472,6 +2472,10 @@ json_conv_number_str(char const *str, size_t *retlen)
  *
  * NOTE: This function will not return on malloc error.
  * NOTE: This function will not return NULL.
+ *
+ * NOTE: We let this function decide whether the string is actually valid
+ * according to the JSON standard so the regex above is for the parser even if
+ * it would theoretically allow invalid JSON strings.
  */
 struct json *
 json_conv_string(char const *ptr, size_t len, bool quote)
@@ -2564,6 +2568,9 @@ json_conv_string(char const *ptr, size_t len, bool quote)
 
     /*
      * determine if decoded string is identical to the original JSON encoded string
+     *
+     * NOTE: We use memcmp() because there might be NUL bytes in the 'char *'
+     * and strcmp() would stop at the first '\0'.
      */
     if (item->as_str_len == item->str_len && memcmp(item->as_str, item->str, item->as_str_len) == 0) {
 	item->same = true;	/* decoded string same an original JSON encoded string (perhaps sans '"'s) */

--- a/json_util.c
+++ b/json_util.c
@@ -768,7 +768,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
     /* case: just e found, no E */
     } else if (e_found != NULL) {
 
-	/* firewall - search for two e's */
+	/* firewall - search for two 'e's */
 	e = strrchr(str, 'e');
 	if (e_found != e) {
 	    dbg(DBG_HIGH, "%s: floating point numbers cannot have more than one e: <%s>",
@@ -782,7 +782,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
     /* case: just E found, no e */
     } else if (cap_e_found != NULL) {
 
-	/* firewall - search for two E's */
+	/* firewall - search for two 'E's */
 	e = strrchr(str, 'E');
 	if (cap_e_found != e) {
 	    dbg(DBG_HIGH, "%s: floating point numbers cannot have more than one E: <%s>",


### PR DESCRIPTION
An interesting thing I pointed out in commit https://github.com/ioccc-src/mkiocccentry/commit/3c65ca0106c91bcd0b9181ebe4377105eee12e52:

```
    Rename 'JSON_INVALID_TOKEN' to be just 'token' for better error
    messages:
    
        [...]
         * Now if bison has an actual reference to the token value itself this would be
         * ideal to pass to the error message but if it does I'm unaware of it and
         * unfortunately UGLY_ABORT is specific to bison and not in flex. That being
         * said it does have a feature for more custom error functions and this can be
         * looked into.
         */
```

I will look into this functionality more. It doesn't appear to have the token itself but it might have something better than what we have here. I'm not sure. I will look into it in the near future. I'd like to do it now but I'm much too tired for that I'm afraid. Good day!