### PR TITLE
Fix txzchk_test.sh under linux

### DIFF
--- a/hostchk.sh
+++ b/hostchk.sh
@@ -136,6 +136,7 @@ if [[ $status -ne 0 ]]; then
     RUN_TAR_TEST=
 fi
 date > "$TEST_FILE"
+status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: date > $TEST_FILE exit code: $status" 1>&2
     EXIT_CODE=31

--- a/test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt.err
+++ b/test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt.err
@@ -1,6 +1,6 @@
 ERROR[11]: main: second '-' separated token length: 50 != 38: ./test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt
 Warning: txzchk: ./test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt: ./fnamchk ./test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt failed with exit code: 11
-Warning: string_to_intmax2: error converting string <fred> to intmax_t: errno[22]: Invalid argument
+Warning: string_to_intmax2: string fred has no digits
 Warning: txzchk: ./test_txzchk/bad/entry.12345678-1234-4321-abcd-1234567890ab-2-19944411114.txt: trying to parse file size in on line: <drw-r--r--  0 501    20       fred Jun  4 04:52 12345678-1234-4321-abcd-1234567890ab-2/extra1/>: token: <fred>
 skipping to next line due to inability to parse file size
 Warning: string_to_intmax2: number 155a has invalid characters

--- a/util.c
+++ b/util.c
@@ -2325,6 +2325,7 @@ bool
 string_to_intmax2(char const *str, intmax_t *ret)
 {
     intmax_t num = 0;
+    int saved_errno = 0;
     char *endptr = NULL;
 
     /*
@@ -2344,14 +2345,16 @@ string_to_intmax2(char const *str, intmax_t *ret)
      */
     errno = 0;		/* pre-clear errno for warnp() */
     num = strtoimax(str, &endptr, 10);
-    if (errno != 0) {
-	warnp(__func__, "error converting string <%s> to intmax_t", str);
-	return false;
-    } else if (endptr == str) {
+    saved_errno = errno;
+    if (endptr == str) {
 	warn(__func__, "string %s has no digits", str);
 	return false;
     } else if (*endptr != '\0') {
 	warn(__func__, "number %s has invalid characters", str);
+	return false;
+    } else if (saved_errno != 0) {
+	errno = saved_errno;
+	warnp(__func__, "error converting string <%s> to intmax_t", str);
 	return false;
     } else if (num <= INTMAX_MIN || num >= INTMAX_MAX) {
 	warn(__func__, "number %s out of range for intmax_t (must be > %jd && < %jd)", str, INTMAX_MIN, INTMAX_MAX);


### PR DESCRIPTION
A problem occurred in string_to_intmax2() in the order of checks for failures so that under linux the errno was set to non-zero but this was not triggered under macOS. This fix saves errno first (as an abundance of caution) and then checks the other conditions. Then after those are passed the saved errno is checked and if not 0 then it's used (setting errno to the saved value).

I also updated the test_txzchk/bad error file. This should solve the problem but if not I'll have to look at it tomorrow.