### PR TITLE
Change typeset to declare in *.sh and new version of bug_report.sh (modularise it) + add version to several scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ hostchk_warning:
 	@echo '=-= WARNING WARNING WARNING =-=' 1>&2
 	@echo '=-= If you think this is a bug, consider filing a bug report via:' 1>&2
 	@echo 1>&2
-	@echo './bug_report.sh.sh' 1>&2
+	@echo './bug_report.sh' 1>&2
 	@echo 1>&2
 	@echo '=-= about to sleep 10 seconds =-=' 1>&2
 	@echo 1>&2

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -125,8 +125,8 @@ echo "## TIME OF REPORT: $(date)" | tee -a -- "$LOG_FILE"
 # Make array of all commands we need.
 #
 # This is done this way so that we can use each command's index as an offset for
-# an exit code that will be added to 11 (the first exit code that is an error
-# beyond the one that does not have an individual code, see below).
+# an exit code that will be added to BASE_ERR_EXIT_CODE (the first exit code
+# that is an error beyond the one that does not have an individual code, see below).
 #
 # Since arrays also don't have to be assigned contiguously this will allow us to
 # also spread commands out for exit codes. We shouldn't need more than the
@@ -135,13 +135,14 @@ echo "## TIME OF REPORT: $(date)" | tee -a -- "$LOG_FILE"
 # There is an exception to the exit codes here and that's the check for if each
 # of our tools is executable. For that we use a single exit code 10. This is not
 # done until later on but with exit code 10 so that it's out of the way of the
+# other exit codes.
 #
 # We assign the commands to the array one at a time so we have control of the
 # index for the command which will also be part of the error code if it goes
 # wrong.
 #
-# The 0th element will be exit code 11 if it fails; the 1st element will be 11
-# and so on.
+# The 0th element will be exit code 0 + BASE_ERR_EXIT_CODE if it fails; the 1st
+# element will be 1 + BASE_ERR_EXIT_CODE and so on.
 #
 # NOTE: make all will indirectly call make fast_hostchk which, if it reports an
 # issue, will be reported here. However we also directly invoke hostchk.sh later

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -98,7 +98,7 @@ function is_exec()
 	echo "$0: ERROR: expected 1 arg to is_exec, found $#" | tee -a -- "$LOG_FILE"
 	return 1
     else
-	typeset f="$1"
+	declare f="$1"
 	if [[ ! -e "$f" ]]; then
 	    echo "$0: ERROR: $1 does not exist" | tee -a -- "$LOG_FILE"
 	    return 1

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -14,6 +14,8 @@
 # NOTE: This is a work in progress.
 #
 
+BUG_REPORT_VERSION="0.3 2022-10-16"
+
 # All of our tools. Kept towards top of file in case the list needs to be
 # changed.
 export TOOLS="./run_bison.sh ./run_flex.sh ./hostchk.sh ./dbg ./dyn_test ./fnamchk
@@ -23,7 +25,6 @@ export TOOLS="./run_bison.sh ./run_flex.sh ./hostchk.sh ./dbg ./dyn_test ./fnamc
 	      ./reset_tstamp.sh ./txzchk ./txzchk_test.sh ./utf8_test ./verge
 	      ./vermod.sh ./jsemcgen.sh ./jsemtblgen"
 
-export BUG_REPORT_VERSION="0.2 2022-10-15"
 export FAILURE_SUMMARY=
 export DBG_LEVEL="0"
 export V_FLAG="0"
@@ -121,100 +122,34 @@ fi
 
 echo "## TIME OF REPORT: $(date)" | tee -a -- "$LOG_FILE"
 
