### PR TITLE
Improve comment in dyn_array.h + mass fix man pages so all references to '-' have a '\' before them

### DIFF
--- a/bug_report.1
+++ b/bug_report.1
@@ -1,4 +1,4 @@
-.TH bug_report 1 "14 October 2022" "bug_report.sh" "IOCCC tools"
+.TH bug_report 1 "18 October 2022" "bug_report.sh" "IOCCC tools"
 .SH NAME
 bug_report.sh \- run a series of tests, collecting system information in the process, to help report bugs and issues
 .SH SYNOPSIS
@@ -20,7 +20,7 @@ Show version and exit.
 .SH EXIT STATUS
 If no issues are detected the script will exit 0.
 In this case it will tell you that all should be okay and you can safely delete the log file.
-If it exits non-zero and it's not because of the \fB\-h\fP or \fB\-V\fP option it will recommend you to report it, reminding you to attach the log in your report.
+If it exits non\-zero and it's not because of the \fB\-h\fP or \fB\-V\fP option it will recommend you to report it, reminding you to attach the log in your report.
 .SH NOTES
 .PP
 Even if the script exits 0 it does not necessarily mean there is no problem.
@@ -28,13 +28,13 @@ If you feel there is a problem that was not detected you may still open an issue
 The script will tell you how to do this whether there are issues detected or not.
 .PP
 The output can seem redundant if it fails because of \fBhostchk(1)\fP since it will trigger a warning that tells you to use \fBhostchk(1)\fP with more verbosity and also tells you to use \fBbug_report(1)\fP which tells you to use \fBhostchk(1)\fP.
-Sorry in advance if (to use an American English phrase which I will happily use for a pun for a pun not made is a wasted opportunity) this throws you for a loop :-) but we feel that it's better that the warning is really stressed as it most likely means that you won't be able to use the toolkit to successfully create a valid IOCCC tarball.
-But now that you're in the loop it shouldn't even matter! :-)
+Sorry in advance if (to use an American English phrase which I will happily use for a pun for a pun not made is a wasted opportunity) this throws you for a loop :\-) but we feel that it's better that the warning is really stressed as it most likely means that you won't be able to use the toolkit to successfully create a valid IOCCC tarball.
+But now that you're in the loop it shouldn't even matter! :\-)
 .SH BUGS
 .PP
 Right now there are no known bugs except that it cannot possibly account for everything.
 Previously there was a bug in this script that made it so that issues detected were not reported.
-This is very ironic and amusing since the purpose of the script is to help identify bugs. :-)
+This is very ironic and amusing since the purpose of the script is to help identify bugs. :\-)
 .PP
 Nevertheless, if you feel there is an issue with this tool you may open an issue at the GitHub issues page.
 Running the script will tell you how to report issues and it would be good if you attach the log file in this report as well.

--- a/chkentry.1
+++ b/chkentry.1
@@ -1,4 +1,4 @@
-.TH chkentry 1 "7 October 2022" "chkentry" "IOCCC tools"
+.TH chkentry 1 "18 October 2022" "chkentry" "IOCCC tools"
 .SH NAME
 chkentry \- check JSON files in an IOCCC entry
 .SH SYNOPSIS
@@ -18,7 +18,7 @@ The one argument form is equivalent to calling the command with two arguments: \
 .PP
 As a sanity check, the \fBmkiocccentry(1)\fP program executes \fBchkentry\fP AFTER both the \fI.info.json\fP and \fI.author.json\fP file have been created and before the compressed tarball is formed.
 If \fBmkiocccentry\fP program sees a 0 exit status, then all is well.
-For a non-zero exit code, the tool aborts because any problems detected by \fBchkentry\fP based on what \fBmkiocccentry\fP wrote into \fI.info.json\fP and/or \fI.author.json\fP indicates there is a serious mismatch between what \fBmkiocccentry\fP is doing and what \fBchkentry\fP expects.
+For a non\-zero exit code, the tool aborts because any problems detected by \fBchkentry\fP based on what \fBmkiocccentry\fP wrote into \fI.info.json\fP and/or \fI.author.json\fP indicates there is a serious mismatch between what \fBmkiocccentry\fP is doing and what \fBchkentry\fP expects.
 .PP
 .SH OPTIONS
 .PP
@@ -53,10 +53,10 @@ As such this man page is also unfinished.
 .PP
 .nf
 Run the tool on an IOCCC entry located in the directory
-\fBentry.1d5E8ac2-2cF5-48FB-aD81-3210d16af8ca-0.1652598666\fP:
+\fBentry.1d5E8ac2\-2cF5\-48FB\-aD81\-3210d16af8ca\-0.1652598666\fP:
 
 \fB
- ./chkentry entry.1d5E8ac2-2cF5-48FB-aD81-3210d16af8ca-0.1652598666\fP
+ ./chkentry entry.1d5E8ac2\-2cF5\-48FB\-aD81\-3210d16af8ca\-0.1652598666\fP
 .fi
 
 .PP

--- a/dbg.3
+++ b/dbg.3
@@ -1,4 +1,4 @@
-.TH dbg 3  "1 July 2022" "dbg"
+.TH dbg 3  "18 October 2022" "dbg"
 .SH NAME
 .BR msg(),
 .BR vmsg(),
@@ -433,8 +433,8 @@ The above two commands could be shortened to just:
 \fBcc \-o dbg_example dbg_example.c dbg.c\fP
 $ ./dbg_example
 NOTE: Setting verbosity_level to DBG_MED: 3
-NOTE: The next line should say: "Warning: main: elephant is sky-blue pink"
-Warning: main: elephant is sky-blue pink
+NOTE: The next line should say: "Warning: main: elephant is sky\-blue pink"
+Warning: main: elephant is sky\-blue pink
 
 NOTE: The next line should read: "debug[3]: file: foo.bar has length: 7"
 debug[3]: file: foo.bar has length: 7

