### PR TITLE
Mass update man pages

### DIFF
--- a/bug_report.1
+++ b/bug_report.1
@@ -12,8 +12,8 @@ If no step fails it will tell you that everything is okay but still informs you 
 \fB\-h\fP
 Show help and exit.
 .TP
-\fB\-v\fP
-Set verbosity level.
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to level.
 .TP
 \fB\-V\fP
 Show version and exit.

--- a/fnamchk.1
+++ b/fnamchk.1
@@ -1,4 +1,4 @@
-.TH fnamchk 1 "15 October 2022" "fnamchk" "IOCCC tools"
+.TH fnamchk 1 "16 October 2022" "fnamchk" "IOCCC tools"
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
@@ -10,27 +10,25 @@ The program validates that the filename is correct, in the form of \fBentry.cont
 \fBcontest_ID\fP is either \fItest\fP or a valid UUID (see below), \fBentry_number\fP is an integer from \fB0\fP through \fBMAX_ENTRY_NUM\fP (see \fIlimit_ioccc.h\fP) inclusive, \fBtimestamp\fP is an integer of the number of seconds since the epoch and \fBext\fP is either \fBtxz\fP or the user supplied extension from the \fB\-E\fP option.
 .PP
 More specifically, the filename \fBmust\fP:
-.PP
-.RS
+.IP \(bu 4
 Start with "\fBentry\fP".
-.PP
+.IP \(bu 4
 Followed by "\fB.\fP".
-.PP
+.IP \(bu 4
 Followed by either "\fBtest\fP" \fIOR\fP a UUID string in the form of \fBxxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx\fP where \fBx\fP is a hexadecimal digit in the range \fB[0-9a-f]\fP.
 And yes, there is a \fB4\fP (UUID version 4) and an \fBa\fP (UUID variant 1) in there.
-.PP
+.IP \(bu 4
 Followed by "\fB\-\fP".
-.PP
+.IP \(bu 4
 Followed by a decimal entry number from \fB0\fP through \fBMAX_ENTRY_NUM\fP (see \fIlimit_ioccc.h\fP) inclusive.
-.PP
+.IP \(bu 4
 Followed by "\fB.\fP".
-.PP
+.IP \(bu 4
 Followed by a positive non-zero 64-bit decimal integer.
-.PP
+.IP \(bu 4
 Followed by "\fB.\fP".
-.PP
+.IP \(bu 4
 Followed by "\fBtxz\fP" (or the user supplied extension from option \fB\-E\fP).
-.RE
 .PP
 NOTE: The quotes above should not be in the filename; they're there only to help distinguish the punctuation from the rest of the format.
 .PP
@@ -71,7 +69,9 @@ If there is an error the error message is printed prior to exiting; else the out
 .PP
 More than 0 humans work on it! :)
 .PP
-If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have an issue with the tool you can open an issue at
+.br
+\fI<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 For the examples below assume that the \fBMIN_TIMESTAMP\fP is \fB(time_t)1662145368\fP.

--- a/have_timegm.8
+++ b/have_timegm.8
@@ -1,6 +1,6 @@
-.TH have_timegm 8 "8 September 2022" "have_timegm.sh" "IOCCC tools"
+.TH have_timegm.sh 8 "17 October 2022" "have_timegm.sh" "IOCCC tools"
 .SH NAME
-have_timegm \- test compiler for \fBtimegm(3)\fP, \fBstrptime(3)\fP and \fBstrftime(3)\fP
+have_timegm.sh \- test compiler for \fBtimegm(3)\fP, \fBstrptime(3)\fP and \fBstrftime(3)\fP
 .SH SYNOPSIS
 \fBhave_timegm.sh\fP [\-h] [\-V] [\-v level]
 .SH DESCRIPTION
@@ -18,29 +18,39 @@ Show version and exit.
 \fB\-v\fP
 Set verbosity level.
 .SH EXIT STATUS
-.PP
-.br
-    0	    all is well
-.br
-    1	    invalid command line
-.br
-    2	    strptime() returned NULL
-.br
-    3	    strptime() return value not '\\0'
-.br
-    4	    strftime() failed
-.br
-    5	    original time string and conversion mismatch
-.br
-    100	    help or version mode used
-.br
-    101	    invalid option or option missing an argument
-.br
-    102	    missing \fIhave_timegm.c\fP
-.br
-    103	    \fIhave_timegm.c\fP not a regular file
-.br
-    104	    \fIhave_timegm.c\fP not a readable file
+.TP
+0
+all is well
+.TQ
+1
+invalid command line
+.TQ
+2
+strptime() returned NULL
+.TQ
+3
+strptime() return value not '\\0'
+.TQ
+4
+strftime() failed
+.TQ
+5
+original time string and conversion mismatch
+.TQ
+100
+help or version mode used
+.TQ
+101
+invalid option or option missing an argument
+.TQ
+102
+missing \fIhave_timegm.c\fP
+.TQ
+103
+\fIhave_timegm.c\fP not a regular file
+.TQ
+104
+\fIhave_timegm.c\fP not a readable file
 .SH NOTES
 .PP
 While there is no bug in the tool we are aware of one issue.

--- a/hostchk.1
+++ b/hostchk.1
@@ -1,4 +1,4 @@
-.TH hostchk 1 "14 October 2022" "hostchk.sh" "IOCCC tools"
+.TH hostchk 1 "17 October 2022" "hostchk.sh" "IOCCC tools"
 .SH NAME
 hostchk.sh \- run a series of checks on your system to help determine if you can correctly use the mkiocccentry toolkit
 .SH SYNOPSIS
@@ -14,17 +14,17 @@ Show help and exit.
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-v\fP
-Set verbosity level.
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
-\fB\-D\fP
-Set verbosity level for the tests the script runs.
+\fB\-D \fIlevel\fP\fP
+Set verbosity level for the tests the script runs to \fIlevel\fP.
 .TP
-\fB\-t\fP
-Set path to tar command.
+\fB\-t \fItar\fP\fP
+Set path to tar command to \fItar\fP.
 .TP
-\fB\-c\fP
-Set path to the compiler (cc).
+\fB\-c \fIcc\fP\fP
+Set path to the compiler (cc) to \fIcc\fP.
 .TP
 \fB\-f\fP
 Fast compile mode.

--- a/ioccc_test.8
+++ b/ioccc_test.8
@@ -1,4 +1,4 @@
-.TH ioccc_test 8 "23 September 2022" "ioccc_test" "IOCCC tools"
+.TH ioccc_test.sh 8 "17 October 2022" "ioccc_test" "IOCCC tools"
 .SH NAME
 ioccc_test.sh \- test suite for IOCCC toolkit
 .SH SYNOPSIS
@@ -19,33 +19,53 @@ Set JSON verbosity level.
 \fB\-V\fP
 Print version and exit.
 .SH EXIT STATUS
-.PP
-Exit codes:
-.br
-0	all tests are OK
-.br
-1	-h and help string printed or -V and version string printed
-.br
-2	Command line usage error
-.br
-3	./iocccsize_test.sh not found or not executable
-.br
-4	./dbg not found or not executable
-.br
-5	./mkiocccentry_test.sh not found or not executable
-.br
-6	./jstr_test.sh not found or not executable
-.br
-7	./jnum_chk not found or not executable
-.br
-8	./dyn_test not found or not executable
-.br
-9	./jparse_test.sh not found or not executable
-.br
-10	./json_teststr.txt not found or not readable
-.br
-11	./txzchk not found or not executable
-.br
->=20	some test failed
+.TP
+0
+all tests are OK
+.TQ
+1
+\-h and help string printed or \-V and version string printed
+.TQ
+2
+Command line usage error
+.TQ
+3
+.B ./iocccsize_test.sh
+not found or not executable
+.TQ
+4
+.B ./dbg
+not found or not executable
+.TQ
+5
+.B ./mkiocccentry_test.sh
+not found or not executable
+.TQ
+6
+.B ./jstr_test.sh
+not found or not executable
+.TQ
+7
+.B ./jnum_chk
+not found or not executable
+.TQ
+8
+.B ./dyn_test
+not found or not executable
+.TQ
+9
+.B ./jparse_test.sh
+not found or not executable
+.TQ
+10
+.I ./json_teststr.txt
+not found or not readable
+.TQ
+11
+.B ./txzchk
+not found or not executable
+.TQ
+>=20
+some test failed
 .SH SEE ALSO
 \fBiocccsize_test(1)\fP, \fBdbg(3)\fP, \fBtxzchk(1)\fP.

--- a/iocccsize.1
+++ b/iocccsize.1
@@ -1,4 +1,4 @@
-.TH iocccsize 1 "16 October 2022" "iocccsize" "IOCCC tools"
+.TH iocccsize 1 "17 October 2022" "iocccsize" "IOCCC tools"
 .SH NAME
 iocccsize \- IOCCC Source Size Tool
 .SH SYNOPSIS
@@ -14,38 +14,42 @@ The source's Rule 2b length is written to stdout; with -v option the Rule 2b len
 The size tool counts most C reserved words (keyword, secondary, and selected preprocessor keywords) as 1.
 The size tool counts all other octets as 1 excluding ASCII whitespace, and excluding any ';', '{' or '}' followed by ASCII whitespace, and excluding any ';', '{' or '}' octet immediately before the end of file.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
+.TP
 \fB\-i\fP
 Ignored for backward compatibility.
-.PP
-\fB\-v\fP \fRlvl\fP
-Set debugging level to \fRlvl\fP.
+.TP
+\fB\-v \fIlevel\fP\fP
+Set debugging level to \fIlevel\fP.
 0, the default, implies no debugging.
-.PP
+.TP
 \fB\-q\fP
 Quiet mode.
 Silence msg(), warn(), warnp() if verbosity level is 0.
-.PP
+.TP
 \fB\-V\fP
 Show version and exit 3.
 .SH EXIT STATUS
-.PP
-Exit codes:
-.PP
-0 \- source code is within Rule 2a and Rule 2b limits
-.PP
-1 \- source code larger than Rule 2a and/or Rule 2b limits
-.PP
-2 \- \-h used and help printed
-.PP
-3 \- \-V used and version printed
-.PP
-4 \- invalid command line
-.PP
->= 5 \- some internal error occurred
+.TP
+0
+source code is within Rule 2a and Rule 2b limits
+.TQ
+1
+source code larger than Rule 2a and/or Rule 2b limits
+.TQ
+2
+\-h used and help printed
+.TQ
+3
+\-V used and version printed
+.TQ
+4
+invalid command line
+.TQ
+>= 5
+some internal error occurred
 .SH EXAMPLES
 .PP
 .nf
@@ -86,27 +90,34 @@ The matched keyword count is currently ignored by the IOCCC.
 Because the original source was an IOCCC winner,
 "You are not expected to understand this" applies to somewhat improved source code. :\-)
 .PP
-But if you think you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/iocccsize/issues\>\fP.
+But if you think you have an issue with the tool you can open an issue at
+.br
+\fI\<https://github.com/ioccc-src/iocccsize/issues\>\fP.
 .SH IOCCC WARNING
 .PP
 For submitting entries to the IOCCC, and to conform with Rule 2,
 please use the official copy of the IOCCC
-\fIiocccsize\fP
-from the following GitHub repo: \fI\<https://github.com/ioccc-src/mkiocccentry>\fP.
+\fBiocccsize\fP
+from the following GitHub repo:
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry>\fP.
 .PP
 \fBWARNING:\fP
 Be sure you are using the current version of
-\fIiocccsize\fP
+.B iocccsize
 as this tool may change from time to time.
 Failure to do so may result in your IOCCC submission being rejected!
 .SH HISTORY
 The
-\fIiocccsize\fP
+.B iocccsize
 tool was created by Anthony Howe in 1992.
 This tool was first referenced by IOCCC Rule 2 in 2013.
 .PP
 This tool is based on Anthony Howe's
-\fIiocccsize\fP
-GitHub repo: \fI\<https://github.com/SirWumpus/iocccsize>\fP.
+\fBiocccsize\fP
+GitHub repo:
+.br
+\fI\<https://github.com/SirWumpus/iocccsize>\fP.
+.PP
 The IOCCC judges appreciate Anthony Howe for allowing the IOCCC
 to use a modified copy of his code.

--- a/iocccsize_test.8
+++ b/iocccsize_test.8
@@ -1,4 +1,4 @@
-.TH iocccsize_test 8 "16 October 2022" "iocccsize_test" "IOCCC tools"
+.TH iocccsize_test.sh 8 "17 October 2022" "iocccsize_test" "IOCCC tools"
 .SH NAME
 iocccsize_test.sh \- test iocccsize tool
 .SH SYNOPSIS
@@ -6,34 +6,33 @@ iocccsize_test.sh \- test iocccsize tool
 .SH DESCRIPTION
 \fBiocccsize_test.sh\fP runs a series of tests on the \fBiocccsize(1)\fP tool, verifying that it is functioning properly.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0).
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .RS
 .PP
 A verbosity level of 1 or more will show the PASS or FAIL of individual tests.
-.PP
-A verbosity level of 3 or more will show details such as what
-was expected and what was discovered during each test.
+.br
+A verbosity level of 3 or more will show details such as what was expected and what was discovered during each test.
 .RE
-.PP
+.TP
 \fB\-V\fP
 Print version and exit.
-.PP
-\fB\-i\fP \fRiocccsize\fP
-Specify path to iocccsize tool (def: ./iocccsize).
-.PP
-\fB\-w\fP \fRwork_dir\fP
-Working directory that is removed & rebuilt during the test of the iocccsize tool (def: ./test_iocccsize).
-.PP
-\fB\-l\fP \fRlimit\fP
+.TP
+\fB\-i \fIiocccsize\fP\fP
+Specify path to iocccsize tool to \fIiocccsize\fP (def: ./iocccsize).
+.TP
+\fB\-w \fIwork_dir\fP\fP
+Working directory that is removed and rebuilt during the test of the iocccsize tool (def: ./test_iocccsize).
+.TP
+\fB\-l\fP \fIlimit\fP
 Path to an executable shell script (def: ./limit_ioccc.sh).
 .RS
 .PP
-A limit of \fR.\fP (dot) will disable use of a executable shell script.
+A limit of \fI.\fP (dot) will disable use of a executable shell script.
 .RE
 .SH EXAMPLES
 Run the \fRiocccsize\fP test suite in silent mode, printing only if a problem is discovered:
@@ -57,16 +56,18 @@ You may also wish to try the test script in even more verbose mode:
 .fi
 .RE
 .SH EXIT STATUS
-.PP
-Exit codes:
-.PP
-	0      all is OK
-.br
-	1      one or more tests failed
-.br
-	2      usage message or version string printed
-.br
-	>=10   internal error
+.TP
+0
+all is OK
+.TQ
+1
+one or more tests failed
+.TQ
+2
+usage message or version string printed
+.TQ
+>=10
+internal error
 .SH SEE ALSO
 \fBiocccsize(1)\fP
 .SH BUGS

--- a/jnum_chk.8
+++ b/jnum_chk.8
@@ -1,4 +1,4 @@
-.TH jnum_chk 8 "23 September 2022" "jnum_chk" "IOCCC tools"
+.TH jnum_chk 8 "17 October 2022" "jnum_chk" "IOCCC tools"
 .SH NAME
 jnum_chk \- tool to check JSON number string conversions
 .SH SYNOPSIS
@@ -9,16 +9,16 @@ By default only 8, 16, 32, 64 bit and max size signed and unsigned integer types
 Floating point, double floating point and long double floating point are also checked but only to 1 part in 4.1943e+06 (\fBMATCH_PRECISION\fP).
 Thus floating point conversions do not have to match fully in order to succeed when strict mode is disabled (the default).
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0).
-.PP
-\fB\-J\fP
-Set JSON verbosity level (def: 0).
-.PP
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to level (def: 0).
+.TP
+\fB\-J \fIlevel\fP\fP
+Set JSON verbosity level to level (def: 0).
+.TP
 \fB\-q\fP
 Set quiet mode.
 This will be passed to the JSON parser.
@@ -26,19 +26,24 @@ This will be passed to the JSON parser.
 \fB\-S\fP
 Set strict mode.
 .SH EXIT STATUS
-.PP
-Exit codes:
-    0	\-  all is OK
-.br
-    1	\-  without -S given and JSON number conversion test suite failed
-.br
-    2	\-  -S given and JSON number conversion test suite failed
-.br
-    3	\-  -h and help string printed or -V and version string printed
-.br
-    4	\-  command line error
-.br
-    >=5	\-  internal error
+.TP
+0
+all is OK
+.TQ
+1
+Without -S given and JSON number conversion test suite failed
+.TQ
+2
+\-S given and JSON number conversion test suite failed
+.TQ
+3
+\-h and help string printed or -V and version string printed
+.TQ
+4
+command line error
+.TQ
+>=5
+internal error
 .SH NOTES
 .PP
 The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
@@ -50,6 +55,8 @@ The strict mode option \fB\-S\fP is for informational purposes only.
 If it fails on your system this is okay: the mkiocccentry repo does not need \fB\-S\fP to pass in order to be able to create a valid IOCCC entry compressed tarball.
 .SH BUGS
 If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
-It can be found at: \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+It can be found at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjnum_gen(8)\fP.

--- a/jnum_gen.8
+++ b/jnum_gen.8
@@ -1,4 +1,4 @@
-.TH jnum_gen 8 "7 October 2022" "jnum_gen" "IOCCC tools"
+.TH jnum_gen 8 "17 October 2022" "jnum_gen" "IOCCC tools"
 .SH NAME
 jnum_gen \- generate JSON number string conversion test data
 .SH SYNOPSIS
@@ -7,32 +7,35 @@ jnum_gen \- generate JSON number string conversion test data
 \fBjnum_gen\fP takes the data in the file and generates JSON number string conversion test data.
 This is used by the \fBjnum_chk(8)\fP tool to verify that JSON number string conversions work as expected.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0).
-.PP
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to level (def: 0).
+.TP
 \fB\-V\fP
 Show version and exit.
-.PP
+.TP
 \fB\-q\fP
 Set quiet mode.
 This will be passed to the JSON parser.
 .SH EXIT STATUS
-.PP
-Exit codes:
-.br
-	0	\- all is OK
-.br
-	1	\- filename does not exist or is not a readable file
-.br
-	3	\- \fB-h\fP and help string printed or \fB\-V\fP and version string printed
-.br
-	4	\- command line error
-.br
-	>=5	\- internal error
+.TP
+0
+all is OK
+.TQ
+1
+filename does not exist or is not a readable file
+.TQ
+3
+\fB-h\fP and help string printed or \fB\-V\fP and version string printed
+.TQ
+4
+command line error
+.TQ
+>=5
+internal error
 .SH NOTES
 .PP
 The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
@@ -42,6 +45,8 @@ The Makefile rule \fBrebuild_jnum_test\fP will create the file \fIjnum_test.c\fP
 The tool \fBjnum_chk(8)\fP in turn will use the data in the \fIjnum_test.c\fP file to verify that the conversions work as expected.
 .SH BUGS
 If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
-It can be found at: \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+It can be found at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjnum_chk(8)\fP.

--- a/jparse.1
+++ b/jparse.1
@@ -1,4 +1,4 @@
-.TH jparse 1 "06 September 2022" "jparse" "IOCCC tools"
+.TH jparse 1 "16 October 2022" "jparse" "IOCCC tools"
 .SH NAME
 jparse \- IOCCC JSON parser
 .SH SYNOPSIS
@@ -7,27 +7,27 @@ jparse \- IOCCC JSON parser
 \fBjparse\fP will parse a block of JSON text either from a file (\fB\-\fP means \fBstdin\fP) or a string passed to the program via the \fB\-s\fP option.
 .PP
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level.
-.PP
-\fB\-J\fP
-Set JSON verbosity level.
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to level.
+.TP
+\fB\-J \fIlevel\fP\fP
+Set JSON verbosity level to level.
 Note that you need to specify this option prior to \fB\-s\fP because \fB\-s\fP is processed immediately.
-.PP
+.TP
 \fB\-q\fP
 Suppresses some of the output (def: not quiet).
 Note that you need to specify this option prior to \fB\-s\fP because \fB\-s\fP is processed immediately.
-.PP
+.TP
 \fB\-V\fP
 Show version and exit 0.
-.PP
+.TP
 \fB\-s\fP
 Parse argument as a string.
-.PP
+.TP
 \fB\-n\fP
 Do not output a newline after parsing a string or file (def: do print a newline).
 .SH EXIT STATUS
@@ -45,6 +45,8 @@ This is because it's incredibly long with a lot of OT things and would take even
 .PP
 Better error reporting and various other things need to be added.
 For example showing the file name and line number have to be added.
+.PP
+It's not yet fully re-entrant.
 .SH EXAMPLES
 .PP
 .nf

--- a/jparse_test.8
+++ b/jparse_test.8
@@ -1,4 +1,4 @@
-.TH jparse_test 8 "23 September 2022" "jparse_test" "IOCCC tools"
+.TH jparse_test 8 "17 October 2022" "jparse_test" "IOCCC tools"
 .SH NAME
 jparse_test.sh \- test jparse on one or more files with one or more one-line JSON blobs
 .SH SYNOPSIS
@@ -15,37 +15,40 @@ Show help and exit.
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-v\fP
-Set verbosity level (def: 0).
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
-\fB\-D\fP
-Set debug level (def: 0).
+\fB\-D \fIlevel\fP\fP
+Set debug level to \fIlevel\fP.
 .TP
-\fB\-J\fP
-Set JSON verbosity level.
+\fB\-J \fIlevel\fP\fP
+Set JSON verbosity level to \fIlevel\fP.
 .TP
 \fB\-q\fP
 Set quiet mode.
 This will be passed to the JSON parser.
 .TP
-\fB\-j\fP
-Specify path to jparse.
+\fB\-j \fIjparse\fP\fP
+Specify path to jparse to \fIjparse\fP.
 .TP
 \fB\-V\fP
 Print version and exit.
 .SH EXIT STATUS
-.PP
-Exit codes:
-.br
-0	all tests are OK
-.br
-1	at least one test failed
-.br
-2	help mode exit
-.br
-3	invalid command line
-.br
->=4	internal error
+.TP
+0
+all tests are OK
+.TQ
+1
+at least one test failed
+.TQ
+2
+help mode exit
+.TQ
+3
+invalid command line
+.TQ
+>=4
+internal error
 .SH FILES
 \fIjson_teststr.txt\fP
 .RS
@@ -60,6 +63,8 @@ It will be removed prior to each time the script is run to keep the state of the
 The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .SH BUGS
 If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
-It can be found at: \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+It can be found at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP.

--- a/jstr_test.8
+++ b/jstr_test.8
@@ -14,41 +14,60 @@ Show help and exit.
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-v\fP
-Set verbosity level (def: 0).
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
-\fB\-e\fP
-Set path to \fBjstrencode(1)\fP tool.
+\fB\-e \fIjstrencode\fP\fP
+Set path to
+.B jstrencode(1)
+tool.
 .TP
-\fB\-d\fP
-Set path to \fBjstrdecode(1)\fP tool.
+\fB\-d \fIjstrdecode\fP\fP
+Set path to
+.B jstrdecode(1)
+tool.
 .SH EXIT STATUS
 .PP
-Exit codes:
-.br
-    0	    \- all is well
-.br
-    1	    \- \-h used
-.br
-    2	    \- invalid option
-.br
-    3	    \- option argument missing
-.br
-    42	    \- test #0 failed
-.br
-    43	    \- test #1 failed
-.br
-    44	    \- test #2 failed
-.br
-    45	    \- test #3 failed
-.br
-    100	    \- jstrencode not executable
-.br
-    101	    \- jstrdecode not executable
-.br
-    102	    \- jstr_test.out exists and can't remove it
-.br
-    103	    \- jstr_test2.out exists and can't remove it
+.TP
+0
+all is well
+.TQ
+1
+\-h used
+.TQ
+2
+invalid option
+.TQ
+3
+option argument missing
+.TQ
+42
+test #0 failed
+.TQ
+43
+test #1 failed
+.TQ
+44
+test #2 failed
+.TQ
+45
+test #3 failed
+.TQ
+100
+.B jstrencode
+not executable
+.TQ
+101
+.B jstrdecode
+not executable
+.TQ
+102
+.I jstr_test.out
+exists and can't remove it
+.TQ
+103
+.I jstr_test2.out
+exists and can't remove it
 .SH FILES
 \fIjstr_test.out\fP
 .RS
@@ -68,6 +87,8 @@ When the script ends this file should be deleted but the script attempts to dele
 The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .SH BUGS
 If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
-It can be found at: \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+It can be found at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjstrencode(1)\fP, \fBjstrdecode(1)\fP.

--- a/jstrdecode.1
+++ b/jstrdecode.1
@@ -1,41 +1,43 @@
-.TH jstrdecode 1 "2 September 2022" "jstrdecode" "IOCCC tools"
+.TH jstrdecode 1 "17 October 2022" "jstrdecode" "IOCCC tools"
 .SH NAME
-jstrdecode \- decode JSON encoded strings
+\fBjstrdecode\fP \- decode JSON encoded strings
 .SH SYNOPSIS
 \fBjstrdecode\fP [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [\-Q] [string ...]
 .SH DESCRIPTION
-\fBjstrdecode\fP decodes JSON encoded strings given on the command line.
+.B jstrdecode
+decodes JSON encoded strings given on the command line.
 If given the \fB\-t\fP option it performs a test on the JSON decode and encode functions.
-.PP
 By default the program reads from \fBstdin\fP.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level.
-.PP
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
+.TP
 \fB\-q\fP
 Suppresses some of the output (def: not quiet).
-.PP
+.TP
 \fB\-V\fP
 Show version and exit.
-.PP
+.TP
 \fB\-t\fP
 Run tests on the JSON decode/encode functions.
-.PP
+.TP
 \fB\-n\fP
 Do not output a newline after the decode function.
-.PP
+.TP
 \fB\-Q\fP
-Enclose output in quotes (def: do not).
+Enclose output in quotes.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 1 for errors or issues found; 0 for success.
 .SH BUGS
 .PP
-If you have an issue with the tool you can report it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have an issue with the tool you can report it at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf

--- a/jstrencode.1
+++ b/jstrencode.1
@@ -1,6 +1,7 @@
-.TH jstrencode 1 "2 September 2022" "jstrencode" "IOCCC tools"
+.TH jstrencode 1 "17 October 2022" "jstrencode" "IOCCC tools"
 .SH NAME
-jstrencode \- encode JSON encoded strings
+.B jstrencode
+\- encode JSON encoded strings
 .SH SYNOPSIS
 \fBjstrencode\fP [\-h] [\-v level] [\-q] [\-V] [\-t] [\-n] [\-Q] [string ...]
 .SH DESCRIPTION
@@ -35,7 +36,9 @@ Enclose output in quotes (def: do not).
 \fBmain()\fP returns 1 for errors or issues found; 0 for success.
 .SH BUGS
 .PP
-If you have an issue with the tool you can report it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have an issue with the tool you can report it at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -4,11 +4,14 @@ mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
 \fBmkiocccentry\fP [options] work_dir prog.c Makefile remarks.md [file ...]
 .SH DESCRIPTION
-\fBmkiocccentry\fP gathers your source file, Makefile, remarks as well as any other files and creates an XZ compressed tarball.
+.B mkiocccentry
+gathers your source file, Makefile, remarks as well as any other files and creates an XZ compressed tarball.
 The tool runs \fBiocccsize\fP and it also runs a test on the Makefile to verify that everything seems in order.
 You can ignore the warnings except that the Makefile cannot be empty.
 The work_dir is a directory that the program will copy the files to (under a subdirectory based on the title of the entry and the entry number), to create the tarball.
-After forming the tarball \fBtxzchk\fP is run which verifies that the tarball is okay (\fBtxzchk\fP in turn will call \fBfnamchk\fP).
+After forming the tarball
+.B txzchk
+is run which verifies that the tarball is okay (\fBtxzchk\fP in turn will call \fBfnamchk\fP).
 Once the writing of the \fI.info.json\fP file is completed \fBmkiocccentry\fP runs \fBchkinfo\fP and if there are any errors it aborts.
 After the writing of the \fI.info.json\fP file the \fI.author.json\fP file is written; once completed \fBmkiocccentry\fP runs \fBchkauth\fP and if there are any errors it aborts.
 If the work_dir already exists the program will tell you to move it or delete it.
@@ -18,42 +21,46 @@ The program does \fBNOT\fP delete it in case you wish to inspect that everything
 \fB\-h\fP
 Show help and exit.
 .TP
-\fB\-v\fP
-Set verbosity level.
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-t\fP
-Specify path to tar that accepts the \fB\-J\fP option.
+\fB\-t \fItar\fP\fP
+Set path to \fBtar\fP that accepts the \fB\-J\fP option to \fItar\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
 .TP
-\fB\-c\fP
-Specify path to cp.
+\fB\-c \fIcp\fP\fP
+Set path to \fBcp\fP to \fIcp\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/cp\fP and \fI/bin/cp\fP if this option is not specified.
 .TP
-\fB\-l\fP
-Specify path to ls.
+\fB\-l \fIls\fP\fP
+Set path to \fBls\fP to \fIls\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/ls\fP and \fI/bin/ls\fP if this option is not specified.
 .TP
-\fB\-T\fP
-Specify path to the \fBtxzchk\fP tool.
+\fB\-T \fItxzchk\fP\fP
+Set path to the \fBtxzchk\fP tool to \fItxzchk\fP.
 \fBmkiocccentry\fP checks \fI./txzchk\fP and \fI/usr/local/bin/txzchk\fP if this option is not specified.
 .TP
-\fB\-F\fP
-Specify path to the \fBfnamchk\fP tool.
+\fB\-F \fIfnamchk\fP\fP
+Set path to the \fBfnamchk\fP tool to \fIfnamchk\fP.
 \fBmkiocccentry\fP checks \fI./fnamchk\fP and \fI/usr/local/bin/fnamchk\fP if this option is not specified.
 .TP
-\fB\-C\fP
-Specify path to the \fBchkentry\fP tool.
+\fB\-C \fIchkentry\fP\fP
+Specify path to the \fBchkentry\fP tool to \fIchkentry\fP.
 \fBmkiocccentry\fP checks \fI./chkentry\fP and \fI/usr/local/bin/chkentry\fP if this option is not specified.
 .TP
-\fB\-a\fP
-Write to file specified the answers for easier updating the entry (via the \fB\-i\fP option).
+\fB\-a \fIanswers\fP\fP
+\fBmkiocccentry\fP will write to the file specified in \fIanswers\fP to make it easier to update your entry (via the \fB\-i\fP option).
 If the file exists \fBmkiocccentry\fP will ask you if you wish to overwrite it unless \fB\-A\fP is specified which will always overwrite the answers file.
 .TP
 \fB\-A\fP
 Always overwrite answers file.
+.TP
+\fB\-i \fIanswers\fP\fP
+Read the answers from the file \fIanswers\fP for easier updating your entry.
+This option cannot be used with \fB\-a\fP or \fB\-A\fP.
 .TP
 \fB\-W\fP
 Ignore all warnings.

--- a/mkiocccentry_test.8
+++ b/mkiocccentry_test.8
@@ -1,4 +1,4 @@
-.TH mkiocccentry_test 8 "16 October 2022" "mkiocccentry_test" "IOCCC tools"
+.TH mkiocccentry_test 8 "17 October 2022" "mkiocccentry_test" "IOCCC tools"
 .SH NAME
 mkiocccentry_test.sh \- run several invocations of \fBmkiocccentry(1)\fP to test that it functions well
 .SH SYNOPSIS
@@ -19,16 +19,18 @@ Set verbosity level (def: 0).
 \fB\-J\fP
 Set JSON verbosity level.
 .SH EXIT STATUS
-.PP
-Exit codes:
-.br
-0	all tests are OK
-.br
-1	-h and help string printed or -V and version string printed
-.br
-2	Command line usage error
-.br
->=10	some make action exited non-zero
+.TP
+0
+all tests are OK
+.TQ
+1
+\-h and help string printed or \-V and version string printed
+.TQ
+2
+Command line usage error
+.TQ
+>=10
+some make action exited non-zero
 .SH BUGS
 .PP
 This script does not let one set the path to the needed tools like the other scripts do and so requires that one is in the clone of the repo directory to successfully run this script.

--- a/run_bison.8
+++ b/run_bison.8
@@ -1,12 +1,20 @@
-.TH run_bison.sh 8 "14 September 2022" "run_bison.sh" "IOCCC tools"
+.TH run_bison.sh 8 "17 October 2022" "run_bison.sh" "IOCCC tools"
 .SH NAME
-run_bison.sh \- run bison to generate C code from a *.y file or use backup files if error
+run_bison.sh \- run
+.B bison
+to generate C code from a
+.I *.y
+file or use backup files if error
 .SH SYNOPSIS
 \fBrun_bison.sh\fP [\-h] [\-V] [\-v level] [\-o] [\-b bison] [\-l limit_ioccc.sh] [\-g verge] [\-p prefix] [\-s sorry.h] [\-B dir] \-\- [bison_flags]
 .SH DESCRIPTION
-\fBrun_bison.sh\fP attempts to find a recent enough version of bison (minimum version defined in \fIlimit_ioccc.sh\fP or file specified by \fB\-l\fP option) and use it to generate code from the \fBprefix.y\fP file.
+\fBrun_bison.sh\fP attempts to find a recent enough version of
+.B bison
+(minimum version defined in \fIlimit_ioccc.sh\fP or file specified by \fB\-l\fP option) and use it to generate code from the \fBprefix.y\fP file.
 The default prefix is \fIjparse\fP but this script can be used for other parsers as well.
-If a recent enough version is not found or bison encounters an error (syntax error or anything else) and the \fB\-o\fP option is not specified, it attempts to use the backup files.
+If a recent enough version is not found or
+.B bison
+encounters an error (syntax error or anything else) and the \fB\-o\fP option is not specified, it attempts to use the backup files.
 .SH OPTIONS
 .TP
 \fB\-h\fP
@@ -15,64 +23,106 @@ Show help and exit.
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-v\fP
-Set verbosity level.
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
 \fB\-o\fP
 Do \fBNOT\fP use backup files.
-If bison cannot be used or fails to generate the files the script will fail.
+If
+.B bison
+cannot be used or fails to generate the files the script will fail.
 .TP
-\fB\-b\fP
-Specify bison basename.
+\fB\-b \fIbison\fP\fP
+Set
+.B bison
+basename to \fIbison\fP.
 .TP
-\fB\-l\fP
-Specify path to version file.
+\fB\-l \fIlimit_ioccc.sh\fP\fP
+Set path of version file to \fIlimit_ioccc.sh\fP.
 .TP
-\fB\-g\fP
-Specify path to the \fBverge\fP tool.
-This is used to determine if the bison tool is recent enough.
+\fB\-g \fIverge\fP\fP
+Set path to the \fBverge\fP tool to \fIverge\fP.
+This is used to determine if the
+.B bison
+tool is recent enough.
 .TP
-\fB\-p\fP
-Specify prefix of files to use.
+\fB\-p \fIprefix\fP\fP
+Set prefix of files to use to \fIprefix\fP.
 The bison input file will be \fIprefix.y\fP.
-If the \fB\-o\fP option was not used and bison cannot be used or fails then the backup file \fIprefix.c\fP will be used.
+If the \fB\-o\fP option was not used and bison cannot be used or fails then the backup file
+.I prefix.c
+will be used.
 .TP
-\fB\-s\fP
-File to prepend to the C output.
+\fB\-s \fIsorry.h\fP\fP
+Set path of file to prepend to the C output to \fIsorry.h\fP.
 .TP
-\fB\-B\fP
-Specify a directory to search for bison in.
-\fB\-B\fP can be used more than once.
+\fB\-B \fIbison_dir\fP\fP
+Add a directory to search for
+.B bison
+in to \fIbison_dir\fP.
+.B \-B
+can be used more than once.
 If not used the script looks at \fB$PATH\fP.
-.TP
+.PP
 The \fBbison_flags\fP are any optional flags to give to bison before the prefix.
 .SH EXIT STATUS
-.PP
-    0	    bison output files formed or backup files used instead
-.br
-    1	    bison not found or too old and -o used
-.br
-    2	    good bison found and ran but failed to form proper output files
-.br
-    3	    bison input file missing or not readable:         backup file(s) had to be used
-.br
-    4	    backup file(s) are missing, or are not readable
-.br
-    5	    failed to use backup file(s) to form the bison C output file(s)
-.br
-    6	    limit_ioccc.sh or sorry file missing/not readable or verge missing/not executable
-.br
-    7	    MIN_BISON_VERSION missing or empty from limit_ioccc.sh
-.br
-    8	    -h and help string printed or -V and version string printed
-.br
-    9	    Command line usage error
-.br
-    >=10	internal error"
+.TP
+0
+.B bison
+output files formed or backup files used instead
+.TQ
+1
+.B bison
+not found or too old and -o used
+.TQ
+2
+good
+.B bison
+found and ran but failed to form proper output files
+.TQ
+3
+.B bison
+input file missing or not readable: backup file(s) had to be used
+.TQ
+4
+backup file(s) are missing, or are not readable
+.TQ
+5
+failed to use backup file(s) to form the
+.B bison
+C output file(s)
+.TQ
+6
+.I limit_ioccc.sh
+or
+.I sorry.h
+file missing/not readable or
+.B verge
+missing/not executable
+.TQ
+7
+.B MIN_BISON_VERSION
+Missing or empty from
+.I limit_ioccc.sh
+.TQ
+8
+\-h and help string printed or \-V and version string printed
+.TQ
+9
+Command line usage error
+.TQ
+>=10
+internal error
 .SH NOTES
 .PP
-The \fB\-o\fP option is mainly for maintainers of the \fBjparse\fP parser and scanner but it can be used to test if you have a recent enough version of bison.
-The idea behind it is if bison fails it might indicate a syntax error which the authors of \fBjparse\fP would need to fix.
+The \fB\-o\fP option is mainly for maintainers of the
+.B jparse
+parser and scanner but it can be used to test if you have a recent enough version of \fBbison\fP.
+The idea behind it is if
+.B bison
+fails it might indicate a syntax error which the authors of
+.B jparse
+would need to fix.
 .PP
 Beware that some make implementations have a default rule for \fI*.y\fP files so that if one were to in this repo do:
 .nf
@@ -91,10 +141,14 @@ This appears to be because foo is actually referenced in the Makefile as a targe
 There's no way to disable prepending a file to the generated files.
 This should probably be fixed at some point.
 .PP
-If you have any issues with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have any issues with the tool you can open an issue at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
-Run \fBrun_bison.sh\fP with default options, which should attempt to run bison on the \fIjparse.y\fP file:
+Run \fBrun_bison.sh\fP with default options, which should attempt to run
+.B bison
+on the \fIjparse.y\fP file:
 .nf
 .RS
 \fB
@@ -102,7 +156,9 @@ Run \fBrun_bison.sh\fP with default options, which should attempt to run bison o
 .fi
 .RE
 .PP
-Run \fBrun_bison.sh\fP but specify that backup files are not to be used in case a recent enough version of bison cannot be found or fails for some reason.
+Run \fBrun_bison.sh\fP but specify that backup files are not to be used in case a recent enough version of
+.B bison
+cannot be found or fails for some reason.
 
 .nf
 .RS
@@ -111,7 +167,9 @@ Run \fBrun_bison.sh\fP but specify that backup files are not to be used in case 
 .fi
 .RE
 .PP
-Try and run bison on the file \fIfoobar.y\fP and don't use any backup files:
+Try and run
+.B bison
+on the file \fIfoobar.y\fP and don't use any backup files:
 .nf
 .RS
 \fB
@@ -119,7 +177,11 @@ Try and run bison on the file \fIfoobar.y\fP and don't use any backup files:
 .fi
 .RE
 .PP
-Try and run bison on the file \fIfoobar.y\fP with yacc instead of bison and don't use any backup files:
+Try and run
+.B bison
+on the file \fIfoobar.y\fP with yacc instead of
+.B bison
+and don't use any backup files:
 .nf
 .RS
 \fB

--- a/run_flex.8
+++ b/run_flex.8
@@ -1,12 +1,20 @@
-.TH run_flex.sh 8 "14 September 2022" "run_flex.sh" "IOCCC tools"
+.TH run_flex.sh 8 "17 October 2022" "run_flex.sh" "IOCCC tools"
 .SH NAME
-run_flex.sh \- run flex to generate C code from a *.l file or use backup files if error
+run_flex.sh \- run
+.B flex
+to generate C code from a
+.I *.l
+file or use backup files if error
 .SH SYNOPSIS
 \fBrun_flex.sh\fP [\-h] [\-V] [\-v level] [\-o] [\-f flex] [\-l limit_ioccc.sh] [\-g verge] [\-p prefix] [\-s sorry.h] [\-F dir] \-\- [flex_flags]
 .SH DESCRIPTION
-\fBrun_flex.sh\fP attempts to find a recent enough version of flex (minimum version defined in \fIlimit_ioccc.sh\fP or file specified by \fB\-l\fP option) and use it to generate code from the \fBprefix.l\fP file.
+\fBrun_flex.sh\fP attempts to find a recent enough version of
+.B flex
+(minimum version defined in \fIlimit_ioccc.sh\fP or file specified by \fB\-l\fP option) and use it to generate code from the \fBprefix.l\fP file.
 The default prefix is \fIjparse\fP but this script can be used for other scanners as well.
-If a recent enough version is not found or flex encounters an error (syntax error or anything else) and the \fB\-o\fP option is not specified, it attempts to use the backup files.
+If a recent enough version is not found or
+.B flex
+encounters an error (syntax error or anything else) and the \fB\-o\fP option is not specified, it attempts to use the backup files.
 .SH OPTIONS
 .TP
 \fB\-h\fP
@@ -15,64 +23,109 @@ Show help and exit.
 \fB\-V\fP
 Show version and exit.
 .TP
-\fB\-v\fP
-Set verbosity level.
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
 .TP
 \fB\-o\fP
 Do \fBNOT\fP use backup files.
-If flex cannot be used or fails to generate the files the script will fail.
+If
+.B flex
+cannot be used or fails to generate the files the script will fail.
 .TP
-\fB\-f\fP
-Specify flex basename.
+\fB\-f \fIflex\fP\fP
+Set
+.B flex
+basename to \fIflex\fP.
 .TP
-\fB\-l\fP
-Specify path to version file.
+\fB\-l \fIlimit_ioccc.sh\fP\fP
+Set path of version file to \fIlimit_ioccc.sh\fP.
 .TP
-\fB\-g\fP
-Specify path to the \fBverge\fP tool.
-This is used to determine if the flex tool is recent enough.
+\fB\-g \fIverge\fP\fP
+Set path to the \fBverge\fP tool to \fIverge\fP.
+This is used to determine if the
+.B flex
+tool is recent enough.
 .TP
-\fB\-p\fP
-Specify prefix of files to use.
-The flex input file will be \fIprefix.l\fP.
-If the \fB\-o\fP option was not used and flex cannot be used or fails then the backup file \fIprefix.c\fP will be used.
+\fB\-p \fIprefix\fP\fP
+Set prefix of files to use to \fIprefix\fP.
+The
+.B flex
+input file will be \fIprefix.l\fP.
+If the \fB\-o\fP option was not used and
+.B flex
+cannot be used or fails then the backup file
+.I prefix.c
+will be used.
 .TP
-\fB\-s\fP
-File to prepend to the C output.
+\fB\-s \fIsorry.h\fP\fP
+Set path to file to prepend to the C output to \fIsorry.h\fP.
 .TP
-\fB\-F\fP
-Specify a directory to search for flex in.
+\fB\-F \fIflex_dir\fP\fP
+Add a directory to search for
+.B flex
+in to \fIflex_dir\fP.
 \fB\-F\fP can be used more than once.
 If not used the script looks at \fB$PATH\fP.
-.TP
-The \fBflex_flags\fP are any optional flags to give to flex before the prefix.
-.SH EXIT STATUS
 .PP
-    0    flex output files formed or backup files used instead
-.br
-    1    flex not found or too old and -o used
-.br
-    2    good flex found and ran but failed to form proper output files
-.br
-    3    flex input file missing or not readable:         backup file(s) had to be used
-.br
-    4    backup file(s) are missing, or are not readable
-.br
-    5    failed to use backup file(s) to form the flex C output file(s)
-.br
-    6    limit_ioccc.sh or sorry file missing/not readable or verge missing/not executable
-.br
-    7    MIN_FLEX_VERSION missing or empty from limit_ioccc.sh
-.br
-    8    -h and help string printed or -V and version string printed
-.br
-    9    Command line usage error
-.br
-    >=10  internal error"
+The
+.B flex_flags
+are any optional flags to give to
+.B flex
+before the prefix.
+.SH EXIT STATUS
+.TP
+0
+.B flex
+output files formed or backup files used instead
+.TQ
+1
+.B flex
+not found or too old and \fB\-o\fP used
+.TQ
+2
+good
+.B flex
+found and ran but failed to form proper output files
+.TQ
+3
+.B flex
+input file missing or not readable: backup file(s) had to be used
+.TQ
+4
+backup file(s) are missing, or are not readable
+.TQ
+5
+failed to use backup file(s) to form the
+.B flex
+C output file(s)
+.TQ
+6
+.I limit_ioccc.sh
+or
+.I sorry.h
+file missing/not readable or
+.B verge
+missing/not executable
+.TQ
+7
+.B MIN_FLEX_VERSION
+missing or empty from
+.I limit_ioccc.sh
+.TQ
+8
+\-h and help string printed or \-V and version string printed
+.TQ
+9
+Command line usage error
+.TQ
+>=10
+internal error
 .SH NOTES
 .PP
-The \fB\-o\fP option is mainly for maintainers of the \fBjparse\fP scanner and parser but it can be used to test if you have a recent enough version of flex.
-The idea behind it is if flex fails it might indicate a syntax error which the authors of \fBjparse\fP would need to fix.
+The \fB\-o\fP option is mainly for maintainers of the \fBjparse\fP scanner and parser but it can be used to test if you have a recent enough version of \fBflex\fP.
+The idea behind it is if
+.B flex
+fails it might indicate a syntax error which the authors of \fBjparse\fP would need to fix.
 .PP
 Beware that some make implementations have a default rule for \fI*.l\fP files so that if one were to in this repo do:
 .nf
@@ -90,10 +143,14 @@ This appears to be because foo is actually referenced in the Makefile as a targe
 There's no way to disable prepending a file to the generated files.
 This should probably be fixed at some point.
 .PP
-If you have any issues with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have any issues with the tool you can open an issue at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
-Run \fBrun_flex.sh\fP with default options, which should attempt to run flex on the \fIjparse.l\fP file:
+Run \fBrun_flex.sh\fP with default options, which should attempt to run
+.B flex
+on the \fIjparse.l\fP file:
 .nf
 .RS
 \fB
@@ -101,7 +158,9 @@ Run \fBrun_flex.sh\fP with default options, which should attempt to run flex on 
 .fi
 .RE
 .PP
-Run \fBrun_flex.sh\fP but specify that backup files are not to be used in case a recent enough version of flex cannot be found or fails for some reason.
+Run \fBrun_flex.sh\fP but specify that backup files are not to be used in case a recent enough version of
+.B flex
+cannot be found or fails for some reason.
 
 .nf
 .RS
@@ -110,7 +169,9 @@ Run \fBrun_flex.sh\fP but specify that backup files are not to be used in case a
 .fi
 .RE
 .PP
-Try and run flex on the file \fIfoobar.l\fP and don't use any backup files:
+Try and run
+.B flex
+on the file \fIfoobar.l\fP and don't use any backup files:
 .nf
 .RS
 \fB
@@ -118,7 +179,11 @@ Try and run flex on the file \fIfoobar.l\fP and don't use any backup files:
 .fi
 .RE
 .PP
-Try and run flex on the file \fIfoobar.l\fP with lex instead of flex and don't use any backup files:
+Try and run
+.B flex
+on the file \fIfoobar.l\fP with lex instead of
+.B flex
+and don't use any backup files:
 .nf
 .RS
 \fB

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,4 +1,4 @@
-.TH txzchk 1 "09 October 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "17 October 2022" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
@@ -15,49 +15,52 @@ The tarball is \fBNOT\fP extracted.
 In other words it makes sure that \fBmkiocccentry(1)\fP was used and that there was no screwing around with the resultant tarball.
 As an important part of the judging process, the Judges will directly execute this tool on every entry's tarball.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
+.TP
+\fB\-v \fIlevel\fP\fP
 Set verbosity level.
-.PP
+.TP
 \fB\-q\fP
 Suppresses some of the output.
 Errors and the output of the \fBtar\fP command are still shown.
 If you need to see warnings with this option, use \fB\-w\fP.
-.PP
+.TP
 \fB\-w\fP
 Always show warnings.
 This is useful for in the \fBtxzchk_test(8)\fP script.
-.PP
+.TP
 \fB\-V\fP
 Show version and exit.
-.PP
-\fB\-t\fP
+.TP
+\fB\-t \fItar\fP\fP
 Specify path to \fBtar\fP that accepts the \fB\-J\fP option.
 \fBtxzchk\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
-.PP
-\fB\-F\fP
+.TP
+\fB\-F \fIfnamchk\fP\fP
 Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
-.PP
+.TP
 \fB\-T\fP
 Assume txzpath is a text file; use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
-.PP
-\fB\-E\fP
+.TP
+\fB\-E \fIext\fP\fP
 Change extension for \fBfnamchk(1)\fP to validate (don't include the dot).
 This is used in conjunction with \fb\-T\fP above for \fBTESTING\fP purposes only!
 .SH EXIT STATUS
-.PP
-.br
-    0	No feathers stuck in tarball. :-)
-.br
-    1	Tarball was successfully parsed :-) but there's at least one feather stuck in it. :-(
-.br
-    2	Usage string was printed either because \fB\-h\fP was used or because of an invalid command line.
-.br
-    >2	An internal error has occurred or unknown tar listing format has been encountered.
+.TP
+0
+No feathers stuck in tarball. :-)
+.TQ
+1
+Tarball was successfully parsed :-) but there's at least one feather stuck in it. :-(
+.TQ
+2
+Usage string was printed either because \fB\-h\fP was used or because of an invalid command line.
+.TQ
+>2
+An internal error has occurred or unknown tar listing format has been encountered.
 .PP
 For exit code > 2 please report (see \fBBUGS\fP section for where to report bugs).
 .SH NOTES
@@ -72,7 +75,9 @@ More importantly, no tar pits \- including the \fBLa Brea Tar Pits\fP \- were di
 Cody Boone Ferguson wrote it! :)
 .PP
 On a more serious note, if you have an issue with the tool please report it at the GitHub issues page.
-You can find it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+You can find it at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 If you would please mention \fB@xexyl\fP as part of the report that would be appreciated.
 .SH EXAMPLES
 .PP

--- a/txzchk_test.8
+++ b/txzchk_test.8
@@ -1,4 +1,4 @@
-.TH txzchk_test 8 "09 October 2022" "txzchk_test" "IOCCC tools"
+.TH txzchk_test 8 "17 October 2022" "txzchk_test" "IOCCC tools"
 .SH NAME
 txzchk_test.sh \- test suite for \fBtxzchk(1)\fP
 .SH SYNOPSIS
@@ -10,41 +10,33 @@ The script enforces that bad files have an associated error file to compare with
 If an error file is missing it is an error.
 Conversely if a good file has an error file it is also an error.
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
+.TP
 \fB\-V\fP
 Print version and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0) for the script.
