### PR TITLE
Many typo fixes in scripts and source files

### DIFF
--- a/jauthchk.c
+++ b/jauthchk.c
@@ -81,7 +81,7 @@ jauthchk_sanity_chks(char const *file, char const *fnamchk)
 	      "    jauthchk [...] <file>",
 	      "",
 	      NULL);
-	err(7, __func__, "file is not a file: %s", file);
+	err(7, __func__, "file is not a regular file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -133,7 +133,7 @@ jauthchk_sanity_chks(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(10, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(10, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {

--- a/jcodechk.sh
+++ b/jcodechk.sh
@@ -100,7 +100,7 @@ if [[ ! -e $JCHKTOOL ]]; then
     exit 4
 fi
 if [[ ! -f $JCHKTOOL ]]; then
-    echo "$0: ERROR: jchktool is not a file: $JCHKTOOL" 1>&2
+    echo "$0: ERROR: jchktool is not a regular file: $JCHKTOOL" 1>&2
     exit 4
 fi
 if [[ ! -x $JCHKTOOL ]]; then
@@ -112,7 +112,7 @@ if [[ ! -e $FILE_JSON ]]; then
     exit 2
 fi
 if [[ ! -f $FILE_JSON ]]; then
-    echo "$0: ERROR: file.json is not a file: $FILE_JSON" 1>&2
+    echo "$0: ERROR: file.json is not a regular file: $FILE_JSON" 1>&2
     exit 2
 fi
 if [[ ! -r $FILE_JSON ]]; then
@@ -125,7 +125,7 @@ if [[ ! -e $CODE_JSON ]]; then
     exit 3
 fi
 if [[ ! -f $CODE_JSON ]]; then
-    echo "$0: ERROR: file.json.code is not a file: $CODE_JSON" 1>&2
+    echo "$0: ERROR: file.json.code is not a regular file: $CODE_JSON" 1>&2
     exit 3
 fi
 if [[ ! -r $CODE_JSON ]]; then
@@ -145,7 +145,7 @@ if [[ $status -ne 0 || ! -e $TMPFILE ]]; then
 fi
 trap "rm -f \$TMPFILE; exit" 0 1 2 3 15
 if [[ ! -f $TMPFILE ]]; then
-    echo "$0: ERROR: TMPFILE is not a file: $TMPFILE" 1>&2
+    echo "$0: ERROR: TMPFILE is not a regular file: $TMPFILE" 1>&2
     exit 7
 fi
 if [[ ! -w $TMPFILE ]]; then

--- a/jinfochk.c
+++ b/jinfochk.c
@@ -83,7 +83,7 @@ jinfochk_sanity_chks(char const *file, char const *fnamchk)
 	      "    jinfochk [...] <file>",
 	      "",
 	      NULL);
