### PR TITLE
Fix make test when txzchk not compiled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,7 +744,7 @@ reset_min_timestamp: reset_tstamp.sh
 # perform all of the mkiocccentry repo required tests
 #
 test ioccc_test: ioccc_test.sh iocccsize_test.sh dbg mkiocccentry_test.sh jstr_test.sh \
-		 jnum_chk dyn_test txzchk_test.sh jparse Makefile
+		 jnum_chk dyn_test txzchk_test.sh txzchk jparse Makefile
 	./ioccc_test.sh
 
 hostchk bug-report: hostchk.sh


### PR DESCRIPTION
For example if one does make clobber test it would fail with the
txzchk_test.sh as txzchk was not compiled. Perhaps the script itself
should do make txzchk but for now make test has txzchk as a dependency.