### PR TITLE
Man page fixes + improvements to hostchk.sh and have_timegm.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ all: ${TARGETS} ${TEST_TARGETS}
 # rules, not file targets
 #
 .PHONY: all all_ref bug-report build checknr clean clean_generated_obj \
-        clean_mkchk_sem clobber configure depend hostchk install ioccc_test \
+        clean_mkchk_sem clobber configure depend hostchk bug-report install ioccc_test \
         legacy_clobber man2html mkchk_sem parser parser-o picky prep prep_clobber \
         pull rebuild_jnum_test release reset_min_timestamp seqcexit shellcheck tags \
         test test-chkentry use_ref
@@ -935,8 +935,10 @@ test ioccc_test: ioccc_test.sh iocccsize_test.sh dbg mkiocccentry_test.sh jstr_t
 		 jnum_chk dyn_test txzchk_test.sh txzchk jparse Makefile
 	./ioccc_test.sh
 
-hostchk bug-report: hostchk.sh
-	./hostchk.sh
+hostchk bug-report:
+	@-./hostchk.sh -v 0; status="$$?"; if [[ $$status -ne 0 ]]; then \
+	    echo "Warning: you might not be able to compile this code, see above for details." 1>&2; \
+	fi
 
 # run test-chkentry on test_JSON files
 #

--- a/have_timegm.8
+++ b/have_timegm.8
@@ -2,7 +2,7 @@
 .SH NAME
 have_timegm \- test compiler for \fBtimegm(3)\fP, \fBstrptime(3)\fP and \fBstrftime(3)\fP
 .SH SYNOPSIS
-\fBhave_timegm.sh\fP [\-h] [\-v level]
+\fBhave_timegm.sh\fP [\-h] [\-V] [\-v level]
 .SH DESCRIPTION
 \fBhave_timegm.sh\fP will attempt to compile and run a test program \fBhave_timegm.c\fP to determine if the compiler can use the functions \fBtimegm(3)\fP, \fBstrptime(3)\fP and \fBstrftime(3)\fP.
 If the system compiler does not work we attempt to compensate by directly declaring the prototype for \fBtimegm(3)\fP to let such systems use the tools in order to submit an IOCCC entry.
@@ -12,32 +12,35 @@ We will stop trying to do this in 2024.
 \fB\-h\fP
 Show help and exit.
 .PP
+\fB\-V\fP
+Show version and exit.
+.PP
 \fB\-v\fP
 Set verbosity level.
 .SH EXIT STATUS
 .PP
 .br
-    0    timestamp updated
+    0	    all is well
 .br
-    1    failed Phase 0 of verification
+    1	    invalid command line
 .br
-    2    failed Phase 1 of verification
+    2	    strptime() returned NULL
 .br
-    3    failed Phase 2 of verification
+    3	    strptime() return value not '\\0'
 .br
-    4    failed Phase 3 of verification
+    4	    strftime() failed
 .br
-    5    failed Phase 4 of verification
+    5	    original time string and conversion mismatch
 .br
-    6    rpl failed to modify limit_ioccc.h
+    100	    help or version mode used
 .br
-    7    limit_ioccc.h not found or not readable and writable
+    101	    invalid option or option missing an argument
 .br
-    8    -h and help string printed or -V and version string printed
+    102	    missing \fIhave_timegm.c\fP
 .br
-    9    Command line usage error
+    103	    \fIhave_timegm.c\fP not a regular file
 .br
-    >=10  internal error
+    104	    \fIhave_timegm.c\fP not a readable file
 .SH NOTES
 .PP
 While there is no bug in the tool we are aware of one issue.
@@ -53,7 +56,7 @@ Running the script under CentOS 7 will result in:
 
 .RS
 \fB
-  $ ./have_timegm.sh 
+  $ ./have_timegm.sh
   -DTIMEGM_PROBLEM\fP
 .fi
 .RE

--- a/have_timegm.sh
+++ b/have_timegm.sh
@@ -15,24 +15,50 @@
 export C_SRC="have_timegm.c"
 export PROG="./have_timegm"
 export V_FLAG="0"
+export HAVE_TIMEGM_VERSION="0.0 2022-08-17"
+
+export USAGE="usage: $0 [-h] [-V] [-v level]
+
+    -h			    print help and exit 2
+    -V			    print version and exit 2
+    -v level		    set verbosity level for this script: (def level: 0)
+
+exit codes:
+    0	- all is well
+    1	- invalid command line
+    2	- strptime() returned NULL
+    3	- strptime() return not '\\0'
+    4	- strftime() failed
+    5	- original time string and conversion mismatch
+    100	- help or version mode used
+    101 - invalid option or option missing an argument
+    102 - missing have_timegm.c
+    103 - have_timegm.c not a regular file
+    104 - have_timegm.c not a readable file
+
+$0 version: $HAVE_TIMEGM_VERSION"
+
 
 # parse args
 #
-while getopts :hv: flag; do
+while getopts :hv:V flag; do
     case "$flag" in
-    h) echo "usage: $0 [-h] [-v level]" 1>&2
-       exit 2
-       ;;
-    v) V_FLAG="$OPTARG";
-       ;;
-    \?) echo "invalid option: -$OPTARG" 1>&2
-       exit 3
-       ;;
-    :) echo "option -$OPTARG requires an argument" 1>&2
-       exit 4
-       ;;
-   *)
-       ;;
+    h)	echo "$USAGE" 1>&2
+	exit 100
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    V)	echo "$0 version $HAVE_TIMEGM_VERSION" 1>&2
+	exit 100
+	;;
+    \?)	echo "invalid option: -$OPTARG" 1>&2
+	exit 101
+	;;
+    :)	echo "option -$OPTARG requires an argument" 1>&2
+	exit 101
+	;;
+    *)
+	;;
     esac
 done
 