-	err(7, __func__, "file is not a file: %s", file);
+	err(7, __func__, "file is not a regular file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
@@ -135,7 +135,7 @@ jinfochk_sanity_chks(char const *file, char const *fnamchk)
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(10, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(10, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {

--- a/jparse.l
+++ b/jparse.l
@@ -393,7 +393,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
     bs = NULL;
 
     /*
-     * announce beginning to parse
+     * announce end of parse
      */
     if (json_dbg_allowed(DBG_VVHIGH)) {
 	fprstr(stderr, "*** END PARSE\n");

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2532,7 +2532,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
     bs = NULL;
 
     /*
-     * announce beginning to parse
+     * announce end of parse
      */
     if (json_dbg_allowed(DBG_VVHIGH)) {
 	fprstr(stderr, "*** END PARSE\n");

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2226,7 +2226,7 @@ ugly_error(struct json *node, char const *format, ...)
     bool allowed = false;	/* true ==> ugly errors are allowed as JSON warnings */
 
     /*
-     * do nothing is the JSON warning system is disabled
+     * do nothing if the JSON warning system is disabled
      *
      * XXX - we use the fake code -1 to prevent is_json_code_ignored() from
      *	     being used.

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -2242,7 +2242,7 @@ ugly_error(struct json *node, char const *format, ...)
     va_start(ap, format);
 
     /*
-     * if we have a node, print the note type
+     * if we have a node, print the node type
      */
     fprint(stderr, "in %s(): node type: %s", __func__, json_element_type_name(node));
 

--- a/jparse.y
+++ b/jparse.y
@@ -783,7 +783,7 @@ ugly_error(struct json *node, char const *format, ...)
     bool allowed = false;	/* true ==> ugly errors are allowed as JSON warnings */
 
     /*
-     * do nothing is the JSON warning system is disabled
+     * do nothing if the JSON warning system is disabled
      *
      * XXX - we use the fake code -1 to prevent is_json_code_ignored() from
      *	     being used.

--- a/jparse.y
+++ b/jparse.y
@@ -799,7 +799,7 @@ ugly_error(struct json *node, char const *format, ...)
     va_start(ap, format);
 
     /*
-     * if we have a node, print the note type
+     * if we have a node, print the node type
      */
     fprint(stderr, "in %s(): node type: %s", __func__, json_element_type_name(node));
 

--- a/jparse_test.sh
+++ b/jparse_test.sh
@@ -80,7 +80,7 @@ if [[ ! -e $JPARSE ]]; then
     exit 4
 fi
 if [[ ! -f $JPARSE ]]; then
-    echo "$0: jparse not a file: $JPARSE"
+    echo "$0: jparse not a regular file: $JPARSE"
     exit 4
 fi
 if [[ ! -x $JPARSE ]]; then
@@ -209,7 +209,7 @@ else
 	    exit 4
 	fi
 	if [[ ! -f $JSON_TEST_FILE ]]; then
-	    echo "$0: test file not a file: $JSON_TEST_FILE"
+	    echo "$0: test file not a regular file: $JSON_TEST_FILE"
 	    exit 4
 	fi
 	if [[ ! -r $JSON_TEST_FILE ]]; then

--- a/json_test.sh
+++ b/json_test.sh
@@ -93,28 +93,28 @@ export JSON_AUTH_TREE="$JSON_TREE/author.json"
 
 # form the temporary exit code file
 #
-export EXIT_CODE_FIlE MKTEMP_TEMPLATE
+export EXIT_CODE_FILE MKTEMP_TEMPLATE
 MKTEMP_TEMPLATE=".exit_code.$(basename "$0").XXXXXXXXXX"
-EXIT_CODE_FIlE=$(mktemp "$MKTEMP_TEMPLATE")
+EXIT_CODE_FILE=$(mktemp "$MKTEMP_TEMPLATE")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: mktemp $MKTEMP_TEMPLATE exit code: $status" 1>&2
     exit 55
 fi
-if [[ ! -e $EXIT_CODE_FIlE ]]; then
-    echo "$0: ERROR: EXIT_CODE_FIlE does not exist: $EXIT_CODE_FIlE" 1>&2
+if [[ ! -e $EXIT_CODE_FILE ]]; then
+    echo "$0: ERROR: EXIT_CODE_FILE does not exist: $EXIT_CODE_FILE" 1>&2
     exit 55
 fi
-if [[ ! -f $EXIT_CODE_FIlE ]]; then
-    echo "$0: ERROR: EXIT_CODE_FIlE not a file: $EXIT_CODE_FIlE" 1>&2
+if [[ ! -f $EXIT_CODE_FILE ]]; then
+    echo "$0: ERROR: EXIT_CODE_FILE not a regular file: $EXIT_CODE_FILE" 1>&2
     exit 55
 fi
-if [[ ! -r $EXIT_CODE_FIlE ]]; then
-    echo "$0: ERROR: EXIT_CODE_FIlE file not readable: $EXIT_CODE_FIlE" 1>&2
+if [[ ! -r $EXIT_CODE_FILE ]]; then
+    echo "$0: ERROR: EXIT_CODE_FILE file not readable: $EXIT_CODE_FILE" 1>&2
     exit 55
 fi
-if [[ ! -w $EXIT_CODE_FIlE ]]; then
-    echo "$0: ERROR: EXIT_CODE_FIlE file not writable: $EXIT_CODE_FIlE" 1>&2
+if [[ ! -w $EXIT_CODE_FILE ]]; then
+    echo "$0: ERROR: EXIT_CODE_FILE file not writable: $EXIT_CODE_FILE" 1>&2
     exit 55
 fi
 
@@ -161,7 +161,7 @@ if [[ -n $RUN_JINFOCHK ]]; then
 	exit 4
     fi
     if [[ ! -f $JINFOCHK ]]; then
-	echo "$0: ERROR: jinfochk not a file: $JINFOCHK" 1>&2
+	echo "$0: ERROR: jinfochk not a regular file: $JINFOCHK" 1>&2
 	exit 4
     fi
     if [[ ! -x $JINFOCHK ]]; then
@@ -207,7 +207,7 @@ if [[ -n $RUN_JAUTHCHK ]]; then
 	exit 4
     fi
     if [[ ! -f $JAUTHCHK ]]; then
-	echo "$0: ERROR: jauthchk not a file: $JAUTHCHK" 1>&2
+	echo "$0: ERROR: jauthchk not a regular file: $JAUTHCHK" 1>&2
 	exit 4
     fi
     if [[ ! -x $JAUTHCHK ]]; then
@@ -252,7 +252,7 @@ if [[ ! -e $JCODECHK ]]; then
     exit 4
 fi
 if [[ ! -f $JCODECHK ]]; then
-    echo "$0: ERROR: jcodechk.sh not a file: $JCODECHK" 1>&2
+    echo "$0: ERROR: jcodechk.sh not a regular file: $JCODECHK" 1>&2
     exit 4
 fi
 if [[ ! -x $JCODECHK ]]; then
@@ -290,7 +290,7 @@ run_test()
 	exit 4
     fi
     if [[ ! -f $test_prog ]]; then
-	echo "$0: in run_test: test_prog not a file: $test_prog"
+	echo "$0: in run_test: test_prog not a regular file: $test_prog"
 	exit 4
     fi
     if [[ ! -x $test_prog ]]; then
@@ -306,7 +306,7 @@ run_test()
 	exit 4
     fi
     if [[ ! -f $test_prog ]]; then
-	echo "$0: in run_test: json_test_file not a file: $json_test_file"
+	echo "$0: in run_test: json_test_file not a regular file: $json_test_file"
 	exit 4
     fi
     if [[ ! -r $test_prog ]]; then
@@ -350,10 +350,10 @@ run_test()
 	    fi
 	    echo | tee -a "${LOGFILE}" 1>&2
 	    EXIT_CODE=1
-	    echo "$EXIT_CODE" > "$EXIT_CODE_FIlE"
+	    echo "$EXIT_CODE" > "$EXIT_CODE_FILE"
 	    status="$?"
-	    if [[ $status -ne 0 || ! -s $EXIT_CODE_FIlE ]]; then
-		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FIlE: $EXIT_CODE_FIlE" 1>&2
+	    if [[ $status -ne 0 || ! -s $EXIT_CODE_FILE ]]; then
+		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FILE: $EXIT_CODE_FILE" 1>&2
 		exit 55
 	    fi
 	elif [[ $V_FLAG -ge 5 ]]; then
@@ -370,10 +370,10 @@ run_test()
 	    fi
 	    echo | tee -a "${LOGFILE}" 1>&2
 	    EXIT_CODE=1
-	    echo "$EXIT_CODE" > "$EXIT_CODE_FIlE"
+	    echo "$EXIT_CODE" > "$EXIT_CODE_FILE"
 	    status="$?"
-	    if [[ $status -ne 0 || ! -s $EXIT_CODE_FIlE ]]; then
-		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FIlE: $EXIT_CODE_FIlE" 1>&2
+	    if [[ $status -ne 0 || ! -s $EXIT_CODE_FILE ]]; then
+		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FILE: $EXIT_CODE_FILE" 1>&2
 		exit 55
 	    fi
 	elif [[ $V_FLAG -ge 5 ]]; then
@@ -403,19 +403,19 @@ run_test()
 	   ;;
 	1) echo "$0: Warning: FAIL: JSON codes for $json_test_file do not match expected code list in $json_code" | tee -a "$LOGFILE" 1>&2
 	   EXIT_CODE=1
-	   echo "$EXIT_CODE" > "$EXIT_CODE_FIlE"
+	   echo "$EXIT_CODE" > "$EXIT_CODE_FILE"
 	   status="$?"
-	   if [[ $status -ne 0 || ! -s $EXIT_CODE_FIlE ]]; then
-		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FIlE: $EXIT_CODE_FIlE" 1>&2
+	   if [[ $status -ne 0 || ! -s $EXIT_CODE_FILE ]]; then
+		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FILE: $EXIT_CODE_FILE" 1>&2
 		exit 55
 	   fi
 	   ;;
 	*) echo "$0: ERROR: FAIL: jcodechk.sh exit status: $status > 1" | tee -a "$LOGFILE" 1>&2
 	   EXIT_CODE=1
-	   echo "$EXIT_CODE" > "$EXIT_CODE_FIlE"
+	   echo "$EXIT_CODE" > "$EXIT_CODE_FILE"
 	   status="$?"
-	   if [[ $status -ne 0 || ! -s $EXIT_CODE_FIlE ]]; then
-		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FIlE: $EXIT_CODE_FIlE" 1>&2
+	   if [[ $status -ne 0 || ! -s $EXIT_CODE_FILE ]]; then
+		echo "$0: FATAL: failed to write $EXIT_CODE into EXIT_CODE_FILE: $EXIT_CODE_FILE" 1>&2
 		exit 55
 	   fi
 	   ;;
@@ -475,18 +475,18 @@ if [[ -n $RUN_JAUTHCHK ]]; then
     done
 fi
 
-# Check for numeric exit code from EXIT_CODE_FIlE as a possible EXIT_CODE
+# Check for numeric exit code from EXIT_CODE_FILE as a possible EXIT_CODE
 #
 if [[ $V_FLAG -ge 5 ]]; then
     echo "$0: debug[5]: near final top level EXIT_CODE: $EXIT_CODE" 1>&2
 fi
-if [[ -s $EXIT_CODE_FIlE ]]; then
-    NEW_EXIT_CODE=$(< "$EXIT_CODE_FIlE")
+if [[ -s $EXIT_CODE_FILE ]]; then
+    NEW_EXIT_CODE=$(< "$EXIT_CODE_FILE")
     if [[ $V_FLAG -ge 5 ]]; then
-	echo "$0: debug[5]: found non-empty EXIT_CODE_FIlE: $EXIT_CODE_FIlE" 1>&2
+	echo "$0: debug[5]: found non-empty EXIT_CODE_FILE: $EXIT_CODE_FILE" 1>&2
     fi
     if [[ -z $NEW_EXIT_CODE ]]; then
-	echo "$0: FATAL: NEW_EXIT_CODE empty but non-empty EXIT_CODE_FIlE exists: $EXIT_CODE_FIlE" 1>&2
+	echo "$0: FATAL: NEW_EXIT_CODE empty but non-empty EXIT_CODE_FILE exists: $EXIT_CODE_FILE" 1>&2
 	exit 55
     fi
     if [[ $NEW_EXIT_CODE =~ ^[0-9]+$ ]]; then
@@ -515,7 +515,7 @@ fi
 if [[ $V_FLAG -ge 1 ]]; then
     echo "$0: debug[1]: top level EXIT_CODE: $EXIT_CODE" 1>&2
 fi
-rm -f "$EXIT_CODE_FIlE"
+rm -f "$EXIT_CODE_FILE"
 
 # All Done!!! -- Jessica Noll, Age 2
 #

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -852,7 +852,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(14, __func__, "tar is not a file: %s", tar);
+	err(14, __func__, "tar is not a regular file: %s", tar);
 	not_reached();
     }
     if (!is_exec(tar)) {
@@ -908,7 +908,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(17, __func__, "cp is not a file: %s", cp);
+	err(17, __func__, "cp is not a regular file: %s", cp);
 	not_reached();
     }
     if (!is_exec(cp)) {
@@ -964,7 +964,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(20, __func__, "ls is not a file: %s", ls);
+	err(20, __func__, "ls is not a regular file: %s", ls);
 	not_reached();
     }
     if (!is_exec(ls)) {
@@ -1020,7 +1020,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(23, __func__, "txzchk is not a file: %s", txzchk);
+	err(23, __func__, "txzchk is not a regular file: %s", txzchk);
 	not_reached();
     }
     if (!is_exec(txzchk)) {
@@ -1076,7 +1076,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(26, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(26, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -1132,7 +1132,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(29, __func__, "jinfochk is not a file: %s", jinfochk);
+	err(29, __func__, "jinfochk is not a regular file: %s", jinfochk);
 	not_reached();
     }
     if (!is_exec(jinfochk)) {
@@ -1188,7 +1188,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *t
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(32, __func__, "jauthchk is not a file: %s", jauthchk);
+	err(32, __func__, "jauthchk is not a regular file: %s", jauthchk);
 	not_reached();
     }
     if (!is_exec(jauthchk)) {
@@ -2237,7 +2237,7 @@ check_prog_c(struct info *infop, char const *entry_dir, char const *cp, char con
 	      "The prog.c path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(83, __func__, "prog.c is not a file: %s", prog_c);
+	err(83, __func__, "prog.c is not a regular file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -2750,7 +2750,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
 	       "The Makefile path, while it exists, is not a regular file.",
 	       "",
 	       NULL);
-	err(97, __func__, "Makefile is not a file: %s", Makefile);
+	err(97, __func__, "Makefile is not a regular file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -2851,7 +2851,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
 	      "The remarks.md path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(105, __func__, "remarks_md is not a file: %s", remarks_md);
+	err(105, __func__, "remarks.md is not a regular file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -2976,7 +2976,7 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 		   "The file, while it exists, is not a regular file.",
 		   "",
 		   NULL);
-	    err(115, __func__, "extra[%i] is not a file: %s", i, args[i]);
+	    err(115, __func__, "extra[%i] is not a regular file: %s", i, args[i]);
 	    not_reached();
 	}
 	if (!is_read(args[i])) {

--- a/prep.sh
+++ b/prep.sh
@@ -100,7 +100,7 @@ if [[ ! -e $MAKEFILE ]]; then
     exit 3
 fi
 if [[ ! -f $MAKEFILE ]]; then
-    echo "$0: ERROR: Makefile not a file: $MAKEFILE" 1>&2
+    echo "$0: ERROR: Makefile not a regular file: $MAKEFILE" 1>&2
     exit 3
 fi
 if [[ ! -r $MAKEFILE ]]; then

--- a/reset_tstamp.sh
+++ b/reset_tstamp.sh
@@ -112,7 +112,7 @@ if [[ ! -e $LIMIT_IOCCC_H ]]; then
     exit 7
 fi
 if [[ ! -f $LIMIT_IOCCC_H ]]; then
-    echo "$0: ERROR: limit_ioccc.h not a file: $LIMIT_IOCCC_H" 1>&2
+    echo "$0: ERROR: limit_ioccc.h not a regular file: $LIMIT_IOCCC_H" 1>&2
     exit 7
 fi
 if [[ ! -r $LIMIT_IOCCC_H ]]; then

--- a/run_bison.sh
+++ b/run_bison.sh
@@ -142,7 +142,7 @@ if [[ ! -e $LIMIT_IOCCC_SH ]]; then
     exit 6
 fi
 if [[ ! -f $LIMIT_IOCCC_SH ]]; then
-    echo "$0: ERROR: limit_ioccc.sh not a file: $LIMIT_IOCCC_SH" 1>&2
+    echo "$0: ERROR: limit_ioccc.sh not a regular file: $LIMIT_IOCCC_SH" 1>&2
     exit 6
 fi
 if [[ ! -r $LIMIT_IOCCC_SH ]]; then
@@ -154,7 +154,7 @@ if [[ ! -e $VERGE ]]; then
     exit 6
 fi
 if [[ ! -f $VERGE ]]; then
-    echo "$0: ERROR: verge not a file: $VERGE" 1>&2
+    echo "$0: ERROR: verge not a regular file: $VERGE" 1>&2
     exit 6
 fi
 if [[ ! -x $VERGE ]]; then
@@ -166,7 +166,7 @@ if [[ ! -e $SORRY_H ]]; then
     exit 6
 fi
 if [[ ! -f $SORRY_H ]]; then
-    echo "$0: ERROR: sorry file not a file: $SORRY_H" 1>&2
+    echo "$0: ERROR: sorry file not a regular file: $SORRY_H" 1>&2
     exit 6
 fi
 if [[ ! -r $SORRY_H ]]; then
@@ -443,8 +443,12 @@ use_bison_backup() {
     BISON_C="$PREFIX.tab.c"
     BISON_BACKUP_H="$PREFIX.tab.ref.h"
     BISON_H="$PREFIX.tab.h"
+    if [[ ! -e $BISON_BACKUP_C ]]; then
+	echo "$0: ERROR: file not found: $BISON_BACKUP_C" 1>&2
+	exit 4
+    fi
     if [[ ! -f $BISON_BACKUP_C ]]; then
-	echo "$0: ERROR: not a file: $BISON_BACKUP_C" 1>&2
+	echo "$0: ERROR: not a regular file: $BISON_BACKUP_C" 1>&2
 	exit 4
     fi
     if [[ ! -r $BISON_BACKUP_C ]]; then
@@ -456,7 +460,7 @@ use_bison_backup() {
 	exit 4
     fi
     if [[ ! -f $BISON_BACKUP_H ]]; then
-	echo "$0: ERROR: not a file: $BISON_BACKUP_H" 1>&2
+	echo "$0: ERROR: not a regular file: $BISON_BACKUP_H" 1>&2
 	exit 4
     fi
     if [[ ! -r $BISON_BACKUP_H ]]; then
@@ -518,7 +522,7 @@ add_sorry() {
 	exit 15
     fi
     if [[ ! -f $TMP_FILE ]]; then
-	echo "$0: ERROR: tmp not a file: $TMP_FILE" 1>&2
+	echo "$0: ERROR: tmp not a regular file: $TMP_FILE" 1>&2
 	exit 16
     fi
     if [[ ! -r $TMP_FILE ]]; then

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -141,7 +141,7 @@ if [[ ! -e $LIMIT_IOCCC_SH ]]; then
     exit 6
 fi
 if [[ ! -f $LIMIT_IOCCC_SH ]]; then
-    echo "$0: ERROR: limit_ioccc.sh not a file: $LIMIT_IOCCC_SH" 1>&2
+    echo "$0: ERROR: limit_ioccc.sh not a regular file: $LIMIT_IOCCC_SH" 1>&2
     exit 6
 fi
 if [[ ! -r $LIMIT_IOCCC_SH ]]; then
@@ -153,7 +153,7 @@ if [[ ! -e $VERGE ]]; then
     exit 6
 fi
 if [[ ! -f $VERGE ]]; then
-    echo "$0: ERROR: verge not a file: $VERGE" 1>&2
+    echo "$0: ERROR: verge not a regular file: $VERGE" 1>&2
     exit 6
 fi
 if [[ ! -x $VERGE ]]; then
@@ -165,7 +165,7 @@ if [[ ! -e $SORRY_H ]]; then
     exit 6
 fi
 if [[ ! -f $SORRY_H ]]; then
-    echo "$0: ERROR: sorry file not a file: $SORRY_H" 1>&2
+    echo "$0: ERROR: sorry file not a regular file: $SORRY_H" 1>&2
     exit 6
 fi
 if [[ ! -r $SORRY_H ]]; then
@@ -430,8 +430,12 @@ use_flex_backup() {
     #
     FLEX_BACKUP_C="$PREFIX.ref.c"
     FLEX_C="$PREFIX.c"
+    if [[ ! -e $FLEX_BACKUP_C ]]; then
+	echo "$0: ERROR: file not found: $FLEX_BACKUP_C" 1>&2
+	exit 4
+    fi
     if [[ ! -f $FLEX_BACKUP_C ]]; then
-	echo "$0: ERROR: not a file: $FLEX_BACKUP_C" 1>&2
+	echo "$0: ERROR: not a regular file: $FLEX_BACKUP_C" 1>&2
 	exit 4
     fi
     if [[ ! -r $FLEX_BACKUP_C ]]; then
@@ -486,7 +490,7 @@ add_sorry() {
 	exit 15
     fi
     if [[ ! -f $TMP_FILE ]]; then
-	echo "$0: ERROR: tmp not a file: $TMP_FILE" 1>&2
+	echo "$0: ERROR: tmp not a regular file: $TMP_FILE" 1>&2
 	exit 16
     fi
     if [[ ! -r $TMP_FILE ]]; then

--- a/txzchk.c
+++ b/txzchk.c
@@ -316,7 +316,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
 		  "    https://www.gnu.org/software/tar/",
 		  "",
 		  NULL);
-	    err(5, __func__, "tar is not a file: %s", tar);
+	    err(5, __func__, "tar is not a regular file: %s", tar);
 	    not_reached();
 	}
 	if (!is_exec(tar)) {
@@ -363,7 +363,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
 	      "",
 	      "    txzchk -F /path/to/fnamchk ...",
 	      NULL);
-	err(8, __func__, "fnamchk is not a file: %s", fnamchk);
+	err(8, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -405,7 +405,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
 	      "    txzchk [...] <txzpath>",
 	      "",
 	      NULL);
-	err(11, __func__, "txzpath is not a file: %s", txzpath);
+	err(11, __func__, "txzpath is not a regular file: %s", txzpath);
 	not_reached();
     }
     if (!is_read(txzpath)) {

--- a/txzchk_test.sh
+++ b/txzchk_test.sh
@@ -100,7 +100,7 @@ if [[ ! -e $EXIT_CODE_FILE ]]; then
     exit 55
 fi
 if [[ ! -f $EXIT_CODE_FILE ]]; then
-    echo "$0: ERROR: EXIT_CODE_FILE not a file: $EXIT_CODE_FILE" 1>&2
+    echo "$0: ERROR: EXIT_CODE_FILE not a regular file: $EXIT_CODE_FILE" 1>&2
     exit 55
 fi
 if [[ ! -r $EXIT_CODE_FILE ]]; then
@@ -164,7 +164,7 @@ if [[ ! -e $TXZCHK ]]; then
     exit 4
 fi
 if [[ ! -f $TXZCHK ]]; then
-    echo "$0: ERROR: txzchk not a file: $TXZCHK" 1>&2
+    echo "$0: ERROR: txzchk not a regular file: $TXZCHK" 1>&2
     exit 4
 fi
 if [[ ! -x $TXZCHK ]]; then
@@ -179,7 +179,7 @@ if [[ ! -e $FNAMCHK ]]; then
     exit 4
 fi
 if [[ ! -f $FNAMCHK ]]; then
-    echo "$0: ERROR: fnamchk not a file: $FNAMCHK" 1>&2
+    echo "$0: ERROR: fnamchk not a regular file: $FNAMCHK" 1>&2
     exit 4
 fi
 if [[ ! -x $FNAMCHK ]]; then
@@ -194,7 +194,7 @@ if [[ ! -e $TAR ]]; then
     exit 4
 fi
 if [[ ! -f $TAR ]]; then
-    echo "$0: ERROR: tar not a file: $TAR" 1>&2
+    echo "$0: ERROR: tar not a regular file: $TAR" 1>&2
     exit 4
 fi
 if [[ ! -x $TAR ]]; then

--- a/vermod.sh
+++ b/vermod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# vermod - modify version strings (and others) under ./test_JSON
+# vermod.sh - modify version strings (and others) under ./test_JSON
 #
 # Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
 #
@@ -139,7 +139,7 @@ if [[ ! -e $LIMIT_SH ]]; then
     exit 3
 fi
 if [[ ! -f $LIMIT_SH ]]; then
-    echo "$0: ERROR: limit.sh is not a file: $LIMIT_SH" 1>&2
+    echo "$0: ERROR: limit.sh is not a regular file: $LIMIT_SH" 1>&2
     exit 3
 fi
 if [[ ! -r $LIMIT_SH ]]; then

--- a/version.h
+++ b/version.h
@@ -167,7 +167,7 @@
   *
   * Because the JSON parser is a self contained system, we cannot define JSON_PARSER_VERSION here.
   * Because the JSON parser is a self contained system, we cannot define JPARSE_VERSION here.
-  * See jparseh for the JSON_PARSER_VERSION value.
+  * See jparse.h for the JSON_PARSER_VERSION value.
   * See jparse_main.h for the JPARSE_VERSION value.
   */
 


### PR DESCRIPTION
There were many references to 'not a file' after first determining that
it actually exists and is a file (should have read 'not a regular
file').

In json_test.sh a variable was called EXIT_CODE_FIlE instead of
EXIT_CODE_FILE (if it's not obvious at a quick glance the former name
had a lower case ell).

The C files:

   jauthchk.c
   jinfochk.c
   mkiocccentry.c
   txzchk.c

All referred to 'not a file' after first determining that said path is
in fact a file (again here should have read 'not a regular file' as they
now do).

In vermod.sh change the name (in comment) to vermod.sh (was vermod).

There might have been some other fixes as well but the above are the
significant ones.