### PR TITLE
Add check for has_nul in json_decode()

### DIFF
--- a/jparse.l
+++ b/jparse.l
@@ -224,17 +224,17 @@ JSON_COMMA		","
  * and report their presence if we find any NUL bytes in data.
  *
  * We scan data for both NUL bytes.  When a NUL byte is detected, count
- * we increment the num_errors external varaible.
+ * we increment the num_errors external variable.
  *
  * We also keep track of newlines.  For the first MAX_NUL_REPORTED occurrences
  * of a NUL byte, we use the werr() function to issue an error reporting
  * both the line number a byte position of the NUL byte.  Once we reach a
- * total of * MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
+ * total of MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
  * style message and stop reporting further NUL byte error messages.
  * This is done in case we encounter a large block of NUL bytes so as to
  * not flood the system with lots of error messages.
  *
- * We also return a false if data == NULL or len <= 0.
+ * We also return false if data == NULL or len <= 0.
  *
  * given:
  *

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2151,17 +2151,17 @@ void yyfree (void * ptr )
  * and report their presence if we find any NUL bytes in data.
  *
  * We scan data for both NUL bytes.  When a NUL byte is detected, count
- * we increment the num_errors external varaible.
+ * we increment the num_errors external variable.
  *
  * We also keep track of newlines.  For the first MAX_NUL_REPORTED occurrences
  * of a NUL byte, we use the werr() function to issue an error reporting
  * both the line number a byte position of the NUL byte.  Once we reach a
- * total of * MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
+ * total of MAX_NUL_REPORTED NUL bytes detected, we issue a "too many NUL"
  * style message and stop reporting further NUL byte error messages.
  * This is done in case we encounter a large block of NUL bytes so as to
  * not flood the system with lots of error messages.
  *
- * We also return a false if data == NULL or len <= 0.
+ * We also return false if data == NULL or len <= 0.
  *
  * given:
  *

--- a/jparse.tab.ref.c
+++ b/jparse.tab.ref.c
@@ -1556,7 +1556,7 @@ yyreduce:
 			   "*tree = NULL;");
 	}
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about also to perform: "
+	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about to also perform: "
 					      "*tree = $json;");
 	}
 	if (tree == NULL) {

--- a/jparse.y
+++ b/jparse.y
@@ -152,7 +152,7 @@ json:
 			   "*tree = NULL;");
 	}
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about also to perform: "
+	    json_dbg(JSON_DBG_HIGH, __func__, "under json: about to also perform: "
 					      "*tree = $json;");
 	}
 	if (tree == NULL) {

--- a/json_parse.h
+++ b/json_parse.h
@@ -456,7 +456,7 @@ extern struct encode jenc[];
 extern char *json_encode(char const *ptr, size_t len, size_t *retlen, bool skip_quote);
 extern char *json_encode_str(char const *str, size_t *retlen, bool skip_quote);
 extern void jencchk(void);
-extern char *json_decode(char const *ptr, size_t len, size_t *retlen);
+extern char *json_decode(char const *ptr, size_t len, size_t *retlen, bool *has_nul);
 extern char *json_decode_str(char const *str, size_t *retlen);
 extern struct json *parse_json_string(char const *string, size_t len);
 extern struct json *parse_json_bool(char const *string);

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -89,7 +89,7 @@ jstrdecode_stream(FILE *in_stream, FILE *out_stream, bool write_quote)
     /*
      * decode data read from input stream
      */
-    buf = json_decode(input, inputlen, &bufsiz);
+    buf = json_decode(input, inputlen, &bufsiz, NULL);
     if (buf == NULL) {
 	warn(__func__, "error while encoding stdin buffer");
 	success = false;

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -125,6 +125,7 @@
 #define ISO_3166_1_CODE_URL4 "https://www.iso.org/glossary-for-iso-3166.html"
 #define IOCCC_REGISTER_URL "https://register.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
 #define IOCCC_SUBMIT_URL "https://submit.ioccc.org/NOT/a/real/URL"	/* XXX - change to real URL when ready */
+#undef IOCCC_SUBMIT_SERVER_READY /* XXX - change to #define when submit server is ready */
 /* NOTE: The next two are for the warn_rule_2a_size() function. Do **NOT** change these values! */
 #define RULE_2A_BIG_FILE_WARNING (0)	/* warn that prog.c appears to be too big under Rule 2a */
 #define RULE_2A_IOCCCSIZE_MISMATCH (1)	/* warn that prog.c iocccsize size differs from the file size */
@@ -226,6 +227,6 @@ static void write_auth(struct auth *authp, char const *entry_dir, char const *ch
 static void form_tarball(char const *work_dir, char const *entry_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk);
 static void remind_user(char const *work_dir, char const *entry_dir, char const *tar, char const *tarball_path, bool test_mode);
-
-
+static void show_registration_url(void);
+static void show_submit_url(char const *work_dir, char const *tarball_path);
 #endif /* INCLUDE_MKIOCCCENTRY_H */


### PR DESCRIPTION
    This commit is on a different branch because it's somewhat hackish and I
    might be missing something. More specifically I'm not quite sure it's
    correct. Although the has_nul is set to true if it's encoded there very
    possibly is a better way. Not only that but I might have missed some
    cases.
    
    Nevertheless with a file like:
    
        $ cat nul.json
        "test\u0000test"
    
        one will see:
    
        $ ./jparse -J 5 nul.json
        in parse_json_stream(): JSON debug[5]: calling parse_json on data block with length 17:
        in yyparse(): JSON debug[5]: under json_string: returning $json_string type: JTYPE_STRING
        JSON tree[5]:       lvl: 0  type: JTYPE_STRING      len{q0a}: 9     value:  "test\0test"
        in yyparse(): JSON debug[5]: under json_value: returning $json_value type: JTYPE_STRING
        JSON tree[5]:       lvl: 0  type: JTYPE_STRING      len{q0a}: 9     value:  "test\0test"
        in yyparse(): JSON debug[5]: under json_element: returning $json_element type: JTYPE_STRING
        JSON tree[5]:       lvl: 0  type: JTYPE_STRING      len{q0a}: 9     value:  "test\0test"
        in yyparse(): JSON debug[5]: under json: starting: json: json_element
        in yyparse(): JSON debug[5]: under json: $json_element type: JTYPE_STRING
        in yyparse(): JSON debug[5]: under json: about to perform: $json = $json_element;
        in yyparse(): JSON debug[5]: under json: returning $json_element type: JTYPE_STRING
        JSON tree[3]:       lvl: 0  type: JTYPE_STRING      len{q0a}: 9     value:  "test\0test"
        in yyparse(): JSON debug[5]: under json: about to also perform: *tree = $json;
        in yyparse(): JSON debug[5]: under json: ending: json: json_element
        in parse_json(): JSON debug[1]: valid JSON
        valid JSON
    
    This output is correct but whether anything else is missing I do not
    know. But that's why it's a separate pull request.
    
    Note that the only time has_nul != NULL is in the function
    json_conv_string().
    
    There were also some typo fixes.