-# uname -a: get system information
-echo "## RUNNING uname -a: " | tee -a -- "$LOG_FILE"
-uname -a | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=10
-    echo "$0: ERROR: uname -a failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    uname -a non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
-
-# which cc: get all paths for cc
-echo "## RUNNING which -a cc: " | tee -a -- "$LOG_FILE"
-which cc | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=11
-    echo "$0: ERROR: which cc failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    which cc non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
-
-# cc -v: get compiler version
-echo "## RUNNING cc -v: " | tee -a -- "$LOG_FILE"
-cc -v 2>&1 | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=12
-    echo "$0: ERROR: cc -v failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    cc -v non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
-
-# which make: get path to make tool
-echo "## RUNNING which make: " | tee -a -- "$LOG_FILE"
-which -a make | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=13
-    echo "$0: ERROR: which -a make failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    which -a make non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
-
-# make -v: get make version
-echo "## RUNNING make -v: " | tee -a -- "$LOG_FILE"
-make -v | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=14
-    echo "$0: ERROR: make -v failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    make -v non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
-
-
-
-# make clobber: start clean
-echo "## RUNNING make clobber: " | tee -a -- "$LOG_FILE"
-make clobber | tee -a -- "$LOG_FILE"  1>&2
-# The below references to PIPESTATUS (instead of $?) fix the bug introduced in commit
-# 8343c4b8cb97e52df64fe8973e68f0d83c6090e1 where the exit status of each command
-# was not checked properly which meant that even if a test failed it would not
-# be reported as an issue which rather defeated the purpose of this script.
+# Make array of all commands we need.
 #
-# As amusing as the thought is that there's a bug in a script to help report
-# bugs and issues, this bug was not in fact intentional. :-) I had thought of it
-# earlier on but I neglected to address it before the commit as I moved on with
-# adding the tests. However since the world definitely needs more reasons to
-# laugh I'm keeping this comment here for the sake of humour and the irony that
-# I caused. You're welcome! :-)
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=15
-    echo "$0: ERROR: make clobber failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    make clobber non-zero exit code: $status"
-fi
-echo '' | tee -a -- "$LOG_FILE"
-
-# make all: compile everything before we do anything else
-echo "## RUNNING make all: " | tee -a -- "$LOG_FILE" 1>&2
-# NOTE: This will indirectly call make fast_hostchk which, if it reports an
+# This is done this way so that we can use each command's index as an offset for
+# an exit code that will be added to 11 (the first exit code that is an error
+# beyond the one that does not have an individual code, see below).
+#
+# Since arrays also don't have to be assigned contiguously this will allow us to
+# also spread commands out for exit codes. We shouldn't need more than the
+# amount of exit codes available so this should be okay.
+#
+# There is an exception to the exit codes here and that's the check for if each
+# of our tools is executable. For that we use a single exit code 10. This is not
+# done until later on but with exit code 10 so that it's out of the way of the
+#
+# We assign the commands to the array one at a time so we have control of the
+# index for the command which will also be part of the error code if it goes
+# wrong.
+#
+# The 0th element will be exit code 11 if it fails; the 1st element will be 11
+# and so on.
+#
+# NOTE: make all will indirectly call make fast_hostchk which, if it reports an
 # issue, will be reported here. However we also directly invoke hostchk.sh later
 # which will also report an issue so that one would likely see the warning more
 # than once. If you only see the warning once then there probably is also a
-# problem. The warning issued will suggest that you can file the issue with
-# this script and it also suggests that you can get more information with
-# running hostchk.sh directly.
+# problem. The warning issued will suggest that you can file the issue with this
+# script and it also suggests that you can get more information with running
+# hostchk.sh directly.
 #
 # Obviously one needn't run this script a second or third time just because it
 # runs hostchk.sh which suggests that you run this script each time it exits
@@ -229,41 +164,46 @@ echo "## RUNNING make all: " | tee -a -- "$LOG_FILE" 1>&2
 # really is likely that, if the script fails, you will be unable to successfully
 # use the mkiocccentry repo to submit a correct IOCCC entry.
 #
