### PR TITLE
New version of hostchk.sh + comments consistency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ verge.html
 oebxergfB.txt
 # bug report logs
 bug-report*.txt
+# hostchk.sh related glob
+hostchk/
 
 # Prerequisites
 *.d

--- a/chk.auth.head.c
+++ b/chk.auth.head.c
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk.auth.head.h
+++ b/chk.auth.head.h
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk.info.head.c
+++ b/chk.info.head.c
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk.info.head.h
+++ b/chk.info.head.h
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk_sem_auth.c
+++ b/chk_sem_auth.c
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk_sem_auth.h
+++ b/chk_sem_auth.h
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk_sem_info.c
+++ b/chk_sem_info.c
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/chk_sem_info.h
+++ b/chk_sem_info.h
@@ -3,6 +3,16 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
+ * This JSON parser was co-developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * The concept of this file was developed by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/hostchk.1
+++ b/hostchk.1
@@ -9,11 +9,11 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH hostchk.sh 1 "22 October 2022" "hostchk.sh" "IOCCC tools"
+.TH hostchk.sh 1 "27 October 2022" "hostchk.sh" "IOCCC tools"
 .SH NAME
 hostchk.sh \- run a series of checks on your system to help determine if you can correctly use the mkiocccentry toolkit
 .SH SYNOPSIS
-\fBhostchk.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-c cc] [\-f]
+\fBhostchk.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-c cc] [\-w work_dir] [\-f]
 .SH DESCRIPTION
 \fBhostchk.sh\fP runs a series of checks to determine if you will be able to create an acceptable IOCCC entry tarball.
 If any step fails we recommend you use the \fBbug_report(1)\fP script to create a log file for filing a bug.
@@ -33,6 +33,9 @@ Set verbosity level for the tests the script runs to \fIlevel\fP.
 .TP
 \fB\-c \fIcc\fP\fP
 Set path to the compiler (cc) to \fIcc\fP.
+.TP
+\fB\-w \fIwork_dir\fP\fP
+Change work directory to\fIwork_dir\fP.
 .TP
 \fB\-f\fP
 Fast compile mode.

--- a/hostchk.sh
+++ b/hostchk.sh
@@ -274,6 +274,55 @@ fi
 
 # now make and test compile and run some C files
 