--- a/dyn_array.h
+++ b/dyn_array.h
@@ -118,7 +118,7 @@
 
 
 /*
- * array - a dynamic array of identical elements
+ * dyn_array - a dynamic array of elements of the same type
  *
  * The dynamic array maintains both an allocated element count
  * and a number of elements in use.

--- a/fnamchk.1
+++ b/fnamchk.1
@@ -1,4 +1,4 @@
-.TH fnamchk 1 "16 October 2022" "fnamchk" "IOCCC tools"
+.TH fnamchk 1 "18 October 2022" "fnamchk" "IOCCC tools"
 .SH NAME
 fnamchk \- IOCCC compressed tarball filename sanity check tool
 .SH SYNOPSIS
@@ -15,7 +15,7 @@ Start with "\fBentry\fP".
 .IP \(bu 4
 Followed by "\fB.\fP".
 .IP \(bu 4
-Followed by either "\fBtest\fP" \fIOR\fP a UUID string in the form of \fBxxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx\fP where \fBx\fP is a hexadecimal digit in the range \fB[0-9a-f]\fP.
+Followed by either "\fBtest\fP" \fIOR\fP a UUID string in the form of \fBxxxxxxxx\-xxxx\-4xxx\-axxx\-xxxxxxxxxxxx\fP where \fBx\fP is a hexadecimal digit in the range \fB[0\-9a\-f]\fP.
 And yes, there is a \fB4\fP (UUID version 4) and an \fBa\fP (UUID variant 1) in there.
 .IP \(bu 4
 Followed by "\fB\-\fP".
@@ -24,7 +24,7 @@ Followed by a decimal entry number from \fB0\fP through \fBMAX_ENTRY_NUM\fP (see
 .IP \(bu 4
 Followed by "\fB.\fP".
 .IP \(bu 4
-Followed by a positive non-zero 64-bit decimal integer.
+Followed by a positive non\-zero 64\-bit decimal integer.
 .IP \(bu 4
 Followed by "\fB.\fP".
 .IP \(bu 4
@@ -56,11 +56,11 @@ This is used for \fBTESTING\fP purposes only!
 .TP
 \fB\-t\fP
 If the filename does not start with the test mode filename format, issue an error.
-In other words the filename has to start with \fIentry.test-\fP or it's an error.
+In other words the filename has to start with \fIentry.test\-\fP or it's an error.
 .TP
 \fB\-u\fP
 If the filename does not start with the normal filename format, issue an error.
-In other words if the filename starts with \fIentry.test-\fP it is an error.
+In other words if the filename starts with \fIentry.test\-\fP it is an error.
 .SH EXIT STATUS
 .PP
 \fBmain()\fP returns 0 on success; if there's an error the end is not reached.
@@ -71,16 +71,16 @@ More than 0 humans work on it! :)
 .PP
 If you have an issue with the tool you can open an issue at
 .br
-\fI<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 For the examples below assume that the \fBMIN_TIMESTAMP\fP is \fB(time_t)1662145368\fP.
 .PP
-Run the program on the filename \fIentry.test-0.1562145368.txz\fP which will fail because the timestamp in the filename is less than the minimum timestamp:
+Run the program on the filename \fIentry.test\-0.1562145368.txz\fP which will fail because the timestamp in the filename is less than the minimum timestamp:
 .nf
 .RS
 \fB
- ./fnamchk -t entry.test-0.1562145368.txz\fP
+ ./fnamchk \-t entry.test\-0.1562145368.txz\fP
 .fi
 .RE
 .PP
@@ -96,7 +96,7 @@ Run the program on the filename \fIentry.test.0.1662145368.txz\fP with the optio
 .nf
 .RS
 \fB
- ./fnamchk -u entry.test-0.1662145368.txz\fP
+ ./fnamchk \-u entry.test\-0.1662145368.txz\fP
 .fi
 .RE
 .PP
@@ -104,7 +104,7 @@ Run the program on the filename \fIentry.test.0.1662145368.txz\fP with the optio
 .nf
 .RS
 \fB
- ./fnamchk -t entry.test-0.1662145368.txz\fP
+ ./fnamchk \-t entry.test\-0.1662145368.txz\fP
 .fi
 .RE
 .PP
@@ -114,7 +114,7 @@ Run the program on the file \fIentry.test.0.1662145368.txt\fP with the option \f
 .nf
 .RS
 \fB
- ./fnamchk -E txt -t entry.test-0.1662145368.txt\fP
+ ./fnamchk \-E txt \-t entry.test\-0.1662145368.txt\fP
 .fi
 .RE
 .PP
@@ -124,7 +124,7 @@ Run the program on the file \fIentry.test.0.1662145368.txz\fP with the options \
 .nf
 .RS
 \fB
- ./fnamchk -E txt -t entry.test-0.1662145368.txz\fP
+ ./fnamchk \-E txt \-t entry.test\-0.1662145368.txz\fP
 .fi
 .RE
 .PP
@@ -134,7 +134,7 @@ Run the program on the file \fIentry.test.0.1662145368.txz\fP without specifying
 .nf
 .RS
 \fB
- ./fnamchk entry.test-0.1662145368.txz\fP
+ ./fnamchk entry.test\-0.1662145368.txz\fP
 .fi
 .RE
 .PP

--- a/have_timegm.8
+++ b/have_timegm.8
@@ -1,4 +1,4 @@
-.TH have_timegm.sh 8 "17 October 2022" "have_timegm.sh" "IOCCC tools"
+.TH have_timegm.sh 8 "18 October 2022" "have_timegm.sh" "IOCCC tools"
 .SH NAME
 have_timegm.sh \- test compiler for \fBtimegm(3)\fP, \fBstrptime(3)\fP and \fBstrftime(3)\fP
 .SH SYNOPSIS
@@ -49,7 +49,7 @@ Running the script under CentOS 7 will result in:
 .RS
 \fB
   $ ./have_timegm.sh
-  -DTIMEGM_PROBLEM\fP
+  \-DTIMEGM_PROBLEM\fP
 .fi
 .RE
 .PP

--- a/hostchk.1
+++ b/hostchk.1
@@ -1,4 +1,4 @@
-.TH hostchk 1 "17 October 2022" "hostchk.sh" "IOCCC tools"
+.TH hostchk 1 "18 October 2022" "hostchk.sh" "IOCCC tools"
 .SH NAME
 hostchk.sh \- run a series of checks on your system to help determine if you can correctly use the mkiocccentry toolkit
 .SH SYNOPSIS
@@ -32,7 +32,7 @@ Instead of testing one required system header file at a time it does it all at o
 The default is not to use \fB\-f\fP because it will give more information to help identify the problem (and also let you know which files work).
 .SH EXIT STATUS
 If no issues are detected the script will exit 0.
-Otherwise it will exit non-zero.
+Otherwise it will exit non\-zero.
 .SH NOTES
 .PP
 Even if the script exits 0 it does not necessarily mean there is no problem.
@@ -41,8 +41,8 @@ In that case you should use \fBbug_report(1)\fP and include the log that it crea
 .PP
 The output can seem redundant if it fails and \fBhostchk(1)\fP was run via the Makefile since it will issue a warning that will tell you to use
 \fBhostchk(1)\fP and also tell you to use \fBbug_report(1)\fP which itself will tell you to use \fBhostchk(1)\fP which will trigger the warning again.
-Sorry in advance if (to use an American English phrase which I will happily use for a pun for a pun not made is a wasted opportunity) this throws you for a loop :-) but we feel that it's better that the warning is really stressed as it most likely means that you won't be able to use the toolkit to successfully create a valid IOCCC tarball.
-But now that you're in the loop it shouldn't even matter! :-)
+Sorry in advance if (to use an American English phrase which I will happily use for a pun for a pun not made is a wasted opportunity) this throws you for a loop :\-) but we feel that it's better that the warning is really stressed as it most likely means that you won't be able to use the toolkit to successfully create a valid IOCCC tarball.
+But now that you're in the loop it shouldn't even matter! :\-)
 .SH BUGS
 .PP
 Right now there are no known bugs except that it is currently incomplete.

--- a/ioccc_test.8
+++ b/ioccc_test.8
@@ -1,4 +1,4 @@
-.TH ioccc_test.sh 8 "17 October 2022" "ioccc_test" "IOCCC tools"
+.TH ioccc_test.sh 8 "18 October 2022" "ioccc_test" "IOCCC tools"
 .SH NAME
 ioccc_test.sh \- test suite for IOCCC toolkit
 .SH SYNOPSIS
@@ -29,7 +29,7 @@ all tests are OK
 2
 command line usage error
 .TQ
-3-19
+3\-19
 something not found, not a file, or not executable
 .TQ
 >=20

--- a/iocccsize.1
+++ b/iocccsize.1
@@ -1,4 +1,4 @@
-.TH iocccsize 1 "17 October 2022" "iocccsize" "IOCCC tools"
+.TH iocccsize 1 "18 October 2022" "iocccsize" "IOCCC tools"
 .SH NAME
 iocccsize \- IOCCC Source Size Tool
 .SH SYNOPSIS
@@ -9,7 +9,7 @@ iocccsize \- IOCCC Source Size Tool
 .PP
 Reading a C source file from standard input or a file arg, apply the IOCCC source size rules as explained in the Guidelines.
 .PP
-The source's Rule 2b length is written to stdout; with -v option the Rule 2b length, gross (Rule 2a) length, and matched keyword count are written to stdout.
+The source's Rule 2b length is written to stdout; with \-v option the Rule 2b length, gross (Rule 2a) length, and matched keyword count are written to stdout.
 .PP
 The size tool counts most C reserved words (keyword, secondary, and selected preprocessor keywords) as 1.
 The size tool counts all other octets as 1 excluding ASCII whitespace, and excluding any ';', '{' or '}' followed by ASCII whitespace, and excluding any ';', '{' or '}' octet immediately before the end of file.
@@ -67,8 +67,8 @@ Test if prog.c fits within Rule 2b and Rule 2b limits: reporting of there's a pr
 Output the Rule 2b length, gross (Rule 2a) length, and matched keyword count:
 .RS
 \fB
- ./iocccsize -v 1 < prog.c
- ./iocccsize -v 1 prog.c\fP
+ ./iocccsize \-v 1 < prog.c
+ ./iocccsize \-v 1 prog.c\fP
 .fi
 .RE
 .PP
@@ -76,14 +76,14 @@ Output the Rule 2b length, gross (Rule 2a) length, and matched keyword count:
 You may also wish to try the test script in verbose mode:
 .RS
 \fB
- ./iocccsize_test.sh -v 3\fP
+ ./iocccsize_test.sh \-v 3\fP
 .fi
 .RE
 .SH SEE ALSO
 \fBiocccsize_test(8)\fP
 .SH BUGS
 .PP
-There are no bugs, only features! :-)
+There are no bugs, only features! :\-)
 .PP
 The matched keyword count is currently ignored by the IOCCC.
 .PP
@@ -92,7 +92,7 @@ Because the original source was an IOCCC winner,
 .PP
 But if you think you have an issue with the tool you can open an issue at
 .br
-\fI\<https://github.com/ioccc-src/iocccsize/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/iocccsize/issues\>\fP.
 .SH IOCCC WARNING
 .PP
 For submitting entries to the IOCCC, and to conform with Rule 2,
@@ -100,7 +100,7 @@ please use the official copy of the IOCCC
 \fBiocccsize\fP
 from the following GitHub repo:
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry>\fP.
 .PP
 \fBWARNING:\fP
 Be sure you are using the current version of

--- a/iocccsize_test.8
+++ b/iocccsize_test.8
@@ -1,8 +1,8 @@
-.TH iocccsize_test.sh 8 "17 October 2022" "iocccsize_test" "IOCCC tools"
+.TH iocccsize_test.sh 8 "18 October 2022" "iocccsize_test" "IOCCC tools"
 .SH NAME
 iocccsize_test.sh \- test iocccsize tool
 .SH SYNOPSIS
-\fBiocccsize_test.sh\fP [\-h] [\-v lvl] [\-V] [\-i iocccsize] [\-w work_dir] \[-l limit]
+\fBiocccsize_test.sh\fP [\-h] [\-v lvl] [\-V] [\-i iocccsize] [\-w work_dir] \[\-l limit]
 .SH DESCRIPTION
 \fBiocccsize_test.sh\fP runs a series of tests on the \fBiocccsize(1)\fP tool, verifying that it is functioning properly.
 .SH OPTIONS
@@ -42,17 +42,17 @@ Run the \fRiocccsize\fP test suite in silent mode, printing only if a problem is
 .fi
 .RE
 .PP
-Run the \fRiocccsize\fP test suite, reporting on each sub-test that is performed:
+Run the \fRiocccsize\fP test suite, reporting on each sub\-test that is performed:
 .RS
 .sp
-\fB./iocccsize_test.sh -v 1\fP
+\fB./iocccsize_test.sh \-v 1\fP
 .fi
 .RE
 .PP
 You may also wish to try the test script in even more verbose mode:
 .PP
 .RS
-\fB./iocccsize_test.sh -v 3\fP
+\fB./iocccsize_test.sh \-v 3\fP
 .fi
 .RE
 .SH EXIT STATUS

--- a/jnum_chk.8
+++ b/jnum_chk.8
@@ -1,4 +1,4 @@
-.TH jnum_chk 8 "17 October 2022" "jnum_chk" "IOCCC tools"
+.TH jnum_chk 8 "18 October 2022" "jnum_chk" "IOCCC tools"
 .SH NAME
 jnum_chk \- tool to check JSON number string conversions
 .SH SYNOPSIS
@@ -49,7 +49,7 @@ command line error
 internal error
 .SH NOTES
 .PP
-The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
+The JSON parser \fBjparse\fP was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .PP
 The strict mode will enable all tests and force the floating point checks to match fully.
 Specifically, if strict mode is disabled (the default) and the two numbers do not match but the difference is <= \fB1.0/MATCH_PRECISION\fP all is OK.
@@ -57,9 +57,9 @@ Otherwise there is an issue.
 The strict mode option \fB\-S\fP is for informational purposes only.
 If it fails on your system this is okay: the mkiocccentry repo does not need \fB\-S\fP to pass in order to be able to create a valid IOCCC entry compressed tarball.
 .SH BUGS
-If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
+If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjnum_gen(8)\fP.

--- a/jnum_gen.8
+++ b/jnum_gen.8
@@ -1,4 +1,4 @@
-.TH jnum_gen 8 "17 October 2022" "jnum_gen" "IOCCC tools"
+.TH jnum_gen 8 "18 October 2022" "jnum_gen" "IOCCC tools"
 .SH NAME
 jnum_gen \- generate JSON number string conversion test data
 .SH SYNOPSIS
@@ -38,15 +38,15 @@ command line error
 internal error
 .SH NOTES
 .PP
-The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
+The JSON parser \fBjparse\fP was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .PP
 This tool is needed in order to generate the test source file for the \fBjnum_chk(8)\fP tool which is needed to verify that the JSON number string conversion routines work as expected.
 The Makefile rule \fBrebuild_jnum_test\fP will create the file \fIjnum_test.c\fP via this tool.
 The tool \fBjnum_chk(8)\fP in turn will use the data in the \fIjnum_test.c\fP file to verify that the conversions work as expected.
 .SH BUGS
-If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
+If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjnum_chk(8)\fP.

--- a/jparse.1
+++ b/jparse.1
@@ -1,4 +1,4 @@
-.TH jparse 1 "16 October 2022" "jparse" "IOCCC tools"
+.TH jparse 1 "18 October 2022" "jparse" "IOCCC tools"
 .SH NAME
 jparse \- IOCCC JSON parser
 .SH SYNOPSIS
@@ -32,36 +32,36 @@ Parse argument as a string.
 Do not output a newline after parsing a string or file (def: do print a newline).
 .SH EXIT STATUS
 .PP
-\fB0\fP for success; different non-zero values for error conditions.
+\fB0\fP for success; different non\-zero values for error conditions.
 .SH NOTES
 .PP
 This JSON parser was written as a collaboration between Cody Boone Ferguson and Landon Curt Noll, one of the IOCCC Judges, to support \fBIOCCCMOCK\fP, \fBIOCCC28\fP and beyond.
 .PP
-For more detailed history that goes beyond this humble man page we recommend you check \fBjparse(1)\fP, \fBchkentry(1)\fP, \fBCHANGES.md\fP, \fBREADME.md\fP, the GitHub git log as well as reading the source code (or not :-) ).
+For more detailed history that goes beyond this humble man page we recommend you check \fBjparse(1)\fP, \fBchkentry(1)\fP, \fBCHANGES.md\fP, \fBREADME.md\fP, the GitHub git log as well as reading the source code (or not :\-) ).
 .PP
-We don't recommend you check the GitHub issue page! :-)
-This is because it's incredibly long with a lot of OT things and would take even the fastest readers a very long time to read. :-(
+We don't recommend you check the GitHub issue page! :\-)
+This is because it's incredibly long with a lot of OT things and would take even the fastest readers a very long time to read. :\-(
 .SH BUGS
 .PP
 Better error reporting and various other things need to be added.
 For example showing the file name and line number have to be added.
 .PP
-It's not yet fully re-entrant.
+It's not yet fully re\-entrant.
 .SH EXAMPLES
 .PP
 .nf
 Parse the JSON string \fB{ "test_mode" : false }\fP:
 .RS
 \fB
- ./jparse -s '{ "test_mode" : false }'\fP
+ ./jparse \-s '{ "test_mode" : false }'\fP
 .fi
 .RE
 .PP
 .nf
-Parse input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to parse):
+Parse input from \fBstdin\fP (send \fBEOF\fP, usually ctrl\-d or \fB^D\fP, to parse):
 .RS
 \fB
- ./jparse -
+ ./jparse \-
  []
  ^D\fP
 .fi
@@ -71,7 +71,7 @@ Parse input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to par
 Parse just a negative number:
 .RS
 \fB
- ./jparse -s -5\fP
+ ./jparse \-s \-5\fP
 .fi
 .RE
 .PP
@@ -87,7 +87,7 @@ Parse .info.json file:
 Run the \fBjparse_test.sh\fP script using the default \fIjson_teststr.txt\fP file with verbosity set at 5:
 .RS
 \fB
- ./jparse_test.sh -v 5\fP
+ ./jparse_test.sh \-v 5\fP
 .fi
 .RE
 .SH SEE ALSO

--- a/jparse_test.8
+++ b/jparse_test.8
@@ -1,6 +1,6 @@
-.TH jparse_test 8 "17 October 2022" "jparse_test" "IOCCC tools"
+.TH jparse_test 8 "18 October 2022" "jparse_test" "IOCCC tools"
 .SH NAME
-jparse_test.sh \- test jparse on one or more files with one or more one-line JSON blobs
+jparse_test.sh \- test jparse on one or more files with one or more one\-line JSON blobs
 .SH SYNOPSIS
 \fBjparse_test.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-J level] [\-q] [\-j jparse] [file ..]
 .SH DESCRIPTION
@@ -60,11 +60,11 @@ The log file kept by \fBjparse_test.sh\fP.
 It will be removed prior to each time the script is run to keep the state of the file consistent with the run.
 .RE
 .SH NOTES
-The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
+The JSON parser \fBjparse\fP was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .SH BUGS
-If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
+If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP.

--- a/json_parse.h
+++ b/json_parse.h
@@ -94,6 +94,8 @@ struct encode
  * and where {JSON_EXPONENT} is of the form:
  *
  *	[Ee][-+]?[0-9]+
+ *
+ * For more information see jparse.y and jparse.l.
  */
 struct json_number
 {

--- a/jstr_test.8
+++ b/jstr_test.8
@@ -1,4 +1,4 @@
-.TH jstr_test 8 "17 October 2022" "jstr_test" "IOCCC tools"
+.TH jstr_test 8 "18 October 2022" "jstr_test" "IOCCC tools"
 .SH NAME
 jstr_test.sh \- JSON string encoding and decoding tests
 .SH SYNOPSIS
@@ -59,11 +59,11 @@ In the script this file is the variable \fBTEST_FILE2\fP.
 When the script ends this file should be deleted but the script attempts to delete it, upon execution, in case it still exists or was created by some other process.
 .RE
 .SH NOTES
-The JSON parser \fBjparse\fP was co-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
+The JSON parser \fBjparse\fP was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .SH BUGS
-If you have a problem with the tool (not JSON itself! :-) ) you can report it at the GitHub issues page.
+If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH SEE ALSO
 \fBjparse(1)\fP, \fBjstrencode(1)\fP, \fBjstrdecode(1)\fP.