@@ -40,15 +66,15 @@ done
 #
 if [[ ! -e $C_SRC ]]; then
     echo "$0: missing have_timegm.c: $C_SRC" 1>&2
-    exit 100
+    exit 102
 fi
 if [[ ! -f $C_SRC ]]; then
-    echo "$0: have_timegm.c is not a file: $C_SRC" 1>&2
-    exit 101
+    echo "$0: have_timegm.c is not a regular file: $C_SRC" 1>&2
+    exit 103
 fi
 if [[ ! -r $C_SRC ]]; then
     echo "$0: have_timegm.c is not a readable file: $C_SRC" 1>&2
-    exit 102
+    exit 104
 fi
 
 # prep for compile
@@ -76,4 +102,4 @@ fi
 
 # All Done!!! -- Jessica Noll, Age 2
 #
-exit 0
+exit "$status"

--- a/hostchk.sh
+++ b/hostchk.sh
@@ -45,9 +45,11 @@ if [[ -z "$TAR" ]]; then
     TAR="/usr/bin/tar"
 fi
 
-export USAGE="usage: $0 [-h] [-v level] [-D dbg_level] [-t tar] [-c cc]
+export HOSTCHK_VERSION="0.2 2022-10-12"
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-t tar] [-c cc]
 
     -h			    print help and exit 2
+    -V			    print version and exit 2
     -v level		    set verbosity level for this script: (def level: 0)
     -D dbg_level	    set verbosity level for tests (def: level: 0)
     -t tar		    path to tar that accepts -J option (def: $TAR)
@@ -56,9 +58,11 @@ export USAGE="usage: $0 [-h] [-v level] [-D dbg_level] [-t tar] [-c cc]
 exit codes:
     0 - all is well
     1 - at least one test failed
-    2 - help mode exit
+    2 - help mode and version mode exit
     3 - invalid command line
-    >= 30 - internal error"
+    >= 30 - internal error
+
+$0 version: $HOSTCHK_VERSION"
 
 export EXIT_CODE=0
 
@@ -66,27 +70,30 @@ export EXIT_CODE=0
 #
 export V_FLAG="0"
 export DBG_LEVEL="0"
-while getopts :hv:D:t:c: flag; do
+while getopts :hv:VD:t:c: flag; do
     case "$flag" in
-    h) echo "$USAGE" 1>&2
-       exit 2
-       ;;
-    v) V_FLAG="$OPTARG";
-       ;;
-    D) DBG_LEVEL="$OPTARG";
-       ;;
-    t) TAR="$OPTARG";
+    h)	echo "$USAGE" 1>&2
+	exit 2
 	;;
-    c) CC="$OPTARG";
+    v)	V_FLAG="$OPTARG";
+	;;
+    V)	echo "$HOSTCHK_VERSION"
+	exit 2
+	;;
+    D)	DBG_LEVEL="$OPTARG";
+	;;
+    t)	TAR="$OPTARG";
+	;;
+    c)	CC="$OPTARG";
 	;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
-       exit 3
-       ;;
-    :) echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
-       exit 3
-       ;;
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	exit 3
+	;;
    *)
-       ;;
+	;;
     esac
 done
 
@@ -225,7 +232,7 @@ if [[ -n $RUN_INCLUDE_TEST ]]; then
 	#
 	status="$?"
 	if [[ $status -ne 0 ]]; then
-	    echo "$0: FATAL: missing system include file <$h>" 1>&2
+	    echo "$0: FATAL: unable to compile with $h" 1>&2
 	    EXIT_CODE=42
 	    INCLUDE_TEST_SUCCESS="false"
 	fi

--- a/vermod.8
+++ b/vermod.8
@@ -41,27 +41,25 @@ List files that do not change or would not be changed.
 This is useful with \fB\-n\fP to show what wouldn't change.
 .SH EXIT STATUS
 .PP
-Exit codes:
+0	    all is well
 .br
-    0 \- all is well
+1	    \fBrpl\fP exited non-zero
 .br
-    1 \- \fBrpl\fP exited non-zero
+2	    \fBrpl\fP not found
 .br
-    2 \- \fBrpl\fP not found
+3	    no limit.sh found or is not readable
 .br
-    3 \- no limit.sh found or is not readable
+4	    no test directory found or is not readable
 .br
-    4 \- no test directory found or is not readable
+5	    usage message due to \fB\-h\fP
 .br
-    5 \- usage message due to \fB\-h\fP
+6	    command line error and usage message printed
 .br
-    6 \- command line error and usage message printed
+7	    no *.json files found under test directory
 .br
-    7 \- no *.json files found under test directory
+8	    new_ver (or old_ver if \fB\-o\fP) not found in limit file
 .br
-    8 \- new_ver (or old_ver if \fB\-o\fP) not found in limit file
-.br
-    >= 9 - internal error
+>= 9	    internal error
 .SH FILES
 \fItest_JSON\fP
 .RS


### PR DESCRIPTION
I hope to get to the two threads later on but I'm fearing that I might not get much more done today. Still these are good changes with the caveat that I'll want to look again at the man page of the scripts to make sure the exit codes are consistent with the actual script.

Or perhaps we don't need to have all the exit codes? It would simplify the man pages. What do you think of that?

The other caveat is I am tired so it's possible I made a mistake with exit code in have_timegm.sh script - specifically being consistent with the have_timegm.c file. I thought I had it but now I'm not certain of it. Still if not it should be fixed but I think it's the right idea as the script should have consistent exit codes with the tool itself I think.