### PR TITLE
Several fixes and enhancements to txzchk + formatting fix in foo

### DIFF
--- a/foo.c
+++ b/foo.c
@@ -61,9 +61,8 @@ static char const *oebxergfB[] =
     "ul twzuespayknueyttf twll bnym '>'. Usiwsmw leawxwd qk.\n"
     "-- Xwzft",
 
-    "C dsm'b hmsx nyto so fsq nyto yl xwtt yl C lnsqtd tuhw;\n"
-    "ymd C tuhw twll bnym"
-    " nyto so fsq nyto yl xwtt yl fsq dwlwavw.\n"
+    "C dsm'b hmsx nyto so fsq nyto yl xwtt yl C lnsqtd tuhw; ymd C tuhw twll\n"
+    "bnym nyto so fsq nyto yl xwtt yl fsq dwlwavw.\n"
     "-- Nutrs Nyppuml",
 
     "I lwebusm: '{}'\n"

--- a/txzchk.h
+++ b/txzchk.h
@@ -57,7 +57,7 @@ static char const *txzpath = NULL;		/* the current tarball being checked */
 static char const *program = NULL;		/* our name */
 static bool text_file_flag_used = false;	/* true ==> assume txzpath is a text file */
 static char const *ext = "txz";			/* force extension in fnamchk to be this value */
-static bool suppress_error_messages = false;	/* true ==> suppress error messages (enabled by -e) */
+static bool suppress_error_messages = false;	/* true ==> suppress error messages (-e used for tests but should be changed) */
 
 /*
  * information about the tarball
@@ -77,6 +77,12 @@ struct txz_info
     unsigned invalid_chars;		    /* > 0 ==> invalid characters found in this number of filenames */
     off_t size;				    /* size of the tarball itself */
     off_t file_sizes;			    /* total size of all the files combined */
+    bool files_size_too_big;		    /* true ==> total files size > MAX_DIR_KSIZE */
+    bool files_size_shrunk;		    /* true ==> total files size shrunk */
+    off_t previous_file_sizes;		    /* the previous total size of all files combined */
+    off_t previous_rounded_file_size;	    /* the previous total file sizes rounded up to 1024 multiple */
+    bool rounded_files_size_shrunk;	    /* true ==> rounded files size shrunk */
+    bool rounded_files_size_too_big;	    /* true ==> rounded files size too big */
     off_t rounded_file_size;		    /* file sizes rounded up to 1024 multiple */
     unsigned correct_directory;		    /* number of files in the correct directory */
     unsigned dot_files;			    /* number of dot files that aren't .author.json and .info.json */
@@ -166,6 +172,8 @@ static unsigned check_tarball(char const *tar, char const *fnamchk);
 static void show_txz_info(char const *txzpath);
 static void check_empty_file(char const *txzpath, off_t size, struct txz_file *file);
 static void check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file);
+static bool convert_file_size(off_t *current_file_size, char *p);
+static void check_txz_files_size(bool show_rounded_size);
 static void check_all_txz_files(char const *dir_name);
 static void check_directories(struct txz_file *file, char const *dir_name, char const *txzpath);
 static bool has_special_bits(char const *str);


### PR DESCRIPTION
The following fixes were made (but note that if a test is not mentioned
below it does not mean it's not already in place and it's entirely
possible I miss below one or more tests that has or have been added).

After each file size is parsed if the new total size is < the previous
size it is an issue.

After each file size is parsed if the new total size is > MAX_DIR_KSIZE
it is an issue (this was only done at the end after all files parsed).

After each file size is parsed if the new total size is < 0 it is an
issue (the current file size was tested for < 0 and also 0 but the total
was not until the very end).

After each file size is parsed if the new rounded file size (up to 1024
multiple) is < the previous it is an issue.

Each test is only displayed once. That is there are new booleans that
disable showing a warning and also increasing the number of feathers
(issues) in the tarball but perhaps the total feathers should be
increased and only the message should not be. The reason I did it this
way is because it's simpler to keep track of the values and if for
example a 0 file size comes in between what should the message be?
Another reason I opted for this is it's less verbose as the tool is
already quite verbose without appropriate options (-q or -e but the
latter should be removed and will be eventually when the test script is
updated to show more details).

Perhaps all the checks made on the tarball should be added to the man
page but if so that's for another time.

I have not added any of these to the final report but perhaps they
should be.

Perhaps the booleans should be an unsigned int being the number of times
it occurs?