### PR TITLE
New version of bug_report.sh

### DIFF
--- a/jparse.l
+++ b/jparse.l
@@ -184,10 +184,10 @@ JSON_COMMA		","
 			     * without knowing what what the token actually is?
 			     * Thus we call it token so that it will read
 			     * literally as 'unexpected token' which removes any
-			     * ambiguity (it could be read as 'it's unexpected
-			     * in this place but it is valid in other contexts'
-			     * but it's never actually valid: it's a catch all
-			     * for anything that's not valid.
+			     * ambiguity (it could otherwise be read as 'it's
+			     * unexpected in this place but it is valid in other
+			     * contexts' but it's never actually valid: it's a
+			     * catch all for anything that's not valid).
 			     *
 			     * We also make use of yytext in yyerror()
 			     * which makes for a somewhat reasonable error

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -1088,10 +1088,10 @@ YY_RULE_SETUP
 			     * without knowing what what the token actually is?
 			     * Thus we call it token so that it will read
 			     * literally as 'unexpected token' which removes any
-			     * ambiguity (it could be read as 'it's unexpected
-			     * in this place but it is valid in other contexts'
-			     * but it's never actually valid: it's a catch all
-			     * for anything that's not valid.
+			     * ambiguity (it could otherwise be read as 'it's
+			     * unexpected in this place but it is valid in other
+			     * contexts' but it's never actually valid: it's a
+			     * catch all for anything that's not valid).
 			     *
 			     * We also make use of yytext in yyerror()
 			     * which makes for a somewhat reasonable error

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3,13 +3,13 @@
  *
  * Make an IOCCC compressed tarball for an IOCCC entry.
  *
- * We will form the IOCCC entry compressed tarball in C.
- * Not in some high level language, but standard vanilla C.
- * Why?  Because this is an obfuscated C contest.  But then why isn't
- * this code obfuscated?  Because the IOCCC judges prefer to write
- * in robust unobfuscated code.  Besides, the IOCCC was started
- * as an ironic commentary on the Bourne shell source and finger daemon
- * source.  Moreover, irony is well baked-in to the IOCCC.  :-)
+ * We will form the IOCCC entry compressed tarball "by hand" in C.
+ * Not in some high level language, but standard vanilla (with a healthy
+ * overdose of chocolate :-) ) C.  Why?  Because this is an obfuscated C
+ * contest.  But then why isn't this code obfuscated?  Because the IOCCC judges
+ * prefer to write in robust unobfuscated code.  Besides, the IOCCC was started
+ * as an ironic commentary on the Bourne shell source and finger daemon source.
+ * Moreover, irony is well baked-in to the IOCCC.  :-)
  *
  * OK, we do make use of shell scripts to help build and test
  * this repo: but who doesn't use a bit of shell scripting now and then?  :-)

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -4,12 +4,12 @@
  * Make an IOCCC compressed tarball for an IOCCC entry.
  *
  * We will form the IOCCC entry compressed tarball "by hand" in C.
- * Not in some high level language, but standard vanilla C.
- * Why?  Because this is an obfuscated C contest.  But then why isn't
- * this code obfuscated?  Because the IOCCC judges prefer to write
- * in robust unobfuscated code.  Besides, the IOCCC was started
- * as an ironic commentary on the Bourne shell source and finger daemon
- * source.  Moreover, irony is well baked-in to the IOCCC.  :-)
+ * Not in some high level language, but standard vanilla (with a healthy
+ * overdose of chocolate :-) ) C.  Why? Because this is an obfuscated C contest.
+ * But then why isn't this code obfuscated?  Because the IOCCC judges prefer to
+ * write in robust unobfuscated code.  Besides, the IOCCC was started as an
+ * ironic commentary on the Bourne shell source and finger daemon source.
+ * Moreover, irony is well baked-in to the IOCCC.  :-)
  *
  * If you do find a problem with this code, please let the judges know.
  * To contact the judges please see:

--- a/version.h
+++ b/version.h
@@ -4,12 +4,12 @@
  * Make an IOCCC compressed tarball for an IOCCC entry.
  *
  * We will form the IOCCC entry compressed tarball "by hand" in C.
