### PR TITLE
Change cnt -> count

### DIFF
--- a/chkentry.c
+++ b/chkentry.c
@@ -247,23 +247,23 @@ main(int argc, char *argv[])
     struct json *auth_tree = NULL;	/* JSON parse tree for .author.json, or NULL ==> not parsed */
     bool info_valid = false;		/* .info.json is valid JSON */
     bool auth_valid = false;		/* .author.json is valid JSON */
-    struct dyn_array *info_cnt_err = NULL;	/* JSON semantic count errors for .info.json */
+    struct dyn_array *info_count_err = NULL;	/* JSON semantic count errors for .info.json */
     struct dyn_array *info_val_err = NULL;	/* JSON semantic validation errors for .info.json */
-    struct dyn_array *auth_cnt_err = NULL;	/* JSON semantic count errors for .author.json */
+    struct dyn_array *auth_count_err = NULL;	/* JSON semantic count errors for .author.json */
     struct dyn_array *auth_val_err = NULL;	/* JSON semantic validation errors for .author.json */
-    uintmax_t info_cnt_err_cnt = 0;	/* semantic count error count from json_sem_check() for .info.json */
-    uintmax_t info_val_err_cnt = 0;	/* semantic validation error count from json_sem_check() for .info.json */
-    uintmax_t info_int_err_cnt = 0;	/* internal error count from json_sem_check() for .info.json */
-    uintmax_t info_all_err_cnt = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .info.json */
-    uintmax_t auth_cnt_err_cnt = 0;	/* semantic count error count from json_sem_check() for .author.json */
-    uintmax_t auth_val_err_cnt = 0;	/* semantic validation count from json_sem_check() for .author.json */
-    uintmax_t auth_int_err_cnt = 0;	/* internal error count from json_sem_check() for .author.json */
-    uintmax_t auth_all_err_cnt = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .author.json */
-    uintmax_t all_cnt_err_cnt = 0;	/* semantic count error count from json_sem_check() for .author.json */
-    uintmax_t all_val_err_cnt = 0;	/* semantic validation error count from json_sem_check() for .author.json */
-    uintmax_t all_int_err_cnt = 0;	/* internal error count from json_sem_check() for .author.json */
-    uintmax_t all_all_err_cnt = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .author.json */
-    struct json_sem_cnt_err *sem_cnt_err = NULL;	/* semantic count error to print */
+    uintmax_t info_count_err_count = 0;	/* semantic count error count from json_sem_check() for .info.json */
+    uintmax_t info_val_err_count = 0;	/* semantic validation error count from json_sem_check() for .info.json */
+    uintmax_t info_int_err_count = 0;	/* internal error count from json_sem_check() for .info.json */
+    uintmax_t info_all_err_count = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .info.json */
+    uintmax_t auth_count_err_count = 0;	/* semantic count error count from json_sem_check() for .author.json */
+    uintmax_t auth_val_err_count = 0;	/* semantic validation count from json_sem_check() for .author.json */
+    uintmax_t auth_int_err_count = 0;	/* internal error count from json_sem_check() for .author.json */
+    uintmax_t auth_all_err_count = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .author.json */
+    uintmax_t all_count_err_count = 0;	/* semantic count error count from json_sem_check() for .author.json */
+    uintmax_t all_val_err_count = 0;	/* semantic validation error count from json_sem_check() for .author.json */
+    uintmax_t all_int_err_count = 0;	/* internal error count from json_sem_check() for .author.json */
+    uintmax_t all_all_err_count = 0;	/* number of errors (count+validation+internal) from json_sem_check() for .author.json */
+    struct json_sem_count_err *sem_count_err = NULL;	/* semantic count error to print */
     struct json_sem_val_err *sem_val_err = NULL;	/* semantic validation error to print */
     uintmax_t i;			/* dynamic array index */
     int c;
@@ -455,23 +455,23 @@ main(int argc, char *argv[])
 	 * perform JSON semantic analysis on the .info.json JSON parse tree
 	 */
 	dbg(DBG_HIGH, "about to perform JSON semantic check for .info.json file: %s", info_path);
-	info_all_err_cnt = json_sem_check(info_tree, JSON_DEFAULT_MAX_DEPTH, sem_info,
-					  &info_cnt_err, &info_val_err);
+	info_all_err_count = json_sem_check(info_tree, JSON_DEFAULT_MAX_DEPTH, sem_info,
+					  &info_count_err, &info_val_err);
 
 	/*
 	 * firewall on json_sem_check() results AND count errors for .info.json
 	 */
