### PR TITLE
Typo fixes

### DIFF
--- a/run_bison.sh
+++ b/run_bison.sh
@@ -498,7 +498,7 @@ add_sorry() {
     # parse args
     #
     if [[ $# -ne 1 ]]; then
-	echo "$0: ERROR: add_sorry function expects 1 args, found $#" 1>&2
+	echo "$0: ERROR: add_sorry function expects 1 arg, found $#" 1>&2
 	exit 13
     fi
     FILE="$1"

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -466,7 +466,7 @@ add_sorry() {
     # parse args
     #
     if [[ $# -ne 1 ]]; then
-	echo "$0: ERROR: add_sorry function expects 1 args, found $#" 1>&2
+	echo "$0: ERROR: add_sorry function expects 1 arg, found $#" 1>&2
 	exit 13
     fi
     FILE="$1"

--- a/util.h
+++ b/util.h
@@ -104,8 +104,7 @@ typedef unsigned char bool;
 #define LITLEN(x) (sizeof(x)-1)	/* length of a literal string w/o the NUL byte */
 #define INITIAL_BUF_SIZE (8192)	/* initial size of buffer allocated by read_all */
 #define READ_ALL_CHUNK (65536)	/* grow this read_all by this amount when needed */
-/* for string to int functions */
-#define LLONG_MAX_BASE10_DIGITS (19)
+#define LLONG_MAX_BASE10_DIGITS (19) /* for string to int functions */
 #define TBLLEN(x) (sizeof(x)/sizeof((x)[0]))	/* number of elements in an initialized table array */
 #define UNUSED_ARG(x) (void)(x)			/* prevent compiler from complaining about an unused arg */
 


### PR DESCRIPTION
In run_bison.sh and run_flex.sh in add_sorry it said 'expects 1 args'
instead of 'arg'.

Why not change it to 'one'? It might be up to debate but the reason I
did not is because $# shows digits and not words so I left it as digits
too to keep it matching.

In util.h: I moved a comment above

    -/* for string to int functions */
    -#define LLONG_MAX_BASE10_DIGITS (19)
    +#define LLONG_MAX_BASE10_DIGITS (19) /* for string to int functions */

because there are lines right below that are not related to string to
int but might be confused as being related in some way or another.