-.PP
-\fB\-t\fP
-Specify path to \fBtxzchk\fP.
-.PP
-\fB\-T\fP
-Specify path to \fBtar\fP.
-.PP
-\fB\-F\fP
-Specify path to \fBfnamchk\fP, which \fBtxzchk\fP uses to test if the tarball is validly named and if the files listed are in the correct directory.
-.PP
-\fB\-d\fP
-Specify path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo-tarballs.
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP for the script.
+.TP
+\fB\-t \fItxzchk\fP\fP
+Specify path to \fBtxzchk\fP to \fItxzchk\fP.
+.TP
+\fB\-T \fItar\fP\fP
+Specify path to \fBtar\fP to \fItar\fP.
+.TP
+\fB\-F \fIfnamchk\fP\fP
+Specify path to \fBfnamchk\fP to \fIfnamchk\fP.
+\fBtxzchk\fP uses \fBfnamchk\fP to test if the tarball is validly named and if the files listed are in the correct directory.
+.TP
+\fB\-d \fItxzchk_tree\fP\fP
+Specify path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo-tarballs, to \fItxzchk_tree\fP.
 As already noted, the \fIbad\fP subdirectory also has error files to compare against the output of \fBtxzchk(1)\fP, in order to make sure that the failure is the correct failure.
 .SH EXIT STATUS
 .PP