-make all | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=16
-    echo "$0: ERROR: make all failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    make all non-zero exit code: $status"
-fi
-echo | tee -a -- "$LOG_FILE"
+BASE_ERR_EXIT_CODE=11
+COMMANDS[0]="uname -a"			# uname -a		get system information
+COMMANDS[1]="which cc"			# which cc		get path for cc
+COMMANDS[2]="cc -v"			# cc -v			get compiler version
+COMMANDS[3]="which make"		# which make		get make path
+COMMANDS[4]="make -v"			# make -v		get make version
+COMMANDS[5]="make clobber"		# make clobber		start clean
+COMMANDS[6]="make all"			# make all		compile everything
+COMMANDS[7]="make test"			# make test		run mkiocccentry test suite
+COMMANDS[8]="which tar"			# which tar		get path to tar
+COMMANDS[9]="./hostchk.sh -v 3"		# ./hostchk.sh -v 3	various checks on the host
+COMMANDS[10]="./run_bison.sh -v 1"	# ./run_bison.sh -v 1	get details about bison
+COMMANDS[11]="./run_flex.sh -v 1"	# ./run_flex.sh -v 1	get details about flex
 
-# make test: run the IOCCC toolkit test suite
-echo "## RUNNING make test: " | tee -a -- "$LOG_FILE"
-make test | tee -a -- "$LOG_FILE"  1>&2
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=17
-    echo "$0: ERROR: make test failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    make test non-zero exit code: $status"
-fi
-echo '' >> "$LOG_FILE" 1>&2
+# NOTE: The below references to PIPESTATUS (instead of $?) fix the bug
+# introduced in commit 8343c4b8cb97e52df64fe8973e68f0d83c6090e1 where the exit
+# status of each command was not checked properly which meant that even if a
+# test failed it would not be reported as an issue which rather defeated the
+# purpose of this script.
+#
+# As amusing as the thought is that there's a bug in a script to help report
+# bugs and issues, this bug was not in fact intentional. :-) I had thought of it
+# earlier on but I neglected to address it before the commit as I moved on with
+# adding the tests. However since the world definitely needs more reasons to
+# laugh I'm keeping this comment here for the sake of humour and the irony that
+# I caused. You're welcome! :-)
 
-# which tar: find the path to tar
-echo "## RUNNING which tar: " | tee -a -- "$LOG_FILE"
-which tar | tee -a -- "$LOG_FILE"
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=18
-    echo "$0: ERROR: which tar failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    which tar non-zero exit code: $status"
-fi
-echo '' | tee -a -- "$LOG_FILE"
-# NOTE: we don't need to check if tar accepts the correct options in this script
-# because hostchk.sh will do that later on.
+for i in "${!COMMANDS[@]}"; do
+    echo "## RUNNING ${COMMANDS[$i]}: " | tee -a -- "$LOG_FILE"
+    command ${COMMANDS[$i]} | tee -a -- "$LOG_FILE"
+    status=${PIPESTATUS[0]}
+    if [[ "$status" -ne 0 ]]; then
+	EXIT_CODE=$((i + BASE_ERR_EXIT_CODE))
+	echo "$0: ERROR: ${COMMANDS[$i]} failed with exit code $status: new exit code $EXIT_CODE" | tee -a -- "$LOG_FILE"
+	FAILURE_SUMMARY="$FAILURE_SUMMARY
+	${COMMANDS[$i]} non-zero exit code: $status"
+    fi
+    echo '' | tee -a -- "$LOG_FILE"
+done
+
 for f in $TOOLS; do
     if is_exec "$f"; then
 	echo "## Checking if $f is executable" | tee -a -- "$LOG_FILE"
@@ -273,25 +213,12 @@ for f in $TOOLS; do
 	"$f" -h 2>&1 | tee -a -- "$LOG_FILE"
 	echo | tee -a -- "$LOG_FILE"
     else
-	EXIT_CODE=19
+	EXIT_CODE=10
 	echo "$0: ERROR: $f is not executable: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
 	FAILURE_SUMMARY="$FAILURE_SUMMARY
 	$f cannot be executed"
     fi
 done
-
-
-echo '' >> "$LOG_FILE" 1>&2
-echo "## RUNNING hostchk.sh -v 3: " | tee -a -- "$LOG_FILE" 1>&2
-./hostchk.sh -v 3 | tee -a -- "$LOG_FILE"  1>&2
-status=${PIPESTATUS[0]}
-if [[ "$status" -ne 0 ]]; then
-    EXIT_CODE=20
-    echo "$0: ERROR: hostchk.sh failed with exit code $status: new exit code: $EXIT_CODE" | tee -a -- "$LOG_FILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    hostchk.sh test non-zero exit code: $status"
-fi
-
 
 if [[ "$EXIT_CODE" -ne 0 ]]; then
     echo 1>&2

