### PR TITLE
Add initial hostchk.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ H_FILES= dbg.h jauthchk.h jinfochk.h json_parse.h jstrdecode.h jstrencode.h limi
 DSYMDIRS= $(TARGETS:=.dSYM)
 SH_FILES= iocccsize_test.sh jstr_test.sh limit_ioccc.sh mkiocccentry_test.sh json_test.sh \
 	  jcodechk.sh vermod.sh prep.sh run_bison.sh run_flex.sh reset_tstamp.sh ioccc_test.sh \
-	  jparse_test.sh txzchk_test.sh
+	  jparse_test.sh txzchk_test.sh hostchk.sh
 BUILD_LOG= build.log
 TXZCHK_LOG=txzchk_test.log
 
@@ -744,6 +744,9 @@ reset_min_timestamp: reset_tstamp.sh
 test ioccc_test: ioccc_test.sh iocccsize_test.sh dbg mkiocccentry_test.sh jstr_test.sh \
 		 jnum_chk dyn_test txzchk_test.sh Makefile
 	./ioccc_test.sh
+
+hostchk bug-report: hostchk.sh
+	./hostchk.sh
 
 # run json_test.sh on test_JSON files
 #

--- a/hostchk.sh
+++ b/hostchk.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# hostchk.sh - make various checks on a host to determine if it can use the
+# mkiocccentry repo.
+#
+# NOTE: This is not perfect and it cannot account for everything.
+#
+# NOTE: This is a work in progress.
+
+# set up
+export EXIT_CODE=0
+
+# set up for tar test
+#
+RUN_TAR_TEST="true"
+TEST_FILE=$(mktemp .hostchk.test_file.XXXXXXXXXX)
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mktemp $TEST_FILE exit code: $status" 1>&2
+    EXIT_CODE=14
+    RUN_TAR_TEST=
+fi
+date > "$TEST_FILE"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: date > $TEST_FILE exit code: $status" 1>&2
+    EXIT_CODE=15
+    RUN_TAR_TEST=
+fi
+if [[ ! -r $TEST_FILE ]]; then
+    echo "$0: ERROR: not a readable TEST_FILE: $TEST_FILE" 1>&2
+    EXIT_CODE=16
+    RUN_TAR_TEST=
+fi
+TAR_ERROR=$(mktemp -u .hostchk.tar_err.XXXXXXXXXX.out)
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mktemp -u $TAR_ERROR exit code: $status" 1>&2
+    EXIT_CODE=17
+    RUN_TAR_TEST=
+fi
+TARBALL=$(mktemp -u .hostchk.tarball.XXXXXXXXXX.tgz)
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mktemp -u $TARBALL exit code: $status" 1>&2
+    EXIT_CODE=18
+    RUN_TAR_TEST=
+fi
+
+# run tar test
+#
+TAR_TEST_SUCCESS="true"
+if [[ -n $RUN_TAR_TEST ]]; then
+    tar --format=v7 -cJf "$TARBALL" "$TEST_FILE" 2>"$TAR_ERROR"
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: tar --format=v7 -cJf $TARBALL $TEST_FILE 2>$TAR_ERROR exit code: $status" 1>&2
+	EXIT_CODE=19
+	TAR_TEST_SUCCESS=
+    fi
+    if [[ ! -s $TARBALL ]]; then
+	echo "$0: ERROR: did not find a non-empty tarball: $TARBALL" 1>&2
+	EXIT_CODE=20
+	TAR_TEST_SUCCESS=
+    fi
+    if [[ -s $TAR_ERROR ]]; then
+	echo "$0: notice: tar stderr follows:" 1>&2
+	cat "$TAR_ERROR" 1>&2
+	echo "$0: notice: end of tar stderr" 1>&2
+	EXIT_CODE=21
+	TAR_TEST_SUCCESS=
+    fi
+else
+    echo "$0: notice: tar test disabled due to test set up error(s)" 1>&2
+    TAR_TEST_SUCCESS=
+fi
+
+# tar test clean up
+#
+if [[ -n $TAR_TEST_SUCCESS ]]; then
+    rm -f "$TEST_FILE" "$TAR_ERROR" "$TARBALL"
+fi
+
+# set up for compile test
+#
+RUN_INCLUDE_TEST="true"
+PROG_FILE=$(mktemp -u .hostchk.prog.XXXXXXXXXX)
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mktemp -u $PROG_FILE exit code: $status" 1>&2
+    EXIT_CODE=41
+    RUN_INCLUDE_TEST=
+fi
+
+# run include tests
+#
+export INCLUDE_TEST_SUCCESS="true"
+if [[ -n $RUN_INCLUDE_TEST ]]; then
+
+    # test each required system include file
+    #
+    while read -r h; do
+
+	# form C prog
+	#
+	rm -f "$PROG_FILE"
+	printf "%s\n%s\n" "$h" "int main(void){ return 0; }" | cc -x c - -o "$PROG_FILE"
+
+	# test compile
+	#
+	status="$?"
+	if [[ $status -ne 0 ]]; then
+	    echo "$0: FATAL: missing system include file <$h>" 1>&2
+	    EXIT_CODE=42
+	    INCLUDE_TEST_SUCCESS="false"
+	fi
+	if [[ -s "$PROG_FILE" && -x "$PROG_FILE" ]]; then
+	    ./"$PROG_FILE"
+	    status="$?"
+	    if [[ $status -ne 0 ]]; then
+		echo "$0: FATAL: unable to run executable compiled using: $h" 1>&2
+		EXIT_CODE=43
+		INCLUDE_TEST_SUCCESS="false"
+	    else
+		# XXX This should only be printed for certain debug levels but
+		# right now there are no debug levels so we always print it to
+		# be sure it works.
+		echo "$0: Running executable compiled using: $h: success"
+	    fi
+	else
+	    echo "$0: FATAL: unable to form an executable compiled using: $h" 1>&2
+	    EXIT_CODE=44
+	    INCLUDE_TEST_SUCCESS="false"
+	fi
+
+	# clean up after compile test
+	#
+	rm -f "$PROG_FILE"
+    done < <(grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u)
+else
+    echo "$0: notice: include test disabled due to test set up error(s)" 1>&2
+    EXIT_CODE=45
+    INCLUDE_TEST_SUCCESS="false"
+fi
+
+exit "$EXIT_CODE"

