### PR TITLE
Fix -h mode when exit code >= 0

### DIFF
--- a/dbg.c
+++ b/dbg.c
@@ -3715,7 +3715,7 @@ printf_usage(int exitcode, char const *fmt, ...)
     /*
      * stage 0: determine if conditions allow function to write, exit or return as required
      */
-    if (usage_output_allowed == true) {
+    if (usage_output_allowed == false) {
 	if (exitcode >= 0) {
 	    exit(exitcode);
 	    not_reached();
@@ -3781,7 +3781,7 @@ vprintf_usage(int exitcode, char const *fmt, va_list ap)
     /*
      * stage 0: determine if conditions allow function to write, exit or return as required
      */
-    if (usage_output_allowed == true) {
+    if (usage_output_allowed == false) {
 	if (exitcode >= 0) {
 	    exit(exitcode);
 	    not_reached();
@@ -3843,7 +3843,7 @@ fprintf_usage(int exitcode, FILE *stream, char const *fmt, ...)
     /*
      * stage 0: determine if conditions allow function to write, exit or return as required
      */
-    if (usage_output_allowed == true) {
+    if (usage_output_allowed == false) {
 	if (exitcode >= 0) {
 	    exit(exitcode);
 	    not_reached();
@@ -3914,7 +3914,7 @@ vfprintf_usage(int exitcode, FILE *stream, char const *fmt, va_list ap)
     /*
      * stage 0: determine if conditions allow function to write, exit or return as required
      */
-    if (usage_output_allowed == true) {
+    if (usage_output_allowed == false) {
 	if (exitcode >= 0) {
 	    exit(exitcode);
 	    not_reached();


### PR DESCRIPTION
In functions

    printf_usage
    vprintf_usage
    fprintf_usage
    vfprintf_usage

if exit code >= 0 it would call exit() if usage messages were allowed
rather than not allowed (in other words if usage_output_allowed == true
instead of == false). Thus doing e.g.:

    ./foo -h

would print nothing.