### PR TITLE
Remove invalid files in test_txzchk/bad

### DIFF
--- a/test_txzchk/bad/entry.test-0.1652598667.txt
+++ b/test_txzchk/bad/entry.test-0.1652598667.txt
@@ -1,1 +1,0 @@
-tar fvt entry.test-0.1644411114.txz

--- a/test_txzchk/bad/entry.test-2.1652598667.txt
+++ b/test_txzchk/bad/entry.test-2.1652598667.txt
@@ -1,1 +1,0 @@
-tar fvt entry.test-2.1644411114.txz

--- a/test_txzchk/bad/entry.test-3.1652598667.txt
+++ b/test_txzchk/bad/entry.test-3.1652598667.txt
@@ -1,1 +1,0 @@
-tar fvt entry.test-3.1644411114.txz

--- a/test_txzchk/bad/entry.test-4.1652598667.txt
+++ b/test_txzchk/bad/entry.test-4.1652598667.txt
@@ -1,1 +1,0 @@
-tar fvt entry.test-4.1644411114.txz

--- a/test_txzchk/bad/entry.test-5.1652598667.txt
+++ b/test_txzchk/bad/entry.test-5.1652598667.txt
@@ -1,1 +1,0 @@
-tar fvt entry.test-5.1644411114.txz


### PR DESCRIPTION
Specifically the following files were removed:

    $ for i in $(grep 'tar fvt' *|cut -f1 -d:); do git rm "${i}"; done
    rm 'test_txzchk/bad/entry.test-0.1652598667.txt'
    rm 'test_txzchk/bad/entry.test-2.1652598667.txt'
    rm 'test_txzchk/bad/entry.test-3.1652598667.txt'
    rm 'test_txzchk/bad/entry.test-4.1652598667.txt'
    rm 'test_txzchk/bad/entry.test-5.1652598667.txt'

The reason being is that they only had:

    $ grep 'tar fvt' *
    entry.test-0.1652598667.txt:tar fvt entry.test-0.1644411114.txz
    entry.test-2.1652598667.txt:tar fvt entry.test-2.1644411114.txz
    entry.test-3.1652598667.txt:tar fvt entry.test-3.1644411114.txz
    entry.test-4.1652598667.txt:tar fvt entry.test-4.1644411114.txz
    entry.test-5.1652598667.txt:tar fvt entry.test-5.1644411114.txz

in them. How this happened I cannot say entirely but they are clearly in
error and entirely unnecessary. The reason it wasn't picked up
originally is they're under the bad subdirectory so naturally the fact
it failed means the tests passed.