### PR TITLE
Use dbg_allowed() throughout dyn_array.c

### DIFF
--- a/dyn_array.c
+++ b/dyn_array.c
@@ -32,11 +32,6 @@
 /*coo*/ /* exit code change of order - use new value in sequencing */
 
 
-/*
- * For performance reasons,
- * XXX - use dbg_allowed() to bypass dbg() calls that lots of args - XXX
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -183,13 +178,13 @@ dyn_array_grow(struct dyn_array *array, intmax_t elms_to_allocate)
     }
     array->data = data;
     array->allocated = new_allocated;
-    if (moved == true) {
+    if (moved == true && dbg_allowed(DBG_VVVVHIGH)) {
 	dbg(DBG_VVVVHIGH, "in %s(array, %jd): moved-place: allocated: %jd elements of size: %ju in use: %jd",
 			  __func__, elms_to_allocate,
 			  dyn_array_alloced(array),
 			  (uintmax_t)array->elm_size,
 			  dyn_array_tell(array));
-    } else {
+    } else if (dbg_allowed(DBG_VVVVVHIGH)) {
 	dbg(DBG_VVVVVHIGH, "in %s(array, %jd): in-place: allocated: %jd elements of size: %ju in use: %jd",
 			   __func__, elms_to_allocate,
 			   dyn_array_alloced(array),
@@ -331,8 +326,10 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 	err(62, __func__, "last_add arg is NULL");
 	not_reached();
     }
-    dbg(DBG_VVVVHIGH, "in %s: first_alloc: %p last_alloc: %p first_add: %p last_add: %p",
+    if (dbg_allowed(DBG_VVVVHIGH)) {
+	dbg(DBG_VVVVHIGH, "in %s: first_alloc: %p last_alloc: %p first_add: %p last_add: %p",
 		      __func__, first_alloc, last_alloc, first_add, last_add);
+    }
     if (first_alloc > last_alloc) {
 	err(63, __func__, "first_alloc: %p > last_alloc: %p", first_alloc, last_alloc);
 	not_reached();
@@ -352,20 +349,26 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 	/*
 	 * case: data to add starts before allocated
 	 */
-	dbg(DBG_VVVVHIGH, "in %s: first_add: %p < first_alloc: %p",
+	if (dbg_allowed(DBG_VVVVHIGH)) {
+	    dbg(DBG_VVVVHIGH, "in %s: first_add: %p < first_alloc: %p",
 			   __func__, first_add, first_alloc);
+	}
 	switch (compare_addr(last_add, first_alloc)) {
 
 	case PTR_BELOW_ADDR:	/* all of data is before allocated */
 	    ret = MOVE_CASE_OUTSIDE;
-	    dbg(DBG_VVVVHIGH, "in %s: ret #0: %s: last_add: %p < first_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "in %s: ret #0: %s: last_add: %p < first_alloc: %p",
 			       __func__, move_case_name(ret), last_add, first_alloc);
+	    }
 	    break;
 
 	case PTR_EQ:		/* only last byte of data is allocated */
 	    ret = MOVE_CASE_BEFORE_INTO;
-	    dbg(DBG_VVVVHIGH, "in %s: ret #1: %s: last_add: %p == first_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "in %s: ret #1: %s: last_add: %p == first_alloc: %p",
 			       __func__, move_case_name(ret), last_add, first_alloc);
+	    }
 	    break;
 
 	case PTR_ABOVE_ADDR:	/* last byte to add is beyond first allocated */
@@ -373,32 +376,46 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 	    /*
 	     * case: data to add starts before allocated AND last byte to add is beyond first allocated
 	     */
-	    dbg(DBG_VVVVHIGH, "in %s: last_add: %p > first_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "in %s: last_add: %p > first_alloc: %p",
 			       __func__, last_add, first_alloc);
