### PR TITLE
dbg interface documentation + jparse.1 updates

### DIFF
--- a/chkentry.1
+++ b/chkentry.1
@@ -64,7 +64,7 @@ JSON parser support code header file.
 JSON parser support code source code.
 .RE
 .SH BUGS
-This tool is not finished yet; it depends on the completion of the JSON parser.
+This tool is not finished yet.
 .SH EXAMPLES
 .PP
 .nf

--- a/chkentry.1
+++ b/chkentry.1
@@ -1,4 +1,4 @@
-.TH chkentry 1 "22 Jun 2022" "chkentry" "IOCCC tools"
+.TH chkentry 1 "2 July 2022" "chkentry" "IOCCC tools"
 .SH NAME
 chkentry \- check JSON files in an IOCCC entry
 .SH SYNOPSIS

--- a/dbg.3
+++ b/dbg.3
@@ -1,21 +1,25 @@
-.TH dbg 3  "8 Jun 2022" "dbg"
+.TH dbg 3  "1 July 2022" "dbg"
 .SH NAME
 .BR msg(),
 .BR vmsg(),
 .BR fmsg(),
 .BR vfmsg(),
+.BR snmsg(),
 .BR dbg(),
 .BR vdbg(),
 .BR fdbg(),
 .BR vfdbg(),
+.BR sndbg(),
 .BR warn(),
 .BR vwarn(),
 .BR fwarn(),
 .BR vfwarn(),
+.BR snwarn(),
 .BR warnp(),
 .BR vwarnp(),
 .BR fwarnp(),
 .BR vfwarnp(),
+.BR snwarnp(),
 .BR err(),
 .BR verr(),
 .BR ferr(),
@@ -28,10 +32,12 @@
 .BR vwerr(),
 .BR fwerr(),
 .BR vfwerr(),
+.BR snwerr(),
 .BR werrp(),
 .BR vwerrp(),
 .BR fwerrp(),
 .BR vfwerrp(),
+.BR snwerrp(),
 .BR warn_or_err(),
 .BR vwarn_or_err(),
 .BR fwarn_or_err(),
@@ -69,6 +75,8 @@
 .BI "void fmsg(FILE *stream, const char *fmt, ...);"
 .br
 .BI "void vfmsg(FILE *stream, char const *fmt, va_list ap);"
+.br
+.BI "void snmsg(char *str, size_t size, char const *fmt, ...);"
 .sp
 .BI "void dbg(int level, const char *fmt, ...);"
 .br
@@ -77,6 +85,8 @@
 .BI "void fdbg(FILE *stream, int level, const char *fmt, ...);"
 .br
 .BI "void vfdbg(FILE *stream, int level, char const *fmt, va_list ap);"
+.br
+.BI "void sndbg(char *str, size_t size, int level, char const *fmt, ...);"
 .sp
 .BI "void warn(const char *name, const char *fmt, ...);"
 .br
@@ -85,6 +95,8 @@
 .BI "void fwarn(FILE *stream, const char *name, const char *fmt, ...);"
 .br
 .BI "void vfwarn(FILE *stream, char const *name, char const *fmt, va_list ap);"
+.br
+.BI "void snwarn(char *str, size_t size, char const *name, char const *fmt, ...);"
 .sp
 .BI "void warnp(const char *name, const char *fmt, ...);"
 .br
@@ -93,6 +105,8 @@
 .BI "void fwarnp(FILE *stream, const char *name, const char *fmt, ...);"
 .br
 .BI "void vfwarnp(FILE *stream, char const *name, char const *fmt, va_list ap);"
+.br
+.BI "void snwarnp(char *str, size_t size, char const *name, char const *fmt, ...);"
 .sp
 .BI "void err(int exitcode, const char *name, const char *fmt, ...);"
 .br
@@ -117,6 +131,8 @@
 .BI "void fwerr(int error_code, FILE *stream, const char *name, const char *fmt, ...);"
 .br
 .BI "void vfwerr(int error_code, FILE *stream, char const *name, char const *fmt, va_list ap);"
