### PR TITLE
Various fixes and updates to txzchk and new test functions for chkentry

### DIFF
--- a/entry_util.c
+++ b/entry_util.c
@@ -701,6 +701,197 @@ test_title(char *str)
 }
 
 
+
+/*
+ * test_empty_override - test if empty_override is valid
+ *
+ * Determine if empty_override boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_empty_override(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "empty_override is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_rule_2a_override - test if rule_2a_override is valid
+ *
+ * Determine if rule_2a_override boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_rule_2a_override(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "rule_2a_override is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_rule_2a_mismatch - test if rule_2a_mismatch is valid
+ *
+ * Determine if rule_2a_mismatch boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_rule_2a_mismatch(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "rule_2a_mismatch is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_rule_2b_override - test if rule_2b_override is valid
+ *
+ * Determine if rule_2b_override boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_rule_2b_override(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "rule_2b_override is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_highbit_warning - test if highbit_warning is valid
+ *
+ * Determine if highbit_warning boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_highbit_warning(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "highbit_warning is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_nul_warning - test if nul_warning is valid
+ *
+ * Determine if nul_warning boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_nul_warning(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "nul_warning is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_trigraph_warning - test if trigraph_warning is valid
+ *
+ * Determine if trigraph_warning boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_trigraph_warning(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "trigraph_warning is %s", booltostr(boolean));
+    return true;
+}
+
+
+/*
+ * test_wordbuf_warning - test if wordbuf_warning is valid
+ *
+ * Determine if wordbuf_warning boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_wordbuf_warning(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "wordbuf_warning is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_ungetc_warning - test if ungetc_warning is valid
+ *
+ * Determine if ungetc_warning boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_ungetc_warning(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "ungetc_warning is %s", booltostr(boolean));
+    return true;
+}
+
 /*
  * test_Makefile_override - test if Makefile_override is valid
  *
@@ -718,9 +909,138 @@ test_title(char *str)
 bool
 test_Makefile_override(bool boolean)
 {
-    json_dbg(JSON_DBG_MED, __func__, "Makefile_override filename is %s", booltostr(boolean));
+    json_dbg(JSON_DBG_MED, __func__, "Makefile_override is %s", booltostr(boolean));
     return true;
 }
+
+/*
+ * test_first_rule_is_all - test if first_rule_is_all is valid
+ *
+ * Determine if first_rule_is_all boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_first_rule_is_all(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "first_rule_is_all is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_found_all_rule - test if found_all_rule is valid
+ *
+ * Determine if found_all_rule boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_found_all_rule(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "found_all_rule is %s", booltostr(boolean));
+    return true;
+}
+
+
+/*
+ * test_found_clean_rule - test if found_clean_rule is valid
+ *
+ * Determine if found_clean_rule boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_found_clean_rule(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "found_clean_rule is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_found_clobber_rule - test if found_clobber_rule is valid
+ *
+ * Determine if found_clobber_rule boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_found_clobber_rule(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "found_clobber_rule is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_found_try_rule - test if found_try_rule is valid
+ *
+ * Determine if found_try_rule boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_found_try_rule(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "found_try_rule is %s", booltostr(boolean));
+    return true;
+}
+
+/*
+ * test_test_mode - test if test_mode is valid
+ *
+ * Determine if test_mode boolean is valid.  :-)
+ * Well this isn't much of a test, but we have to keep
+ * up with the general form of tests!  :-)
+ *
+ * given:
+ *	boolean	boolean to test
+ *
+ * returns:
+ *	true ==> bool is valid,
+ *	false ==> bool is NOT valid, or some internal error
+ */
+bool
+test_test_mode(bool boolean)
+{
+    json_dbg(JSON_DBG_MED, __func__, "test_mode is %s", booltostr(boolean));
+    return true;
+}
+
+
 
 
 /*

--- a/entry_util.h
+++ b/entry_util.h
@@ -176,6 +176,21 @@ extern bool test_abstract(char *str);
 extern bool test_affiliation(char *str);
 extern bool test_author_JSON(char *str);
 extern bool test_author_count(int author_count);
+extern bool test_empty_override(bool boolean);
+extern bool test_rule_2a_override(bool boolean);
+extern bool test_rule_2a_mismatch(bool boolean);
+extern bool test_rule_2b_override(bool boolean);
+extern bool test_highbit_warning(bool boolean);
+extern bool test_nul_warning(bool boolean);
+extern bool test_trigraph_warning(bool boolean);
+extern bool test_wordbuf_warning(bool boolean);
+extern bool test_ungetc_warning(bool boolean);
+extern bool test_first_rule_is_all(bool boolean);
+extern bool test_found_all_rule(bool boolean);
+extern bool test_found_clean_rule(bool boolean);
+extern bool test_found_clobber_rule(bool boolean);
+extern bool test_found_try_rule(bool boolean);
+extern bool test_test_mode(bool boolean);
 
 
 #endif /* INCLUDE_ENTRY_UTIL_H */

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,11 +1,11 @@
-.TH txzchk 1 "12 June 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "29 July 2022" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
 \fBtxzchk\fP [\-h] [\-v level] [\-q] [\-V] [\-t tar] [\-F fnamchk] [\-T] [\-E ext] [\-e] txzpath
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs.
-It is invoked by \fBmkiocccentry(1)\fP after the tarball is formed, reporting any issues found and exiting the program accordingly; if \fBtxzchk\fP does not return 0 \fBmkiocccentry\fP will exit with an error.
+It is invoked by \fBmkiocccentry(1)\fP after the tarball is formed, reporting any feathers stuck in the tarball (i.e. issues found) and exiting the program accordingly; if \fBtxzchk\fP does not return 0 \fBmkiocccentry\fP will exit with an error.
 .PP
 The program runs \fBtar \-tJvf\fP on the \fItxzpath\fP and parses the output of the command, performing a variety of tests on the tarball.
 As a side effect it will show the user the contents of the tarball.