--- a/iocccsize_test.sh
+++ b/iocccsize_test.sh
@@ -82,17 +82,17 @@ fi
 
 get_wc()
 {
-	typeset file="$1"
-	typeset field="$2"
+	declare file="$1"
+	declare field="$2"
 	wc "$file" | sed -e's/^ *//; s/  */ /g' | cut -d' ' "-f$field"
 }
 
 test_size()
 {
-	typeset file="test_iocccsize/$1"
-	typeset expect="$2"
-	typeset gross_count
-	typeset got
+	declare file="test_iocccsize/$1"
+	declare expect="$2"
+	declare gross_count
+	declare got
 
 	got=$("$__tool" "$__tool_args" "$file" 2>/dev/null)
 	if [[ -n $__verbose ]]; then

--- a/jparse_test.8
+++ b/jparse_test.8
@@ -2,32 +2,35 @@
 .SH NAME
 jparse_test.sh \- test jparse on one or more files with one or more one-line JSON blobs
 .SH SYNOPSIS
-\fBjparse_test.sh\fP [\-h] [\-v level] [\-D dbg_level] [\-J level] [\-q] [\-j jparse] [file ..]
+\fBjparse_test.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-J level] [\-q] [\-j jparse] [file ..]
 .SH DESCRIPTION
 \fBjparse_test.sh\fP tests each line in each file for valid JSON.
 The file name \fI\-\fP means read from stdin.
 It keeps a log of all the tests in \fIjparse_test.log\fP for later inspection.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
+.TP
+\fB\-V\fP
+Show version and exit.
+.TP
 \fB\-v\fP
 Set verbosity level (def: 0).
-.PP
+.TP
 \fB\-D\fP
 Set debug level (def: 0).
-.PP
+.TP
 \fB\-J\fP
 Set JSON verbosity level.
-.PP
+.TP
 \fB\-q\fP
 Set quiet mode.
 This will be passed to the JSON parser.
-.PP
+.TP
 \fB\-j\fP
 Specify path to jparse.
-.PP
+.TP
 \fB\-V\fP
 Print version and exit.
 .SH EXIT STATUS

--- a/jparse_test.sh
+++ b/jparse_test.sh
@@ -123,11 +123,11 @@ run_test()
 	echo "$0: ERROR: expected 5 args to run_test, found $#" 1>&2
 	exit 4
     fi
-    typeset jparse="$1"
-    typeset dbg_level="$2"
-    typeset json_dbg_level="$3"
-    typeset quiet_mode="$4"
-    typeset json_doc_string="$5"
+    declare jparse="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+    declare json_doc_string="$5"
 
     # debugging
     #

--- a/jparse_test.sh
+++ b/jparse_test.sh
@@ -4,10 +4,12 @@
 
 # setup
 #
+export JPARSE_TEST_VERSION="0.2 2022-07-02"
 export CHK_TEST_FILE="./json_teststr.txt"
-export USAGE="usage: $0 [-h] [-v level] [-D dbg_level] [-J level] [-q] [-j jparse] [file ..]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jparse] [file ..]
 
     -h			print help and exit 2
+    -V			print version and exit 2
     -v level		set verbosity level for this script: (def level: 0)
     -D dbg_level	set verbosity level for tests (def: level: 0)
     -J level		set JSON parser verbosity level (def level: 0)
@@ -22,7 +24,10 @@ Exit codes:
      1   at least one test failed
      2   help mode exit
      3   invalid command line
-  >= 4   internal error"
+  >= 4   internal error
+
+$0 version: $JPARSE_TEST_VERSION"
+
 export V_FLAG="0"
 export DBG_LEVEL="0"
 export JSON_DBG_LEVEL="0"
@@ -33,9 +38,12 @@ export EXIT_CODE=0
 
 # parse args
 #
-while getopts :hv:D:J:qj: flag; do
+while getopts :hVv:D:J:qj: flag; do
     case "$flag" in
     h) echo "$USAGE" 1>&2