+# compile_test	- compile test source file, checking that an executable was
+#		  created
+#
+# usage:
+#	compile exit_code source output
+#
+#	exit_code   - new exit code of rule fails
+#	source	    - source file
+#	output	    - output file of compiler
+#
+compile_test() {
+
+    # parse args
+    #
+    if [[ $# -ne 3 ]]; then
+	echo "$0: ERROR: function expects 3 args, found $#" 1>&2
+	return 1
+    fi
+    local CODE="$1"
+    local SOURCE="$2"
+    local OUTPUT="$3"
+
+    if [[ ! -e "$SOURCE" ]]; then
+	echo "$0: ERROR: source code does not exist: $SOURCE: new exit code: $CODE" 1>&2
+	EXIT_CODE="$CODE"
+	return 1
+    fi
+
+    if [[ ! -r "$SOURCE" ]]; then
+	echo "$0: ERROR: source file not readable: $SOURCE: new exit code: $CODE" 1>&2
+	EXIT_CODE="$CODE"
+	return 1
+    fi
+
+    $CC -o "$OUTPUT" "$SOURCE"
+    if [[ ! -e "$OUTPUT" ]]; then
+	echo "$0: ERROR: could not create executable from $SOURCE: new exit code: $CODE" 1>&2
+	EXIT_CODE="$CODE"
+	return 1
+    fi
+    if [[ ! -x "$WORK_FILE" ]]; then
+	echo "$0: ERROR: could not create executable from $SOURCE: new exit code: $CODE" 1>&2
+	EXIT_CODE="$CODE"
+    fi
+
+    return 0
+}
+
+
 # pre-errno test: get value of ENOENT
 if [[ $V_FLAG -gt 1 ]]; then
     echo "$0: creating source that should print the value of ENOENT" 1>&2
@@ -290,20 +339,12 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/pre-errno"
-$CC -o "$WORK_FILE" "$WORK_DIR/pre-errno.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno set up file"
-    exit 46
+if compile_test 46 "$WORK_DIR/pre-errno.c" "$WORK_FILE"; then
+    ENOENT=$("$WORK_FILE")
+    if [[ $V_FLAG -gt 1 ]]; then
+	echo "$0: got: ENOENT == $ENOENT" 1>&2
+    fi
 fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno set up file"
-    exit 47
-fi
-ENOENT=$("$WORK_FILE")
-if [[ $V_FLAG -gt 1 ]]; then
-    echo "$0: got: ENOENT == $ENOENT" 1>&2
-fi
-
 # errno test 0: test printf of errno == ENOENT. If program does not print:
 #
 #   errno: $ENOENT
@@ -326,21 +367,14 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/errno0"
-$CC -o "$WORK_FILE" "$WORK_DIR/errno0.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno0"
-    exit 48
-fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno0"
-    exit 49
-fi
-if ! "$WORK_FILE" | grep -q "errno: $ENOENT"; then
-    # XXX should we not use -q to grep so we can print the actual value?
-    echo "$0: ERROR: inconsistent ENOENT value: did not get: "errno: $ENOENT"" 1>&2
-    exit 50
-elif [[ $V_FLAG -gt 1 ]]; then
-    echo "$0: got: errno: $ENOENT" 1>&2
+if compile_test 47 "$WORK_DIR/errno0.c" "$WORK_FILE"; then
+    if ! "$WORK_FILE" | grep -q "errno: $ENOENT"; then
+	# XXX should we not use -q to grep so we can print the actual value?
+	EXIT_CODE=48
+	echo "$0: ERROR: inconsistent ENOENT value: did not get: \"errno: $ENOENT\": new exit code: $EXIT_CODE" 1>&2
+    elif [[ $V_FLAG -gt 1 ]]; then
+	echo "$0: got: errno: $ENOENT" 1>&2
+    fi
 fi
 
 # errno1: create source file that when compiled should return 1 (errno is set to
@@ -359,23 +393,15 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/errno1"
-$CC -o "$WORK_FILE" "$WORK_DIR/errno1.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno1" 1>&2
-    exit 51
-fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable errno1" 1>&2
-    exit 52
-fi
-
-"$WORK_FILE"
-status=$?
-if [[ "$status" -ne 1 ]] ; then
-    echo "$0: ERROR: errno != ENOENT" 1>&2
-    exit 53
-elif [[ "$V_FLAG" -gt 1 ]]; then
-    echo "$0: got return value 1: errno == ENOENT"
+if compile_test 49 "$WORK_DIR/errno1.c" "$WORK_FILE"; then
+    "$WORK_FILE"
+    status=$?
+    if [[ "$status" -ne 1 ]] ; then
+	EXIT_CODE=50
+	echo "$0: ERROR: errno != ENOENT: new exit code: $EXIT_CODE" 1>&2
+    elif [[ "$V_FLAG" -gt 1 ]]; then
+	echo "$0: got return value 1: errno == ENOENT"
+    fi
 fi
 
 # hello.c: print "Hello, world".
@@ -392,20 +418,13 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/hello"
-$CC -o "$WORK_FILE" "$WORK_DIR/hello.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable hello" 1>&2
-    exit 54
-fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable hello" 1>&2
-    exit 55
-fi
-if ! "$WORK_FILE" | grep -q "Hello, world"; then
-    echo "$0: ERROR: expected string "Hello, world" not found" 1>&2
-    exit 56
-elif [[ "$V_FLAG" -gt 1 ]]; then
-    echo "$0: got: "Hello, world"" 1>&2
+if compile_test 51 "$WORK_DIR/hello.c" "$WORK_FILE"; then
+    if ! "$WORK_FILE" | grep -q "Hello, world"; then
+	EXIT_CODE=52
+	echo "$0: ERROR: expected string "Hello, world" not found: new exit code: $EXIT_CODE" 1>&2
+    elif [[ "$V_FLAG" -gt 1 ]]; then
+	echo "$0: got: "Hello, world"" 1>&2
+    fi
 fi
 
 # main0: create source file that should return 0
@@ -420,20 +439,13 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/main0"
-$CC -o "$WORK_FILE" "$WORK_DIR/main0.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable main0" 1>&2
-    exit 57
-fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable main0" 1>&2
-    exit 58
-fi
-if ! "$WORK_FILE"; then
-    echo "$0: ERROR: expected return value 0 not returned: got $?" 1>&2
-    exit 59
-elif [[ "$V_FLAG" -gt 1 ]]; then
-    echo "$0: got return value 0" 1>&2
+if compile_test 52 "$WORK_DIR/main0.c" "$WORK_FILE"; then
+    if ! "$WORK_FILE"; then
+	EXIT_CODE=53
+	echo "$0: ERROR: expected return value 0 not returned: got $?: new exit code: $EXIT_CODE" 1>&2
+    elif [[ "$V_FLAG" -gt 1 ]]; then
+	echo "$0: got return value 0" 1>&2
+    fi
 fi
 
 
@@ -449,20 +461,13 @@ main(void)
 }
 EOF
 WORK_FILE="$WORK_DIR/main1"
-$CC -o "$WORK_FILE" "$WORK_DIR/main1.c"
-if [[ ! -e "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable main1" 1>&2
-    exit 60
-fi
-if [[ ! -x "$WORK_FILE" ]]; then
-    echo "$0: ERROR: could not create executable main1" 1>&2
-    exit 61
-fi
-if "$WORK_FILE"; then
-    echo "$0: ERROR: expected return value 1 not returned: got $?" 1>&2
-    exit 62
-elif [[ "$V_FLAG" -gt 1 ]]; then
-    echo "$0: got return value 1" 1>&2
+if compile_test 54 "$WORK_DIR/main1.c" "$WORK_FILE"; then
+    if "$WORK_FILE"; then
+	EXIT_CODE=55
+	echo "$0: ERROR: expected return value 1 not returned: got $?: new exit code: $EXIT_CODE" 1>&2
+    elif [[ "$V_FLAG" -gt 1 ]]; then
+	echo "$0: got return value 1" 1>&2
+    fi
 fi
 
 # remove work directory

--- a/hostchk.sh
+++ b/hostchk.sh
@@ -70,14 +70,16 @@ if [[ -z "$CC" ]]; then
     CC="/usr/bin/cc"
 fi
 
-export HOSTCHK_VERSION="0.2 2022-10-12"
-export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-f]
+export WORK_DIR="./hostchk"
+export HOSTCHK_VERSION="0.3 2022-10-27"
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w work_dir] [-f]
 
     -h			    print help and exit
     -V			    print version and exit
     -v level		    set verbosity level for this script: (def level: 0)
     -D dbg_level	    set verbosity level for tests (def: level: 0)
     -c cc		    path to compiler (def: $CC)
+    -w work_dir		    change work directory (def: $WORK_DIR)
     -f			    faster check (def: run slower for better diagnostics)
 
 Exit codes:
@@ -96,7 +98,7 @@ export EXIT_CODE=0
 export V_FLAG="0"
 export DBG_LEVEL="0"
 export F_FLAG=
-while getopts :hv:VD:c:f flag; do
+while getopts :hv:VD:c:w:f flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -109,6 +111,8 @@ while getopts :hv:VD:c:f flag; do
     D)	DBG_LEVEL="$OPTARG";
 	;;
     c)	CC="$OPTARG";