+.br
+.BI "void snwerr(int error_code, char *str, size_t size, char const *name, char const *fmt, ...);"
 .sp
 .BI "void werrp(int error_code, const char *name, const char *fmt, ...);"
 .br
@@ -125,6 +141,8 @@
 .BI "void fwerrp(int error_code, FILE *stream, const char *name, const char *fmt, ...);"
 .br
 .BI "void vfwerrp(int error_code, FILE *stream, char const *name, char const *fmt, va_list ap);"
+.br
+.BI "void snwerrp(int error_code, char *str, size_t size, char const *name, char const *fmt, ...);"
 .sp
 .BI "void warn_or_err(int exitcode, const char *name, bool warning, const char *fmt, ...);"
 .br
@@ -136,7 +154,7 @@
 .RE
 .SH DESCRIPTION
 These functions provide a way to write informative messages, debug messages, warning messages, error messages, non\-fatal error messages as well as usage messages.
-.SS Alternative output stream
+.SS Alternative output \fBFILE *\fP stream
 The functions that do not take a \fBFILE *\fP write to \fBstderr\fP.
 The functions
 .BR fmsg(),
@@ -160,6 +178,18 @@ The functions
 and
 .BR vfprintf_usage()
 can write to an alternative \fBFILE *\fP stream.
+.SS Writing to a \fBchar *\fP buffer
+The functions
+.BR snmsg(),
+.BR sndbg(),
+.BR snwarn(),
+.BR snwarnp(),
+.BR snwerr()
+and
+.BR snwerrp()
+write a message to a buffer of a fixed size.
+They do not write a newline after the message but the string is NUL terminated.
+They do not do anything if passed a NULL pointer or \fBsize <= 1\fP.
 .SS Variadic versions
 .PP
 The functions
@@ -242,6 +272,7 @@ These functions return void except that the functions
 and
 .BR vferrp()
 do not return at all.
+More specifically they do call \fBexit(3)\fP but immediately after call either \fB__builtin_unreachable\fP or \fBabort(3)\fP depending on the value of \fB__has_builtin(__builtin_unreachable)\fP, thereby terminating the program.
 .PP
 The functions
 .BR warn_or_err(),
@@ -253,7 +284,16 @@ The functions
 .BR fwarnp_or_errp()
 and
 .BR vfwarnp_or_errp()
-do not return if warning is false.
+do not return if warning is false in the same manner as the functions
+.BR err(),
+.BR verr(),
+.BR ferr(),
+.BR vferr(),
+.BR errp(),
+.BR verrp(),
+.BR ferrp(),
+and
+.BR vferrp()
 .PP
 The functions
 .BR printf_usage(),
@@ -264,7 +304,7 @@ and
 do not return if exitcode >= 0.
 .SH NOTES
 .SS Variadic arguments
-For the \fIva_list\fP functions, the argument \fIap\fP is not checked for consistency like they are using the primary interfaces.
+In the \fIva_list\fP functions, the argument \fIap\fP is not checked for consistency like they are using the primary interfaces.
 For this reason these versions are not recommended for use.
 .SS In case of NULL name
 If \fIname\fP is \fBNULL\fP it will be set to
@@ -293,21 +333,25 @@ All functions output extra newlines to help let the messages stand out better.
 
 $ cat dbg_example.c
 /*
- * This is just a trivial demo, see the main
- * function in dbg.c for a better example.
+ * This is just a trivial demo for the dbg api, see the main function in dbg.c
+ * for a better example.
  */
 
 #include "dbg.h"
 
 #define filename "foo.bar"
+
 long length = 7;
