### PR TITLE
Remove unused function prototypes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 0.7 2022-11-03
+
+Released IOCCC entry toolkit v0.7 2022-11-03
+
+`chkentry` is now code complete!
+Added test suite for `chkentry`. More test files will be added in time.
+
+Removed prefix in bison and flex code. The programmer's apology and warning are
+still in `sorry.tm.ca.h`.
+
+A test suite for `txzchk` was added.
+
+Removed the `MAX_DIR_KSIZE` limit. There still is a maximum tarball size but now
+there also is a limit of the number of files in the tarball. `txzchk` and
+`mkiocccentry` were updated for this.
+
+There probably were other changes as well but we're one step closer to IOCCCMOCK
+with `chkentry` being complete!
+
 
 ## Release 0.6 2022-09-02
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ actually there and `mkiocccentry` will fail.
 
 As a stand-alone tool it will report whether the files are validly formed.
 
-*NOTE*: This tool is **very much a work in progress**. Although the JSON parser
-(see `jparse` below) is complete there are still some things that have to be
-done before this tool can be finished.
+This tool was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
 
 For more information and examples, try:
 

--- a/entry_util.c
+++ b/entry_util.c
@@ -12,7 +12,7 @@
  *
  * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
  *
- * The JSON parser was co-developed by:
+ * This tool and the JSON parser were co-developed by:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson

--- a/entry_util.h
+++ b/entry_util.h
@@ -7,7 +7,7 @@
  *
  * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
  *
- * The JSON parser was co-developed by:
+ * This tool and the JSON parser were co-developed by:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson

--- a/foo.c
+++ b/foo.c
@@ -14,9 +14,7 @@
  *
  * "Because Cody enjoys being a bit eccentric and he is rather proud of it too!" :-)
  *
- * This tool is being co-developed by Cody Boone Ferguson and Landon Curt Noll.
- *
- * The JSON parser was co-developed by:
+ * This tool and the JSON parser were co-developed by:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson

--- a/foo.h
+++ b/foo.h
@@ -14,9 +14,7 @@
  *
  * "Because Cody enjoys being a bit eccentric and he is rather proud of it too!" :-)
  *
- * This tool is being co-developed by Cody Boone Ferguson and Landon Curt Noll.
- *
- * The JSON parser was co-developed by:
+ * This tool and the JSON parser were co-developed by:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -313,7 +313,7 @@ gen_sem_tbl(struct json *tree, unsigned int max_depth, ...)
 
 
 /*
- * vupdate_tbl - tree talk callback to update semantic table for a given JSON node
+ * vupdate_tbl - tree walk callback to update semantic table for a given JSON node
  *
  * If the JSON node is represented in the semantic table, update the count.
  * If the JSON node is not in the semantic table, this function will add a
@@ -336,7 +336,7 @@ static void
 vupdate_tbl(struct json *node, unsigned int depth, va_list ap)
 {
     struct dyn_array *tbl = NULL;    /* semantic table - array of struct json_sem */
-    struct json_sem *p = NULL;	     /* i-th entey in the semantic */
+    struct json_sem *p = NULL;	     /* i-th entry in the semantics table */
     struct json_sem new;	     /* new semantic table entry */
     va_list ap2;		     /* copy of va_list ap */
     intmax_t len = 0;		     /* number of semantic table entries */
@@ -550,15 +550,15 @@ sem_cmp(void const *a, void const *b)
  * Print str a valid C function.  Any character that is not
  * alphanumeric is printed as an underscore ("_") character.
  *
- * If the first character if str is a digit,
+ * If the first character of str is a digit,
  * a leading x ("x") will be printed before str is processed.
  *
- * If the first character if str is an underscore ("_"),
+ * If the first character of str is an underscore ("_"),
  * a leading x ("x") will be printed before str is processed.
  * C names starting with underscore ("_") are reserved, so this
  * rule prevents the function from being a reserved function.
  *
- * An empty string will cause x ("x") will be printed.
+ * An empty string will cause x ("x") to be printed.
  *
  * If a C reserved word would otherwise be printed, a leading
  * x ("x") will be printed before str is processed.