+	;;
+    w)	WORK_DIR="$OPTARG";
 	;;
     f)	F_FLAG="true";
 	;;
@@ -129,16 +133,32 @@ done
 #
 if [[ ! -e $CC ]]; then
     echo "$0: ERROR: cc not found: $CC" 1>&2
-    exit 4
+    exit 10
 fi
 if [[ ! -f $CC ]]; then
     echo "$0: ERROR: cc not a regular file: $CC" 1>&2
-    exit 4
+    exit 10
 fi
 if [[ ! -x $CC ]]; then
     echo "$0: ERROR: cc not executable: $CC" 1>&2
-    exit 4
+    exit 10
 fi
+
+# create an empty working directory
+#
+rm -rf  "$WORK_DIR"
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: rm -rf $WORK_DIR failed, error code: $status" 1>&2
+    exit 11
+fi
+mkdir -p "$WORK_DIR"
+status="$?"
+if [[ $status -ne 0 ]]; then
+    echo "$0: ERROR: mkdir -p $WORK_DIR failed, error code: $status" 1>&2
+    exit 11
+fi
+
 
 # set up for compile test
 #
@@ -147,12 +167,13 @@ RUN_INCLUDE_TEST="true"
 PROG_FILE=$(mktemp -u .hostchk.prog.XXXXXXXXXX)
 status="$?"
 if [[ $status -ne 0 ]]; then