--- a/jstrdecode.1
+++ b/jstrdecode.1
@@ -1,4 +1,4 @@
-.TH jstrdecode 1 "17 October 2022" "jstrdecode" "IOCCC tools"
+.TH jstrdecode 1 "18 October 2022" "jstrdecode" "IOCCC tools"
 .SH NAME
 \fBjstrdecode\fP \- decode JSON encoded strings
 .SH SYNOPSIS
@@ -50,7 +50,7 @@ internal error
 .PP
 If you have an issue with the tool you can report it at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf
@@ -62,11 +62,11 @@ Decode the JSON string \fB{ "test_mode" : false }\fP:
 .RE
 .PP
 .nf
-Decode input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to decode):
+Decode input from \fBstdin\fP (send \fBEOF\fP, usually ctrl\-d or \fB^D\fP, to decode):
 .RS
 \fB
  ./jstrdecode
- -5
+ \-5
  ^D\fP
 .fi
 .RE
@@ -75,7 +75,7 @@ Decode input from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to de
 Decode just a negative number:
 .RS
 \fB
- ./jstrdecode -- -5\fP
+ ./jstrdecode \-\- \-5\fP
 .fi
 .RE
 .SH SEE ALSO

--- a/jstrencode.1
+++ b/jstrencode.1
@@ -1,4 +1,4 @@
-.TH jstrencode 1 "17 October 2022" "jstrencode" "IOCCC tools"
+.TH jstrencode 1 "18 October 2022" "jstrencode" "IOCCC tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -52,7 +52,7 @@ internal error
 .PP
 If you have an issue with the tool you can report it at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf
@@ -64,7 +64,7 @@ Encode the JSON string \fB{ "test_mode" : false }\fP:
 .RE
 .PP
 .nf
-Encode a string containing an escaped \fB"\fP from \fBstdin\fP (send \fBEOF\fP, usually ctrl-d or \fB^D\fP, to encode):
+Encode a string containing an escaped \fB"\fP from \fBstdin\fP (send \fBEOF\fP, usually ctrl\-d or \fB^D\fP, to encode):
 .RS
 \fB
  ./jstrencode
@@ -77,7 +77,7 @@ Encode a string containing an escaped \fB"\fP from \fBstdin\fP (send \fBEOF\fP, 
 Encode just a negative number:
 .RS
 \fB
- ./jstrencode -- -5\fP
+ ./jstrencode \-\- \-5\fP
 .fi
 .RE
 .SH SEE ALSO

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -1,4 +1,4 @@
-.TH mkiocccentry 1 "2 September 2022" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "18 October 2022" "mkiocccentry" "IOCCC tools"
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
@@ -75,7 +75,7 @@ Silence msg(), warn(), warnp() if verbosity level is 0.
 all is well
 .TQ
 2
-\-h and help string printed or -V and version string printed
+\-h and help string printed or \-V and version string printed
 .TQ
 3
 invalid command line, invalid option or option missing an argument