+       exit 2
+	;;
+    V) echo "$JPARSE_TEST_VERSION" 1>&2
        exit 2
 	;;
     v) V_FLAG="$OPTARG";

--- a/jstr_test.8
+++ b/jstr_test.8
@@ -1,22 +1,25 @@
-.TH jstr_test 8 "7 October 2022" "jstr_test" "IOCCC tools"
+.TH jstr_test 8 "16 October 2022" "jstr_test" "IOCCC tools"
 .SH NAME
 jstr_test.sh \- JSON string encoding and decoding tests
 .SH SYNOPSIS
-\fBjstr_test.sh\fP [\-h] [\-v level] [\-e jstrencode] [\-d jstrdecode]
+\fBjstr_test.sh\fP [\-h] [\-V] [\-v level] [\-e jstrencode] [\-d jstrdecode]
 .SH DESCRIPTION
 Using \fBjstrencode(1)\fP and \fBjstrdecode(1)\fP the \fBjstr_test.sh\fP script runs a series of tests to make sure that both encoding and decoding of JSON strings work as expected.
 This is important because if either is not working right then there will be a problem with the JSON parser as well as these tools use the same routines that the JSON parser uses.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
+.TP
+\fB\-V\fP
+Show version and exit.
+.TP
 \fB\-v\fP
 Set verbosity level (def: 0).
-.PP
+.TP
 \fB\-e\fP
 Set path to \fBjstrencode(1)\fP tool.
-.PP
+.TP
 \fB\-d\fP
 Set path to \fBjstrdecode(1)\fP tool.
 .SH EXIT STATUS

--- a/jstr_test.sh
+++ b/jstr_test.sh
@@ -6,10 +6,12 @@ export JSTRENCODE="./jstrencode"
 export JSTRDECODE="./jstrdecode"
 export TEST_FILE="jstr_test.out"
 export TEST_FILE2="jstr_test2.out"
+export JSTR_TEST_VERSION="0.4 2022-09-28"
 
-export USAGE="usage: $0 [-h] [-v level] [-e jstrencode] [-d jstrdecode]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode]
 
     -h		print help and exit 1
+    -V		print version and exit 1
     -v		set verbosity level for this script (def level: 0)
     -e		path to jstrencode tool (def: $JSTRENCODE)
     -d		path to jstrdecode tool (def: $JSTRDECODE)
@@ -20,13 +22,16 @@ Exit codes:
      2	 invalid command line, invalid option or option missing an argument
      3	 help message printed
  >= 10	 internal error
-"
+$0 version: $JSTR_TEST_VERSION"
 # parse args
 #
 export V_FLAG="0"
-while getopts :hv:e:d: flag; do
+while getopts :hVv:e:d: flag; do
     case "$flag" in
     h) echo "$USAGE" 1>&2
+       exit 3
+       ;;
+    V) echo "$JSTR_TEST_VERSION" 1>&2
        exit 3
        ;;
     v) V_FLAG="$OPTARG";

--- a/mkiocccentry_test.8
+++ b/mkiocccentry_test.8
@@ -1,23 +1,23 @@
-.TH mkiocccentry_test 8 "23 September 2022" "mkiocccentry_test" "IOCCC tools"
+.TH mkiocccentry_test 8 "16 October 2022" "mkiocccentry_test" "IOCCC tools"
 .SH NAME
 mkiocccentry_test.sh \- run several invocations of \fBmkiocccentry(1)\fP to test that it functions well
 .SH SYNOPSIS
-\fBmkiocccentry_test.sh\fP [\-h] [\-v level] [\-J level] [\-V]
+\fBmkiocccentry_test.sh\fP [\-h] [\-V] [\-v level] [\-J level]
 .SH DESCRIPTION
 \fBmkiocccentry_test.sh\fP runs a series of invocations of \fBmkiocccentry\fP, testing various types of inputs including multiple authors some of which have non-ASCII characters in their name.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0).
-.PP
-\fB\-J\fP
-Set JSON verbosity level.
-.PP
+.TP
 \fB\-V\fP
 Print version and exit.
