### PR TITLE
Fix potential invocation error in run_{flex,bison}

### DIFF
--- a/entry_util.c
+++ b/entry_util.c
@@ -3179,7 +3179,7 @@ test_highbit_warning(bool boolean)
 /*
  * test_info_JSON - test if info_JSON is valid
  *
- * Determine if info_JSON matches AUTHOR_JSON_FILENAME.
+ * Determine if info_JSON matches INFO_JSON_FILENAME.
  *
  * given:
  *	str	string to test

--- a/run_bison.sh
+++ b/run_bison.sh
@@ -357,7 +357,7 @@ on_path() {
 
     # ignore if tool is not on path
     #
-    TOOL_PATH=$(command -v "$TOOL" 2>/dev/null)
+    TOOL_PATH=$(type -P "$TOOL" 2>/dev/null)
     status="$?"
     if [[ $status -ne 0 || -z $TOOL_PATH ]]; then
 	if [[ $V_FLAG -ge 7 ]]; then

--- a/run_flex.sh
+++ b/run_flex.sh
@@ -346,7 +346,7 @@ on_path() {
 
     # ignore if tool is not on path
     #
-    TOOL_PATH=$(command -v "$TOOL" 2>/dev/null)
+    TOOL_PATH=$(type -P "$TOOL" 2>/dev/null)
     status="$?"
     if [[ $status -ne 0 || -z $TOOL_PATH ]]; then
 	if [[ $V_FLAG -ge 7 ]]; then


### PR DESCRIPTION
The scripts used command -v to determine the path of the tools. But this is a problem because it doesn't force checking of the path. For example on my macOS system doing command -v ls reports:

    alias ls='ls -GF'

but with type -P ls:

    /bin/ls

It's improbable that most would have an alias for flex or bison but better safe than sorry. At this time no other scripts use command but instead use type (if necessary). However the Makefile does use it but I'm not sure if this is good or bad. Probably it should also be fixed but for now I'm leaving it off pending discussion.