### PR TITLE
Add more test_ functions to entry_util + fix typos

### DIFF
--- a/entry_util.c
+++ b/entry_util.c
@@ -1407,7 +1407,7 @@ test_Makefile_override(bool boolean)
 /*
  * test_abstract - test if abstract is valid
  *
- * Determine if abstract length is <= MAX_ABSTRACT_LEN.
+ * Determine if abstract length is > 0 && <= MAX_ABSTRACT_LEN.
  *
  * given:
  *	str	string to test
@@ -2122,25 +2122,25 @@ test_extra_file(char *str)
     }
 
     /* verify that extra_file does not match a mandatory filename */
-    if (strcmp(str, ".info.json") == 0) {
+    if (strcmp(str, INFO_JSON_FILENAME) == 0) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file .info.json");
+		 "invalid: extra_file matches a mandatory file %s", INFO_JSON_FILENAME);
 	return false;
-    } else if (strcmp(str, ".author.json") == 0) {
+    } else if (strcmp(str, AUTHOR_JSON_FILENAME) == 0) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file .author.json");
+		 "invalid: extra_file matches a mandatory file %s", AUTHOR_JSON_FILENAME);
 	return false;
-    } else if (strcmp(str, "prog.c") == 0) {
+    } else if (strcmp(str, PROG_C_FILENAME) == 0) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file prog.c");
+		 "invalid: extra_file matches a mandatory file %s", PROG_C_FILENAME);
 	return false;
-    } else if (strcmp(str, "Makefile") == 0) {
+    } else if (strcmp(str, MAKEFILE_FILENAME) == 0) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file Makefile");
+		 "invalid: extra_file matches a mandatory file %s", MAKEFILE_FILENAME);
 	return false;
-    } else if (strcmp(str, "remarks.md") == 0) {
+    } else if (strcmp(str, REMARKS_FILENAME) == 0) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file remarks.md");
+		 "invalid: extra_file matches a mandatory file %s", REMARKS_FILENAME);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "extra_file is valid");
@@ -3225,4 +3225,111 @@ test_url(char *str)
 
     json_dbg(JSON_DBG_MED, __func__, "url is valid");
     return true;
+}
+
+/*
+ * test_remarks - test that remarks filename is valid
+ *
+ * Test that length is > 0 and that the string is equal to REMARKS_FILENAME.
+ *
+ * given:
+ *	str	string to test
+ *
+ * returns:
+ *	true ==> string is valid
+ *	false ==> string is NOT valid, or NULL pointer, or some internal error
+*
+ */
+bool
+test_remarks(char *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	warn(__func__, "str is NULL");
+	return false;
+    }
+
+    if (*str == '\0') { /* strlen(str) == 0 */
+	json_dbg(JSON_DBG_MED, __func__,
+		 "empty remarks filename is invalid");
+	return false;
+    } else if (strcmp(str, REMARKS_FILENAME)) {
+	json_dbg(JSON_DBG_MED, __func__,
+		 "remarks filename '%s' is invalid: does not match '%s'", str, REMARKS_FILENAME);
+	return false;
+    }
+
+    json_dbg(JSON_DBG_MED, __func__, "remarks filename is valid");
+    return true;
+}
+
+/*
+ * test_min_timestamp - test if min_timestamp is valid
+ *
+ * Determine if min_timestamp == MIN_TIMESTAMP.
+ *
+ * given:
+ *	tstamp		timestamp as time_t to test
+ *
+ * returns:
+ *	true ==> min_timestamp is valid,
+ *	false ==> min_timestamp is NOT valid, or some internal error
+ */
+bool
+test_min_timestamp(time_t tstamp)
+{
+    /*
+     * compare with the minimum timestamp
+     */
+    if (tstamp != MIN_TIMESTAMP) {
+	json_dbg(JSON_DBG_MED, __func__,
+		 "invalid: min_timestamp != MIN_TIMESTAMP");
+	return false;
+    }
+    json_dbg(JSON_DBG_MED, __func__,
+	     "valid: min_timestamp == MIN_TIMESTAMP");
+    return true;
+}
+
+/*
+ * test_timestamp_epoch - test if timestamp_epoch is valid
+ *
+ * Determine if timestamp_epoch string is equal to TIMESTAMP_EPOCH.
+ *
+ * given:
+ *	str		timestamp_epoch to test
+ *
+ * returns:
+ *	true ==> min_timestamp is valid,
+ *	false ==> min_timestamp is NOT valid, or some internal error
+ */
+bool
+test_timestamp_epoch(char *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	warn(__func__, "str is NULL");
+	return false;
+    }
+    else if (*str == '\0') { /* strlen(str) == 0 */
+	json_dbg(JSON_DBG_MED, __func__,
+		 "invalid: timestamp_epoch is empty");
+	return false;
+    }
+    /*
+     * compare with the timestamp epoch
+     */
+    if (strcmp(str, TIMESTAMP_EPOCH)) {
+	json_dbg(JSON_DBG_MED, __func__,
+		 "invalid: timestamp_epoch != TIMESTAMP_EPOCH");
+	return false;
+    }
+    json_dbg(JSON_DBG_MED, __func__,
+	     "valid: timestamp_epoch == TIMESTAMP_EPOCH");
+    return true;
+
 }