-Exit codes:
-.br
-    0 \- all is well
-.br
-    1 \- at least one test failed
-.br
-    2 \- help mode exit
-.br
-    3 \- invalid command line
-.br
-    >= 4 \- internal or test error
+An exit code of 0 means everything is well.
+An non-zero exit code means that either help or version was requested at the command line, at least one test failed or there was an internal or test error.
 .SH FILES
 \fItest_txzchk\fP
 .RS

--- a/utf8_test.8
+++ b/utf8_test.8
@@ -7,13 +7,13 @@ utf8_test \- test translate UTF-8 chars into POSIX portable filename and +
 \fButf8_test\fP translates a UTF-8 string into a POSIX portable filename (allowing for char \fI+\fP as well: that is a plus sign, not a plus or minus sign).
 .PP
 .SH OPTIONS
-.PP
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
-Set verbosity level (def: 0).
-.PP
+.TP
+\fB\-v \fIlevel\fP\fP
+Set verbosity level to \fIlevel\fP.
+.TP
 \fB\-q\fP
 Suppresses some of the output (def: not quiet).
 .SH EXIT STATUS

--- a/verge.8
+++ b/verge.8
@@ -1,4 +1,4 @@
-.TH verge 8 "8 September 2022" "verge" "IOCCC tools"
+.TH verge 8 "17 October 2022" "verge" "IOCCC tools"
 .SH NAME
 verge \- determine if first version >= second version
 .SH SYNOPSIS