-int main(void)
+
+int
+main(void)
 {
 
     /*
      * We suggest you use getopt(3) and strtol(3) (cast to an int)
      * to convert \-v verbosity_level on the command line.
      */
+    msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */
 
     /*
@@ -317,7 +361,8 @@ int main(void)
      *
      * with newlines as described.
      */
-    warn(__func__, "elephant is sky\-blue pink");
+    msg("NOTE: The next line should say: \\"Warning: %s: %s", __func__, "elephant is sky\-blue pink\\"");
+    warn(__func__, "elephant is sky\-blue pink\n");
 
     /* this will not print anything as verbosity_level 3 (DBG_MED) < 5 (DBG_HIGH): */
     dbg(DBG_HIGH, "starting critical section");
@@ -328,7 +373,8 @@ int main(void)
      *
      *	    debug[3]: file: foo.bar has length: 7
      */
-    dbg(DBG_MED, "file: %s has length: %ld", filename, length);
+    msg("NOTE: The next line should read: \\"debug[3]: file: %s has length: %ld\\"", filename, length);
+    dbg(DBG_MED, "file: %s has length: %ld\n", filename, length);
 
     /*
      * If EPERM == 1 then this will print:
@@ -338,15 +384,24 @@ int main(void)
      * with newlines as discussed and then exit 2.
      */
     errno = EPERM;
+    msg("NOTE: The next line should read: \\"ERROR[2]: main: test: errno[%d]: %s\\"", errno, strerror(errno));
     errp(2, __func__, "test");
+
+    return 2; /* this return is never reached */
 }
 $ cc \-c dbg.c
 $ cc \-o dbg_example dbg_example.c dbg.o
 The above two commands could be shortened to just:
 \fBcc \-o dbg_example dbg_example.c dbg.c\fP
 $ ./dbg_example
-Warning: main: elephant is sky\-blue pink
+NOTE: Setting verbosity_level to DBG_MED: 3
+NOTE: The next line should say: "Warning: main: elephant is sky-blue pink"
+Warning: main: elephant is sky-blue pink
+
+NOTE: The next line should read: "debug[3]: file: foo.bar has length: 7"
 debug[3]: file: foo.bar has length: 7
+
+NOTE: The next line should read: "ERROR[2]: main: test: errno[1]: Operation not permitted"
 ERROR[2]: main: test: errno[1]: Operation not permitted
 $ echo $?
 2
@@ -356,4 +411,4 @@ $ echo $?
 .BR printf(3)
 .SH HISTORY
 The dbg facility was first written by Landon Curt Noll in 1989.
-Version 2.0 was developed and test tested within the IOCCC mkiocccentry GitHub repo.
+Version 2.0 was developed and tested within the IOCCC mkiocccentry GitHub repo.

--- a/dbg.c
+++ b/dbg.c
@@ -260,7 +260,7 @@ fmsg_write(FILE *stream, char const *caller, char const *fmt, va_list ap)
  * Unlike fmsg_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str	pointer to buffer in which to write a message