+	    }
 	    switch (compare_addr(last_add, last_alloc)) {
 
 	    case PTR_BELOW_ADDR:	/* data ends before end of allocated */
-		dbg(DBG_VVVVHIGH, "in %s: last_add: %p < last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: last_add: %p < last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_BEFORE_INTO;
-		dbg(DBG_VVVVHIGH, "in %s: ret #2: %s: last_add: %p < last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: ret #2: %s: last_add: %p < last_alloc: %p",
 				  __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    case PTR_EQ:		/* end of data matches end of allocated */
-		dbg(DBG_VVVVHIGH, "in %s: last_add: %p == last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: last_add: %p == last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_BEFORE_INTO;
-		dbg(DBG_VVVVHIGH, "in %s: ret #3: %s: last_add: %p == last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: ret #3: %s: last_add: %p == last_alloc: %p",
 				  __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    case PTR_ABOVE_ADDR:	/* data ends beyond end of allocated */
-		dbg(DBG_VVVVHIGH, "in %s: last_add: %p > last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: last_add: %p > last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_BEFORE_IN_BEYOND;
-		dbg(DBG_VVVVHIGH, "in %s: ret #4: %s: last_add: %p > last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "in %s: ret #4: %s: last_add: %p > last_alloc: %p",
 				  __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    default:
@@ -418,32 +435,46 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 	/*
 	 * case: data starts at beginning of allocated
 	 */
-	dbg(DBG_VVVVHIGH, "is %s: first_add: %p == first_alloc: %p",
+	if (dbg_allowed(DBG_VVVVHIGH)) {
+	    dbg(DBG_VVVVHIGH, "is %s: first_add: %p == first_alloc: %p",
 			  __func__, first_add, first_alloc);
+	}
 	switch (compare_addr(last_add, last_alloc)) {
 
 	case PTR_BELOW_ADDR:	/* data ends before end of allocated */
-	    dbg(DBG_VVVVHIGH, "is %s: last_add: %p < last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: last_add: %p < last_alloc: %p",
 			      __func__, last_add, last_alloc);
+	    }
 	    ret = MOVE_CASE_INSIDE;
-	    dbg(DBG_VVVVHIGH, "is %s: ret #5: %s: last_add: %p < last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: ret #5: %s: last_add: %p < last_alloc: %p",
 			      __func__, move_case_name(ret), last_add, last_alloc);
+	    }
 	    break;
 
 	case PTR_EQ:		/* data ends at end of allocated */
-	    dbg(DBG_VVVVHIGH, "is %s: last_add: %p == last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: last_add: %p == last_alloc: %p",
 			      __func__, last_add, last_alloc);
+	    }
 	    ret = MOVE_CASE_INSIDE;
-	    dbg(DBG_VVVVHIGH, "is %s: ret #6: %s: last_add: %p == last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: ret #6: %s: last_add: %p == last_alloc: %p",
 			       __func__, move_case_name(ret), last_add, last_alloc);
+	    }
 	    break;
 
 	case PTR_ABOVE_ADDR:	/* data ends beyond end of allocated */
-	    dbg(DBG_VVVVHIGH, "is %s: last_add: %p > last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: last_add: %p > last_alloc: %p",
 			      __func__, last_add, last_alloc);
+	    }
 	    ret = MOVE_CASE_IN_BEYOND;
-	    dbg(DBG_VVVVHIGH, "is %s: ret #7: %s: last_add: %p > last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: ret #7: %s: last_add: %p > last_alloc: %p",
 			      __func__, move_case_name(ret), last_add, last_alloc);
+	    }
 	    break;
 
 	default:
@@ -457,36 +488,52 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 	/*
 	 * case: data to add starts after allocated starts
 	 */
-	dbg(DBG_VVVVHIGH, "is %s: first_add: %p > first_alloc: %p",
+	if (dbg_allowed(DBG_VVVVHIGH)) {
+	    dbg(DBG_VVVVHIGH, "is %s: first_add: %p > first_alloc: %p",
 			  __func__, first_add, first_alloc);
+	}
 	switch (compare_addr(first_add, last_alloc)) {
 
 	case PTR_BELOW_ADDR:	/* data starts before end of allocated */
-	    dbg(DBG_VVVVHIGH, "is %s: first_add: %p < last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: first_add: %p < last_alloc: %p",
 			      __func__, first_add, last_alloc);
+	    }
 	    switch (compare_addr(last_add, last_alloc)) {
 	    case PTR_BELOW_ADDR:	/* data ends before end of allocated */
-		dbg(DBG_VVVVHIGH, "is %s: last_add: %p < last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: last_add: %p < last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_INSIDE;
-		dbg(DBG_VVVVHIGH, "is %s: ret #8: %s: last_add: %p == last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: ret #8: %s: last_add: %p == last_alloc: %p",
 				   __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    case PTR_EQ:		/* data ends matches end of allocated */
-		dbg(DBG_VVVVHIGH, "is %s: last_add: %p == last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: last_add: %p == last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_INSIDE;
-		dbg(DBG_VVVVHIGH, "is %s: ret #9: %s: last_add: %p == last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: ret #9: %s: last_add: %p == last_alloc: %p",
 				   __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    case PTR_ABOVE_ADDR:	/* data ends beyond end of allocated */
-		dbg(DBG_VVVVHIGH, "is %s: last_add: %p > last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: last_add: %p > last_alloc: %p",
 				  __func__, last_add, last_alloc);
+		}
 		ret = MOVE_CASE_IN_BEYOND;
-		dbg(DBG_VVVVHIGH, "is %s: ret #10: %s: last_add: %p > last_alloc: %p",
+		if (dbg_allowed(DBG_VVVVHIGH)) {
+		    dbg(DBG_VVVVHIGH, "is %s: ret #10: %s: last_add: %p > last_alloc: %p",
 				   __func__, move_case_name(ret), last_add, last_alloc);
+		}
 		break;
 
 	    default:
@@ -497,16 +544,22 @@ determine_move_case(void *first_alloc, void *last_alloc, void *first_add, void *
 
 	case PTR_EQ:		/* data start matches end of allocated */
 	    ret = MOVE_CASE_INSIDE;
-	    dbg(DBG_VVVVHIGH, "is %s: ret #11: %s: first_add: %p == last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: ret #11: %s: first_add: %p == last_alloc: %p",
 			       __func__, move_case_name(ret), first_add, last_alloc);
+	    }
 	    break;
 
 	case PTR_ABOVE_ADDR:	/* data start beyond end of allocated */
-	    dbg(DBG_VVVVHIGH, "is %s: first_add: %p > last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: first_add: %p > last_alloc: %p",
 			      __func__, first_add, last_alloc);
+	    }
 	    ret = MOVE_CASE_OUTSIDE;
-	    dbg(DBG_VVVVHIGH, "is %s: ret #12: %s: first_add: %p > last_alloc: %p",
+	    if (dbg_allowed(DBG_VVVVHIGH)) {
+		dbg(DBG_VVVVHIGH, "is %s: ret #12: %s: first_add: %p > last_alloc: %p",
 			      __func__, move_case_name(ret), first_add, last_alloc);
+	    }
 	    break;
 
 	default:
@@ -659,10 +712,12 @@ dyn_array_create(size_t elm_size, intmax_t chunk, intmax_t start_elm_count, bool
     /*
      * Return newly allocated array
      */
-    dbg(DBG_VVVVHIGH, "in %s(%ju, %jd, %jd, %s): initialized empty dynamic array, allocated: %jd elements of size: %ju",
+    if (dbg_allowed(DBG_VVVVHIGH)) {
+	dbg(DBG_VVVVHIGH, "in %s(%ju, %jd, %jd, %s): initialized empty dynamic array, allocated: %jd elements of size: %ju",
 		      __func__, (uintmax_t)elm_size, chunk, start_elm_count,
 		      booltostr(zeroize),
 		      dyn_array_alloced(ret), (uintmax_t)ret->elm_size);
+    }
     return ret;
 }
 
@@ -819,22 +874,28 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
 	/*
 	 * determine our move case
 	 */
-	dbg(DBG_VVVHIGH, "in %s(array: %p, array_to_add_p: %p, %jd)", __func__,
+	if (dbg_allowed(DBG_VVVHIGH)) {
+	    dbg(DBG_VVVHIGH, "in %s(array: %p, array_to_add_p: %p, %jd)", __func__,
 			 (void *)array, (void *)array_to_add_p, count_of_elements_to_add);
+	}
 	last_add_byte = (uint8_t *)(array_to_add_p) + (data_size - 1);
 	last_alloc_byte = (uint8_t *)(array->data) + (alloc_size - 1);
 	data_first_offset = (uint8_t *)(array_to_add_p) - (uint8_t *)(array->data);
 	data_last_offset = (uint8_t *)(last_add_byte) - (uint8_t *)(array->data);
-	dbg(DBG_VVVVHIGH, "in %s: array->data: %p", __func__, (void *)array->data);
-	dbg(DBG_VVVVHIGH, "in %s: alloc_size: %jd", __func__, alloc_size);
-	dbg(DBG_VVVVHIGH, "in %s: last_alloc_byte: %p", __func__, (void *)last_alloc_byte);
-	dbg(DBG_VVVVHIGH, "in %s: array_to_add_p: %p", __func__, (void *)array_to_add_p);
-	dbg(DBG_VVVVHIGH, "in %s: data_size: %jd", __func__, data_size);
-	dbg(DBG_VVVVHIGH, "in %s: last_add_byte: %p", __func__, (void *)last_add_byte);
-	dbg(DBG_VVVVHIGH, "in %s: data_first_offset: %d", __func__, data_first_offset);
-	dbg(DBG_VVVVHIGH, "in %s: data_last_offset: %d", __func__, data_last_offset);
+	if (dbg_allowed(DBG_VVVVHIGH)) {
+	    dbg(DBG_VVVVHIGH, "in %s: array->data: %p", __func__, (void *)array->data);
+	    dbg(DBG_VVVVHIGH, "in %s: alloc_size: %jd", __func__, alloc_size);
+	    dbg(DBG_VVVVHIGH, "in %s: last_alloc_byte: %p", __func__, (void *)last_alloc_byte);
+	    dbg(DBG_VVVVHIGH, "in %s: array_to_add_p: %p", __func__, (void *)array_to_add_p);
+	    dbg(DBG_VVVVHIGH, "in %s: data_size: %jd", __func__, data_size);
+	    dbg(DBG_VVVVHIGH, "in %s: last_add_byte: %p", __func__, (void *)last_add_byte);
+	    dbg(DBG_VVVVHIGH, "in %s: data_first_offset: %d", __func__, data_first_offset);
+	    dbg(DBG_VVVVHIGH, "in %s: data_last_offset: %d", __func__, data_last_offset);
+	}
 	mv_case = determine_move_case(array->data, last_alloc_byte, array_to_add_p, last_add_byte);
-	dbg(DBG_VVVVHIGH, "in %s: move case: %s", __func__, move_case_name(mv_case));
+	if (dbg_allowed(DBG_VVVVHIGH)) {
+	    dbg(DBG_VVVVHIGH, "in %s: move case: %s", __func__, move_case_name(mv_case));
+	}
 
 	/*
 	 * determine the new allocated data size that as need
@@ -903,10 +964,12 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
 
 	    /* append the entire chunk of data */
 	    new_array_to_add_p = (uint8_t *)(array->data) + data_first_offset;	/* new stating location */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p, new_array_to_add_p: %p, data_size: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)new_array_to_add_p, data_size);
+	    }
 	    memmove((void *)beyond, (void *)new_array_to_add_p, data_size);
 	    break;
 
@@ -932,17 +995,21 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
 	    }
 
 	    /* append data that is before the dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p, new_array_to_add_p: %p, pre_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)new_array_to_add_p, pre_length);
+	    }
 	    memmove((void *)beyond, (void *)array_to_add_p, pre_length);
 
 	    /* append data that moved with the dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p, array->data: %p, in_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, array->data, in_length);
+	    }
 	    memmove((void *)beyond, array->data, in_length);
 	    break;
 
@@ -972,24 +1039,30 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
 	    }
 
 	    /* append data that is before the dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p array_to_add_p: %p, pre_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)array_to_add_p, pre_length);
+	    }
 	    memmove((void *)beyond, (void *)array_to_add_p, pre_length);
 
 	    /* append the section that was part of the previous dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p array->data: %p, alloc_size: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, array->data, alloc_size);
+	    }
 	    memmove((void *)beyond, array->data, alloc_size);
 
 	    /* append the data that was beyond the end of the previous dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p array_to_add_p+pre_length+data_size: %p, post_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)((uint8_t *)(array_to_add_p) + pre_length+data_size), post_length);
+	    }
 	    memmove((void *)beyond, (void *)((uint8_t *)(array_to_add_p) + pre_length+data_size), post_length);
 	    break;
 
@@ -1016,17 +1089,21 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
 
 	    /* append the data that stated inside the previous dynamic array allocated data */
 	    new_array_to_add_p = (uint8_t *)(array->data) + data_first_offset;	/* new stating location */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p new_array_to_add_p: %p, in_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)new_array_to_add_p, in_length);
+	    }
 	    memmove((void *)beyond, (void *)new_array_to_add_p, in_length);
 
 	    /* append the data that was beyond the end of the previous dynamic array allocated data */
-	    dbg(DBG_VVVHIGH, "mv_case: %s special "
+	    if (dbg_allowed(DBG_VVVHIGH)) {
+		dbg(DBG_VVVHIGH, "mv_case: %s special "
 			     "memmove(beyond: %p array_to_add_p+in_length: %p, post_length: %ju)",
 			     move_case_name(mv_case),
 			     (void *)beyond, (void *)((uint8_t *)(array_to_add_p) + in_length), post_length);
+	    }
 	    memmove((void *)beyond, (void *)((uint8_t *)(array_to_add_p) + in_length), post_length);
 	    break;
 
@@ -1040,13 +1117,15 @@ dyn_array_append_set(struct dyn_array *array, void *array_to_add_p, intmax_t cou
      * increase the amount of data that is in use, in the dynamic array
      */
     array->count += count_of_elements_to_add;
-    dbg(DBG_VVVVVHIGH, "in %s(array: %p, array_to_add_p %p, %jd): %s: allocated: %jd elements of size: %ju in use: %jd",
+    if (dbg_allowed(DBG_VVVVVHIGH)) {
+	dbg(DBG_VVVVVHIGH, "in %s(array: %p, array_to_add_p %p, %jd): %s: allocated: %jd elements of size: %ju in use: %jd",
 		       __func__, (void *)array, (void *)array_to_add_p,
 		       (intmax_t)count_of_elements_to_add,
 		       (moved == true ? "moved" : "in-place"),
 		       dyn_array_alloced(array),
 		       (uintmax_t)array->elm_size,
 		       dyn_array_tell(array));
+    }
 
     /* return array moved condition */
     return moved;
@@ -1313,7 +1392,8 @@ dyn_array_seek(struct dyn_array *array, off_t offset, int whence)
 
     /* set new in use count */
     array->count = setpoint;
-    dbg(DBG_VVVVVHIGH, "in %s(array, %jd, %s): %s: allocated: %jd elements of size: %ju in use: %jd",
+    if (dbg_allowed(DBG_VVVVVHIGH)) {
+	dbg(DBG_VVVVVHIGH, "in %s(array, %jd, %s): %s: allocated: %jd elements of size: %ju in use: %jd",
 		       __func__,
 		       (intmax_t)offset,
 		       (whence == SEEK_SET ? "SEEK_SET" : (whence == SEEK_CUR ? "SEEK_CUR" : "SEEK_END")),
@@ -1321,6 +1401,7 @@ dyn_array_seek(struct dyn_array *array, off_t offset, int whence)
 		       dyn_array_alloced(array),
 		       (uintmax_t)array->elm_size,
 		       dyn_array_tell(array));
+    }
 
     /* return array moved condition */
     return moved;
@@ -1389,11 +1470,13 @@ dyn_array_clear(struct dyn_array *array)
      * Set the number of elements in the array to zero
      */
     array->count = 0;
-    dbg(DBG_VVHIGH, "in %s(array) not-moved: allocated: %jd elements of size: %ju in use: %jd",
+    if (dbg_allowed(DBG_VVHIGH)) {
+	dbg(DBG_VVHIGH, "in %s(array) not-moved: allocated: %jd elements of size: %ju in use: %jd",
 		     __func__,
 		     dyn_array_alloced(array),
 		     (uintmax_t)array->elm_size,
 		     dyn_array_tell(array));
+    }
     return;
 }
 
@@ -1448,6 +1531,8 @@ dyn_array_free(struct dyn_array *array)
     array->count = 0;
     array->allocated = 0;
     array->chunk = 0;
-    dbg(DBG_VVVHIGH, "in %s(array)", __func__);
+    if (dbg_allowed(DBG_VVVHIGH)) {
+	dbg(DBG_VVVHIGH, "in %s(array)", __func__);
+    }
     return;
 }


### PR DESCRIPTION
This completes the TODO item in commit
976f311d84dc9124da8fdeed6abd35f3ae935136:

    TODO: Make use of dbg_allowed(level) in dyn_array.c to reduce the
	  CPU impact of dbg() calls that have lots of args.