### PR TITLE
Add check for IOCCC submit server readiness

### DIFF
--- a/jparse.l
+++ b/jparse.l
@@ -224,17 +224,17 @@ JSON_COMMA		","
  * and report their presence if we find any NUL bytes in data.
  *
  * We scan data for both NUL bytes.  When a NUL byte is detected, count
- * we increment the num_errors external varaible.
+ * we increment the num_errors external variable.
  *
  * We also keep track of newlines.  For the first MAX_NUL_REPORTED occurrences
  * of a NUL byte, we use the werr() function to issue an error reporting
  * both the line number a byte position of the NUL byte.  Once we reach a
- * total of * MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
+ * total of MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
  * style message and stop reporting further NUL byte error messages.
  * This is done in case we encounter a large block of NUL bytes so as to
  * not flood the system with lots of error messages.
  *
- * We also return a false if data == NULL or len <= 0.
+ * We also return false if data == NULL or len <= 0.
  *
  * given:
  *

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2151,17 +2151,17 @@ void yyfree (void * ptr )
  * and report their presence if we find any NUL bytes in data.
  *
  * We scan data for both NUL bytes.  When a NUL byte is detected, count
- * we increment the num_errors external varaible.
+ * we increment the num_errors external variable.
  *
  * We also keep track of newlines.  For the first MAX_NUL_REPORTED occurrences
  * of a NUL byte, we use the werr() function to issue an error reporting
  * both the line number a byte position of the NUL byte.  Once we reach a
- * total of * MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
+ * total of MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
  * style message and stop reporting further NUL byte error messages.
  * This is done in case we encounter a large block of NUL bytes so as to
  * not flood the system with lots of error messages.
  *
- * We also return a false if data == NULL or len <= 0.
+ * We also return false if data == NULL or len <= 0.
  *
  * given:
  *

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1556,7 +1556,7 @@ yyreduce:
 			   "*tree = NULL;");
 	}
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about also to perform: "
+	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about to also perform: "
 					      "*tree = $json;");
 	}
 	if (tree == NULL) {

--- a/jparse.y
+++ b/jparse.y
@@ -152,7 +152,7 @@ json:
 			   "*tree = NULL;");
 	}
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about also to perform: "
+	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about to also perform: "
 					      "*tree = $json;");
 	}
 	if (tree == NULL) {

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -125,6 +125,7 @@
 #define ISO_3166_1_CODE_URL4 "https://www.iso.org/glossary-for-iso-3166.html"
 #define IOCCC_REGISTER_URL "https://register.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
 #define IOCCC_SUBMIT_URL "https://submit.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
+#undef IOCCC_SUBMIT_SERVER_READY /* XXX - change to #define when submit server is ready */
 /* NOTE: The next two are for the warn_rule_2a_size() function. Do **NOT** change these values! */
 #define RULE_2A_BIG_FILE_WARNING (0)	/* warn that prog.c appears to be too big under Rule 2a */
 #define RULE_2A_IOCCCSIZE_MISMATCH (1)	/* warn that prog.c iocccsize size differs from the file size */
@@ -226,6 +227,6 @@ static void write_auth(struct auth *authp, char const *entry_dir, char const *ch
 static void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk);
 static void remind_user(char const *work_dir, char const *entry_dir, char const *tar, char const *tarball_path, bool test_mode);
-
-
+static void show_registration_url(void);
+static void show_submit_url(char const *work_dir, char const *tarball_path);
 #endif /* INCLUDE_MKIOCCCENTRY_H */


### PR DESCRIPTION
    If the submit server is not ready the user of mkiocccentry is told that
    because the submit server is not ready they may not enter the contest.
    It also asks them to please not email the Judges. If however the server
    is ready it tells them how to register as well as (after forming the
    tarball that's not a test entry) where they can upload their entry
    (again assuming they've registered).
    
    This commit makes these checks a bit more modular (well - the checks
    weren't actually in before except for test mode but the display of these
    things were there and it is this that is modular but the check for the
    submit server being ready was added to it in the two new functions).

That commit also fixed some typos and in commit d4e9f088c9aefe1be679927842a8e45b8de8bf34 there was also a typo fix (jparse.y).