@@ -86,7 +86,7 @@ internal error
 .PP
 More than 0 humans work on it! :)
 .PP
-If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+If you have an issue with the tool you can open an issue at \fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf
@@ -104,7 +104,7 @@ Make \fIwork_dir\fP and then make an entry from the files \fIprog.c\fP, \fIMakef
 .RS
 \fB
  mkdir work_dir
- ./mkiocccentry -a answers work_dir prog.c Makefile remarks.md\fP
+ ./mkiocccentry \-a answers work_dir prog.c Makefile remarks.md\fP
 .fi
 .RE
 .PP
@@ -113,7 +113,7 @@ Use the answers file from the previous invocation to quickly update the entry wi
 
 .RS
 \fB
- ./mkiocccentry -i answers work_dir prog.c Makefile remarks.md data.txt\fP
+ ./mkiocccentry \-i answers work_dir prog.c Makefile remarks.md data.txt\fP
 .fi
 .RE
 .PP
@@ -122,6 +122,6 @@ Run program, specifying alternative path to \fBtar\fP and \fBtxzchk\fP:
 
 .RS
 \fB
- ./mkiocccentry -t /path/to/tar -T /path/to/txzchk\fP
+ ./mkiocccentry \-t /path/to/tar \-T /path/to/txzchk\fP
 .fi
 .RE