--- a/json_util.c
+++ b/json_util.c
@@ -1996,8 +1996,8 @@ json_tree_free(struct json *node, int max_depth, ...)
  *	...	    extra args for vcallback
  *
  * The vcallback() function must NOT call va_arg() nor call va_end() on the
- * the va_list argument directly.  Instead they must call va_copy()
- * and then use va_arg() and va_end() on the va_list copy.
+ * va_list argument directly.  Instead they must call va_copy() and then use
+ * va_arg() and va_end() on the va_list copy.
  *
  * Although in C ALL functions are pointers which means one can call foo()
  * as foo() or (*foo)() we use the latter format for the callback function
@@ -2068,8 +2068,8 @@ json_tree_walk(struct json *node, int max_depth, void (*vcallback)(struct json *
  *	ap	    variable argument list
  *
  * The vcallback() function must NOT call va_arg() nor call va_end() on the
- * the va_list argument directly.  Instead they must call va_copy()
- * and then use va_arg() and va_end() on the va_list copy.
+ * va_list argument directly.  Instead they must call va_copy() and then use
+ * va_arg() and va_end() on the va_list copy.
  *
  * Although in C ALL functions are pointers which means one can call foo()
  * as foo() or (*foo)() we use the latter format for the callback function


### PR DESCRIPTION
Currently it does not parse options and there are only two checks:

Checks that tar with the required options is available.

Test compiles a C program with each of the system header files included
in all the C and header files in the repo. See below for how this is
done.

Rather than have to update the script each time a header file is removed
or added it uses a pipeline of grep and sort in a while read loop. The
pipeline itself is:

    grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u

and the top and bottom of the loop is:

    while read -r h; do

    ...

    done < <(grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u)

But instead of creating a C file for each header file used we use some
magic with the compiler and stdin. Thus the part that compiles each test
file is:

    printf "%s\n%s\n" "$h" "int main(void){ return 0; }" | cc -x c - -o "$PROG_FILE"

Thus there's no need to write to the actual disk as it's all stdin and
stdout.

To run this script use make hostchk or make bug-report.

At the risk of stating the obvious this is not complete.