-	if (info_cnt_err == NULL) {
-	    err(31, __func__, "json_sem_check() left info_cnt_err as NULL for .info.json file: %s", info_path);
+	if (info_count_err == NULL) {
+	    err(31, __func__, "json_sem_check() left info_count_err as NULL for .info.json file: %s", info_path);
 	    not_reached();
 	}
-	if (dyn_array_tell(info_cnt_err) < 0) {
-	    err(32, __func__, "dyn_array_tell(info_cnt_err): %jd < 0 "
+	if (dyn_array_tell(info_count_err) < 0) {
+	    err(32, __func__, "dyn_array_tell(info_count_err): %jd < 0 "
 		   "for .info.json file: %s",
-		   dyn_array_tell(info_cnt_err), info_path);
+		   dyn_array_tell(info_count_err), info_path);
 	    not_reached();
 	}
-	info_cnt_err_cnt = (uintmax_t) dyn_array_tell(info_cnt_err);
+	info_count_err_count = (uintmax_t) dyn_array_tell(info_count_err);
 	if (info_val_err == NULL) {
 	    err(33, __func__, "json_sem_check() left info_val_err as NULL for .info.json file: %s", info_path);
 	    not_reached();
@@ -482,14 +482,14 @@ main(int argc, char *argv[])
 		   dyn_array_tell(info_val_err), info_path);
 	    not_reached();
 	}
-	info_val_err_cnt = (uintmax_t) dyn_array_tell(info_val_err);
-	if (info_all_err_cnt < info_cnt_err_cnt+info_val_err_cnt) {
-	    err(35, __func__, "info_all_err_cnt: %ju < info_cnt_err_cnt: %ju + info_val_err_cnt: %ju "
+	info_val_err_count = (uintmax_t) dyn_array_tell(info_val_err);
+	if (info_all_err_count < info_count_err_count+info_val_err_count) {
+	    err(35, __func__, "info_all_err_count: %ju < info_count_err_count: %ju + info_val_err_count: %ju "
 		   "for .info.json file: %s",
-		   info_all_err_cnt, info_cnt_err_cnt, info_val_err_cnt, info_path);
+		   info_all_err_count, info_count_err_count, info_val_err_count, info_path);
 	    not_reached();
 	}
-	info_int_err_cnt = info_all_err_cnt - (info_cnt_err_cnt+info_val_err_cnt);
+	info_int_err_count = info_all_err_count - (info_count_err_count+info_val_err_count);
     }
 
     /*
@@ -501,22 +501,22 @@ main(int argc, char *argv[])
 	 * perform JSON semantic analysis on the .author.json JSON parse tree
 	 */
 	dbg(DBG_HIGH, "about to perform JSON semantic check for .author.json file: %s", auth_path);
-	auth_all_err_cnt = json_sem_check(auth_tree, JSON_DEFAULT_MAX_DEPTH, sem_auth,
-					  &auth_cnt_err, &auth_val_err);
+	auth_all_err_count = json_sem_check(auth_tree, JSON_DEFAULT_MAX_DEPTH, sem_auth,
+					  &auth_count_err, &auth_val_err);
 
 	/*
 	 * firewall on json_sem_check() results AND count errors for .author.json
 	 */
-	if (auth_cnt_err == NULL) {
-	    err(36, __func__, "json_sem_check() left auth_cnt_err as NULL for .author.json file: %s", auth_path);
+	if (auth_count_err == NULL) {
+	    err(36, __func__, "json_sem_check() left auth_count_err as NULL for .author.json file: %s", auth_path);
 	    not_reached();
 	}
-	if (dyn_array_tell(auth_cnt_err) < 0) {
-	    err(37, __func__, "dyn_array_tell(auth_cnt_err): %jd < 0 "
-		   "for .author.json file: %s", dyn_array_tell(auth_cnt_err), auth_path);
+	if (dyn_array_tell(auth_count_err) < 0) {
+	    err(37, __func__, "dyn_array_tell(auth_count_err): %jd < 0 "
+		   "for .author.json file: %s", dyn_array_tell(auth_count_err), auth_path);
 	    not_reached();
 	}
-	auth_cnt_err_cnt = (uintmax_t) dyn_array_tell(auth_cnt_err);
+	auth_count_err_count = (uintmax_t) dyn_array_tell(auth_count_err);
 	if (auth_val_err == NULL) {
 	    err(38, __func__, "json_sem_check() left auth_val_err as NULL for .author.json file: %s", auth_path);
 	    not_reached();
@@ -526,118 +526,118 @@ main(int argc, char *argv[])
 		   "for .author.json file: %s", dyn_array_tell(auth_val_err), auth_path);
 	    not_reached();
 	}
-	auth_val_err_cnt = (uintmax_t) dyn_array_tell(auth_val_err);
-	if (auth_all_err_cnt < auth_cnt_err_cnt+auth_val_err_cnt) {
-	    err(40, __func__, "auth_all_err_cnt: %ju < auth_cnt_err_cnt: %ju + auth_val_err_cnt: %ju "
+	auth_val_err_count = (uintmax_t) dyn_array_tell(auth_val_err);
+	if (auth_all_err_count < auth_count_err_count+auth_val_err_count) {
+	    err(40, __func__, "auth_all_err_count: %ju < auth_count_err_count: %ju + auth_val_err_count: %ju "
 		   "for .author.json file: %s",
-		   auth_all_err_cnt, auth_cnt_err_cnt, auth_val_err_cnt, auth_path);
+		   auth_all_err_count, auth_count_err_count, auth_val_err_count, auth_path);
 	    not_reached();
 	}
-	auth_int_err_cnt = auth_all_err_cnt - (auth_cnt_err_cnt+auth_val_err_cnt);
+	auth_int_err_count = auth_all_err_count - (auth_count_err_count+auth_val_err_count);
     }
 
     /*
      * count all errors
      */
-    all_cnt_err_cnt = info_cnt_err_cnt + auth_cnt_err_cnt;
-    all_val_err_cnt = info_val_err_cnt + auth_val_err_cnt;
-    all_int_err_cnt = info_int_err_cnt + auth_int_err_cnt;
-    all_all_err_cnt = info_all_err_cnt + auth_all_err_cnt;
+    all_count_err_count = info_count_err_count + auth_count_err_count;
+    all_val_err_count = info_val_err_count + auth_val_err_count;
+    all_int_err_count = info_int_err_count + auth_int_err_count;
+    all_all_err_count = info_all_err_count + auth_all_err_count;
 
     /*
      * report details of any .info.json semantic errors
      */
-    if (info_all_err_cnt > 0) {
+    if (info_all_err_count > 0) {
 	fpr(stderr, __func__, "What follows are semantic errors for .info.json file: %s\n", info_path);
-	if (info_cnt_err == NULL) {
-	    fpr(stderr, __func__, "  info_cnt_err is NULL!!!\n");
+	if (info_count_err == NULL) {
+	    fpr(stderr, __func__, "  info_count_err is NULL!!!\n");
 	} else {
-	    for (i=0; i < info_cnt_err_cnt; ++i) {
-		sem_cnt_err = dyn_array_addr(info_cnt_err, struct json_sem_cnt_err, i);
-		fprint_cnt_err(stderr, "  .info.json count error ", sem_cnt_err, "\n");
+	    for (i=0; i < info_count_err_count; ++i) {
+		sem_count_err = dyn_array_addr(info_count_err, struct json_sem_count_err, i);
+		fprint_count_err(stderr, "  .info.json count error ", sem_count_err, "\n");
 	    }
-	    for (i=0; i < info_val_err_cnt; ++i) {
+	    for (i=0; i < info_val_err_count; ++i) {
 		sem_val_err = dyn_array_addr(info_val_err, struct json_sem_val_err, i);
 		fprint_val_err(stderr, "  .info.json validation error ", sem_val_err, "\n");
 	    }
 	}
-	if (info_int_err_cnt > 0) {
-	    fpr(stderr, __func__, "  .info.json internal errors found: %ju", info_int_err_cnt);
+	if (info_int_err_count > 0) {
+	    fpr(stderr, __func__, "  .info.json internal errors found: %ju", info_int_err_count);
 	}
     }
 
     /*
      * report details of any .author.json semantic errors
      */
-    if (auth_all_err_cnt > 0) {
+    if (auth_all_err_count > 0) {
 	fpr(stderr, __func__, "What follows are semantic errors for .author.json file: %s\n", auth_path);
-	if (auth_cnt_err == NULL) {
-	    fpr(stderr, __func__, "  auth_cnt_err is NULL!!!\n");
+	if (auth_count_err == NULL) {
+	    fpr(stderr, __func__, "  auth_count_err is NULL!!!\n");
 	} else {
-	    for (i=0; i < auth_cnt_err_cnt; ++i) {
-		sem_cnt_err = dyn_array_addr(auth_cnt_err, struct json_sem_cnt_err, i);
-		fprint_cnt_err(stderr, "  .author.json count error ", sem_cnt_err, "\n");
+	    for (i=0; i < auth_count_err_count; ++i) {
+		sem_count_err = dyn_array_addr(auth_count_err, struct json_sem_count_err, i);
+		fprint_count_err(stderr, "  .author.json count error ", sem_count_err, "\n");
 	    }
-	    for (i=0; i < auth_val_err_cnt; ++i) {
+	    for (i=0; i < auth_val_err_count; ++i) {
 		sem_val_err = dyn_array_addr(auth_val_err, struct json_sem_val_err, i);
 		fprint_val_err(stderr, "  .author.json validation error ", sem_val_err, "\n");
 	    }
 	}
-	if (auth_int_err_cnt > 0) {
-	    fpr(stderr, __func__, "  .author.json internal errors found: %ju", auth_int_err_cnt);
+	if (auth_int_err_count > 0) {
+	    fpr(stderr, __func__, "  .author.json internal errors found: %ju", auth_int_err_count);
 	}
     }
 
     /*
      * report on semantic count errors
      error: */
-    if (all_cnt_err_cnt > 0) {
-	if (info_cnt_err_cnt > 0) {
-	    dbg(DBG_LOW, "count errors for   .info.json: %ju", info_cnt_err_cnt);
+    if (all_count_err_count > 0) {
+	if (info_count_err_count > 0) {
+	    dbg(DBG_LOW, "count errors for   .info.json: %ju", info_count_err_count);
 	}
-	if (auth_cnt_err_cnt > 0) {
-	    dbg(DBG_LOW, "count errors for .author.json: %ju", auth_cnt_err_cnt);
+	if (auth_count_err_count > 0) {
+	    dbg(DBG_LOW, "count errors for .author.json: %ju", auth_count_err_count);
 	}
-	dbg(DBG_LOW, "count errors for   both files: %ju", all_cnt_err_cnt);
+	dbg(DBG_LOW, "count errors for   both files: %ju", all_count_err_count);
     }
 
     /*
      * report on semantic validation errors
      */
-    if (all_val_err_cnt > 0) {
-	if (info_val_err_cnt > 0) {
-	    dbg(DBG_LOW, "validation errors for   .info.json: %ju", info_val_err_cnt);
+    if (all_val_err_count > 0) {
+	if (info_val_err_count > 0) {
+	    dbg(DBG_LOW, "validation errors for   .info.json: %ju", info_val_err_count);
 	}
-	if (auth_val_err_cnt > 0) {
-	    dbg(DBG_LOW, "validation errors for .author.json: %ju", auth_val_err_cnt);
+	if (auth_val_err_count > 0) {
+	    dbg(DBG_LOW, "validation errors for .author.json: %ju", auth_val_err_count);
 	}
-	dbg(DBG_LOW, "validation errors for   both files: %ju", all_val_err_cnt);
+	dbg(DBG_LOW, "validation errors for   both files: %ju", all_val_err_count);
     }
 
     /*
      * report on internal errors
      */
-    if (all_int_err_cnt > 0) {
-	if (info_int_err_cnt > 0) {
-	    dbg(DBG_LOW, "internal errors for   .info.json: %ju", info_int_err_cnt);
+    if (all_int_err_count > 0) {
+	if (info_int_err_count > 0) {
+	    dbg(DBG_LOW, "internal errors for   .info.json: %ju", info_int_err_count);
 	}
-	if (auth_int_err_cnt > 0) {
-	    dbg(DBG_LOW, "internal errors for .author.json: %ju", auth_int_err_cnt);
+	if (auth_int_err_count > 0) {
+	    dbg(DBG_LOW, "internal errors for .author.json: %ju", auth_int_err_count);
 	}
-	dbg(DBG_LOW, "internal errors for   both files: %ju", all_int_err_cnt);
+	dbg(DBG_LOW, "internal errors for   both files: %ju", all_int_err_count);
     }
 
     /*
      * report on total error counts
      */
-    if (all_all_err_cnt > 0) {
-	if (info_all_err_cnt > 0) {
-	    dbg(DBG_LOW, "total semantic errors for   .info.json: %ju", info_all_err_cnt);
+    if (all_all_err_count > 0) {
+	if (info_all_err_count > 0) {
+	    dbg(DBG_LOW, "total semantic errors for   .info.json: %ju", info_all_err_count);
 	}
-	if (auth_all_err_cnt > 0) {
-	    dbg(DBG_LOW, "total semantic errors for .author.json: %ju", auth_all_err_cnt);
+	if (auth_all_err_count > 0) {
+	    dbg(DBG_LOW, "total semantic errors for .author.json: %ju", auth_all_err_count);
 	}
-	dbg(DBG_LOW, "total semantic errors for   both files: %ju", all_all_err_cnt);
+	dbg(DBG_LOW, "total semantic errors for   both files: %ju", all_all_err_count);
     }
 
     /*
@@ -659,17 +659,17 @@ main(int argc, char *argv[])
 	json_tree_free(auth_tree, JSON_DEFAULT_MAX_DEPTH);
 	auth_tree = NULL;
     }
-    if (info_cnt_err != NULL) {
-	free_cnt_err(info_cnt_err);
-	info_cnt_err = NULL;
+    if (info_count_err != NULL) {
+	free_count_err(info_count_err);
+	info_count_err = NULL;
     }
     if (info_val_err != NULL) {
 	free_val_err(info_val_err);
 	info_val_err = NULL;
     }
-    if (auth_cnt_err != NULL) {
-	free_cnt_err(auth_cnt_err);
-	auth_cnt_err = NULL;
+    if (auth_count_err != NULL) {
+	free_count_err(auth_count_err);
+	auth_count_err = NULL;
     }
     if (auth_val_err != NULL) {
 	free_val_err(auth_val_err);
@@ -680,8 +680,8 @@ main(int argc, char *argv[])
      * All Done!!! - Jessica Noll, age 2
      *
      */
-    if (all_all_err_cnt > 0) {
-	if (info_all_err_cnt > 0) {
+    if (all_all_err_count > 0) {
+	if (info_all_err_count > 0) {
 	    if (info_path == NULL) {
 		werr(1, __func__, "JSON semantic check failed for .info.json file: ((NULL))"); /*ooo*/
 	    } else {
@@ -690,7 +690,7 @@ main(int argc, char *argv[])
 		info_path = NULL;
 	    }
 	}
-	if (auth_all_err_cnt > 0) {
+	if (auth_all_err_count > 0) {
 	    if (auth_path == NULL) {
 		werr(1, __func__, "JSON semantic check failed for .author.json file: ((NULL))"); /*ooo*/
 	    } else {

--- a/entry_util.c
+++ b/entry_util.c
@@ -1320,10 +1320,10 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    }
 
 	    /* count valid occurrence */
-	    ++manp->cnt_info_JSON;
+	    ++manp->count_info_JSON;
 
 	    /* we are allowed only 1 of these mandatory manifest filenames */
-	    if (manp->cnt_info_JSON != 1) {
+	    if (manp->count_info_JSON != 1) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(125, node, depth, sem, __func__,
 					    "manifest found more than one info_JSON filename");
@@ -1347,10 +1347,10 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    }
 
 	    /* count valid occurrence */
-	    ++manp->cnt_author_JSON;
+	    ++manp->count_author_JSON;
 
 	    /* we are allowed only 1 of these mandatory manifest filenames */
-	    if (manp->cnt_c_src != 1) {
+	    if (manp->count_c_src != 1) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(128, node, depth, sem, __func__,
 					    "manifest found more than one author_JSON filename");
@@ -1374,10 +1374,10 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    }
 
 	    /* count valid occurrence */
-	    ++manp->cnt_c_src;
+	    ++manp->count_c_src;
 
 	    /* we are allowed only 1 of these mandatory manifest filenames */
-	    if (manp->cnt_c_src != 1) {
+	    if (manp->count_c_src != 1) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(130, node, depth, sem, __func__,
 					    "manifest found more than one c_src (prog.c) filename");
@@ -1401,10 +1401,10 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    }
 
 	    /* count valid occurrence */
-	    ++manp->cnt_Makefile;
+	    ++manp->count_Makefile;
 
 	    /* we are allowed only 1 of these mandatory manifest filenames */
-	    if (manp->cnt_Makefile != 1) {
+	    if (manp->count_Makefile != 1) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(132, node, depth, sem, __func__,
 					    "manifest found more than one Makefile filename");
@@ -1428,10 +1428,10 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    }
 
 	    /* count valid occurrence */
-	    ++manp->cnt_remarks;
+	    ++manp->count_remarks;
 
 	    /* we are allowed only 1 of these mandatory manifest filenames */
-	    if (manp->cnt_remarks != 1) {
+	    if (manp->count_remarks != 1) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(134, node, depth, sem, __func__,
 					    "remarks found more than one remarks filename");
@@ -1451,7 +1451,7 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(135, node, depth, sem, __func__,
 					    "manifest extra_file #%jd filename is invalid",
-					    manp->cnt_extra_file);
+					    manp->count_extra_file);
 		}
 		dyn_array_free(man.extra);
 		return false;
@@ -1461,7 +1461,7 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	    (void) dyn_array_append_value(manp->extra, value);
 
 	    /* count valid occurrence */
-	    ++manp->cnt_extra_file;
+	    ++manp->count_extra_file;
 
 	/*
 	 * case: invalid JTYPE_MEMBER - not part of an IOCCC manifest JTYPE_OBJECT
@@ -1480,47 +1480,47 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
     /*
      * verify that we have 1 each of the required mandatory files in manifest
      */
-    if (man.cnt_info_JSON != 1) {
+    if (man.count_info_JSON != 1) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(137, node, depth+2, sem, __func__,
 				    "manifest: expected 1 valid info_JSON, found: %jd",
-				    man.cnt_info_JSON);
+				    man.count_info_JSON);
 	}
 	dyn_array_free(man.extra);
         return false;
     }
-    if (man.cnt_author_JSON != 1) {
+    if (man.count_author_JSON != 1) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(138, node, depth+2, sem, __func__,
 				    "manifest: expected 1 valid author_JSON, found: %jd",
-				    man.cnt_author_JSON);
+				    man.count_author_JSON);
 	}
 	dyn_array_free(man.extra);
         return false;
     }
-    if (man.cnt_c_src != 1) {
+    if (man.count_c_src != 1) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(139, node, depth+2, sem, __func__,
 				    "manifest: expected 1 valid c_src, found: %jd",
-				    man.cnt_c_src);
+				    man.count_c_src);
 	}
 	dyn_array_free(man.extra);
         return false;
     }
-    if (man.cnt_Makefile != 1) {
+    if (man.count_Makefile != 1) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(140, node, depth+2, sem, __func__,
 				    "manifest: expected 1 valid Makefile, found: %jd",
-				    man.cnt_Makefile);
+				    man.count_Makefile);
 	}
 	dyn_array_free(man.extra);
         return false;
     }
-    if (man.cnt_remarks != 1) {
+    if (man.count_remarks != 1) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(141, node, depth+2, sem, __func__,
 				    "manifest: expected 1 valid remarks, found: %jd",
-				    man.cnt_remarks);
+				    man.count_remarks);
 	}
 	dyn_array_free(man.extra);
         return false;
@@ -1531,7 +1531,7 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
      *
      * The author_count will be a small number, so we can get away with a lazy O(n^2) match.
      */
-    for (i=1; i < man.cnt_extra_file; ++i) {
+    for (i=1; i < man.count_extra_file; ++i) {
 
 	/* obtain first extra filename to compare against */
 	extra_filename = dyn_array_value(man.extra, char *, i);
@@ -3458,7 +3458,7 @@ test_location_name(char const *str)
 bool
 test_manifest(struct manifest *manp)
 {
-    intmax_t cnt_extra_file = -1;		/* number of extra files */
+    intmax_t count_extra_file = -1;		/* number of extra files */
     bool test = false;			/* test_extra_file() test result */
     char *extra_filename = NULL;	/* filename of an extra file */
     char *extra_filename2 = NULL;	/* second filename of an extra file */
@@ -3476,50 +3476,50 @@ test_manifest(struct manifest *manp)
 	warn(__func__, "manp->extra is NULL");
 	return false;
     }
-    if (manp->cnt_extra_file < 0) {
-	warn(__func__, "manp->cnt_extra_file: %jd < 0", manp->cnt_extra_file);
+    if (manp->count_extra_file < 0) {
+	warn(__func__, "manp->count_extra_file: %jd < 0", manp->count_extra_file);
 	return false;
     }
-    if (manp->cnt_extra_file != dyn_array_tell(manp->extra)) {
-	warn(__func__, "manp->cnt_extra_file: %jd != dyn_array_tell(manp->extra): %jd",
-		       manp->cnt_extra_file, dyn_array_tell(manp->extra));
+    if (manp->count_extra_file != dyn_array_tell(manp->extra)) {
+	warn(__func__, "manp->count_extra_file: %jd != dyn_array_tell(manp->extra): %jd",
+		       manp->count_extra_file, dyn_array_tell(manp->extra));
 	return false;
     }
-    cnt_extra_file = manp->cnt_extra_file;
+    count_extra_file = manp->count_extra_file;
 
     /*
      * look for required mandatory files in manifest
      */
-    if (manp->cnt_info_JSON != 1) {
+    if (manp->count_info_JSON != 1) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: expected 1 valid info_JSON, found: %jd", manp->cnt_info_JSON);
+		 "invalid: expected 1 valid info_JSON, found: %jd", manp->count_info_JSON);
         return false;
     }
-    if (manp->cnt_author_JSON != 1) {
+    if (manp->count_author_JSON != 1) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: expected 1 valid author_JSON, found: %jd", manp->cnt_author_JSON);
+		 "invalid: expected 1 valid author_JSON, found: %jd", manp->count_author_JSON);
         return false;
     }
-    if (manp->cnt_c_src != 1) {
+    if (manp->count_c_src != 1) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: expected 1 valid c_src, found: %jd", manp->cnt_c_src);
+		 "invalid: expected 1 valid c_src, found: %jd", manp->count_c_src);
         return false;
     }
-    if (manp->cnt_Makefile != 1) {
+    if (manp->count_Makefile != 1) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: expected 1 valid Makefile, found: %jd", manp->cnt_Makefile);
+		 "invalid: expected 1 valid Makefile, found: %jd", manp->count_Makefile);
         return false;
     }
-    if (manp->cnt_remarks != 1) {
+    if (manp->count_remarks != 1) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: expected 1 valid remarks, found: %jd", manp->cnt_remarks);
+		 "invalid: expected 1 valid remarks, found: %jd", manp->count_remarks);
         return false;
     }
 
     /*
      * case: no extra files
      */
-    if (cnt_extra_file == 0) {
+    if (count_extra_file == 0) {
 	json_dbg(JSON_DBG_MED, __func__, "manifest is complete with no extra files");
 	return true;
     }
@@ -3527,7 +3527,7 @@ test_manifest(struct manifest *manp)
     /*
      * verify that extra files are valid filenames and do not match a mandatory file
      */
-    for (i=0; i < cnt_extra_file; ++i) {
+    for (i=0; i < count_extra_file; ++i) {
 
 	/* obtain this valid extra filename */
 	extra_filename = dyn_array_value(manp->extra, char *, i);
@@ -3551,7 +3551,7 @@ test_manifest(struct manifest *manp)
     /*
      * case: only 1 extra file
      */
-    if (cnt_extra_file == 1) {
+    if (count_extra_file == 1) {
 	json_dbg(JSON_DBG_MED, __func__, "manifest is complete with only 1 valid extra filename");
 	return true;
     }
@@ -3561,7 +3561,7 @@ test_manifest(struct manifest *manp)
      *
      * The author_count will be a small number, so we can get away with a lazy O(n^2) match.
      */
-    for (i=1; i < cnt_extra_file; ++i) {
+    for (i=1; i < count_extra_file; ++i) {
 
 	/* obtain first extra filename to compare against */
 	extra_filename = dyn_array_value(manp->extra, char *, i);

--- a/entry_util.h
+++ b/entry_util.h
@@ -213,12 +213,12 @@ struct info
  */
 struct manifest
 {
-    intmax_t cnt_info_JSON;	/* count of info_JSON JSON member found (will be ".info.json") */
-    intmax_t cnt_author_JSON;	/* count of author_JSON JSON member found (will be ".author.json") */
-    intmax_t cnt_c_src;		/* count of c_src JSON member found (will be "prog.c") */
-    intmax_t cnt_Makefile;	/* count of Makefile JSON member found (will be "Makefile") */
-    intmax_t cnt_remarks;	/* count of remarks JSON member found (will be "remarks") */
-    intmax_t cnt_extra_file;	/* count of extra JSON members found */
+    intmax_t count_info_JSON;	/* count of info_JSON JSON member found (will be ".info.json") */
+    intmax_t count_author_JSON;	/* count of author_JSON JSON member found (will be ".author.json") */
+    intmax_t count_c_src;		/* count of c_src JSON member found (will be "prog.c") */
+    intmax_t count_Makefile;	/* count of Makefile JSON member found (will be "Makefile") */
+    intmax_t count_remarks;	/* count of remarks JSON member found (will be "remarks") */
+    intmax_t count_extra_file;	/* count of extra JSON members found */
     struct dyn_array *extra;	/* dynamic array of extra JSON member filenames (char *) */
 };
 

--- a/jnum_chk.c
+++ b/jnum_chk.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     struct json *node = NULL;	/* allocated JSON parser tree node */
     struct json_number *item = NULL;	/* JSON parser tree node for a JSON number */
     size_t len = 0;		/* length of str */
-    int arg_cnt = 0;		/* number of args to process */
+    int arg_count = 0;		/* number of args to process */
     int i;
 
     /*
@@ -101,9 +101,9 @@ main(int argc, char *argv[])
 	    not_reached();
 	 }
     }
-    arg_cnt = argc - optind;
-    if (arg_cnt != REQUIRED_ARGS) {
-	usage(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_cnt); /*ooo*/
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
+	usage(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_count); /*ooo*/
     }
     dbg(DBG_MED, "strict mode: %s", (strict == true) ? "enabled" : "disabled");
 

--- a/jnum_gen.c
+++ b/jnum_gen.c
@@ -48,7 +48,7 @@ main(int argc, char *argv[])
     char const *program = NULL;	/* our name */
     extern char *optarg;	/* option argument */
     extern int optind;		/* argv index of the next arg */
-    int arg_cnt = 0;		/* number of args to process */
+    int arg_count = 0;		/* number of args to process */
     char *filename = NULL;	/* name of file containing test cases */
     FILE *stream = NULL;	/* test case open stream */
     char *readline_buf = NULL;	/* test case readline_buf buffer */
@@ -96,9 +96,9 @@ main(int argc, char *argv[])
 	    not_reached();
 	 }
     }
-    arg_cnt = argc - optind;
-    if (arg_cnt != REQUIRED_ARGS) {
-	usage(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_cnt); /*ooo*/
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
+	usage(4, program, "expected %d arguments, found: %d", REQUIRED_ARGS, arg_count); /*ooo*/
 	not_reached();
     }
     filename = argv[optind];

--- a/jparse_main.c
+++ b/jparse_main.c
@@ -46,7 +46,7 @@ main(int argc, char **argv)
     bool string_flag_used = false;  /* true ==> -S string was used */
     bool valid_json = false;	    /* true ==> JSON parse was valid */
     struct json *tree = NULL;	    /* JSON parse tree or NULL */
-    int arg_cnt = 0;		    /* number of args to process */
+    int arg_count = 0;		    /* number of args to process */
     int i;
 
     /*
@@ -87,8 +87,8 @@ main(int argc, char **argv)
 	    not_reached();
 	}
     }
-    arg_cnt = argc - optind;
-    if (arg_cnt != REQUIRED_ARGS) {
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
 	usage(3, "wrong number of arguments", program); /*ooo*/
 	not_reached();
     }

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -70,7 +70,7 @@ main(int argc, char **argv)
     bool string_flag_used = false;  /* true ==> -S string was used */
     bool valid_json = false;	    /* true ==> JSON parse was valid */
     struct json *tree = NULL;	    /* JSON parse tree or NULL */
-    int arg_cnt = 0;		    /* number of args to process */
+    int arg_count = 0;		    /* number of args to process */
     char *cap_tbl_name = NULL;	    /* UPPER case copy of tbl_name */
     size_t len = 0;		    /* length pf tbl_name */
     size_t i;
@@ -150,8 +150,8 @@ main(int argc, char **argv)
 	    not_reached();
 	}
     }
-    arg_cnt = argc - optind;
-    if (arg_cnt != REQUIRED_ARGS) {
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
 	usage(3, "wrong number of arguments", program); /*ooo*/
 	not_reached();
     }

--- a/json_sem.c
+++ b/json_sem.c
@@ -361,7 +361,7 @@ sem_chk_null_args(struct json const *node, unsigned int depth, struct json_sem *
  *	true ==> JSON node is converted and a valid JTYPE
  *	    The val_err arg is ignored
  *	NULL ==> JSON node is not converted, invalid node type, or internal error
- *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
  */
 bool
 sem_node_valid_converted(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -703,7 +703,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
  *	!= NULL ==> JSON node that is the name of a JTYPE_MEMBER
  *	    The val_err arg is ignored
  *	NULL ==> invalid arguments or JSON error
- *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_count_err)
  */
 struct json *
 sem_member_name(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -792,7 +792,7 @@ sem_member_name(struct json const *node, unsigned int depth, struct json_sem *se
  *	!= NULL ==> JSON node that is the value of a JTYPE_MEMBER
  *	    The val_err arg is ignored
  *	NULL ==> invalid arguments or JSON error
- *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_count_err)
  */
 struct json *
 sem_member_value(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -871,7 +871,7 @@ sem_member_value(struct json const *node, unsigned int depth, struct json_sem *s
  *	!= NULL ==> decoded JTYPE_STRING from the name part of JTYPE_MEMBER
  *	    The val_err arg is ignored
  *	NULL ==> invalid arguments or JSON conversion error
- *	    If val_err != NULL, then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULL, then *val_err is JSON semantic validation error (struct json_count_err)
  */
 char *
 sem_member_name_decoded_str(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -1404,7 +1404,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
  *	!= NULL ==> valid parent JSON node
  *	    The val_err arg is ignored
  *	NULL ==> no parent node, invalid parent node, or internal error
- *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_count_err)
  */
 struct json *
 sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -1490,7 +1490,7 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
  *	!= NULL ==> JTYPE_MEMBER with a given name
  *	    The val_err arg is ignored
  *	NULL ==> no such JTYPE_MEMBER found, or invalid arguments or JSON conversion error
- *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_cnt_err)
+ *	    If val_err != NULLm then *val_err is JSON semantic validation error (struct json_count_err)
  */
 struct json *
 sem_object_find_name(struct json const *node, unsigned int depth, struct json_sem *sem,
@@ -1643,9 +1643,9 @@ json_sem_zero_count(struct json_sem *sem)
  *	sem		pointer to a JSON semantic table (ends with a JTYPE_UNSET JSON type)
  */
 void
-json_sem_count_chk(struct json_sem *sem, struct dyn_array *cnt_err)
+json_sem_count_chk(struct json_sem *sem, struct dyn_array *count_err)
 {
-    struct json_sem_cnt_err cnt;	/* semantic count error */
+    struct json_sem_count_err count;	/* semantic count error */
     int i;
 
     /*
@@ -1655,8 +1655,8 @@ json_sem_count_chk(struct json_sem *sem, struct dyn_array *cnt_err)
 	warn(__func__, "sem is NULL");
 	return;
     }
-    if (cnt_err == NULL) {
-	warn(__func__, "cnt_err is NULL");
+    if (count_err == NULL) {
+	warn(__func__, "count_err is NULL");
 	return;
     }
 
@@ -1673,28 +1673,28 @@ json_sem_count_chk(struct json_sem *sem, struct dyn_array *cnt_err)
 	    /*
 	     * form count is too small error
 	     */
-	    cnt.node = NULL;
-	    cnt.sem = &(sem[i]);
-	    cnt.count = sem[i].count;
-	    cnt.bad_min = true;
-	    cnt.bad_max = false;
-	    cnt.unknown_node = false;
-	    cnt.sem_index = i;
-	    cnt.diagnostic = calloc(BUFSIZ+1, sizeof(char));
-	    if (cnt.diagnostic == NULL) {
-		cnt.diagnostic = "calloc BUFSIZ calloc failed for count is too small";
-		cnt.malloced = false;
+	    count.node = NULL;
+	    count.sem = &(sem[i]);
+	    count.count = sem[i].count;
+	    count.bad_min = true;
+	    count.bad_max = false;
+	    count.unknown_node = false;
+	    count.sem_index = i;
+	    count.diagnostic = calloc(BUFSIZ+1, sizeof(char));
+	    if (count.diagnostic == NULL) {
+		count.diagnostic = "calloc BUFSIZ calloc failed for count is too small";
+		count.malloced = false;
 	    } else {
-		snmsg(cnt.diagnostic, BUFSIZ, "node type %s parse tree depth %u%s%s: found %u < minimum: %d",
+		snmsg(count.diagnostic, BUFSIZ, "node type %s parse tree depth %u%s%s: found %u < minimum: %d",
 		      json_type_name(sem[i].type), sem[i].depth,
 		      (sem[i].name != NULL) ? " member name: " : "",
 		      (sem[i].name != NULL) ? sem[i].name : "",
 		      sem[i].count, sem[i].min);
-		cnt.malloced = true;
+		count.malloced = true;
 	    }
 
 	    /* save semantic count error */
-	    dyn_array_append_value(cnt_err, &cnt);
+	    dyn_array_append_value(count_err, &count);
 
 	/*
 	 * case: count is too large
@@ -1704,28 +1704,28 @@ json_sem_count_chk(struct json_sem *sem, struct dyn_array *cnt_err)
 	    /*
 	     * form count is too large error
 	     */
-	    cnt.node = NULL;
-	    cnt.sem = &(sem[i]);
-	    cnt.count = sem[i].count;
-	    cnt.bad_min = false;
-	    cnt.bad_max = true;
-	    cnt.unknown_node = false;
-	    cnt.sem_index = i;
-	    cnt.diagnostic = calloc(BUFSIZ+1, sizeof(char));
-	    if (cnt.diagnostic == NULL) {
-		cnt.diagnostic = "calloc BUFSIZ calloc failed for count is too small";
-		cnt.malloced = false;
+	    count.node = NULL;
+	    count.sem = &(sem[i]);
+	    count.count = sem[i].count;
+	    count.bad_min = false;
+	    count.bad_max = true;
+	    count.unknown_node = false;
+	    count.sem_index = i;
+	    count.diagnostic = calloc(BUFSIZ+1, sizeof(char));
+	    if (count.diagnostic == NULL) {
+		count.diagnostic = "calloc BUFSIZ calloc failed for count is too small";
+		count.malloced = false;
 	    } else {
-		snmsg(cnt.diagnostic, BUFSIZ, "node type %s parse tree depth %u%s%s: found %u > maximum: %d",
+		snmsg(count.diagnostic, BUFSIZ, "node type %s parse tree depth %u%s%s: found %u > maximum: %d",
 		      json_type_name(sem[i].type), sem[i].depth,
 		      (sem[i].name != NULL) ? " member name: " : "",
 		      (sem[i].name != NULL) ? sem[i].name : "",
 		      sem[i].count, sem[i].max);
-		cnt.malloced = true;
+		count.malloced = true;
 	    }
 
 	    /* save semantic count error */
-	    dyn_array_append_value(cnt_err, &cnt);
+	    dyn_array_append_value(count_err, &count);
 	}
     }
     return;
@@ -1832,7 +1832,7 @@ json_sem_find(struct json *node, unsigned int depth, struct json_sem *sem)
  *	ap	variable argument list, required ap args:
  *
  *		sem		JSON semantic table (ends with a JTYPE_UNSET JSON type)
- *		cnt_err		dynamic array of JSON semantic count errors
+ *		count_err		dynamic array of JSON semantic count errors
  *		val_err		dynamic array of JSON semantic validation errors
  *
  * NOTE: This function does nothing if node == NULL.
@@ -1844,11 +1844,11 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
 {
     va_list ap2;			/* copy of va_list ap */
     struct json_sem *sem = NULL;	/* JSON semantic table (ends with a JTYPE_UNSET JSON type) */
-    struct dyn_array *cnt_err = NULL;	/* dynamic array of JSON semantic count errors */
+    struct dyn_array *count_err = NULL;	/* dynamic array of JSON semantic count errors */
     struct dyn_array *val_err = NULL;	/* dynamic array of JSON semantic validation errors */
     bool test = false;			/* validation test result */
     struct json_sem_val_err *err = NULL;/* pointer to semantic validation error */
-    struct json_sem_cnt_err cnt;	/* semantic count error */
+    struct json_sem_count_err count;	/* semantic count error */
     int index = -1;			/* semantic array index match or -1 ==> no march or < -1 ==> error */
 
     /*
@@ -1871,8 +1871,8 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
 	va_end(ap2); /* stdarg variable argument list cleanup */
 	return;
     }
-    cnt_err = va_arg(ap2, struct dyn_array *);
-    if (cnt_err == NULL) {
+    count_err = va_arg(ap2, struct dyn_array *);
+    if (count_err == NULL) {
 	va_end(ap2); /* stdarg variable argument list cleanup */
 	return;
     }
@@ -1934,24 +1934,24 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
 	/*
 	 * semantic table non-match
 	 */
-	cnt.node = node;
-	cnt.sem = NULL;
-	cnt.count = 1;
-	cnt.bad_min = false;
-	cnt.bad_max = false;
-	cnt.unknown_node = true;
-	cnt.sem_index = -1;
-	cnt.diagnostic = calloc(BUFSIZ+1, sizeof(char));
-	if (cnt.diagnostic == NULL) {
-	    cnt.diagnostic = "calloc BUFSIZ calloc failed for unexpected node";
-	    cnt.malloced = false;
+	count.node = node;
+	count.sem = NULL;
+	count.count = 1;
+	count.bad_min = false;
+	count.bad_max = false;
+	count.unknown_node = true;
+	count.sem_index = -1;
+	count.diagnostic = calloc(BUFSIZ+1, sizeof(char));
+	if (count.diagnostic == NULL) {
+	    count.diagnostic = "calloc BUFSIZ calloc failed for unexpected node";
+	    count.malloced = false;
 	} else {
 	    if (node->type == JTYPE_MEMBER) {
 		char *name = NULL;	/* name of JTYPE_MEMBER */
 
 		name = sem_member_name_decoded_str(node, depth, sem, __func__, &err);
 		if (name == NULL) {
-		    snmsg(cnt.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u%ss",
+		    snmsg(count.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u%ss",
 			  json_item_type_name(node), depth,
 			  " unnamed member");
 
@@ -1965,44 +1965,44 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
 		    dyn_array_append_value(val_err, err);
 
 		} else {
-		    snmsg(cnt.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u%s%s",
+		    snmsg(count.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u%s%s",
 			  json_item_type_name(node), depth,
 			  " member name: ", name);
 		}
 	    } else {
-		snmsg(cnt.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u",
+		snmsg(count.diagnostic, BUFSIZ, "unexpected node: type %s parse tree depth %u",
 		      json_item_type_name(node), depth);
 	    }
-	    cnt.malloced = true;
+	    count.malloced = true;
 	}
 
 	/* save semantic count error */
-	dyn_array_append_value(cnt_err, &cnt);
+	dyn_array_append_value(count_err, &count);
 
     } else {
 
 	/*
 	 * error searching semantic table
 	 */
-	cnt.node = node;
-	cnt.sem = NULL;
-	cnt.count = 1;
-	cnt.bad_min = false;
-	cnt.bad_max = false;
-	cnt.unknown_node = true;
-	cnt.node = NULL;
-	cnt.diagnostic = calloc(BUFSIZ+1, sizeof(char));
-	if (cnt.diagnostic == NULL) {
-	    cnt.diagnostic = "calloc BUFSIZ calloc failed for json_sem_find result < -1";
-	    cnt.malloced = false;
+	count.node = node;
+	count.sem = NULL;
+	count.count = 1;
+	count.bad_min = false;
+	count.bad_max = false;
+	count.unknown_node = true;
+	count.node = NULL;
+	count.diagnostic = calloc(BUFSIZ+1, sizeof(char));
+	if (count.diagnostic == NULL) {
+	    count.diagnostic = "calloc BUFSIZ calloc failed for json_sem_find result < -1";
+	    count.malloced = false;
 	} else {
-	    snwerr(index, cnt.diagnostic, BUFSIZ, "json_sem_find",
+	    snwerr(index, count.diagnostic, BUFSIZ, "json_sem_find",
 			  "json_sem_find failed, returned %d < -1", index);
-	    cnt.malloced = true;
+	    count.malloced = true;
 	}
 
 	/* save semantic count error */
-	dyn_array_append_value(cnt_err, &cnt);
+	dyn_array_append_value(count_err, &count);
     }
 
     /*
@@ -2016,15 +2016,15 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
 /*
  * json_sem_check - check a JSON parse tree against a JSON semantic table
  *
- * First, if *pcnt_err == NULL, then dynamic array *pcnt_err is
- * created as an empty dynamic array, else the existing dynamic array *pcnt_err
+ * First, if *pcount_err == NULL, then dynamic array *pcount_err is
+ * created as an empty dynamic array, else the existing dynamic array *pcount_err
  * is used.  If *pval_err == NULL, then dynamic array *pval_err is
  * created as an empty dynamic array, else the existing dynamic array *pval_err
  * is used.
  *
  * We then walk the JSON parse tree and check each node against the JSON semantic table,
  * counting as nodes on the 1st match found in the JSON semantic table,
- * or appending a JSON semantic count error to the *pcnt_err dynamic array
+ * or appending a JSON semantic count error to the *pcount_err dynamic array
  * when an unknown JSON node is found.
  *
  * When a JSON node matches a JSON semantic table entry that has a non-NULL
@@ -2035,7 +2035,7 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
  * Once the JSON parse tree is walked, the counts in the JSON semantic table
  * are checked against the minimum and maximum allowed counts.  When a count
  * is found to be out of range, JSON semantic count error is appended to
- * the *pcnt_err dynamic array.
+ * the *pcount_err dynamic array.
  *
  * given:
  *	node		pointer to a JSON parse tree
@@ -2043,12 +2043,12 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
  *			    NOTE: Use JSON_INFINITE_DEPTH for infinite depth
  *			    NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
  *	sem		pointer to a JSON semantic table (ends with a JTYPE_UNSET JSON type)
- *	pcnt_err	pointer to dynamic array of JSON semantic count errors,
- *			    NOTE: If *pcnt_err == NULL, the dynamic array will be created,
- *				  If *pcnt_err != NULL, the existing dynamic array will be used.
+ *	pcount_err	pointer to dynamic array of JSON semantic count errors,
+ *			    NOTE: If *pcount_err == NULL, the dynamic array will be created,
+ *				  If *pcount_err != NULL, the existing dynamic array will be used.
  *	pval_err	pointer to dynamic array of JSON semantic validation errors
- *			    NOTE: If *pcnt_err == NULL, the dynamic array will be created,
- *				  If *pcnt_err != NULL, the existing dynamic array will be used.
+ *			    NOTE: If *pcount_err == NULL, the dynamic array will be created,
+ *				  If *pcount_err != NULL, the existing dynamic array will be used.
  *
  * return:
  *	0 ==> JSON parse tree is semantically consistent with the JSON semantic table,
@@ -2057,14 +2057,14 @@ sem_walk(struct json *node, unsigned int depth, va_list ap)
  * NOTE: The number of errors do not reflect the sum of JSON semantic count and
  *	 JSON semantic validation errors because internal errors are also counted.
  *	 When evaluating a non-zero return and both the *pval_err dynamic array
- *	 and the *pcnt_err dynamic array are empty, them report an internal json_sem_check()
+ *	 and the *pcount_err dynamic array are empty, them report an internal json_sem_check()
  *	 error was encountered.
  */
 uintmax_t
 json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
-	       struct dyn_array **pcnt_err, struct dyn_array **pval_err)
+	       struct dyn_array **pcount_err, struct dyn_array **pval_err)
 {
-    struct dyn_array *cnt_err = NULL;		/* JSON semantic count errors */
+    struct dyn_array *count_err = NULL;		/* JSON semantic count errors */
     struct dyn_array *val_err = NULL;		/* JSON semantic validation errors */
     uintmax_t err = 0;				/* number of errors (count+validation+internal) */
 
@@ -2079,8 +2079,8 @@ json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
 	warn(__func__, "sem is NULL");
 	++err;
     }
-    if (pcnt_err == NULL) {
-	warn(__func__, "pcnt_err is NULL");
+    if (pcount_err == NULL) {
+	warn(__func__, "pcount_err is NULL");
 	++err;
     }
     if (pval_err == NULL) {
@@ -2095,15 +2095,15 @@ json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
     /*
      * allocate empty dynamic arrays if dynamic array pointers are NULL
      */
-    if (*pcnt_err == NULL) {
-	cnt_err = dyn_array_create(sizeof(struct json_sem_cnt_err), JSON_CHUNK, JSON_CHUNK, true);
-	if (cnt_err == NULL) {
-	    warn(__func__, "dyn_array_create() failed to create cnt_err");
+    if (*pcount_err == NULL) {
+	count_err = dyn_array_create(sizeof(struct json_sem_count_err), JSON_CHUNK, JSON_CHUNK, true);
+	if (count_err == NULL) {
+	    warn(__func__, "dyn_array_create() failed to create count_err");
 	    ++err;
 	}
-	*pcnt_err = cnt_err;
+	*pcount_err = count_err;
     } else {
-	cnt_err = *pcnt_err;
+	count_err = *pcount_err;
     }
     if (*pval_err == NULL) {
 	val_err = dyn_array_create(sizeof(struct json_sem_val_err), JSON_CHUNK, JSON_CHUNK, true);
@@ -2115,8 +2115,8 @@ json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
     } else {
 	val_err = *pval_err;
     }
-    if (cnt_err == NULL) {
-	warn(__func__, "cnt_err remains NULL in dyn_array_create()");
+    if (count_err == NULL) {
+	warn(__func__, "count_err remains NULL in dyn_array_create()");
 	++err;
     }
     if (val_err == NULL) {
@@ -2140,17 +2140,17 @@ json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
     /*
      * perform a semantic scan of the JSON parse tree
      */
-    json_tree_walk(node, max_depth, sem_walk, sem, cnt_err, val_err);
+    json_tree_walk(node, max_depth, sem_walk, sem, count_err, val_err);
 
     /*
      * check semantic table counts
      */
-    json_sem_count_chk(sem, cnt_err);
+    json_sem_count_chk(sem, count_err);
 
     /*
      * count errors, if any
      */
-    err = dyn_array_tell(cnt_err) + dyn_array_tell(val_err);
+    err = dyn_array_tell(count_err) + dyn_array_tell(val_err);
 
     /*
      * report on the number of errors found
@@ -2160,36 +2160,36 @@ json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
 
 
 /*
- * free_cnt_err - free semantic count errors
+ * free_count_err - free semantic count errors
  *
  * given:
- *	cnt_err		semantic count error dynamic array to free
+ *	count_err		semantic count error dynamic array to free
  */
 void
-free_cnt_err(struct dyn_array *cnt_err)
+free_count_err(struct dyn_array *count_err)
 {
-    struct json_sem_cnt_err *p = NULL;	/* pointer to JSON semantic count error */
+    struct json_sem_count_err *p = NULL;	/* pointer to JSON semantic count error */
     uintmax_t count = 0;		/* length of semantic count array */
     uintmax_t i = 0;
 
     /*
      * firewall
      */
-    if (cnt_err == NULL) {
-	warn(__func__, "cnt_err is NULL");
+    if (count_err == NULL) {
+	warn(__func__, "count_err is NULL");
 	return;
     }
 
     /*
      * free each semantic count error if malloced
      */
-    count = dyn_array_tell(cnt_err);
+    count = dyn_array_tell(count_err);
     for (i=0; i < count; ++i) {
 
 	/*
 	 * free diagnostic is malloced
 	 */
-	p = dyn_array_addr(cnt_err, struct json_sem_cnt_err, i);
+	p = dyn_array_addr(count_err, struct json_sem_count_err, i);
 	if (p->malloced == true) {
 	    free(p->diagnostic);
 	    p->diagnostic = NULL;
@@ -2200,7 +2200,7 @@ free_cnt_err(struct dyn_array *cnt_err)
     /*
      * free the dynamic array
      */
-    dyn_array_free(cnt_err);
+    dyn_array_free(count_err);
     return;
 }
 
@@ -2252,16 +2252,16 @@ free_val_err(struct dyn_array *val_err)
 
 
 /*
- * fprint_cnt_err - print information about a count error on stream
+ * fprint_count_err - print information about a count error on stream
  *
  * given:
  *	stream		open stream to write on
  *	prefix		print prefix, if non-NULL, before printing info
- *	sem_cnt_err	pointer to semantic count error to print information about
+ *	sem_count_err	pointer to semantic count error to print information about
  *	postfix		print postfix, if non-NULL, after printing info
  */
 void
-fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cnt_err, char const *postfix)
+fprint_count_err(FILE *stream, char const *prefix, struct json_sem_count_err *sem_count_err, char const *postfix)
 {
     int ret = 0;	/* libc return value */
     char *p = NULL;	/* JSON node related string */
@@ -2278,15 +2278,15 @@ fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cn
 	warn(__func__, "stream is is not an open FILE *stream");
 	return;
     }
-    if (sem_cnt_err == NULL) {
-	warn(__func__, "sem_cnt_err is NULL");
+    if (sem_count_err == NULL) {
+	warn(__func__, "sem_count_err is NULL");
 	return;
     }
 
     /*
      * fill in sem_node for use if needed
      */
-    if (sem_cnt_err->sem == NULL) {
+    if (sem_count_err->sem == NULL) {
 	/* setup a dummy struct json_sem if the error has a NULL sem */
 	memset(&sem_node, 0, sizeof(sem_node));
 	sem_node.depth = INF_DEPTH;
@@ -2294,7 +2294,7 @@ fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cn
 	sem_node.validate = NULL;
 	sem_node.name = NULL;
     } else {
-	memmove(&sem_node, sem_cnt_err->sem, sizeof(sem_node));
+	memmove(&sem_node, sem_count_err->sem, sizeof(sem_node));
     }
 
     /*
@@ -2310,25 +2310,25 @@ fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cn
 	/*
 	 * case: we have a JSON semantic table index
 	 */
-	if (sem_cnt_err->sem_index >= 0) {
-	    fpr(stream, __func__, "sem_tbl[%d]: ", sem_cnt_err->sem_index);
+	if (sem_count_err->sem_index >= 0) {
+	    fpr(stream, __func__, "sem_tbl[%d]: ", sem_count_err->sem_index);
 	}
 
 	/*
-	 * case: sem_cnt_err->node != NULL
+	 * case: sem_count_err->node != NULL
 	 */
-	if (sem_cnt_err->node != NULL) {
+	if (sem_count_err->node != NULL) {
 
 	    /*
 	     * print JSON node type
 	     */
-	    fpr(stream, __func__, "node type: %s ", json_item_type_name((struct json *)sem_cnt_err->node));
+	    fpr(stream, __func__, "node type: %s ", json_item_type_name((struct json *)sem_count_err->node));
 
 	    /*
 	     * case: JSON node is a member, print name
 	     */
-	    if (sem_cnt_err->node->type == JTYPE_MEMBER) {
-		p = sem_member_name_decoded_str(sem_cnt_err->node, INF_DEPTH, &sem_node, __func__, NULL);
+	    if (sem_count_err->node->type == JTYPE_MEMBER) {
+		p = sem_member_name_decoded_str(sem_count_err->node, INF_DEPTH, &sem_node, __func__, NULL);
 		fpr(stream, __func__, "name: \"%s\" ", p);
 	    }
 	}
@@ -2336,29 +2336,29 @@ fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cn
 	/*
 	 * case: bad_min
 	 */
-	if (sem_cnt_err->bad_min == true) {
-	    fpr(stream, __func__, "count: %u < min: %u ", sem_cnt_err->count, sem_node.min);
+	if (sem_count_err->bad_min == true) {
+	    fpr(stream, __func__, "count: %u < min: %u ", sem_count_err->count, sem_node.min);
 	}
 
 	/*
 	 * case: bad_max
 	 */
-	if (sem_cnt_err->bad_max == true) {
-	    fpr(stream, __func__, "count: %u > max: %u ", sem_cnt_err->count, sem_node.max);
+	if (sem_count_err->bad_max == true) {
+	    fpr(stream, __func__, "count: %u > max: %u ", sem_count_err->count, sem_node.max);
 	}
 
 	/*
 	 * case: unknown_node
 	 */
-	if (sem_cnt_err->unknown_node == true) {
-	    fpr(stream, __func__, "unknown node found: %u times ", sem_cnt_err->count);
+	if (sem_count_err->unknown_node == true) {
+	    fpr(stream, __func__, "unknown node found: %u times ", sem_count_err->count);
 	}
 
 	/*
 	 * case: we have a diagnostic string
 	 */
-	if (sem_cnt_err->diagnostic != NULL) {
-	    fpr(stream, __func__, "error: %s ", sem_cnt_err->diagnostic);
+	if (sem_count_err->diagnostic != NULL) {
+	    fpr(stream, __func__, "error: %s ", sem_count_err->diagnostic);
 	}
 
     /*
@@ -2369,8 +2369,8 @@ fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cn
 	/*
 	 * case: we have a diagnostic string
 	 */
-	if (sem_cnt_err->diagnostic != NULL) {
-	    fpr(stream, __func__, "%s ", sem_cnt_err->diagnostic);
+	if (sem_count_err->diagnostic != NULL) {
+	    fpr(stream, __func__, "%s ", sem_count_err->diagnostic);
 	}
     }
 

--- a/json_sem.h
+++ b/json_sem.h
@@ -52,7 +52,7 @@
  /*
   * JSON semantic count error
   */
-struct json_sem_cnt_err
+struct json_sem_count_err
 {
     struct json const *node;	/* JSON parse node in question or NULL */
     struct json_sem const *sem;	/* semantic node in question or NULL (unknown_node == true) */
@@ -158,10 +158,10 @@ extern struct json *sem_object_find_name(struct json const *node, unsigned int d
 extern void json_sem_zero_count(struct json_sem *sem);
 extern int json_sem_find(struct json *node, unsigned int depth, struct json_sem *sem);
 extern uintmax_t json_sem_check(struct json *node, unsigned int max_depth, struct json_sem *sem,
-				struct dyn_array **pcnt_err, struct dyn_array **pval_err);
-extern void free_cnt_err(struct dyn_array *cnt_err);
+				struct dyn_array **pcount_err, struct dyn_array **pval_err);
+extern void free_count_err(struct dyn_array *count_err);
 extern void free_val_err(struct dyn_array *val_err);
-extern void fprint_cnt_err(FILE *stream, char const *prefix, struct json_sem_cnt_err *sem_cnt_err, char const *postfix);
+extern void fprint_count_err(FILE *stream, char const *prefix, struct json_sem_count_err *sem_count_err, char const *postfix);
 extern void fprint_val_err(FILE *stream, char const *prefix, struct json_sem_val_err *sem_val_err, char const *postfix);
 
 #endif /* INCLUDE_JSON_SEM_H */

--- a/util.c
+++ b/util.c
@@ -1239,7 +1239,7 @@ para(char const *line, ...)
     va_list ap;			/* variable argument list */
     int ret;			/* libc function return value */
     int fd;			/* stdout as a file descriptor or -1 */
-    int line_cnt;		/* number of lines in the paragraph */
+    int line_count;		/* number of lines in the paragraph */
 
     /*
      * stdarg variable argument list setup
@@ -1268,7 +1268,7 @@ para(char const *line, ...)
     /*
      * print paragraph strings followed by newlines
      */
-    line_cnt = 0;
+    line_count = 0;
     while (line != NULL) {
 
 	/*
@@ -1308,7 +1308,7 @@ para(char const *line, ...)
 		not_reached();
 	    }
 	}
-	++line_cnt;		/* count this line as printed */
+	++line_count;		/* count this line as printed */
 
 	/*
 	 * move to next line string
@@ -1339,7 +1339,7 @@ para(char const *line, ...)
 	    not_reached();
 	}
     }
-    dbg(DBG_VVHIGH, "%s() printed %d line paragraph", __func__, line_cnt);
+    dbg(DBG_VVHIGH, "%s() printed %d line paragraph", __func__, line_count);
     return;
 }
 
@@ -1367,7 +1367,7 @@ fpara(FILE * stream, char const *line, ...)
     va_list ap;			/* variable argument list */
     int ret;			/* libc function return value */
     int fd;			/* stream as a file descriptor or -1 */
-    int line_cnt;		/* number of lines in the paragraph */
+    int line_count;		/* number of lines in the paragraph */
 
     /*
      * stdarg variable argument list setup
@@ -1397,7 +1397,7 @@ fpara(FILE * stream, char const *line, ...)
     /*
      * print paragraph strings followed by newlines
      */
-    line_cnt = 0;
+    line_count = 0;
     while (line != NULL) {
 
 	/*
@@ -1437,7 +1437,7 @@ fpara(FILE * stream, char const *line, ...)
 		not_reached();
 	    }
 	}
-	++line_cnt;		/* count this line as printed */
+	++line_count;		/* count this line as printed */
 
 	/*
 	 * move to next line string
@@ -1468,7 +1468,7 @@ fpara(FILE * stream, char const *line, ...)
 	    not_reached();
 	}
     }
-    dbg(DBG_VVHIGH, "%s() printed %d line paragraph", __func__, line_cnt);
+    dbg(DBG_VVHIGH, "%s() printed %d line paragraph", __func__, line_count);
     return;
 }
 

--- a/verge.c
+++ b/verge.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
     char const *program = NULL;	/* our name */
     extern char *optarg;	/* option argument */
     extern int optind;		/* argv index of the next arg */
-    int arg_cnt = 0;		/* number of args to process */
+    int arg_count = 0;		/* number of args to process */
     char *ver1 = NULL;		/* first version string */
     char *ver2 = NULL;		/* second version string */
     int ver1_levels = 0;	/* number of version levels for first version string */
@@ -82,8 +82,8 @@ main(int argc, char *argv[])
 	    not_reached();
 	 }
     }
-    arg_cnt = argc - optind;
-    if (arg_cnt != REQUIRED_ARGS) {
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
 	usage(4, "two args are required", program); /*ooo*/
 	not_reached();
     }


### PR DESCRIPTION
There are two reasons for this. First is so that it spells a word and does not trigger vim spellcheck (a bonus is it also is more descriptive). The other is it's too lexicographically close or similar to another word that one might accidentally type (or read) if one is tired or distracted. :-) This is probably not good.

Of course it might be wrong for me to write that in the log but I'm not sure where else to put it so there it is.