@@ -47,13 +47,14 @@ This is used in conjunction with \fb\-T\fP above for \fBTESTING\fP purposes only
 Suppress error messages.
 .SH EXIT STATUS
 .PP
-An exit code of 0 indicates there were no issues found in the tarball.
+An exit code of 0 indicates there are no feathers stuck in the tarball.
 .PP
-An exit code of 1 indicates that the tarball was successfully parsed and there was at least one issue found in the tarball.
+An exit code of 1 indicates that the tarball was successfully parsed and there's at least one feather stuck in the tarball.
 .PP
 An exit code of 2 indicates that the usage string was printed either because \fB\-h\fP was specified or an invalid command line.
 .PP
 Any value > 2 indicates an internal error or an unknown tar listing format.
+Please report this if this happens (see \fBBUGS\fP section for where to report bugs).
 .SH FILES
 \fItxzchk.c\fP
 .RS

--- a/txzchk.c
+++ b/txzchk.c
@@ -159,9 +159,9 @@ main(int argc, char **argv)
     if (!quiet) {
 	para("", "Performing checks on tarball ...", NULL);
     }
-    txz_info.total_issues = check_tarball(tar, fnamchk);
-    if (!quiet && !txz_info.total_issues) {
-	para("No feathers found in tarball.", "", NULL);
+    txz_info.total_feathers = check_tarball(tar, fnamchk);
+    if (!quiet && !txz_info.total_feathers) {
+	para("No feathers stuck in tarball.", "", NULL);
     }
 
     show_txz_info(txzpath);
@@ -169,7 +169,7 @@ main(int argc, char **argv)
     /*
      * All Done!!! - Jessica Noll, age 2
      */
-    exit(txz_info.total_issues != 0); /*ooo*/
+    exit(txz_info.total_feathers != 0); /*ooo*/
 }
 
 
@@ -196,25 +196,25 @@ show_txz_info(char const *txzpath)
 	/* show information about tarball */
 	para("", "The following information about the tarball was collected:", NULL);
 