@@ -8,32 +8,41 @@ verge \- determine if first version >= second version
 .PP
 This program requires two arguments but accepts several options.
 .SH OPTIONS
+.TP
 \fB\-h\fP
 Show help and exit.
-.PP
-\fB\-v\fP
+.TP
+\fB\-v \fIlevel\fP\fP
 Set verbosity level.
-.PP
+.TP
 \fB\-V\fP
 Show version and exit.
 .SH EXIT STATUS
-.PP
-0	First version >= second version.
-.br
-1	First version < second version.
-.br
-2	One or more invalid version strings.
-.br
-3	\fB\-h\fP and help string printed or \fB\-V\fP and version string printed.
-.br
-4	Command line error.
-.br
->=5	Internal error.
+.TP
+0
+First version >= second version.
+.TQ
+1
+First version < second version.
+.TQ
+2
+One or more invalid version strings.
+.TQ
+3
+\fB\-h\fP and help string printed or \fB\-V\fP and version string printed.
+.TQ
+4
+Command line error.
+.TQ
+>=5
+Internal error.
 .SH NOTES
 This tool is used in the \fBrun_flex.sh\fP and \fBrun_bison.sh\fP scripts to determine if the locally installed flex and bison tools are recent enough to generate the JSON parser from the \fBjparse.l\fP and \fBjparse.y\fP files.
 .SH BUGS
 .PP
