### PR TITLE
Typo fixes in chkentry.1 and dbg.3

### DIFF
--- a/chkentry.1
+++ b/chkentry.1
@@ -77,7 +77,7 @@ Run the tool on an IOCCC entry located in the directory
 
 .PP
 .nf
-Run the tool on just the IOCCC entry information JSON file \fBtest/info.JSON\fR:
+Run the tool on just the IOCCC entry information JSON file \fBtest/info.JSON\fP:
 
 \fB
  ./chkentry test/info.JSON .\fP
@@ -85,12 +85,11 @@ Run the tool on just the IOCCC entry information JSON file \fBtest/info.JSON\fR:
 
 .PP
 .nf
-Run the tool on just the IOCCC entry author JSON file \fBtest/author.JSON\fR:
+Run the tool on just the IOCCC entry author JSON file \fBtest/author.JSON\fP:
 
 \fB
  ./chkentry . test/author.JSON\fP
 .fi
-.RE
 .SH SEE ALSO
 .PP
 \fBmkiocccentry(1)\fP,  \fBfnamchk(1)\fP, \fBjparse(1)\fP.

--- a/dbg.3
+++ b/dbg.3
@@ -293,7 +293,7 @@ do not return if warning is false in the same manner as the functions
 .BR verrp(),
 .BR ferrp(),
 and
-.BR vferrp()
+.BR vferrp().
 .PP
 The functions
 .BR printf_usage(),


### PR DESCRIPTION
The typos had to do with formatting and now make checknr passes.