- * Not in some high level language, but standard vanilla C.
- * Why?  Because this is an obfuscated C contest.  But then why isn't
- * this code obfuscated?  Because the IOCCC judges prefer to write
- * in robust unobfuscated code.  Besides, the IOCCC was started
- * as an ironic commentary on the Bourne shell source and finger daemon
- * source.  Moreover, irony is well baked-in to the IOCCC.  :-)
+ * Not in some high level language, but standard vanilla (with a healthy
+ * overdose of chocolate :-) ) C.  Why? Because this is an obfuscated C contest.
+ * But then why isn't this code obfuscated?  Because the IOCCC judges prefer to
+ * write in robust unobfuscated code.  Besides, the IOCCC was started as an
+ * ironic commentary on the Bourne shell source and finger daemon source.
+ * Moreover, irony is well baked-in to the IOCCC.  :-)
  *
  * If you do find a problem with this code, please let the judges know.
  * To contact the judges please see:


### PR DESCRIPTION
This is a big update which adds checks for all the tools we need as well as all the optional tools. This does which(1) on each tool but depending on if it's optional or not it will be reported differently if it's not found.

Add more thorough version checks as well. The comments in the script explain the process which I will repeat here but first an important point is that for some tools we do not try getting the version. For example echo supposedly has a --version option in linux but from quick tests it doesn't work and in macOS (and presumably BSD) it does not even have that option in the man page. Another example is cat because some options namely -v are valid and cat would block whether or not you consider -v harmful (as a certain person (in?)famously suggested (perhaps controversially and perhaps not) in USENIX Summer Conference Proceedings in 1983. Another example is 'yes' because trying `yes --version' would just repeatedly show --version on a line by itself as that's entirely the point of the command. What's worse with these is that since it's first redirected to stderr, only showing the output if it succeeds, it would appear to hang to the user.

As for what steps are taken for version it goes like this:

    # A question is how do to determine the version of a tool when there's no
    # universal option to get the version of _all_ tools (and in some tools we
    # cannot detect the version as it will block instead or in the case of echo or
    # yes just print the args).
    #
    # This is a good question and there's no guarantee we can obtain a version. In
    # that case we will report it as an unknown version. Nevertheless we go through
    # a series of steps as follows. First (step 0) we attempt to get the path to the
    # command and then we run the following on the path (if it appears to be a
    # built-in we cannot use the path of course).
    #
    #   1)  use --version (note: under macOS and BSD this will fail on several
    #       tools and in some tools it will fail under linux as well)
    #   2)  use -V (note: this might fail due to multiple reasons)
    #   3)  use -v (note: this might fail due to multiple reasons)
    #   4)  try what(1) (note: this is a macOS and seems available under some BSDs
    #       as well - but despite the man page saying it conforms to to IEEE Std
    #       1003.1-2001 ("POSIX.1") it is not available under linux)
    #   5)  try ident(1) (note: this appears to be a BSD command that's not
    #       available under macOS either)
    #   6)  try strings(1) with showing just the first 10 lines
    #
    # As soon as one of these returns a zero exit code (except for what(1) which is
    # described in the function below) we will stop. If we get through all steps
    # without any results we will mark it as an unknown version.  The first step to
    # succeed we will run a second time to record the output.
    #
    # Unfortunately this is far from perfect but we hope that it will help in a lot
    # of cases. A note about what(1) and ident(1) is that we will only check for it
    # once and if it does not exist we won't try it again. We also use the command
    # command -p in hopes to get the actual path. This also might not be perfect.
    #

As for optional tools it does not warn it is a problem except that run_bison.sh and run_flex.sh have to succeed as they use backup files if the tools cannot be used and not being able to use the backup tools would be a problem (the -o option is for the maintainers / developers of jparse - Landon and me).

For more details on optional tools missing and anything else read the comments. I added a lot for this purpose. Is bug_report.sh finished? I'm not sure. I think it's close to being finished but I'm not sure if it is or isn't finished entirely. Certainly hostchk.sh is not finished.