-	dbg(DBG_MED, "txzchk: %s: has .info.json:\t\t%d", txzpath, txz_info.has_info_json);
-	dbg(DBG_HIGH, "txzchk: %s: empty .info.json:\t\t%d", txzpath, txz_info.empty_info_json);
-	dbg(DBG_MED, "txzchk: %s: has .author.json:\t\t%d", txzpath, txz_info.has_author_json);
-	dbg(DBG_HIGH, "txzchk: %s: empty .author.json:\t\t%d", txzpath, txz_info.empty_author_json);
-	dbg(DBG_MED, "txzchk: %s: has prog.c:\t\t\t%d", txzpath, txz_info.has_prog_c);
-	dbg(DBG_HIGH, "txzchk: %s: empty prog.c:\t\t\t%d", txzpath, txz_info.empty_prog_c);
-	dbg(DBG_MED, "txzchk: %s: has remarks.md:\t\t\t%d", txzpath, txz_info.has_remarks_md);
-	dbg(DBG_HIGH, "txzchk: %s: empty remarks.md:\t\t%d", txzpath, txz_info.empty_remarks_md);
-	dbg(DBG_MED, "txzchk: %s: has Makefile:\t\t\t%d", txzpath, txz_info.has_Makefile);
-	dbg(DBG_HIGH, "txzchk: %s: empty Makefile:\t\t\t%d", txzpath, txz_info.empty_Makefile);
-	dbg(DBG_MED, "txzchk: %s: size:\t\t\t\t%jd", txzpath, (intmax_t)txz_info.size);
+	dbg(DBG_MED, "txzchk: %s: has .info.json:\t\t%s", txzpath, booltostr(txz_info.has_info_json));
+	dbg(DBG_HIGH, "txzchk: %s: empty .info.json:\t\t%s", txzpath, booltostr(txz_info.empty_info_json));
+	dbg(DBG_MED, "txzchk: %s: has .author.json:\t\t%s", txzpath, booltostr(txz_info.has_author_json));
+	dbg(DBG_HIGH, "txzchk: %s: empty .author.json:\t\t%s", txzpath, booltostr(txz_info.empty_author_json));
+	dbg(DBG_MED, "txzchk: %s: has prog.c:\t\t\t%s", txzpath, booltostr(txz_info.has_prog_c));
+	dbg(DBG_HIGH, "txzchk: %s: empty prog.c:\t\t%s", txzpath, booltostr(txz_info.empty_prog_c));
+	dbg(DBG_MED, "txzchk: %s: has remarks.md:\t\t%s", txzpath, booltostr(txz_info.has_remarks_md));
+	dbg(DBG_HIGH, "txzchk: %s: empty remarks.md:\t\t%s", txzpath, booltostr(txz_info.empty_remarks_md));
+	dbg(DBG_MED, "txzchk: %s: has Makefile:\t\t%s", txzpath, booltostr(txz_info.has_Makefile));
+	dbg(DBG_HIGH, "txzchk: %s: empty Makefile:\t\t%s", txzpath, booltostr(txz_info.empty_Makefile));
+	dbg(DBG_MED, "txzchk: %s: size:\t\t\t%jd", txzpath, (intmax_t)txz_info.size);
 	dbg(DBG_MED, "txzchk: %s: size of all files:\t\t%jd", txzpath, (intmax_t)txz_info.file_sizes);
 	dbg(DBG_MED, "txzchk: %s: rounded files size:\t\t%jd", txzpath, (intmax_t)txz_info.rounded_file_size);
 	dbg(DBG_MED, "txzchk: %s: total files:\t\t\t%d", txzpath, txz_info.total_files);
 	dbg(DBG_MED, "txzchk: %s: incorrect directory found:\t%d", txzpath, txz_info.correct_directory != txz_info.total_files);
-	dbg(DBG_MED, "txzchk: %s: invalid dot files found:\t\t%d", txzpath, txz_info.dot_files);
-	dbg(DBG_MED, "txzchk: %s: files named '.':\t\t\t%d", txzpath, txz_info.named_dot);
+	dbg(DBG_MED, "txzchk: %s: invalid dot files found:\t%d", txzpath, txz_info.dot_files);
+	dbg(DBG_MED, "txzchk: %s: files named '.':\t\t%d", txzpath, txz_info.named_dot);
 	dbg(DBG_MED, "txzchk: %s: files with invalid chars:\t%u", txzpath, txz_info.invalid_chars);
-	dbg(DBG_VHIGH, "txzchk: %s: issues found:\t\t\t%d", txzpath, txz_info.total_issues);
+	dbg(DBG_VHIGH, "txzchk: %s: feathers stuck in tarball:\t%d", txzpath, txz_info.total_feathers);
 
     }
 }