@@ -411,7 +411,7 @@ fdbg_write(FILE *stream, char const *caller, int level, char const *fmt, va_list
  * Unlike fdbg_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str	pointer to buffer in which to write a message
@@ -575,7 +575,7 @@ fwarn_write(FILE *stream, char const *caller, char const *name, char const *fmt,
  * Unlike fwarn_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str	pointer to buffer in which to write a message
@@ -738,7 +738,7 @@ fwarnp_write(FILE *stream, char const *caller, char const *name, char const *fmt
  * Unlike fwarnp_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str	pointer to buffer in which to write a message
@@ -914,7 +914,7 @@ ferr_write(FILE *stream, int error_code, char const *caller,
  * Unlike ferr_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str		pointer to buffer in which to write a message
@@ -1081,7 +1081,7 @@ ferrp_write(FILE *stream, int error_code, char const *caller,
  * Unlike ferrp_write(), this function does NOT add a final newline to str.
  *
  * The str[size-1] byte is set to NUL (if str != NULL && size > 0) in paranoia.
- * I.e., str is always NUL terminated unless str == NULL or unless size == 0.
+ * I.e., str is always NUL terminated unless str == NULL or size == 0.
  *
  * given:
  *	str		pointer to buffer in which to write a message

--- a/dbg_example.c
+++ b/dbg_example.c
@@ -1,6 +1,6 @@
 /*
- * This is just a trivial demo, see the main
- * function in dbg.c for a better example.
+ * This is just a trivial demo for the dbg api, see the main function in dbg.c
+ * for a better example.
  */
 
 #include "dbg.h"
@@ -17,6 +17,7 @@ main(void)
      * We suggest you use getopt(3) and strtol(3) (cast to an int)
      * to convert -v verbosity_level on the command line.
      */
+    msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */
 
     /*
@@ -26,7 +27,8 @@ main(void)
      *
      * with newlines as described.
      */
-    warn(__func__, "elephant is sky-blue pink");
+    msg("NOTE: The next line should say: \"Warning: %s: %s", __func__, "elephant is sky-blue pink\"");
+    warn(__func__, "elephant is sky-blue pink\n");
 
     /* this will not print anything as verbosity_level 3 (DBG_MED) < 5 (DBG_HIGH): */
     dbg(DBG_HIGH, "starting critical section");
@@ -37,7 +39,8 @@ main(void)
      *
      *	    debug[3]: file: foo.bar has length: 7
      */
-    dbg(DBG_MED, "file: %s has length: %ld", filename, length);
+    msg("NOTE: The next line should read: \"debug[3]: file: %s has length: %ld\"", filename, length);
+    dbg(DBG_MED, "file: %s has length: %ld\n", filename, length);
 
     /*
      * If EPERM == 1 then this will print:
@@ -47,6 +50,8 @@ main(void)
      * with newlines as discussed and then exit 2.
      */
     errno = EPERM;
+    msg("NOTE: The next line should read: \"ERROR[2]: main: test: errno[%d]: %s\"", errno, strerror(errno));
     errp(2, __func__, "test");
+
     return 2; /* this return is never reached */
 }

--- a/entry_util.c
+++ b/entry_util.c
@@ -1,6 +1,6 @@
 /* vim: set tabstop=8 softtabstop=4 shiftwidth=4 noexpandtab : */
 /*
- * entry_util - utilities supporting mkiocccentry JSON files
+ * entry_util - utility functions supporting mkiocccentry JSON files
  *
  * JSON related functions to support formation of .info.json files
  * and .author.json files, their related check tools, test code,

--- a/jparse.1
+++ b/jparse.1
@@ -1,4 +1,4 @@
-.TH jparse 1 "26 June 2022" "jparse" "IOCCC tools"
+.TH jparse 1 "29 June 2022" "jparse" "IOCCC tools"
 .SH NAME
 jparse \- IOCCC JSON parser
 .SH SYNOPSIS
@@ -80,8 +80,6 @@ Header file for general JSON parser utility support functions.
 Source code of the general JSON parser utility support functions.
 .RE
 .SH BUGS
-.PP
-Although \fBjparse\fP is complete in a sense the parser still does not return a parse tree even though it does parse JSON completely.
 .PP
 Better error reporting and various other things need to be added.
 .SH EXAMPLES

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -83,7 +83,7 @@ main(int argc, char **argv)
 	     * enable bison internal debugging if -J is verbose enough
 	     */
 	    if (json_dbg_allowed(JSON_DBG_VHIGH)) {
-		ugly_debug = 0;	/* verbose bison debug on */
+		ugly_debug = 1;	/* verbose bison debug on */
 	    } else {
 		ugly_debug = 0;	/* verbose bison debug off */
 	    }
@@ -160,7 +160,7 @@ main(int argc, char **argv)
     /*
      * free the JSON parse tree
      */
-    if (tree == NULL) {
+    if (tree != NULL) {
 	json_tree_free(tree, JSON_INFINITE_DEPTH);
 	free(tree);
 	tree = NULL;

--- a/json_parse.h
+++ b/json_parse.h
@@ -72,9 +72,10 @@ struct encode {
  * as an integer.  In this case the "integer values" fields will be used and
  * the "floating point values" fields will be unused (set to false, or 0.0);
  *
- * If is_floating == then, then the JSON number was attempted to be parsed
- * as a floating point value.  In this case the "floating point values" fields
- * will be used, and the "integer values" fields will be unused (set to false, or 0).
+ * If is_floating == true then, then the JSON number was attempted to be parsed
+ * as a floating point value. In this case the "floating point values" fields
+ * will be used, and the "integer values" fields will be unused (set to false,
+ * or 0).
  *
  * A JSON number string is of the form:
  *
@@ -203,13 +204,13 @@ struct json_string
 {
     bool converted;		/* true ==> able to decode JSON string, false ==> str is invalid or not decoded */
 
-    char *as_str;		/* allocated non-decoded JSON string, NUL terminated (perhaps sans JSON "s) */
+    char *as_str;		/* allocated non-decoded JSON string, NUL terminated (perhaps sans JSON '"'s) */
     char *str;			/* allocated decoded JSON string, NUL terminated */
 
     size_t as_str_len;		/* length of as_str, not including final NUL */
     size_t str_len;		/* length of str, not including final NUL */
 
-    bool quote;			/* The original JSON string included surrounding "'s */
+    bool quote;			/* The original JSON string included surrounding '"'s */
 
     bool same;			/* true => as_str same as str, JSON decoding not required */
     bool has_nul;		/* true ==> decoded JSON string has a NUL byte inside it */

--- a/json_sem.h
+++ b/json_sem.h
@@ -2,7 +2,7 @@
 /*
  * json_sem - JSON semantics support
  *
- * "Because grammar and syntax alone to not make a complete language." :-)
+ * "Because grammar and syntax alone do not make a complete language." :-)
  *
  * This JSON parser was co-developed by:
  *

--- a/sanity.c
+++ b/sanity.c
@@ -81,15 +81,15 @@ find_utils(bool tar_flag_used, char **tar, bool cp_flag_used, char **cp, bool ls
      */
     if (tar != NULL && !tar_flag_used && !is_exec(TAR_PATH_0) && is_exec(TAR_PATH_1)) {
 	*tar = TAR_PATH_1;
-	dbg(DBG_MED, "tar is not in historic location: %s : will try alternate location: %s", TAR_PATH_0, *tar);
+	dbg(DBG_MED, "tar is not in historic location: %s : will use alternate location: %s", TAR_PATH_0, *tar);
     }
     if (cp != NULL && !cp_flag_used && !is_exec(CP_PATH_0) && is_exec(CP_PATH_1)) {
 	*cp = CP_PATH_1;
-	dbg(DBG_MED, "cp is not in historic location: %s : will try alternate location: %s", CP_PATH_0, *cp);
+	dbg(DBG_MED, "cp is not in historic location: %s : will use alternate location: %s", CP_PATH_0, *cp);
     }
     if (ls != NULL && !ls_flag_used && !is_exec(LS_PATH_0) && is_exec(LS_PATH_1)) {
 	*ls = LS_PATH_1;
-	dbg(DBG_MED, "ls is not in historic location: %s : will try alternate location: %s", LS_PATH_0, *ls);
+	dbg(DBG_MED, "ls is not in historic location: %s : will use alternate location: %s", LS_PATH_0, *ls);
     }
 
     /* now do the same for our utilities: txzchk, fnamchk, and chkentry */


### PR DESCRIPTION
Update the dbg.3 man page to refer to the functions added in commit
09b6563:

    extern void snmsg(char *str, size_t size, char const *fmt, ...)
    extern void sndbg(char *str, size_t size, int level, char const *fmt, ...);
    extern void snwarn(char *str, size_t size, char const *name, char const *fmt, ...);
    extern void snwarnp(char *str, size_t size, char const *name, char const *fmt, ...);
    extern void snwerr(int error_code, char *str, size_t size, char const *name, char const *fmt, ...);
    extern void snwerrp(int error_code, char *str, size_t size, char const *name, char const *fmt, ...);

Additionally the dbg_example.c file with a message for each output that
says what the next line should print so that the user can verify it's
correct. It does not make use of the sn functions above (though I did
think of this to do a strcmp()) as it's just a simple example program.
The source code has been updated in the man page and the output has as
well.