-If you have an issue with the tool you can report it at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have an issue with the tool you can report it at
+.br
+\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf

--- a/vermod.8
+++ b/vermod.8
@@ -1,4 +1,4 @@
-.TH vermod 8 "12 September 2022" "vermod" "IOCCC tools"
+.TH vermod 8 "17 October 2022" "vermod" "IOCCC tools"
 .SH NAME
 vermod \- modify version strings (and others) under ./test_JSON/
 .SH SYNOPSIS
@@ -43,26 +43,36 @@ This is useful with \fB\-n\fP to show what would change.
 List files that do not change or would not be changed.
 This is useful with \fB\-n\fP to show what wouldn't change.
 .SH EXIT STATUS
-.PP
-0	    all is well
-.br
-1	    \fBrpl\fP exited non-zero
-.br
-2	    \fBrpl\fP not found
-.br
-3	    no limit.sh found or is not readable
-.br
-4	    no test directory found or is not readable
-.br
-5	    usage message due to \fB\-h\fP
-.br
-6	    command line error and usage message printed
-.br
-7	    no *.json files found under test directory
-.br
-8	    new_ver (or old_ver if \fB\-o\fP) not found in limit file
-.br
->= 9	    internal error
+.TP
+0
+all is well
+.TQ
+1
+\fBrpl\fP exited non-zero
+.TQ
+2
+\fBrpl\fP not found
+.TQ
+3
+no limit.sh found or is not readable
+.TQ
+4
+no test directory found or is not readable
+.TQ
+5
+usage message due to \fB\-h\fP
+.TQ
+6
+command line error and usage message printed
+.TQ
+7
+no *.json files found under test directory
+.TQ
+8
+new_ver (or old_ver if \fB\-o\fP) not found in limit file
+.TQ
+>= 9
+internal error
 .SH FILES
 \fItest_JSON\fP
 .RS