--- a/entry_util.h
+++ b/entry_util.h
@@ -65,7 +65,9 @@
  */
 #define INFO_JSON_FILENAME ".info.json"
 #define AUTHOR_JSON_FILENAME ".author.json"
-
+#define PROG_C_FILENAME "prog.c"
+#define REMARKS_FILENAME "remarks.md"
+#define MAKEFILE_FILENAME "Makefile"
 
 /*
  * IOCCC author information
@@ -268,5 +270,7 @@ extern bool test_txzchk_version(char *str);
 extern bool test_title(char *str);
 extern bool test_twitter(char *str);
 extern bool test_url(char *str);
-
+extern bool test_remarks(char *str);
+extern bool test_min_timestamp(time_t tstamp);
+extern bool test_timestamp_epoch(char *str);
 #endif /* INCLUDE_ENTRY_UTIL_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -2719,8 +2719,7 @@ check_Makefile(struct info *infop, char const *entry_dir, char const *cp, char c
  * check_remarks_md - check remarks_md arg and if OK, copy into entry_dir/Makefile
  *
  * Check if the remarks_md argument is a readable file, and
- * if it is not empty,
- * use cp to copy into entry_dir/remarks.md.
+ * if it is not empty, use cp to copy into entry_dir/remarks.md.
  *
  * given:
  *      infop           - pointer to info structure
@@ -2775,7 +2774,7 @@ check_remarks_md(struct info *infop, char const *entry_dir, char const *cp, char
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(102, __func__, "file_size error: %jd on remarks_md %s", (intmax_t)filesize, remarks_md);
+	err(102, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
 	err(103, __func__, "remarks.md cannot be empty: %s", remarks_md);


### PR DESCRIPTION
The following functions were added:

    +extern bool test_remarks(char *str);
    +extern bool test_min_timestamp(time_t tstamp);
    +extern bool test_timestamp_epoch(char *str);

To clarify the difference between test_min_timestamp() with the already
existing test_formed_timestamp() (since it also refers to
MIN_TIMESTAMP): the test_formed_timestamp() function verifies that the
formed timestamp >= MIN_TIMESTAMP whereas test_min_timestamp() tests
that the entry has the same minimum timestamp required.

I also fixed some typos.

As well I added some defines:

    #define PROG_C_FILENAME "prog.c"
    #define REMARKS_FILENAME "remarks.md"
    #define MAKEFILE_FILENAME "Makefile"

and made use of these in the entry_util.c file. Perhaps these can also
be used in mkiocccentry.c but I only just thought of this and I must
leave for now (there was a typo fix in mkiocccentry.c however).