-    echo "$0: ERROR: mktemp -u $PROG_FILE exit code: $status" 1>&2
     EXIT_CODE=41
+    echo "$0: ERROR: mktemp -u $PROG_FILE exit code: $status: new exit code: $EXIT_CODE" 1>&2
     RUN_INCLUDE_TEST=
 fi
 
-trap "rm -f \$PROG_FILE; exit" 1 2 3 15
+# trap to remove prog and also work directory
+trap "rm -rf \$PROG_FILE \$WORK_DIR; exit" 1 2 3 15
 
 # Previously, -f was so fast it did absolutely nothing! :-)
 #
@@ -173,15 +194,15 @@ if [[ -n "$F_FLAG" ]]; then
     #
     status="$?"
     if [[ $status -ne 0 ]]; then
-	echo "$0: ERROR: unable to compile test file with all necessary system include files $h" 1>&2
 	EXIT_CODE=42
+	echo "$0: ERROR: unable to compile test file with all necessary system include files $h: new exit code: $EXIT_CODE" 1>&2
 	INCLUDE_TEST_SUCCESS="false"
     elif [[ -s "$PROG_FILE" && -x "$PROG_FILE" ]]; then
 	./"$PROG_FILE"
 	status="$?"
 	if [[ $status -ne 0 ]]; then
-	    echo "$0: ERROR: unable to run executable compiled with all necessary system include files" 1>&2
 	    EXIT_CODE=43
+	    echo "$0: ERROR: unable to run executable compiled with all necessary system include files: new exit code: $EXIT_CODE" 1>&2
 	    INCLUDE_TEST_SUCCESS="false"
 	else
 	    if [[ $V_FLAG -gt 1 ]]; then
@@ -189,8 +210,8 @@ if [[ -n "$F_FLAG" ]]; then
 	    fi
 	fi
     else
-	echo "$0: ERROR: unable to form an executable compiled using all necessary system include files" 1>&2
 	EXIT_CODE=44
+	echo "$0: ERROR: unable to form an executable compiled using all necessary system include files: new exit code: $EXIT_CODE" 1>&2
 	INCLUDE_TEST_SUCCESS="false"
     fi
 
@@ -219,15 +240,15 @@ else
 	    #
 	    status="$?"
 	    if [[ $status -ne 0 ]]; then
-		echo "$0: ERROR: unable to compile with $h" 1>&2
 		EXIT_CODE=42
+		echo "$0: ERROR: unable to compile with $h: new exit code: $EXIT_CODE" 1>&2
 		INCLUDE_TEST_SUCCESS="false"
 	    elif [[ -s "$PROG_FILE" && -x "$PROG_FILE" ]]; then
 		./"$PROG_FILE"
 		status="$?"
 		if [[ $status -ne 0 ]]; then