--- a/mkiocccentry_test.8
+++ b/mkiocccentry_test.8
@@ -1,10 +1,10 @@
-.TH mkiocccentry_test 8 "17 October 2022" "mkiocccentry_test" "IOCCC tools"
+.TH mkiocccentry_test.sh 8 "18 October 2022" "mkiocccentry_test" "IOCCC tools"
 .SH NAME
 mkiocccentry_test.sh \- run several invocations of \fBmkiocccentry(1)\fP to test that it functions well
 .SH SYNOPSIS
 \fBmkiocccentry_test.sh\fP [\-h] [\-V] [\-v level] [\-J level]
 .SH DESCRIPTION
-\fBmkiocccentry_test.sh\fP runs a series of invocations of \fBmkiocccentry\fP, testing various types of inputs including multiple authors some of which have non-ASCII characters in their name.
+\fBmkiocccentry_test.sh\fP runs a series of invocations of \fBmkiocccentry\fP, testing various types of inputs including multiple authors some of which have non\-ASCII characters in their name.
 .SH OPTIONS
 .TP
 \fB\-h\fP
@@ -30,7 +30,7 @@ all tests are OK
 Command line usage error
 .TQ
 >=10
-some make action exited non-zero
+some make action exited non\-zero
 .SH BUGS
 .PP
 This script does not let one set the path to the needed tools like the other scripts do and so requires that one is in the clone of the repo directory to successfully run this script.

--- a/run_bison.8
+++ b/run_bison.8
@@ -1,4 +1,4 @@
-.TH run_bison.sh 8 "17 October 2022" "run_bison.sh" "IOCCC tools"
+.TH run_bison.sh 8 "18 October 2022" "run_bison.sh" "IOCCC tools"
 .SH NAME
 run_bison.sh \- run
 .B bison
@@ -73,7 +73,7 @@ output files formed or backup files used instead
 .TQ
 1
 .B bison
-not found or too old and -o used
+not found or too old and \-o used
 .TQ
 2
 good
@@ -143,7 +143,7 @@ This should probably be fixed at some point.
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 Run \fBrun_bison.sh\fP with default options, which should attempt to run
@@ -163,7 +163,7 @@ cannot be found or fails for some reason.
 .nf
 .RS
 \fB
- ./run_bison.sh -o\fP
+ ./run_bison.sh \-o\fP
 .fi
 .RE
 .PP
@@ -173,7 +173,7 @@ on the file \fIfoobar.y\fP and don't use any backup files:
 .nf
 .RS
 \fB
- ./run_bison.sh -o -p foobar\fP
+ ./run_bison.sh \-o \-p foobar\fP
 .fi
 .RE
 .PP
@@ -185,6 +185,6 @@ and don't use any backup files:
 .nf
 .RS
 \fB
- ./run_bison.sh -o -p foobar -b yacc\fP
+ ./run_bison.sh \-o \-p foobar \-b yacc\fP
 .fi
 .RE

--- a/run_flex.8
+++ b/run_flex.8
@@ -1,4 +1,4 @@
-.TH run_flex.sh 8 "17 October 2022" "run_flex.sh" "IOCCC tools"
+.TH run_flex.sh 8 "18 October 2022" "run_flex.sh" "IOCCC tools"
 .SH NAME
 run_flex.sh \- run
 .B flex
@@ -145,7 +145,7 @@ This should probably be fixed at some point.
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 Run \fBrun_flex.sh\fP with default options, which should attempt to run
@@ -165,7 +165,7 @@ cannot be found or fails for some reason.
 .nf
 .RS
 \fB
- ./run_flex.sh -o\fP
+ ./run_flex.sh \-o\fP
 .fi
 .RE
 .PP
@@ -175,7 +175,7 @@ on the file \fIfoobar.l\fP and don't use any backup files:
 .nf
 .RS
 \fB
- ./run_flex.sh -o -p foobar\fP
+ ./run_flex.sh \-o \-p foobar\fP
 .fi
 .RE
 .PP
@@ -187,6 +187,6 @@ and don't use any backup files:
 .nf
 .RS
 \fB
- ./run_flex.sh -o -p foobar -f lex\fP
+ ./run_flex.sh \-o \-p foobar \-f lex\fP
 .fi
 .RE

--- a/run_usage.8
+++ b/run_usage.8
@@ -1,6 +1,6 @@
-.TH run_usage 8 "16 October 2022" "run_usage" "IOCCC tools"
+.TH run_usage 8 "18 October 2022" "run_usage" "IOCCC tools"
 .SH NAME
-run_usage \- run -h on a tool to extract usage information to help with checking man page \fBSYNOPSIS\fP \- tool usage consistency
+run_usage \- run \-h on a tool to extract usage information to help with checking man page \fBSYNOPSIS\fP \- tool usage consistency
 .SH SYNOPSIS
 \fBrun_usage.sh\fP [\-h] [\-V] [\-m section] [\-M man file] tool
 .SH DESCRIPTION
@@ -25,30 +25,37 @@ Default is 1.
 Specify the man page filename.
 This is useful when the name of the tool does not match what the man page should be (for example \fBrun_usage.sh\fP has \fBrun_usage.1\fP and not \fBrun_usage.sh.1\fP).
 .SH EXIT STATUS
-.PP
-.PP
-0	    all okay
-.br
-1	    help string printed
-.br
-2	    tool missing or command used missing
-.br
-3	    man page missing
-.br
-4	    command line usage error
-.br
-5	    missing or inconsistent synopsis
-.br
->=42	    some internal error occurred
+.TP
+0
+all okay
+.TQ
+1
+help string printed
+.TQ
+2
+tool missing or command used missing
+.TQ
+3
+man page missing
+.TQ
+4
+command line usage error
+.TQ
+5
+missing or inconsistent synopsis
+.TQ
+>=42
+some internal error occurred
 .SH NOTES
 .PP
 It has a \fBvery fixed\fP idea of what formatting is correct.
 As this can vary we don't try figuring it out.
 Fortunately the formatting of the \fBSYNOPSIS\fP in the man pages in the repo actually matches the script's idea of correct.
 In particular the tool was even used to generate the \fBSYNOPSIS\fP of this man page.
+However according to standards it is actually not quite correct and I (Cody) will at the end fix the SYNOPSIS of each man page to account for this.
 .PP
 If there's more than one usage string then the script only can detect the number of usage strings matched in the man page.
