### PR TITLE
Typo (struct name) fix in jnum_chk usage message

### DIFF
--- a/jnum_chk.h
+++ b/jnum_chk.h
@@ -75,7 +75,7 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit 3\n"
     "\t-q\t\tquiet mode (def: not quiet)\n"
     "\t\t\t    NOTE: -q will also silence msg(), warn(), warnp() if -v 0\n"
-    "\t-S\t\tstrict testing for all struct number elements\n"
+    "\t-S\t\tstrict testing for all struct json_number elements\n"
     "\t\t\t    (def: test only 8, 16, 32, 64 bit signed and unsigned integer types)\n"
     "\t\t\t    (def: test floating point with match to only 1 part in 4194304)\n"
     "\n"

--- a/json_chk.c
+++ b/json_chk.c
@@ -2,20 +2,23 @@
 /*
  * json_ckk - support jinfochk and jauthchk services
  *
- * "Because sometimes even the IOCCC Judges need some help." :-)
  *
  * This is currently being worked on by:
+ *
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * and
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
  *
- * and
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * This is very much a work in progress!
+ * This is very much a work in progress! See jparse.h, jparse.l, jparse.y,
+ * json_util.h and json_util.c.
  */
+
 
 
 #include <stdio.h>

--- a/json_chk.h
+++ b/json_chk.h
@@ -2,19 +2,21 @@
 /*
  * json_ckk - support jinfochk and jauthchk services
  *
- * "Because sometimes even the IOCCC Judges need some help." :-)
- *
  * This is currently being worked on by:
+ *
+ *
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * and
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
  *
- * and
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * This is very much a work in progress!
+ * This is very much a work in progress! See jparse.h, jparse.l, jparse.y,
+ * json_util.h and json_util.c.
  */
 
 

--- a/json_parse.c
+++ b/json_parse.c
@@ -20,8 +20,8 @@
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
- * well as json_util.c and json_util.h.
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y,
+ * json_chk.h, json_chk.c as well as json_util.h and json_util.c.
  *
  */
 

--- a/json_parse.h
+++ b/json_parse.h
@@ -20,9 +20,8 @@
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
- * well as json_util.c and json_util.h.
- *
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y,
+ * json_chk.h, json_chk.c as well as json_util.h and json_util.c.
  */
 
 

--- a/json_util.c
+++ b/json_util.c
@@ -15,8 +15,8 @@
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
- * well as json_util.c and json_util.h.
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y,
+ * json_chk.h, json_chk.c as well as json_parse.h and json_parse.c.
  */
 
 #include <stdio.h>

--- a/json_util.h
+++ b/json_util.h
@@ -15,8 +15,8 @@
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * This is very much a work in progress! See jparse.h, jparse.l and jparse.y as
- * well as json_util.c and json_util.h.
+ * This is very much a work in progress! See jparse.h, jparse.l and jparse.y,
+ * json_chk.h, json_chk.c as well as json_parse.h and json_parse.c.
  */
 
 


### PR DESCRIPTION
It referred to the old 'struct number' which quite a while back was
changed to 'struct json_number'. The rest of jnum_chk already have
'struct json_number'.