### PR TITLE
Man page updates + addition of mkiocccentry_test.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ MAN1_TARGETS= mkiocccentry txzchk fnamchk iocccsize chkentry jstrdecode jstrenco
 	      jparse
 MAN3_TARGETS= dbg
 MAN8_TARGETS= reset_tstamp verge limit_ioccc iocccsize_test ioccc_test run_usage utf8_test \
-	      have_timegm jparse_test txzchk_test run_flex run_bison vermod
+	      have_timegm jparse_test txzchk_test run_flex run_bison vermod mkiocccentry_test
 MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 HTML_MAN_TARGETS= $(patsubst %,%.html,$(MAN_TARGETS))
 # This is a simpler way to do:

--- a/ioccc_test.8
+++ b/ioccc_test.8
@@ -1,10 +1,10 @@
-.TH ioccc_test 8 "8 September 2022" "ioccc_test" "IOCCC tools"
+.TH ioccc_test 8 "23 September 2022" "ioccc_test" "IOCCC tools"
 .SH NAME
-ioccc_test \- test suite for IOCCC toolkit
+ioccc_test.sh \- test suite for IOCCC toolkit
 .SH SYNOPSIS
 \fBioccc_test.sh\fP [\-h] [\-v level] [\-J json_level] [\-V]
 .SH DESCRIPTION
-\fBioccc_test\fP tests every module of the IOCCC toolkit.
+\fBioccc_test.sh\fP tests every module of the IOCCC toolkit.
 .SH OPTIONS
 .PP
 \fB\-h\fP

--- a/iocccsize_test.8
+++ b/iocccsize_test.8
@@ -1,10 +1,10 @@
-.TH iocccsize_test 8 "8 September 2022" "iocccsize_test" "IOCCC tools"
+.TH iocccsize_test 8 "23 September 2022" "iocccsize_test" "IOCCC tools"
 .SH NAME
-iocccsize_test \- test iocccsize tool
+iocccsize_test.sh \- test iocccsize tool
 .SH SYNOPSIS
 \fBiocccsize_test.sh\fP [\-h] [\-b] [\-v lvl] [\-V] [\-t tool]
 .SH DESCRIPTION
-\fBiocccsize_test\fP runs a series of tests on the \fBiocccsize(1)\fP tool, verifying that it is functioning properly.
+\fBiocccsize_test.sh\fP runs a series of tests on the \fBiocccsize(1)\fP tool, verifying that it is functioning properly.
 .SH OPTIONS
 .PP
 \fB\-h\fP

--- a/jparse_test.8
+++ b/jparse_test.8
@@ -1,10 +1,10 @@
-.TH jparse_test 8 "12 September 2022" "jparse_test" "IOCCC tools"
+.TH jparse_test 8 "23 September 2022" "jparse_test" "IOCCC tools"
 .SH NAME
-jparse_test \- test jparse on one or more files with one or more one-line JSON blobs
+jparse_test.sh \- test jparse on one or more files with one or more one-line JSON blobs
 .SH SYNOPSIS
 \fBjparse_test.sh\fP [\-h] [\-v level] [\-D dbg_level] [\-J level] [\-q] [\-j jparse] [file ..]
 .SH DESCRIPTION
-\fBjparse_test\fP tests each line in each file for valid JSON.
+\fBjparse_test.sh\fP tests each line in each file for valid JSON.
 The file name \fI\-\fP means read from stdin.
 It keeps a log of all the tests in \fIjparse_test.log\fP for later inspection.
 .SH OPTIONS

--- a/mkiocccentry_test.8
+++ b/mkiocccentry_test.8
@@ -1,0 +1,37 @@
+.TH mkiocccentry_test 8 "23 September 2022" "mkiocccentry_test" "IOCCC tools"
+.SH NAME
+mkiocccentry_test.sh \- run several invocations of \fBmkiocccentry(1)\fP to test that it functions well
+.SH SYNOPSIS
+\fBmkiocccentry_test.sh\fP [\-h] [\-v level] [\-J level] [\-V]
+.SH DESCRIPTION
+\fBmkiocccentry_test.sh\fP runs a series of invocations of \fBmkiocccentry\fP, testing various types of inputs including multiple authors some of which have non-ASCII characters in their name.
+.SH OPTIONS
+.PP
+\fB\-h\fP
+Show help and exit.
+.PP
+\fB\-v\fP
+Set verbosity level (def: 0).
+.PP
+\fB\-J\fP
+Set JSON verbosity level.
+.PP
+\fB\-V\fP
+Print version and exit.
+.SH EXIT STATUS
+.PP
+Exit codes:
+.br
+0	all tests are OK
+.br
+1	-h and help string printed or -V and version string printed
+.br
+2	Command line usage error
+.br
+>=10	some make action exited non-zero
+.SH BUGS
+.PP
+This script does not let one set the path to the needed tools like the other scripts do and so requires that one is in the clone of the repo directory to successfully run this script.
+This should probably be fixed.
+.SH SEE ALSO
+\fBioccc_test(8)\fP, \fBiocccsize_test(8)\fP.

--- a/txzchk_test.8
+++ b/txzchk_test.8
@@ -1,6 +1,6 @@
-.TH txzchk_test 8 "12 September 2022" "txzchk_test" "IOCCC tools"
+.TH txzchk_test 8 "23 September 2022" "txzchk_test" "IOCCC tools"
 .SH NAME
-txzchk_test \- test suite for \fBtxzchk(1)\fP
+txzchk_test.sh \- test suite for \fBtxzchk(1)\fP
 .SH SYNOPSIS
 \fBtxzchk_test.sh\fP [\-h] [\-v level] [\-D dbg_level] [\-t txzchk] [\-T tar] [\-F fnamchk] [\-d txzchk_tree]
 .SH DESCRIPTION


### PR DESCRIPTION
As for the files not named I simply fixed the name so that they all have .sh in the name as they're all shell scripts.

The usage of make install will now install mkiocccentry_test.8 as well.