-In particular if at least one of the lines matches and there are the correct number of usages it will not report a problem because it checks for the number of matches via \fBgrep -c\fP and since it has a correct match it assumes that it's correct.
+In particular if at least one of the lines matches and there are the correct number of usages it will not report a problem because it checks for the number of matches via \fBgrep \-c\fP and since it has a correct match it assumes that it's correct.
 This is a necessary hack because not all greps allow for line crossing and even if they did it could be broken by the order in the file (or tool).
 To fix this would complicate the script more and it's not worth it because we still will visually inspect the man pages.
 .PP
@@ -80,6 +87,6 @@ Determine if the \fBSYNOPSIS\fP in this file is correct (according to the script
 
 .RS
 \fB
- ./run_usage.sh -M run_usage.1 run_usage.sh\fP
+ ./run_usage.sh \-M run_usage.1 run_usage.sh\fP
 .fi
 .RE

--- a/txzchk.1
+++ b/txzchk.1
@@ -1,4 +1,4 @@
-.TH txzchk 1 "17 October 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "18 October 2022" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
@@ -51,10 +51,10 @@ This is used in conjunction with \fb\-T\fP above for \fBTESTING\fP purposes only
 .SH EXIT STATUS
 .TP
 0
-no feathers stuck in tarball  :-)
+no feathers stuck in tarball  :\-)
 .TQ
 1
-tarball was successfully parsed :-) but there's at least one feather stuck in it  :-(
+tarball was successfully parsed :\-) but there's at least one feather stuck in it  :\-(
 .TQ
 2
 \-h and help string printed or \-V and version string printed
@@ -69,7 +69,7 @@ internal error has occurred or unknown tar listing format has been encountered
 This tool was written by \fBCody Boone Ferguson\fP for the \fBIOCCC Judges\fP in early 2022 for the \fBIOCCCMOCK\fP, \fBIOCCC28\fP and all future \fBIOCCC\fP competitions after discussing the requirements with \fBLandon Curt Noll\fP, one of the IOCCC Judges.
 For more history see \fBtxzchk(1)\fP, \fBCHANGES.md\fP, \fBREADME.md\fP, the GitHub git log and of course reading the source itself.
 .PP
-No pitman or coal mine was harmed in the making of this tool. :-)
+No pitman or coal mine was harmed in the making of this tool. :\-)
 More importantly, no tar pits \- including the \fBLa Brea Tar Pits\fP \- were disturbed in the making of this tool.
 .SH BUGS
 .PP
@@ -78,34 +78,34 @@ Cody Boone Ferguson wrote it! :)
 On a more serious note, if you have an issue with the tool please report it at the GitHub issues page.
 You can find it at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 If you would please mention \fB@xexyl\fP as part of the report that would be appreciated.
 .SH EXAMPLES
 .PP
 .nf
-Run the program on the tarball \fIentry.test-1.1644094311.txz\fP:
+Run the program on the tarball \fIentry.test\-1.1644094311.txz\fP:
 
 .RS
 \fB
- ./txzchk entry.test-1.1644094311.txz\fP
+ ./txzchk entry.test\-1.1644094311.txz\fP
 .fi
 .RE
 .PP
 .nf
-Run the program on the tarball \fIentry.test-1.1644094311.txz\fP, specifying an alternate path to \fBtar\fP and \fBfnamchk\fP:
+Run the program on the tarball \fIentry.test\-1.1644094311.txz\fP, specifying an alternate path to \fBtar\fP and \fBfnamchk\fP:
 
 .RS
 \fB
- ./txzchk -t /path/to/some/tar -F ./filenamechk entry.test-1.1644094311.txz\fP
+ ./txzchk \-t /path/to/some/tar \-F ./filenamechk entry.test\-1.1644094311.txz\fP
 .fi
 .RE
 .PP
 .nf
-Run the program on the file \fIentry.test-1.1644094311.txt\fP, specifying that it's a text file (which means \fB\-T\fP and \fB-E\fP have to be used):
+Run the program on the file \fIentry.test\-1.1644094311.txt\fP, specifying that it's a text file (which means \fB\-T\fP and \fB\-E\fP have to be used):
 
 .RS
 \fB
- ./txzchk -T -E txt entry.test-1.1644094311.txt\fP
+ ./txzchk \-T \-E txt entry.test\-1.1644094311.txt\fP
 .fi
 .RE
 .SH SEE ALSO

--- a/txzchk_test.8
+++ b/txzchk_test.8
@@ -1,10 +1,10 @@
-.TH txzchk_test 8 "17 October 2022" "txzchk_test" "IOCCC tools"
+.TH txzchk_test 8 "18 October 2022" "txzchk_test" "IOCCC tools"
 .SH NAME
 txzchk_test.sh \- test suite for \fBtxzchk(1)\fP
 .SH SYNOPSIS
 \fBtxzchk_test.sh\fP [\-h] [\-V] [\-v level] [\-t txzchk] [\-T tar] [\-F fnamchk] [\-d txzchk_tree]
 .SH DESCRIPTION
-\fBtxzchk_test.sh\fP runs \fBtxzchk\fP in text file mode on pseudo-tar listings to make sure that bad tarballs are flagged with issues and good tarballs are not.
+\fBtxzchk_test.sh\fP runs \fBtxzchk\fP in text file mode on pseudo\-tar listings to make sure that bad tarballs are flagged with issues and good tarballs are not.
 For the bad files it checks that the issues reported are the same as expected.
 The script enforces that bad files have an associated error file to compare with the errors reported by \fBtxzchk(1)\fP so that this can be done without a problem.
 If an error file is missing it is an error.
@@ -31,7 +31,7 @@ Specify path to \fBfnamchk\fP to \fIfnamchk\fP.
 \fBtxzchk\fP uses \fBfnamchk\fP to test if the tarball is validly named and if the files listed are in the correct directory.
 .TP
 \fB\-d \fItxzchk_tree\fP\fP
-Specify path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo-tarballs, to \fItxzchk_tree\fP.
+Specify path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo\-tarballs, to \fItxzchk_tree\fP.
 As already noted, the \fIbad\fP subdirectory also has error files to compare against the output of \fBtxzchk(1)\fP, in order to make sure that the failure is the correct failure.
 .SH EXIT STATUS
 .TP
@@ -52,7 +52,7 @@ internal error
 .SH FILES
 \fItest_txzchk\fP
 .RS
-Default directory of good and bad subdirectories each respectively with good and bad pseudo-tarballs.
+Default directory of good and bad subdirectories each respectively with good and bad pseudo\-tarballs.
 .RE
 \fItxzchk_test.log\fP
 .RS