### PR DESCRIPTION
This commit was in part an experiment with fixing formatting in some places in man pages. Possibly for some of the changes some files need to be updated still and there also definitely has to be more consistency updates but these can wait until another time. I went ahead and did certain things for a number of man pages as follows:

In the case of specific exit codes being in a list use .TP and .TQ macros. This makes it much cleaner and it aligns the two columns correctly. The .TQ macro might be used in one other man page in one place too though not sure which one that might be now.

In some cases I have used .I and .B instead of \fI..\fP and \fB..\fP but this is not consistent and in some cases it cannot be done this way (thinking of a full stop or dot as the very next character - it might be possible but I'm not sure how yet if it is).

Move URLs to their own line (one exception in txzchk.1). This is because sometimes (depending on the size of the screen) the url might be spread across more than one line and this can cause a problem. Thus before URLs I have added a line with the .br macro by itself for a line break.

The options should all use .TP now instead of .PP. Again I might have missed some files but most of them should have this now. This is cleaner.

Additionally for the files edited if an option arg is needed in the OPTIONS section I have made it in italic and refer to it in the description.

I've updated the dates on the man pages and hopefully all the ones I have edited now have the date of 17 October 2022.

Again much more has to be done but this is a good update on the man pages. Probably more needs to be discussed but this can wait. I did this commit as I did not feel up to anything else and it was something I could do that is needed (even if more can be done). One reason I did not try and finish it all is because it's almost certain I'll have to do it again and so better to go through things once in full than more than once.