### PR TITLE
Minor typo fixes in mkiocccentry.c

### DIFF
--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
     bool overwrite_answers_flag_used = false;	/* true ==> don't prompt to overwrite answers if it already exists */
     bool txzchk_flag_used = false;		/* true ==> -T /path/to/txzchk was given */
     bool fnamchk_flag_used = false;		/* true ==> -F /path/to/fnamchk was given */
-    bool chkentry_flag_used = false;		/* true ==> -J /path/to/chkentry was given */
+    bool chkentry_flag_used = false;		/* true ==> -C /path/to/chkentry was given */
     bool overwrite_answers = true;		/* true ==> overwrite answers file even if it already exists */
     RuleCount size;				/* rule_count() processing results */
     int ret;					/* libc return code */
@@ -4691,9 +4691,6 @@ write_info(struct info *infop, char const *entry_dir, char const *chkentry, char
 	not_reached();
     }
 
-    /*
-     * perform the chkentry which will indirectly show the user the tarball contents
-     */
     if (!quiet) {
 	para("",
 	    "Checking the format of .info.json ...", NULL);
@@ -4864,9 +4861,6 @@ write_author(struct info *infop, int author_count, struct author *authorp, char 
 	    "Checking the format of .author.json ...", NULL);
     }
 
-    /*
-     * perform the chkentry which will indirectly show the user the tarball contents
-     */
     dbg(DBG_HIGH, "about to perform: %s -q -- . %s", chkentry, author_path);
     exit_code = shell_cmd(__func__, true, "% -q -- . %", chkentry, author_path);
     if (exit_code != 0) {


### PR DESCRIPTION
The chkentry flag is -C but the comment said the old -J.

Running chkentry does not indirectly show the user the contents of the
tarball; that's txzchk which is called in form_tarball().