-		    echo "$0: ERROR: unable to run executable compiled using: $h" 1>&2
 		    EXIT_CODE=43
+		    echo "$0: ERROR: unable to run executable compiled using: $h: new exit code: $EXIT_CODE" 1>&2
 		    INCLUDE_TEST_SUCCESS="false"
 		else
 		    if [[ $V_FLAG -gt 1 ]]; then
@@ -235,8 +256,8 @@ else
 		    fi
 		fi
 	    else
-		echo "$0: ERROR: unable to form an executable compiled using: $h" 1>&2
 		EXIT_CODE=44
+		echo "$0: ERROR: unable to form an executable compiled using: $h: new exit code: $EXIT_CODE" 1>&2
 		INCLUDE_TEST_SUCCESS="false"
 	    fi
 
@@ -245,11 +266,207 @@ else
 	    rm -f "$PROG_FILE"
 	done < <(grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u)
     else
-	echo "$0: notice: include test disabled due to test set up error(s)" 1>&2
 	EXIT_CODE=45
+	echo "$0: notice: include test disabled due to test set up error(s): new exit code: $EXIT_CODE" 1>&2
 	INCLUDE_TEST_SUCCESS="false"
     fi
 fi
+
+# now make and test compile and run some C files
+
+# pre-errno test: get value of ENOENT
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should print the value of ENOENT" 1>&2
+fi
+cat <<EOF>"$WORK_DIR/pre-errno.c"
+#include <errno.h>
+#include <stdio.h>
+int
+main(void)
+{
+    printf("%d", ENOENT);
+
+    return 0;
+}
+EOF
+WORK_FILE="$WORK_DIR/pre-errno"
+$CC -o "$WORK_FILE" "$WORK_DIR/pre-errno.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno set up file"
+    exit 46
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno set up file"
+    exit 47
+fi
+ENOENT=$("$WORK_FILE")
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: got: ENOENT == $ENOENT" 1>&2
+fi
+
+# errno test 0: test printf of errno == ENOENT. If program does not print:
+#
+#   errno: $ENOENT
+#
+# where $ENOENT was obtained above then there's an inconsistency with the errno
+# value.
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should print: errno: $ENOENT" 1>&2
+fi
+cat <<EOF>"$WORK_DIR/errno0.c"
+#include <errno.h>
+#include <stdio.h>
+int
+main(void)
+{
+    errno = ENOENT;
+
+    (void) printf("errno: %d\n", errno);
+    return 0;
+}
+EOF
+WORK_FILE="$WORK_DIR/errno0"
+$CC -o "$WORK_FILE" "$WORK_DIR/errno0.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno0"
+    exit 48
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno0"
+    exit 49
+fi
+if ! "$WORK_FILE" | grep -q "errno: $ENOENT"; then
+    # XXX should we not use -q to grep so we can print the actual value?
+    echo "$0: ERROR: inconsistent ENOENT value: did not get: "errno: $ENOENT"" 1>&2
+    exit 50
+elif [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: got: errno: $ENOENT" 1>&2
+fi
+
+# errno1: create source file that when compiled should return 1 (errno is set to
+# ENOENT so errno == ENOENT should be 1)
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should verify errno == $ENOENT, returning 1" 1>&2
+fi
+cat<<EOF>"$WORK_DIR/errno1.c"
+#include <errno.h>
+int
+main(void)
+{
+    errno = ENOENT;
+
+    return errno == ENOENT;
+}
+EOF
+WORK_FILE="$WORK_DIR/errno1"
+$CC -o "$WORK_FILE" "$WORK_DIR/errno1.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno1" 1>&2
+    exit 51
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable errno1" 1>&2
+    exit 52
+fi
+
+"$WORK_FILE"
+status=$?
+if [[ "$status" -ne 1 ]] ; then
+    echo "$0: ERROR: errno != ENOENT" 1>&2
+    exit 53
+elif [[ "$V_FLAG" -gt 1 ]]; then
+    echo "$0: got return value 1: errno == ENOENT"
+fi
+
+# hello.c: print "Hello, world".
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should print: "Hello, world"" 1>&2
+fi
+cat <<EOF>"$WORK_DIR/hello.c"
+#include <stdio.h>
+int
+main(void)
+{
+    (void) printf("Hello, world\n");
+    return 0;
+}
+EOF
+WORK_FILE="$WORK_DIR/hello"
+$CC -o "$WORK_FILE" "$WORK_DIR/hello.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable hello" 1>&2
+    exit 54
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable hello" 1>&2
+    exit 55
+fi
+if ! "$WORK_FILE" | grep -q "Hello, world"; then
+    echo "$0: ERROR: expected string "Hello, world" not found" 1>&2
+    exit 56
+elif [[ "$V_FLAG" -gt 1 ]]; then
+    echo "$0: got: "Hello, world"" 1>&2
+fi
+
+# main0: create source file that should return 0
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should simply return 0" 1>&2
+fi
+cat <<EOF>"$WORK_DIR/main0.c"
+int
+main(void)
+{
+    return 0;
+}
+EOF
+WORK_FILE="$WORK_DIR/main0"
+$CC -o "$WORK_FILE" "$WORK_DIR/main0.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable main0" 1>&2
+    exit 57
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable main0" 1>&2
+    exit 58
+fi
+if ! "$WORK_FILE"; then
+    echo "$0: ERROR: expected return value 0 not returned: got $?" 1>&2
+    exit 59
+elif [[ "$V_FLAG" -gt 1 ]]; then
+    echo "$0: got return value 0" 1>&2
+fi
+
+
+# main1: create source file that should return 1
+if [[ $V_FLAG -gt 1 ]]; then
+    echo "$0: creating source that should simply return 1" 1>&2
+fi
+cat <<EOF>"$WORK_DIR/main1.c"
+int
+main(void)
+{
+    return 1;
+}
+EOF
+WORK_FILE="$WORK_DIR/main1"
+$CC -o "$WORK_FILE" "$WORK_DIR/main1.c"
+if [[ ! -e "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable main1" 1>&2
+    exit 60
+fi
+if [[ ! -x "$WORK_FILE" ]]; then
+    echo "$0: ERROR: could not create executable main1" 1>&2
+    exit 61
+fi
+if "$WORK_FILE"; then
+    echo "$0: ERROR: expected return value 1 not returned: got $?" 1>&2
+    exit 62
+elif [[ "$V_FLAG" -gt 1 ]]; then
+    echo "$0: got return value 1" 1>&2
+fi
+
+# remove work directory
+rm -rf "$WORK_DIR"
 
 # All Done!!! -- Jessica Noll, Age 2
 #

--- a/verge.c
+++ b/verge.c
@@ -5,25 +5,15 @@
  *
  * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ * This JSON parser was co-developed by:
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/verge.h
+++ b/verge.h
@@ -5,25 +5,15 @@
  *
  * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ * This JSON parser was co-developed by:
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)


### PR DESCRIPTION
Added test source files that must return specific values (and in the case of one print a certain string).

It's not modular yet. Whether this should be done or not I don't know. One benefit from that might be that we be that it would be easier to run all of these tests even if one fails. Currently when one fails no further tests are run.

There are several kinds of tests. First we obtain the value of ENOENT and then verify that setting errno = ENOENT will indeed be the value previously obtained. We then check for the string: "errno: $ENOENT" (whatever ENOENT might be: keep it in a variable for consistency check but also in case some system has a different value). We also print "Hello, world" and check that that was indeed printed. There are checks for return values 1 and 0 and maybe another one or two I've forgotten.

I'm not sure if this is all that needs to be done but it might be (other than possibly making it modular).

Updated .gitignore: added hostchk/. Even though I explicitly remove it when the script finishes and also via trap it's now in the .gitignore just in case something goes wrong.