### PR TITLE
`make parser' now compiles chkentry + update readme for txzchk_test.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -700,6 +700,7 @@ parser: jparse.y jparse.l Makefile
 	${CP} -f -v jparse.c jparse.ref.c
 	${MAKE} jparse
 	${MAKE} jsemtblgen
+	${MAKE} chkentry
 
 #
 # make parser-o: Force the rebuild of the JSON parser.

--- a/jparse.l
+++ b/jparse.l
@@ -37,7 +37,7 @@
 
 
 /*
- * jparse - JSON parser tool
+ * jparse - JSON parser demo tool
  */
 #include "jparse.h"
 

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -611,7 +611,7 @@ char *yytext;
 
 
 /*
- * jparse - JSON parser tool
+ * jparse - JSON parser demo tool
  */
 #include "jparse.h"
 

--- a/test_txzchk/README.md
+++ b/test_txzchk/README.md
@@ -7,18 +7,17 @@ The `good/` subdirectory has files that `txzchk` MUST report as valid.
 
 The `bad/` subdirectory has files that `txzchk` MUST report as invalid.
 
-The files MUST end with either `.txt` or `.txz` and the test script will do the
-right thing. For good files the filename MUST match the rules of the `fnamchk`
-tool; this is not as clear for the bad tests though generally speaking it should
-also follow the rules as it will make it harder to get valid test results.
+The filenames MUST end with `.txt` and the script will do the right thing.  For
+good files the filename MUST match the rules of the `fnamchk` tool; this is not
+as clear for the bad tests though generally speaking it should also follow the
+rules as it will make it harder to get valid test results.
 
 The typical format is that which would be generated from `tar -tJvf` but
-importantly most of these files are **NOT** tarballs: they are text files that
+importantly these files are **NOT** tarballs: they are text files that
 would have the output of the tar command. This is to make it much easier to add
 test cases and it also prevents having the need to have tarballs in the repo (as
 well as constructing said tarballs with invalid input that might be submitted
-due to abuse). There are a couple tarballs in both good and bad but many more
-text files should be added.
+due to abuse). Over time more text files have been and will be added.
 
 Here's an example good file:
 


### PR DESCRIPTION
The question of whether or not it should just do `make all' is certainly something to consider but for now this covers everything that will need to be recompiled after the parser is regenerated.

There was also a typo fix in jparse.l - kind of. I had removed 'demo' from 'demo tool' but I meant to add it back as maybe jparse itself is kind of a demo as it doesn't actually do anything with it - it just parses it but does nothing with it other than report if it's valid or not.