+.TP
+\fB\-v\fP
+Set verbosity level (def: 0).
+.TP
+\fB\-J\fP
+Set JSON verbosity level.
 .SH EXIT STATUS
 .PP
 Exit codes:

--- a/mkiocccentry_test.sh
+++ b/mkiocccentry_test.sh
@@ -5,12 +5,12 @@
 # setup
 #
 export MKIOCCCENTRY_TEST_VERSION="0.2 2022-08-13"
-export USAGE="usage: $0 [-h] [-v level] [-J level] [-V]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-J level]
 
     -h              print help and exit 1
+    -V              print version and exit 1
     -v level        flag ignored
     -J level	    set JSON verbosity level
-    -V              print version and exit 1
 
 Exit codes:
      0   all is OK
@@ -30,12 +30,12 @@ while getopts :hv:J:V flag; do
     h) echo "$USAGE" 1>&2
        exit 1
        ;;
+    V) echo "$MKIOCCCENTRY_TEST_VERSION"
+       exit 1
+       ;;
     v) V_FLAG="$OPTARG";
        ;;
     J) J_FLAG="$OPTARG";
-       ;;
-    V) echo "$MKIOCCCENTRY_TEST_VERSION"
-       exit 1
        ;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
        exit 2

--- a/prep.sh
+++ b/prep.sh
@@ -28,6 +28,7 @@
 
 # setup
 #
+export PREP_VERSION="0.1 2022-04-19"
 export USAGE="usage: $0 [-h] [-v level] [-V] [-e] [-o] [-m make] [-M Makefile]
 
     -h              print help and exit 1
@@ -45,10 +46,11 @@ Exit codes:
      2	 command line error
      3	 Makefile not a readable file that exists
      4	 Internal function error
- >= 10   some make action exited non-zero"
+ >= 10   some make action exited non-zero
+
+$0 version: $PREP_VERSION"
 export MAKE="make"
 export MAKEFILE="./Makefile"
-export PREP_VERSION="0.1 2022-04-19"
 export V_FLAG="0"
 export E_FLAG=
 export EXIT_CODE="0"

--- a/reset_tstamp.8
+++ b/reset_tstamp.8
@@ -1,21 +1,21 @@
-.TH reset_tstamp 8 "7 September 2022" "reset_tstamp.sh" "IOCCC tools"
+.TH reset_tstamp 8 "16 October 2022" "reset_tstamp.sh" "IOCCC tools"
 .SH NAME
 reset_tstamp \- reset the minimum timestamp \fBMIN_TIMESTAMP\fP
 .SH SYNOPSIS
-\fBreset_tstamp.sh\fP [\-h] [\-v level] [\-V] [\-l limit_ioccc.h]
+\fBreset_tstamp.sh\fP [\-h] [\-V] [\-v level] [\-l limit_ioccc.h]
 .SH DESCRIPTION
 \fBreset_tstamp.sh\fP will reset the minimum timestamp allowed for entries to the contest.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level.
-.PP
+.TP
 \fB\-V\fP
 Print version and exit.
-.PP
+.TP
+\fB\-v\fP
+Set verbosity level.
+.TP
 \fB\-l\fP
 Specify limit file.
 .SH EXIT STATUS

--- a/reset_tstamp.sh
+++ b/reset_tstamp.sh
@@ -39,11 +39,12 @@
 
 # setup
 #
-export USAGE="usage: $0 [-h] [-v level] [-V] [-l limit_ioccc.h]
+export RESET_TSTAMP_VERSION="0.4 2022-04-23"
+export USAGE="usage: $0 [-h] [-V] [-v level] [-l limit_ioccc.h]
 
     -h              print help and exit 2
-    -v level        set debug level (def: 0)
     -V              print version and exit 2
+    -v level        set debug level (def: 0)
     -l limit_ioccc.h   limit file (def: ./limit_ioccc.h)
 
 Exit codes:
@@ -51,8 +52,9 @@ Exit codes:
      1   A verification phase test failed
      2   -h and help string printed or -V and version string printed
      3   Command line usage error
- >= 10   internal error"
-export RESET_TSTAMP_VERSION="0.4 2022-04-23"
+ >= 10   internal error
+
+$0 version: $RESET_TSTAMP_VERSION"
 export V_FLAG="0"
 export LIMIT_IOCCC_H="./limit_ioccc.h"
 

