### PR TITLE
Change lambda transliterations in utf8_posix_map.c + update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # mkiocccentry specific
 .exit_code.*
 .sorry.*
+.hostchk.*
 answers.txt
 build.log
 chkauth

--- a/ioccc_test.sh
+++ b/ioccc_test.sh
@@ -50,6 +50,7 @@ Exit codes:
     8    ./dyn_test not found or not executable
     9	 ./jparse_test.sh not found or not executable
     10	 ./json_teststr.txt not found or not readable
+    11	 ./txzchk not found or not executable
 
     >=20  some test failed"
 export TEST_VERSION="0.462022-04-23"
@@ -197,6 +198,19 @@ fi
 if [[ ! -r json_teststr.txt ]]; then
     echo "$0: ERROR: json_teststr.txt is not readable" 1>&2
     exit 10
+fi
+# txzchk
+if [[ ! -e ./txzchk ]]; then
+    echo "$0: ERROR: ./txzchk file not found" 1>&2
+    exit 11
+fi
+if [[ ! -f ./txzchk ]]; then
+    echo "$0: ERROR: ./txzchk is not a regular file" 1>&2
+    exit 11
+fi
+if [[ ! -x ./txzchk ]]; then
+    echo "$0: ERROR: ./txzchk is not executable" 1>&2
+    exit 11
 fi
 
 

--- a/utf8_posix_map.c
+++ b/utf8_posix_map.c
@@ -516,7 +516,7 @@ struct utf8_posix_map hmap[] =
     { "\xc6\x98", "k" , -1, -1},	/*  U+0198 - Ƙ - LATIN CAPITAL LETTER K WITH HOOK */
     { "\xc6\x99", "k" , -1, -1},	/*  U+0199 - ƙ - LATIN SMALL LETTER K WITH HOOK */
     { "\xc6\x9a", "l" , -1, -1},	/*  U+019A - ƚ - LATIN SMALL LETTER L WITH BAR */
-    { "\xc6\x9b", "y" , -1, -1},	/*  U+019B - ƛ - LATIN SMALL LETTER LAMBDA WITH STROKE */
+    { "\xc6\x9b", "l" , -1, -1},	/*  U+019B - ƛ - LATIN SMALL LETTER LAMBDA WITH STROKE */
     { "\xc6\x9c", "w" , -1, -1},	/*  U+019C - Ɯ - LATIN CAPITAL LETTER TURNED M */
     { "\xc6\x9d", "n" , -1, -1},	/*  U+019D - Ɲ - LATIN CAPITAL LETTER N WITH LEFT HOOK */
     { "\xc6\x9e", "n" , -1, -1},	/*  U+019E - ƞ - LATIN SMALL LETTER N WITH LONG RIGHT LEG */
@@ -1028,7 +1028,7 @@ struct utf8_posix_map hmap[] =
     { "\xce\x98", "o" , -1, -1},	/*  U+0398 - Θ - GREEK CAPITAL LETTER THETA */
     { "\xce\x99", "i" , -1, -1},	/*  U+0399 - Ι - GREEK CAPITAL LETTER IOTA */
     { "\xce\x9a", "k" , -1, -1},	/*  U+039A - Κ - GREEK CAPITAL LETTER KAPPA */
-    { "\xce\x9b", "n" , -1, -1},	/*  U+039B - Λ - GREEK CAPITAL LETTER LAMDA */
+    { "\xce\x9b", "L" , -1, -1},	/*  U+039B - Λ - GREEK CAPITAL LETTER LAMBDA */
     { "\xce\x9c", "m" , -1, -1},	/*  U+039C - Μ - GREEK CAPITAL LETTER MU */
     { "\xce\x9d", "n" , -1, -1},	/*  U+039D - Ν - GREEK CAPITAL LETTER NU */
     { "\xce\x9e", "-" , -1, -1},	/*  U+039E - Ξ - GREEK CAPITAL LETTER XI */
@@ -1060,7 +1060,7 @@ struct utf8_posix_map hmap[] =
     { "\xce\xb8", "o" , -1, -1},	/*  U+03B8 - θ - GREEK SMALL LETTER THETA */
     { "\xce\xb9", "l" , -1, -1},	/*  U+03B9 - ι - GREEK SMALL LETTER IOTA */
     { "\xce\xba", "k" , -1, -1},	/*  U+03BA - κ - GREEK SMALL LETTER KAPPA */
-    { "\xce\xbb", "y" , -1, -1},	/*  U+03BB - λ - GREEK SMALL LETTER LAMDA */
+    { "\xce\xbb", "l" , -1, -1},	/*  U+03BB - λ - GREEK SMALL LETTER LAMBDA */
     { "\xce\xbc", "u" , -1, -1},	/*  U+03BC - μ - GREEK SMALL LETTER MU */
     { "\xce\xbd", "v" , -1, -1},	/*  U+03BD - ν - GREEK SMALL LETTER NU */
     { "\xce\xbe", "e" , -1, -1},	/*  U+03BE - ξ - GREEK SMALL LETTER XI */


### PR DESCRIPTION
According to OED lambda is:

    the eleventh letter of the Greek alphabet (Λ, λ), transliterated as ‘l’.

so it should be capital (or uncial; majuscule) and lower case (or
minuscule) ELL and not y and n. Thus:

    -    { "\xc6\x9b", "y" , -1, -1},	/*  U+019B - ƛ - LATIN SMALL LETTER LAMBDA WITH STROKE */
    +    { "\xc6\x9b", "l" , -1, -1},	/*  U+019B - ƛ - LATIN SMALL LETTER LAMBDA WITH STROKE */

    -    { "\xce\x9b", "n" , -1, -1},	/*  U+039B - Λ - GREEK CAPITAL LETTER LAMDA */
    +    { "\xce\x9b", "L" , -1, -1},	/*  U+039B - Λ - GREEK CAPITAL LETTER LAMBDA */

    -    { "\xce\xbb", "y" , -1, -1},	/*  U+03BB - λ - GREEK SMALL LETTER LAMDA */
    +    { "\xce\xbb", "l" , -1, -1},	/*  U+03BB - λ - GREEK SMALL LETTER LAMBDA */

Now the question of the Latin version. As best I could find this is not
even actually a thing other than in Unicode. I believe the Greek lambda
created the Latin L though so it seems appropriate that the change be
made for the Latin version too.

Also I fixed the spelling 'lamda' to 'lambda'. Apparently Unicode uses
'lamda' for Greek and lambda for Latin which is both ironic and
ridiculous as lambda is the actual letter in the Greek alphabet and it's
spelt lambda not 'lamda' as well.

If there's a 'Latin capital letter lambda with stroke' it probably
should be changed to 'L' as well. However I don't see it in the table so
I'm guessing there isn't anything left to do here.