@@ -69,7 +69,7 @@ When a new bad test file is added one has to update the error files. This can be
 .nf
 .RS
 \fB
-    for i in ./test_txzchk/bad/*.txt; do ./txzchk -q -v 0 -w -T -E txt "${i}" 2>"${i}".err; done\fP
+    for i in ./test_txzchk/bad/*.txt; do ./txzchk \-q \-v 0 \-w \-T \-E txt "${i}" 2>"${i}".err; done\fP
 .RE
 .fi
 .PP

--- a/utf8_test.8
+++ b/utf8_test.8
@@ -1,10 +1,10 @@
-.TH utf8_test 8 "7 October 2022" "utf8_test" "IOCCC tools"
+.TH utf8_test 8 "18 October 2022" "utf8_test" "IOCCC tools"
 .SH NAME
-utf8_test \- test translate UTF-8 chars into POSIX portable filename and +
+utf8_test \- test translate UTF\-8 chars into POSIX portable filename and +
 .SH SYNOPSIS
 \fButf8_test\fP [\-h] [\-v level] [\-V] [\-q] name ...
 .SH DESCRIPTION
-\fButf8_test\fP translates a UTF-8 string into a POSIX portable filename (allowing for char \fI+\fP as well: that is a plus sign, not a plus or minus sign).
+\fButf8_test\fP translates a UTF\-8 string into a POSIX portable filename (allowing for char \fI+\fP as well: that is a plus sign, not a plus or minus sign).
 .PP
 .SH OPTIONS
 .TP

--- a/verge.8
+++ b/verge.8
@@ -1,4 +1,4 @@
-.TH verge 8 "17 October 2022" "verge" "IOCCC tools"
+.TH verge 8 "18 October 2022" "verge" "IOCCC tools"
 .SH NAME
 verge \- determine if first version >= second version
 .SH SYNOPSIS
@@ -42,7 +42,7 @@ This tool is used in the \fBrun_flex.sh\fP and \fBrun_bison.sh\fP scripts to det
 .PP
 If you have an issue with the tool you can report it at
 .br
-\fI\<https://github.com/ioccc-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
 .SH EXAMPLES
 .PP
 .nf
@@ -50,7 +50,7 @@ Determine if first version, \fB1.1.3\fP, is > the second version, \fB1.1.4\fP:
 .RS
 \fB
  ./verge 1.1.3 1.1.4
- [[ $? -eq 0 ]] && echo 'first version, 1.1.3, is >= second version, 1.1.4'\fP
+ [[ $? \-eq 0 ]] && echo 'first version, 1.1.3, is >= second version, 1.1.4'\fP
 .fi
 .RE
 .PP
@@ -61,7 +61,7 @@ Determine if the first version, \fB1.1.3\fP, is < the second version, \fB1.1.4\f
 .RS
 \fB
  ./verge 1.1.3 1.1.4
- [[ $? -eq 1 ]] && echo 'first version, 1.1.3, is < second version, 1.1.4'\fP
+ [[ $? \-eq 1 ]] && echo 'first version, 1.1.3, is < second version, 1.1.4'\fP
 .fi
 .RE
 .PP

--- a/vermod.8
+++ b/vermod.8
@@ -1,4 +1,4 @@
-.TH vermod 8 "17 October 2022" "vermod" "IOCCC tools"
+.TH vermod 8 "18 October 2022" "vermod" "IOCCC tools"
 .SH NAME
 vermod \- modify version strings (and others) under ./test_JSON/
 .SH SYNOPSIS
@@ -48,7 +48,7 @@ This is useful with \fB\-n\fP to show what wouldn't change.
 all is well
 .TQ
 1
-\fBrpl\fP exited non-zero
+\fBrpl\fP exited non\-zero
 .TQ
 2
 \fBrpl\fP not found
@@ -71,7 +71,7 @@ no *.json files found under test directory
 8
 new_ver (or old_ver if \-o) not found in limit file
 .TQ
->= 10 
+>= 10
 internal error
 .SH FILES
 \fItest_JSON\fP
@@ -86,17 +86,17 @@ The tool \fBsed(1)\fP and various others could also be used to do this but this 
 .SH EXAMPLES
 .PP
 .nf
-After changing the version of \fBtxzchk\fP to \fB0.12 2022-09-2\fP from \fB0.11 2022-08-23\fP show what files would change:
+After changing the version of \fBtxzchk\fP to \fB0.12 2022\-09\-2\fP from \fB0.11 2022\-08\-23\fP show what files would change:
 .RS
 \fB
- ./vermod.sh -l -n '0.11 2022-08-23' '0.12 2022-09-22'\fP
+ ./vermod.sh \-l \-n '0.11 2022\-08\-23' '0.12 2022\-09\-22'\fP
 .RE
 .PP
 .nf
 After verifying that the above command is correct, run the script again to actually make the changes:
 .RS
 \fB
- ./vermod.sh  '0.11 2022-08-23' '0.12 2022-09-22'\fP
+ ./vermod.sh  '0.11 2022\-08\-23' '0.12 2022\-09\-22'\fP
 .RE
 .SH SEE ALSO
 \fBrpl(1)\fP


### PR DESCRIPTION
For the latter commit I also did this with the `dbg` repo. This is the commit log for this repo:

    Fix - to \- in man pages
    
    Because I could not think of a way at this hour with such poor sleep to
    do it directly I just removed \ before all '-'s and then added them back
    like:
    
        sed -i -e 's/\\-/-/g' -e 's/-/\\-/g' *.[138]
    
    I then updated the date of the man page. This was started because of a
    mkiocccentry commit ce061e0e160004d2de7d8e5fd145bcb79ab7eb48:
    
        Made -h, -V and other -option in man pages consistent
    
        We are NOT sure of this is the best way, but
        when a -option is mentioned in the EXIT STATUS section
        of the man page, we put a \ in front of it.
    
        Example:
    
        \-h and help string printed or \-V and version string printed
    
    That is indeed the correct way. I fix them as I notice them but this
    time I just did a mass replace as above.
    
    In all likelihood this will have to be done again but for now they're
    all correct.


Although I'm probably not going to be able to I'm going to try resting now. Maybe I can do more later on.