--- a/json_util.c
+++ b/json_util.c
@@ -53,21 +53,6 @@ int json_verbosity_level = JSON_DBG_NONE;	/* json debug level set by -J in jpars
  * static declarations
  */
 
-/*
- * JSON warn (NOT error) codes to ignore
- *
- * When a tool is given command line arguments of the form:
- *
- *	.. -W 123 -W 1345 -W 56 ...
- *
- * this means the tool will ignore {JSON-0123}, {JSON-1345}, and {JSON-0056}.
- * The code_ignore_settable holds the JSON codes to ignore.
- *
- * NOTE: A NULL ignore_json_code_set means that the set has not been setup.
- */
-static void alloc_json_code_ignore_set(void);
-static int cmp_codes(const void *a, const void *b);
-static void expand_json_code_ignore_set(void);
 
 
 /*

--- a/oebxergfB.h
+++ b/oebxergfB.h
@@ -19,9 +19,7 @@
  * too of course and there's plenty of humour as well. Of course one has to
  * figure out how to trigger them too but that shouldn't be too hard to do.
  *
- * This tool is being co-developed by Cody Boone Ferguson and Landon Curt Noll.
- *
- * The JSON parser was co-developed by:
+ * This tool and the JSON parser were co-developed by:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
@@ -800,7 +798,7 @@ static char const *oebxergfB[] =
 "fsqlaw aqufudw ua ytas uttwpyt? :-) )\n"
 ,
 "    Rud msq hesx bnyb ue Lyuew, yb twyab yffslduep bs asiw asqlfwa, yobwl\n"
-"    Ayeqylm 37bn msq xutt kw fnylpwd y ouew osl nyvuep Inluabiya dwfslybusea\n"
+"    37 Ayeqylm msq xutt kw fnylpwd y ouew osl nyvuep Inluabiya dwfslybusea\n"
 "    abutt qr?\n"
 "\n"
 "Nqb nwlw'a y oqeem bnuep yksqb tsfybuse yed dybwa: tspufyttm arwyhuep, wvwe\n"
@@ -1912,8 +1910,7 @@ static char const *oebxergfB[] =
 "dlwia sv jw rwrta so Slsr vut oueytu nyv hqi blq. Cb ua nsrd jyb jwa\n"
 "aupeuouhyeb hseawanqea vut oueytm lwyansl jw 'Slsahwrbuha'!\n"
 ,
-"Co msq qaw Wssptw (yed xns dswae'b ? :) ) msq iupnb oued bnua lwasqlfw so\n"
-"vytqw:\n"
+"Co msq qaw Wssptw msq iupnb oued bnua lwasqlfw so vytqw:\n"
 "\n"
 "    nbbra://xxx.pssptwpqudw.fsi\n"
 "\n"

--- a/util.h
+++ b/util.h
@@ -137,7 +137,7 @@ typedef unsigned char bool;
 
 
 /*
- * invalid exit codes (values < 0): that may be returned by shell_cmd()
+ * invalid exit codes (values < 0) that may be returned by shell_cmd()
  */
 #define CALLOC_FAILED_EXIT (-2)		/* invalid exit code - calloc() failure */
 #define SYSTEM_FAILED_EXIT (-3)		/* invalid exit code - system() failed - returned exit 127 */

--- a/vermod.8
+++ b/vermod.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH vermod 8 "29 October 2022" "vermod" "IOCCC tools"
+.TH vermod 8 "02 November 2022" "vermod" "IOCCC tools"
 .SH NAME
 vermod \- modify version strings (and others) under ./test_JSON/
 .SH SYNOPSIS
@@ -32,7 +32,7 @@ Set verbosity level (def: 0).
 Set the directory where the '*.json' files are expected.
 .TP
 \fB\-i\fP
-Set limit.sh file to verify new version.
+Set limit.sh file to verify version.
 .TP
 \fB\-o\fP
 Verify old version instead of the new version (which is the default).


### PR DESCRIPTION
The functionality for ignoring warnings has been not needed for quite some time. The functions were removed but the prototypes were not.

I also updated comments so that any reference to 'being co-developed by' was changed to 'was co-developed by' (or if both chkentry and the JSON parser 'were'). I'm aware of some files that still need some of this added but those that had it in some form should be fixed.