### PR TITLE
Typo fixes and rewording in man pages

### DIFF
--- a/iocccsize_test.8
+++ b/iocccsize_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH iocccsize_test.sh 8 "22 October 2022" "iocccsize_test" "IOCCC tools"
+.TH iocccsize_test.sh 8 "26 October 2022" "iocccsize_test" "IOCCC tools"
 .SH NAME
 iocccsize_test.sh \- test iocccsize tool
 .SH SYNOPSIS
@@ -34,16 +34,16 @@ A verbosity level of 3 or more will show details such as what was expected and w
 Print version and exit.
 .TP
 \fB\-i \fIiocccsize\fP\fP
-Specify path to iocccsize tool to \fIiocccsize\fP (def: ./iocccsize).
+Set iocccsize path to \fIiocccsize\fP (def: ./iocccsize).
 .TP
 \fB\-w \fIwork_dir\fP\fP
 Working directory that is removed and rebuilt during the test of the iocccsize tool (def: ./test_iocccsize).
 .TP
 \fB\-l\fP \fIlimit\fP
-Path to an executable shell script (def: ./limit_ioccc.sh).
+Path to an executable shell script with the correct specific limits extracted from various files (def: ./limit_ioccc.sh).
 .RS
 .PP
-A limit of \fI.\fP (dot) will disable use of a executable shell script.
+A limit of \fI.\fP (dot) will disable use of an executable shell script.
 .RE
 .SH EXAMPLES
 Run the \fRiocccsize\fP test suite in silent mode, printing only if a problem is discovered:

--- a/mkiocccentry.1
+++ b/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "22 October 2022" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "26 October 2022" "mkiocccentry" "IOCCC tools"
 .SH NAME
 mkiocccentry \- make an IOCCC compressed tarball for an IOCCC entry
 .SH SYNOPSIS
@@ -43,23 +43,23 @@ Set path to \fBtar\fP that accepts the \fB\-J\fP option to \fItar\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/tar\fP and \fI/bin/tar\fP if this option is not specified.
 .TP
 \fB\-c \fIcp\fP\fP
-Set path to \fBcp\fP to \fIcp\fP.
+Set \fBcp\fP path to \fIcp\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/cp\fP and \fI/bin/cp\fP if this option is not specified.
 .TP
 \fB\-l \fIls\fP\fP
-Set path to \fBls\fP to \fIls\fP.
+Set \fBls\fP path to \fIls\fP.
 \fBmkiocccentry\fP checks \fI/usr/bin/ls\fP and \fI/bin/ls\fP if this option is not specified.
 .TP
 \fB\-T \fItxzchk\fP\fP
-Set path to the \fBtxzchk\fP tool to \fItxzchk\fP.
+Set \fBtxzchk\fP path to \fItxzchk\fP.
 \fBmkiocccentry\fP checks \fI./txzchk\fP and \fI/usr/local/bin/txzchk\fP if this option is not specified.
 .TP
 \fB\-F \fIfnamchk\fP\fP
-Set path to the \fBfnamchk\fP tool to \fIfnamchk\fP.
+Set \fBfnamchk\fP path to \fIfnamchk\fP.
 \fBmkiocccentry\fP checks \fI./fnamchk\fP and \fI/usr/local/bin/fnamchk\fP if this option is not specified.
 .TP
 \fB\-C \fIchkentry\fP\fP
-Specify path to the \fBchkentry\fP tool to \fIchkentry\fP.
+Set \fBchkentry\fP path to \fIchkentry\fP.
 \fBmkiocccentry\fP checks \fI./chkentry\fP and \fI/usr/local/bin/chkentry\fP if this option is not specified.
 .TP
 \fB\-a \fIanswers\fP\fP

--- a/txzchk_test.8
+++ b/txzchk_test.8
@@ -26,7 +26,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH txzchk_test 8 "22 October 2022" "txzchk_test" "IOCCC tools"
+.TH txzchk_test 8 "26 October 2022" "txzchk_test" "IOCCC tools"
 .SH NAME
 txzchk_test.sh \- test suite for \fBtxzchk(1)\fP
 .SH SYNOPSIS
@@ -53,17 +53,17 @@ Print version and exit.
 Set verbosity level to \fIlevel\fP for the script.
 .TP
 \fB\-t \fItxzchk\fP\fP
-Specify path to \fBtxzchk\fP to \fItxzchk\fP.
+Set \fBtxzchk\fP path to \fItxzchk\fP.
 .TP
 \fB\-T \fItar\fP\fP
-Specify path to \fBtar\fP to \fItar\fP.
+Set \fBtar\fP path to \fItar\fP.
 .TP
 \fB\-F \fIfnamchk\fP\fP
-Specify path to \fBfnamchk\fP to \fIfnamchk\fP.
+Set \fBfnamchk\fP path to \fIfnamchk\fP.
 \fBtxzchk\fP uses \fBfnamchk\fP to test if the tarball is validly named and if the files listed are in the correct directory.
 .TP
 \fB\-d \fItxzchk_tree\fP\fP
-Specify path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo\-tarballs, to \fItxzchk_tree\fP.
+Set path to the directory with the expected subdirectories \fIgood\fP and \fIbad\fP, each containing text files of good and bad pseudo\-tarballs, to \fItxzchk_tree\fP.
 As already noted, the \fIbad\fP subdirectory also has error files to compare against the output of \fBtxzchk(1)\fP, in order to make sure that the failure is the correct failure.
 .SH EXIT STATUS
 .TP


### PR DESCRIPTION
I have tried to make some options a bit clearer and I fixed a typo as well.