@@ -444,7 +444,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
  *	dir_name	- the directory name (if fnamchk passed - else NULL)
  *	file		- file structure
  *
- * Report issues on the current file's path.
+ * Report feathers stuck in the current file's path.
  *
  * Returns void. Does not return on error.
  *
@@ -466,8 +466,8 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
      * identify if file is an allowed '.' file
      *
      * NOTE: Files that are allowed to begin with '.' must also be lower case.
-     * In other words if any of the letters in ".info.json" or ".author.json"
-     * are upper case the file is an invalid dot file.
+     * In other words if any of the letters in INFO_JSON_FILENAME or
+     * AUTHOR_JSON_FILENAME are upper case the file is an invalid dot file.
      */
     if (!strcmp(file->basename, INFO_JSON_FILENAME) || !strcmp(file->basename, AUTHOR_JSON_FILENAME)) {
 	allowed_dot_file = true;
@@ -477,7 +477,7 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
      * filename must use only POSIX portable filename and + chars plus /
      */
     if (!posix_plus_safe(file->filename, false, true, false)) {
-	++txz_info.total_issues; /* report it once and consider it only one issue */
+	++txz_info.total_feathers; /* report it once and consider it only one feather */
 	++txz_info.invalid_chars;
 	warn(__func__, "%s: file does not match regexp ^[/0-9a-z][/0-9a-z._+-]*$: %s",
 		       txzpath, file->filename);
@@ -490,19 +490,19 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 	/*
 	 * Check for dot files but note that a basename of only '.' also counts
 	 * as a filename with just '.': so if the file starts with a '.' and
-	 * it's not ".author.json" and not ".info.json" then it's an invalid dot
-	 * file; if it's ONLY '.' it counts as BOTH an invalid dot file AND a
-	 * file called just '.' (which would likely be a directory but is abuse
-	 * nonetheless).
+	 * it's not AUTHOR_JSON_FILENAME and not INFO_JSON_FILENAME then it's an
+	 * invalid dot file; if it's ONLY '.' it counts as BOTH an invalid dot
+	 * file AND a file called just '.' (which would likely be a directory
+	 * but is abuse nonetheless).
 	 */
 	if (*(file->basename) == '.') {
-	    ++txz_info.total_issues;
-	    warn("txzchk", "%s: found non .author.json and .info.json dot file %s", txzpath, file->basename);
+	    ++txz_info.total_feathers;
+	    warn("txzchk", "%s: found non %s and %s dot file %s", txzpath, AUTHOR_JSON_FILENAME, INFO_JSON_FILENAME, file->basename);
 	    txz_info.dot_files++;
 
 	    /* check for files called '.' without anything after the dot */
 	    if (file->basename[1] == '\0') {
-		++txz_info.total_issues;
+		++txz_info.total_feathers;
 		++txz_info.named_dot;
 		warn("txzchk", "%s: found file called '.' in path %s", txzpath, file->filename);
 	    }
@@ -512,7 +512,7 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 	 * basename must use only POSIX portable filename and + chars
 	 */
 	if (!posix_plus_safe(file->basename, false, false, true)) {
-	    ++txz_info.total_issues; /* report it once and consider it only one issue */
+	    ++txz_info.total_feathers; /* report it once and consider it only one feather */
 	    ++txz_info.invalid_chars;
 	    warn(__func__, "%s: file basename does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$: %s",
 			   txzpath, file->basename);
@@ -554,27 +554,27 @@ check_empty_file(char const *txzpath, off_t size, struct txz_file *file)
 
     if (size == 0) {
 	if (!strcmp(file->basename, AUTHOR_JSON_FILENAME)) {
-	    ++txz_info.total_issues;
-	    warn("txzchk", "%s: found empty .author.json file", txzpath);
+	    ++txz_info.total_feathers;
+	    warn("txzchk", "%s: found empty %s file", txzpath, AUTHOR_JSON_FILENAME);
 	    txz_info.empty_author_json = true;
 	}
 	else if (!strcmp(file->basename, INFO_JSON_FILENAME)) {
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    txz_info.empty_info_json = true;
-	    warn("txzchk", "%s: found empty .info.json file", txzpath);
+	    warn("txzchk", "%s: found empty %s file", txzpath, INFO_JSON_FILENAME);
 	}
 	else if (!strcmp(file->basename, "remarks.md")) {
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    txz_info.empty_remarks_md = true;
 	    warn("txzchk", "%s: found empty remarks.md", txzpath);
 	}
 	else if (!strcmp(file->basename, "Makefile")) {
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    txz_info.empty_Makefile = true;
 	    warn("txzchk", "%s: found empty Makefile", txzpath);
 	}
 	else if (!strcmp(file->basename, "prog.c")) {
-	    /* this is NOT an issue: it's only for debugging information! */
+	    /* this is NOT a feather: it's only for debugging information! */
 	    txz_info.empty_prog_c = true;
 	}
     }
@@ -588,7 +588,8 @@ check_empty_file(char const *txzpath, off_t size, struct txz_file *file)
  *
  *	dir_name	- fnamchk result (if passed - else NULL)
  *
- * Reports any additional issues found in the tarball (or text file).
+ * Reports any additional feathers stuck in the tarball (or issues in the text
+ * file).
  *
  * Returns void. Ignores empty files (though these should not be in the list at
  * all).
@@ -607,7 +608,7 @@ check_all_txz_files(char const *dir_name)
 	not_reached();
     } else if (txz_info.file_sizes == 0) {
 	warn("txzchk", "%s: total size of all files == 0", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
     txz_info.rounded_file_size = round_to_multiple(txz_info.file_sizes, 1024);
     if (txz_info.rounded_file_size < 0) {
@@ -617,7 +618,7 @@ check_all_txz_files(char const *dir_name)
 	warn("txzchk", "%s: total size of files %jd rounded up to multiple of 1024 %jd > %d",
 		       txzpath, (intmax_t)txz_info.file_sizes,
 		       (intmax_t) txz_info.rounded_file_size, MAX_DIR_KSIZE);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     } else if (!quiet) {
 	printf("txzchk: %s total size of files %jd rounded up to 1024 multiple: %jd OK\n",
 		txzpath, (intmax_t) txz_info.file_sizes, (intmax_t) txz_info.rounded_file_size);
@@ -626,7 +627,8 @@ check_all_txz_files(char const *dir_name)
 
     /*
      * Now go through the files list to verify the required files are there and
-     * also to detect any additional issues.
+     * also to detect any additional feathers stuck in the tarball (or issues in
+     * the text file).
      */
     for (file = txz_files; file != NULL; file = file->next) {
 	if (file->basename == NULL) {
@@ -650,45 +652,45 @@ check_all_txz_files(char const *dir_name)
 	if (dir_name != NULL && txz_info.correct_directory) {
 	    if (strncmp(file->filename, dir_name, strlen(dir_name))) {
 		warn("txzchk", "%s: found directory change in filename %s", txzpath, file->filename);
-		++txz_info.total_issues;
+		++txz_info.total_feathers;
 	    }
 	}
 
 	if (file->count > 1) {
 	    warn("txzchk", "%s: found a total of %u files with the name %s", txzpath, file->count, file->basename);
-	    txz_info.total_issues += file->count - 1;
+	    txz_info.total_feathers += file->count - 1;
 	}
     }
 
     /* determine if the required files are there */
     if (!txz_info.has_info_json) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: no .info.json found", txzpath);
     }
     if (!txz_info.has_author_json) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: no .author.json found", txzpath);
     }
     if (!txz_info.has_prog_c) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: no prog.c found", txzpath);
     }
     if (!txz_info.has_Makefile) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: no Makefile found", txzpath);
     }
     if (!txz_info.has_remarks_md) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: no remarks.md found", txzpath);
     }
     if (txz_info.correct_directory < txz_info.total_files) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: not all files in correct directory", txzpath);
     }
 
     /*
      * Report total number of non .author.json and .info.json dot files.
-     * Don't increment the number of issues as this was done in
+     * Don't increment the number of feathers as this was done in
      * check_txz_file().
      */
     if (txz_info.dot_files > 0) {
@@ -697,10 +699,10 @@ check_all_txz_files(char const *dir_name)
     }
 
     /*
-     * report total issues found
+     * report total feathers found
      */
-    if (txz_info.total_issues > 0) {
-	warn("txzchk", "%s: found %u issue%s", txzpath, txz_info.total_issues, txz_info.total_issues==1?"":"s");
+    if (txz_info.total_feathers > 0) {
+	warn("txzchk", "%s: found %u feather%s stuck in the tarball", txzpath, txz_info.total_feathers, txz_info.total_feathers==1?"":"s");
     }
 }
 
@@ -738,7 +740,7 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
     /* check that there is a directory */
     if (strchr(file->filename, '/') == NULL && strcmp(file->filename, ".")) {
 	warn("txzchk", "%s: no directory found in filename %s", txzpath, file->filename);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
     if (strstr(file->filename, "..")) { /* check for '..' in path */
 	/*
@@ -746,11 +748,11 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
 	 * but since the basename of each file is checked in check_txz_file() this
 	 * is okay.
 	 */
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: found file with .. in the path: %s", txzpath, file->filename);
     }
     if (*(file->filename) == '/') {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: found absolute path %s", txzpath, file->filename);
     }
 
@@ -797,20 +799,20 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
 	prev = file->filename[i];
     }
     if (dir_count > 1) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	warn("txzchk", "%s: found more than one directory in path %s", txzpath, file->filename);
     }
     /*
      * Now we have to run some tests on the directory name which we obtained
      * from fnamchk earlier on - but only if fnamchk did not return an
-     * error! If it did we'll report other issues but we won't check
+     * error! If it did we'll report other feathers/issues but we won't check
      * directory names (at least the directory name expected in the
      * tarball).
      */
     if (dir_name != NULL && strlen(dir_name) > 0) {
 	if (strncmp(file->filename, dir_name, strlen(dir_name))) {
 	    warn("txzchk", "%s: found incorrect directory in filename %s", txzpath, file->filename);
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	}
 	else {
 	    /* This file is in the right directory */
@@ -859,12 +861,12 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 
     if (*p != '/') {
 	warn("txzchk", "found non-numerical UID in line %s", line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	p = strchr(p, '/');
     }
     if (p == NULL) {
 	warn("txzchk", "encountered NULL pointer when parsing line %s", line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
     ++p;
@@ -878,12 +880,12 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 
     if (*p) {
 	warn("txzchk", "found non-numerical GID in file in line %s", line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
     p = strtok_r(NULL, " \t", saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
 
@@ -891,10 +893,10 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     current_file_size = strtoll(p, NULL, 10);
     if (errno != 0) {
 	warnp("txzchk", "%s: trying to parse file size in on line: %s, string: %s, reading next line", txzpath, line_dup, p);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     } else if (current_file_size < 0) {
 	warn("txzchk", "%s: file size < 0", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
     txz_info.file_sizes += current_file_size;
 
@@ -906,7 +908,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 	p = strtok_r(NULL, " \t", saveptr);
 	if (p == NULL) {
 	    warn("txzchk", "%s: NULL pointer trying to parse line, reading next line", txzpath);
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    return;
 	}
     }
@@ -917,11 +919,13 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 	err(22, __func__, "alloc_txz_file() returned NULL");
 	not_reached();
     }
-    p = strtok_r(NULL, " \t", saveptr);
-    if (p != NULL) {
-	warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
-	++txz_info.total_issues;
-    }
+    do {
+	p = strtok_r(NULL, " \t", saveptr);
+	if (p != NULL) {
+	    warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
+	    ++txz_info.total_feathers;
+	}
+    } while (p != NULL);
 
 
     /*
@@ -975,7 +979,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     p = strtok_r(NULL, " \t", saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
     /*
@@ -987,7 +991,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 
     if (*p) {
 	warn("txzchk", "%s: found non-numerical UID in file in line %s", txzpath, line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
 
     /*
@@ -996,7 +1000,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     p = strtok_r(NULL, " \t", saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
     for (; p && *p && isdigit(*p); )
@@ -1004,13 +1008,13 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 
     if (*p) {
 	warn("txzchk", "%s: found non-numerical GID in file in line: %s", txzpath, line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
 
     p = strtok_r(NULL, " \t", saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
 
@@ -1029,7 +1033,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 	p = strtok_r(NULL, " \t", saveptr);
 	if (p == NULL) {
 	    warn("txzchk", "%s: NULL pointer trying to parse line, reading next line", txzpath);
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    return;
 	}
     }
@@ -1041,11 +1045,13 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 	not_reached();
     }
 
-    p = strtok_r(NULL, " \t", saveptr);
-    if (p != NULL) {
-	warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
-	++txz_info.total_issues;
-    }
+    do {
+	p = strtok_r(NULL, " \t", saveptr);
+	if (p != NULL) {
+	    warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
+	    ++txz_info.total_feathers;
+	}
+    } while (p != NULL);
 
     /*
      * although we could check these later we check here because the
@@ -1072,7 +1078,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
  *	txzpath		-   the tarball path
  *	dir_count	-   pointer to dir_count (from check_tarball())
  *
- *  Function updates txz_info.total_issues, txz_info.file_sizes and dir_count. Returns void.
+ *  Function updates txz_info.total_feathers, txz_info.file_sizes and dir_count. Returns void.
  *
  *  Function does not return on error.
  */
@@ -1097,7 +1103,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
 	++(*dir_count);
 	if (*dir_count > 1) {
 	    warn("txzchk", "%s: found more than one directory entry: %s", txzpath, linep);
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	}
 
     /*
@@ -1105,20 +1111,20 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
      */
     } else if (*linep != '-') {
 	warn("txzchk", "%s: found a non-directory non-regular non-hard-lined item: %s", txzpath, linep);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
 
     /* extract each field, one at a time, to do various tests */
     p = strtok_r(linep, " \t", &saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
 
     if (has_special_bits(p)) {
 	warn("txzchk", "%s: found special bits on line: %s", txzpath, line_dup);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     }
 
     /*
@@ -1128,7 +1134,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
     p = strtok_r(NULL, " \t", &saveptr);
     if (p == NULL) {
 	warn("txzchk", "%s: NULL pointer encountered trying to parse line, reading next line", txzpath);
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	return;
     }
     if (strchr(p, '/') != NULL) {
@@ -1153,7 +1159,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
  *
  * returns:
  *
- *	total number of issues found (txz_info.total_issues).
+ *	total number of feathers/issues found (txz_info.total_feathers).
  *
  * NOTE: Does not return on error.
  */
@@ -1196,7 +1202,7 @@ check_tarball(char const *tar, char const *fnamchk)
     }
     if (exit_code != 0) {
 	warn("txzchk", "%s: %s %s failed with exit code: %d", txzpath, fnamchk, txzpath, WEXITSTATUS(exit_code));
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
     } else {
 	fnamchk_okay = true;
     }
@@ -1208,8 +1214,8 @@ check_tarball(char const *tar, char const *fnamchk)
      * format of the tool changes this must also change!
      *
      * Note that the reason we don't exit if fnamchk reports an error is we
-     * still can detect other issues; we just won't detect issues with the entry
-     * number and directory.
+     * still can detect other feathers/issues; we just won't detect feathers
+     * with the entry number and directory.
      */
     if (fnamchk_okay) {
 
@@ -1254,7 +1260,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	not_reached();
     }
     else if (txz_info.size > MAX_TARBALL_LEN) {
-	++txz_info.total_issues;
+	++txz_info.total_feathers;
 	fpara(stderr,
 	      "",
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
@@ -1367,12 +1373,13 @@ check_tarball(char const *tar, char const *fnamchk)
     } while (readline_len >= 0);
 
     /*
-     * now parse the lines, reporting any issue that have to be done while parsing
+     * now parse the lines, reporting any feathers stuck in the tarball that
+     * have to be detected while parsing
      */
     parse_all_txz_lines(dir_name, txzpath);
 
     /*
-     * check files list and report any additional issues
+     * check files list and report any additional feathers stuck in the tarball
      */
     check_all_txz_files(dir_name);
 
@@ -1395,7 +1402,7 @@ check_tarball(char const *tar, char const *fnamchk)
     }
     input_stream = NULL;
 
-    return txz_info.total_issues;
+    return txz_info.total_feathers;
 }
 
 
@@ -1472,7 +1479,10 @@ add_txz_line(char const *str, int line_num)
 
 
 /*
- * parse_all_txz_lines - parse txz_lines, reporting any issues found
+ * parse_all_txz_lines
+ *
+ * Parse the txz_lines list and report any feathers stuck in the tarball. After
+ * all the lines have been parsed additional tests will be performed.
  *
  * given:
  *
@@ -1502,7 +1512,7 @@ parse_all_txz_lines(char const *dir_name, char const *txzpath)
     for (line = txz_lines; line != NULL; line = line->next) {
 	if (line->line == NULL) {
 	    warn("txzchk", "encountered NULL string on line %d", line->line_num);
-	    ++txz_info.total_issues;
+	    ++txz_info.total_feathers;
 	    continue;
 	}
 	line_dup = strdup(line->line);
@@ -1525,8 +1535,11 @@ parse_all_txz_lines(char const *dir_name, char const *txzpath)
  * the tarball together without interspersing it with any warnings. Thus we show
  * the files list, adding each line to the list in the process, and then after
  * that we can iterate through the lines and show any warnings. After that we
- * report any issues that haven't been reported yet (some warnings have to be
- * issued while parsing the lines).
+ * report any feathers stuck in the tarball that haven't been reported yet (some
+ * warnings have to be issued while parsing the lines so those were already
+ * reported).
+ *
+ * Once the lines are all parsed we must free the list.
  *
  * This function returns void.
  */

--- a/txzchk.h
+++ b/txzchk.h
@@ -82,7 +82,7 @@ struct txz_info
     unsigned dot_files;			    /* number of dot files that aren't .author.json and .info.json */
     unsigned named_dot;			    /* number of files called just '.' */
     unsigned total_files;		    /* total files in the tarball */
-    unsigned total_issues;		    /* number of total issues in tarball */
+    unsigned total_feathers;		    /* number of total feathers stuck in tarball (i.e. issues found) */
 };
 
 static struct txz_info txz_info;	    /* all the information collected from txzpath */


### PR DESCRIPTION
The following commits were made but due to conflicts in other commits I
am making a new pull request. Unfortunately it's harder to keep track of
what commit did what as I have it all in one commit now but the
following commits were made except that I have attempted to merge some
of the logs together. The commit ids will no longer be valid of course
but I'm doing it this way to try and keep it more organised (try but
maybe not succeed):

commit 7ceb5e60d15400dc02d4ea8875f1c516efcdd9fc
Date:   Fri Jul 29 07:55:11 2022 -0700

    Minor updates and fixes in txzchk

    Change remaining references of 'issues' to 'feathers' to continue the
    fun of:

        "Because sometimes people add feathers to tar." :-(

    (There are still a few references to issues but this is only to make it
    clear that it's just wordplay: all messages and variables now refer to
    feathers though.)

    I've also improved show_txz_info() in the following ways:

    It now shows the booleans as true or false.

    I have attempted (keyword) to make it all the debug information lined up
    (matching columns for names and values). This might not always work as
    \t is funny like that but for some tarballs it works fine at least. For
    example with the file test_work/entry.test-0.1659097955.txz the
    alignment is still not consistent for every line but for
    test_txzchk/entry.test-0.1658587455.txt (which is only on my system) it
    works fine. It might be a bit better though.

    I thought of making this a new version but that would require updating
    the version in the json files and the changes are only cosmetic anyway
    so it doesn't warrant a new version anyway.

    Minor updates in txzchk.1

commit e0e7c8e578b3ae8cbb7c731cbbc871a95d256aa2
Date:   Fri Jul 29 05:10:30 2022 -0700

    Check for multiple bogus fields in txzchk

    In other words a line like:

        -rw-r--r--  0 501    20          0 Jul 28 08:25 test-0/file bogus data

    will report (for this line specifically):

        Warning: txzchk: test_txzchk/entry.test-0.1658587455.txt: bogus field found after filename: bogus
        Warning: txzchk: test_txzchk/entry.test-0.1658587455.txt: bogus field found after filename: data

    Previously it would have only detected 'bogus'.

    A question that was brought up is whether or not the line should count
    as a filename of 'file bogus data' or if considering 'bogus' and 'data'
    as bogus fields is enough. On the one hand the most likely case is it
    would be a filename with spaces (unless of course the tarball was
    created by mkiocccentry); but on the other hand it might also be someone
    messing with the tarball and since strtok_r() is used (with " \t") it
    would require more code to detect and display the full filename and
    since it's also bogus this works (for now if not indefinitely).