--- a/run_usage.8
+++ b/run_usage.8
@@ -1,24 +1,26 @@
-.TH run_usage 8 "16 September 2022" "run_usage" "IOCCC tools"
+.TH run_usage 8 "16 October 2022" "run_usage" "IOCCC tools"
 .SH NAME
 run_usage \- run -h on a tool to extract usage information to help with checking man page \fBSYNOPSIS\fP \- tool usage consistency
 .SH SYNOPSIS
-\fBrun_usage.sh\fP [\-h] [\-m section] [\-M man file] tool
+\fBrun_usage.sh\fP [\-h] [\-V] [\-m section] [\-M man file] tool
 .SH DESCRIPTION
 .PP
 This script does a best guess at what the \fBSYNOPSIS\fP should be for the supplied tool with certain limitations (see \fBBUGS\fP).
 If the man page exists it attempts to, based on the \fB\-h\fP option of the tool, create the correct regexp for the \fBSYNOPSIS\fP and then uses \fBgrep\fP to check for it in the man page.
 .PP
 If the man page does not exist or is not a regular file or is not readable it is an error but a helpful note is given of what the \fBSYNOPSIS\fP might look like.
-.PP
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
-Show help and exit 1.
-.PP
+Show help and exit.
+.TP
+\fB\-V\fP
+Show version and exit.
+.TP
 \fB\-m\fP
 Specify a different man page section.
 Default is 1.
-.PP
+.TP
 \fB\-M\fP
 Specify the man page filename.
 This is useful when the name of the tool does not match what the man page should be (for example \fBrun_usage.sh\fP has \fBrun_usage.1\fP and not \fBrun_usage.sh.1\fP).

--- a/run_usage.sh
+++ b/run_usage.sh
@@ -21,9 +21,11 @@ export MAN_SECTION="1"
 export M_FLAG=""
 export MAN_FLAG=""
 export MAN_PAGE=""
-export USAGE="usage: $0 [-h] [-m section] [-M man file] tool
+export RUN_USAGE_VERSION="0.2 2022-09-06"
+export USAGE="usage: $0 [-h] [-V] [-m section] [-M man file] tool
 
     -h		    print help and exit 1
+    -V		    print version and exit 1
     -m section	    man page section (def: $MAN_SECTION)
     -M man file	    man page (including extension)
     --		    end of $0 flags
@@ -37,13 +39,18 @@ Exit codes:
      4	 command line usage error
      5	 missing or inconsistent synopsis
      6	 tool does not have usage string
- >= 10   internal error"
+ >= 10   internal error
+
+$0 version: $RUN_USAGE_VERSION"
 
 # parse args
 #
-while getopts :hm:M: flag; do
+while getopts :hVm:M: flag; do
     case "$flag" in
     h) echo "$USAGE" 1>&2
+       exit 1
+       ;;
+    V) echo "$RUN_USAGE_VERSION" 1>&2
        exit 1
        ;;
     m) M_FLAG="-m"

--- a/txzchk_test.sh
+++ b/txzchk_test.sh
@@ -274,9 +274,9 @@ run_test()
 	echo "$0: ERROR: expected 2 args to run_test, found $#" 1>&2
 	exit 32
     fi
-    typeset pass_fail="$1"
-    typeset txzchk_test_file="$2"
-    typeset txzchk_err_file="$txzchk_test_file.err"
+    declare pass_fail="$1"
+    declare txzchk_test_file="$2"
+    declare txzchk_err_file="$txzchk_test_file.err"
 
     if [[ ! -e $txzchk_test_file ]]; then
 	echo "$0: in run_test: txzchk_test_file not found: $txzchk_test_file"


### PR DESCRIPTION
It appears that typeset is just an alias for declare so make it declare:

    $ help typeset
    typeset: typeset [-aAfFgiIlnrtux] [-p] name[=value] ...
	Set variable values and attributes.

	A synonym for `declare'.  See `help declare'.

This commit is also part of a test to make sure that my fork is okay as something happened that made me fear that I might have to re-fork.