### PR TITLE
Update JSON parser version + use usage() with wrong number of args

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -59,7 +59,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "0.8 2022-06-12"		/* format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "0.10 2022-07-03"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse_main.c
+++ b/jparse_main.c
@@ -85,10 +85,6 @@ main(int argc, char **argv)
 	    not_reached();
 	    break;
 	case 's':
-	    /*
-	     * So we don't trigger missing arg. Maybe there's another way but
-	     * nothing is coming to my mind right now.
-	     */
 	    string_flag_used = true;
 	    break;
 	default:
@@ -98,7 +94,7 @@ main(int argc, char **argv)
     }
     arg_cnt = argc - optind;
     if (arg_cnt != REQUIRED_ARGS) {
-	err(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_cnt); /*ooo*/
+	usage(4, "wrong number of arguments", program); /*ooo*/
 	not_reached();
     }
 

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -103,10 +103,6 @@ main(int argc, char **argv)
 	    not_reached();
 	    break;
 	case 's':
-	    /*
-	     * So we don't trigger missing arg. Maybe there's another way but
-	     * nothing is coming to my mind right now.
-	     */
 	    string_flag_used = true;
 	    break;
 	default:
@@ -116,7 +112,7 @@ main(int argc, char **argv)
     }
     arg_cnt = argc - optind;
     if (arg_cnt != REQUIRED_ARGS) {
-	err(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_cnt); /*ooo*/
+	usage(4, "wrong number of arguments", program); /*ooo*/
 	not_reached();
     }
 

--- a/verge.c
+++ b/verge.c
@@ -317,7 +317,7 @@ allocate_vers(char *str, long **pvers)
     len = i;
 
     /*
-     * we now have a string that start and ends with digits
+     * we now have a string that starts and ends with digits
      *
      * Inspect the remaining string for digits and '.'s only.
      * Also reject string if we find more than 2 '.'s in a row.

--- a/version.h
+++ b/version.h
@@ -164,7 +164,7 @@
 
 
  /*
-  * Generate JSON semantics table vresion
+  * Generate JSON semantics table version
   *
   * Because the JSON parser is a self contained system, we cannot define
   * JSEMTBLGEN_VERSION here. See jsemtblgen.h for the JSEMTBLGEN_VERSION value.


### PR DESCRIPTION
See the rationale of updating the json parser version in commit https://github.com/ioccc-src/mkiocccentry/commit/96b58dd3090f199babf28d1507869004e6e5dcc6:

    The previous version was 0.8 2022-06-12 but since that time the parser
    was code complete (this happened with commit
    7f8d7411c9157fe314a237a3eec5c404a4de3c79 at Thu Jun 23 15:41:54 2022
    -0700) which by itself warrants a new version. That should be 0.9
    2022-06-23.
    
    But earlier this morning (00:48:17) some additional changes were made
    and since the jparse version was updated at this point I believe it
    worth updating the json parser version as well. The two now are the same
    version: 0.10 2022-07-03.

As for the other fix it's simply so the user can see the usage message as is done with other tools.

I might end up doing more later on today but this is far from certain. Right now I'm going back to rest. Hope you're having a nice sleep my friend and good day!