### PR TITLE
Minor fixes in two man pages

### DIFF
--- a/man/chkentry_test.8
+++ b/man/chkentry_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH chkentry_test.sh 8 "30 October 2022" "chkentry_test.sh" "IOCCC tools"
+.TH chkentry_test.sh 8 "05 November 2022" "chkentry_test.sh" "IOCCC tools"
 .SH NAME
 chkentry_test.sh \- test chkentry on good and bad auth.json and info.json files
 .SH SYNOPSIS
@@ -89,11 +89,6 @@ The default JSON tree with good and bad subdirectories for files that must pass 
 .SH NOTES
 The JSON parser \fBjparse(1)\fP and \fBchkentry(1)\fP were co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC Judges) in support for IOCCCMOCK, IOCCC28 and beyond.
 .SH BUGS
-.PP
-Currently some of the tests actually fail.
-This appears to be because the test cases are actually bad.
-This will be fixed in the near future.
-.PP
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br

--- a/man/hostchk.1
+++ b/man/hostchk.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH hostchk.sh 1 "29 October 2022" "hostchk.sh" "IOCCC tools"
+.TH hostchk.sh 1 "05 November 2022" "hostchk.sh" "IOCCC tools"
 .SH NAME
 hostchk.sh \- run a series of checks on your system to help determine if you can correctly use the mkiocccentry toolkit
 .SH SYNOPSIS
@@ -37,7 +37,7 @@ Set path to the compiler (cc) to \fIcc\fP.
 \fB\-w \fIwork_dir\fP\fP
 Use a working directory of \fIwork_dir\fP.
 By default a temporary working directory is used.
-The \fIwork_dir\fP\fP must not exist.
+The \fIwork_dir\fP must not exist.
 .TP
 \fB\-f\fP
 Fast compile mode.


### PR DESCRIPTION
In chkentry_test.8: remove from the BUGS section the statement that some of the tests fail as this no longer is true.

In hostchk.1: fix formatting detected by checknr.