### PR TITLE
Fix segfault in chkentry and memory leak in jparse

### DIFF
--- a/chkentry.c
+++ b/chkentry.c
@@ -659,16 +659,13 @@ main(int argc, char *argv[])
     }
 
     /*
-     * cleanup - except for info_path and auth_path
+     * cleanup - except for info_path, auth_path, info_stream and auth_stream.
+     *
+     * We don't try closing info_stream or auth_stream because the json parser
+     * already does that at this point. This is because we no longer use yyin
+     * due to complications introduced when making the lexer re-entrant. This is
+     * not a problem under macOS but it is under linux.
      */
-    if (info_stream != NULL) {
-	clearerr_or_fclose(info_stream);
-	info_stream = NULL;
-    }
-    if (auth_stream != NULL) {
-	clearerr_or_fclose(auth_stream);
-	auth_stream = NULL;
-    }
     if (info_tree != NULL) {
 	json_tree_free(info_tree, JSON_DEFAULT_MAX_DEPTH);
 	info_tree = NULL;

--- a/chkentry.c
+++ b/chkentry.c
@@ -423,7 +423,7 @@ main(int argc, char *argv[])
      * parse .info.json if it is open
      */
     if (info_stream != NULL) {
-	info_tree = parse_json_stream(info_stream, &info_valid);
+	info_tree = parse_json_stream(info_path, info_stream, &info_valid);
 	if (info_valid == false || info_tree == NULL) {
 	    err(4, __func__, "failed to JSON parse of .info.json file: %s", info_path); /*ooo*/
 	    not_reached();
@@ -435,7 +435,7 @@ main(int argc, char *argv[])
      * parse .auth.json if it is open
      */
     if (auth_stream != NULL) {
-	auth_tree = parse_json_stream(auth_stream, &auth_valid);
+	auth_tree = parse_json_stream(auth_path, auth_stream, &auth_valid);
 	if (auth_valid == false || auth_tree == NULL) {
 	    err(4, __func__, "failed to JSON parse of .auth.json file: %s", auth_path); /*ooo*/
 	    not_reached();

--- a/jparse.h
+++ b/jparse.h
@@ -70,11 +70,13 @@
  */
 extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern char const *json_parser_version;	/* official JSON parser version */
-extern char const *filename;		/* if != NULL this is the filename we're parsing */
 /* lexer and parser specific variables */
-extern unsigned num_errors;		/* > 0 number of errors encountered */
 extern int yydebug;
 
+struct json_extra
+{
+    char const *filename;	/* filename being parsed ("-" means stdin) */
+};
 
 /*
  * lexer specific
@@ -89,8 +91,8 @@ extern void yyerror(YYLTYPE *yyltype, struct json **tree, yyscan_t scanner, char
 /*
  * function prototypes for jparse.l
  */
-extern struct json *parse_json(char const *ptr, size_t len, bool *is_valid);
-extern struct json *parse_json_stream(FILE *stream, bool *is_valid);
+extern struct json *parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid);
+extern struct json *parse_json_stream(char const *filename, FILE *stream, bool *is_valid);
 extern struct json *parse_json_file(char const *name, bool *is_valid);
 
 

--- a/jparse.l
+++ b/jparse.l
@@ -50,7 +50,7 @@ YY_BUFFER_STATE bs;
  * locations in the file / json block
  */
 #define YY_USER_ACTION \
-			yylloc->filename = yyextra->filename; \
+			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line = yylineno; \
 			yylloc->first_column = yyget_column(yyscanner); \
 			yylloc->last_column = yyget_column(yyscanner)+yyget_leng(yyscanner)-1; \
@@ -547,7 +547,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
     ret = yyparse(&tree, scanner);
 
     /*
-     * scan and parse clean up
+     * free memory associated with bytes scanned by yy_scan_bytes()
      */
     yy_delete_buffer(bs, scanner);
     bs = NULL;

--- a/jparse.l
+++ b/jparse.l
@@ -490,7 +490,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
     }
 
     if (filename == NULL) {
-	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
 	filename = "-";	/* assume stdin */
     }
 
@@ -658,7 +658,7 @@ parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
     }
 
     if (filename == NULL) {
-	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
 	filename = "-";
     }
 

--- a/jparse.l
+++ b/jparse.l
@@ -268,7 +268,8 @@ JSON_COMMA		","
  *	nul_bytes   - pointer to set the number of NUL bytes found in
  *
  * return:
- *	true ==> data == NULL  OR  len <= 0 OR  one or more [\x00-\x08\x0e-\x1f] bytes are found
+ *	true ==> data == NULL  OR  len <= 0 OR  one or more [\x00-\x08\x0e-\x1f]
+ *		 bytes are found OR low_bytes == NULL OR nul_bytes == NULL
  *	false ==> data != NULL AND len > 0  AND no NUL [\x00-\x08\x0e-\x1f] bytes were found
  */
 static bool
@@ -286,17 +287,17 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
     if (data == NULL) {
 	werr(30, __func__, "data is NULL");
 	++num_errors;
-	return false;
+	return true;
     }
     if (len <= 0) {
 	werr(31, __func__, "len: %zu <= 0 ", len);
 	++num_errors;
-	return false;
+	return true;
     }
     if (low_bytes == NULL) {
 	werr(32, __func__, "low_bytes is NULL");
 	++num_errors;
-	return false;
+	return true;
     } else {
 	/* set *low_bytes to 0 */
 	*low_bytes = 0;
@@ -304,7 +305,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
     if (nul_bytes == NULL) {
 	werr(33, __func__, "nul_bytes is NULL"); /* nul_bytes is ironically NULL! :-) */
 	++num_errors;
-	return false;
+	return true;
     } else {
 	*nul_bytes = 0;
     }

--- a/jparse.l
+++ b/jparse.l
@@ -29,6 +29,7 @@
 %option noyywrap yylineno nodefault 8bit
 %option bison-bridge bison-locations reentrant
 %option header-file="jparse.lex.h"
+%option extra-type="struct json_extra *"
 
 %{
 /* Declarations etc. go here.
@@ -49,7 +50,7 @@ YY_BUFFER_STATE bs;
  * locations in the file / json block
  */
 #define YY_USER_ACTION \
-			yylloc->filename = filename; \
+			yylloc->filename = yyextra->filename; \
 			yylloc->first_line = yylloc->last_line = yylineno; \
 			yylloc->first_column = yyget_column(yyscanner); \
 			yylloc->last_column = yyget_column(yyscanner)+yyget_leng(yyscanner)-1; \
@@ -431,6 +432,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  * given:
  *
+ *	filename    - filename or NULL for stdin
  *	ptr	    - pointer to start of json blob
  *	len	    - length of the json blob
  *	is_valid    - != NULL ==> set to true or false depending on json validity
@@ -446,11 +448,12 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * enough (or otherwise if this information is requested).
  */
 struct json *
-parse_json(char const *ptr, size_t len, bool *is_valid)
+parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     int ret = 0;			/* yyparse() return value */
     yyscan_t scanner;			/* scanner instance: is a void * */
+    struct json_extra extra;
 
     /*
      * We set *is_valid = true if is_valid != NULL so that the caller does not
@@ -486,10 +489,16 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
 	return tree;
     }
 
+    if (filename == NULL) {
+	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	filename = "-";	/* assume stdin */
+    }
+
     /*
      * initialise scanner
      */
-    yylex_init(&scanner);
+    extra.filename = filename;
+    yylex_init_extra(&extra, &scanner);
 
     /*
      * scan the blob
@@ -585,6 +594,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
  * then parse that data as if it were JSON.
  *
  * given:
+ *	filename    - name of file or NULL for stdin
  *	stream      - open file stream containing JSON data
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
@@ -604,7 +614,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_stream(FILE *stream, bool *is_valid)
+parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
 {
     struct json *node = NULL;		/* the JSON parse tree */
     char *data = NULL;			/* used to determine if there are NUL bytes in the file */
@@ -645,6 +655,11 @@ parse_json_stream(FILE *stream, bool *is_valid)
 	/* return a blank JSON tree */
 	node = json_alloc(JTYPE_UNSET);
 	return node;
+    }
+
+    if (filename == NULL) {
+	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	filename = "-";
     }
 
     /*
@@ -710,7 +725,7 @@ parse_json_stream(FILE *stream, bool *is_valid)
      * JSON parse the data from the file
      */
     json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
-    node = parse_json(data, len, is_valid);
+    node = parse_json(filename, data, len, is_valid);
 
     /* free data */
     if (data != NULL) {
@@ -808,7 +823,7 @@ parse_json_file(char const *name, bool *is_valid)
     } else {
 
 	/*
-	 * validate name
+	 * validate filename
 	 */
 	if (!exists(name)) {
 	    /* report missing file */
@@ -880,7 +895,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    node = parse_json_stream(stream, is_valid);
+    node = parse_json_stream(name, stream, is_valid);
 
     /*
      * return the JSON parse tree node

--- a/jparse.lex.ref.h
+++ b/jparse.lex.ref.h
@@ -309,9 +309,7 @@ void yyfree ( void * , yyscan_t yyscanner );
 #include <unistd.h>
 #endif
 
-#ifndef YY_EXTRA_TYPE
-#define YY_EXTRA_TYPE void *
-#endif
+#define YY_EXTRA_TYPE struct json_extra *
 
 int yylex_init (yyscan_t* scanner);
 
@@ -569,9 +567,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 200 "jparse.l"
+#line 201 "jparse.l"
 
 
-#line 524 "jparse.lex.h"
+#line 522 "jparse.lex.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -580,7 +580,7 @@ static const flex_int32_t yy_rule_can_match_eol[16] =
  * problems. Another way is to provide 'int yywrap() { return 1; }' but this is
  * unnecessary.
  */
-#line 34 "jparse.l"
+#line 35 "jparse.l"
 /* Declarations etc. go here.
  *
  * Code is copied verbatim near the top of the generated code.
@@ -599,7 +599,7 @@ YY_BUFFER_STATE bs;
  * locations in the file / json block
  */
 #define YY_USER_ACTION \
-			yylloc->filename = filename; \
+			yylloc->filename = yyextra->filename; \
 			yylloc->first_line = yylloc->last_line = yylineno; \
 			yylloc->first_column = yyget_column(yyscanner); \
 			yylloc->last_column = yyget_column(yyscanner)+yyget_leng(yyscanner)-1; \
@@ -634,9 +634,7 @@ YY_BUFFER_STATE bs;
 #include <unistd.h>
 #endif
 
-#ifndef YY_EXTRA_TYPE
-#define YY_EXTRA_TYPE void *
-#endif
+#define YY_EXTRA_TYPE struct json_extra *
 
 /* Holds the entire state of the reentrant scanner. */
 struct yyguts_t
@@ -906,9 +904,9 @@ YY_DECL
 		}
 
 	{
-#line 94 "jparse.l"
+#line 95 "jparse.l"
 
-#line 860 "jparse.c"
+#line 858 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -979,7 +977,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 95 "jparse.l"
+#line 96 "jparse.l"
 {
 			    /*
 			     * Whitespace excluding newlines
@@ -999,14 +997,14 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 111 "jparse.l"
+#line 112 "jparse.l"
 {
 			    yycolumn = 1;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 115 "jparse.l"
+#line 116 "jparse.l"
 {
 			    /* string */
 			    return JSON_STRING;
@@ -1014,7 +1012,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 120 "jparse.l"
+#line 121 "jparse.l"
 {
 			    /* number */
 			    return JSON_NUMBER;
@@ -1022,7 +1020,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 125 "jparse.l"
+#line 126 "jparse.l"
 {
 			    /* null object */
 			    return JSON_NULL;
@@ -1030,7 +1028,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 130 "jparse.l"
+#line 131 "jparse.l"
 {
 			    /* boolean: true */
 			    return JSON_TRUE;
@@ -1038,7 +1036,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 134 "jparse.l"
+#line 135 "jparse.l"
 {
 			    /* boolean: false */
 			    return JSON_FALSE;
@@ -1046,7 +1044,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 139 "jparse.l"
+#line 140 "jparse.l"
 {
 			    /* start of object */
 			    return JSON_OPEN_BRACE;
@@ -1054,7 +1052,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 143 "jparse.l"
+#line 144 "jparse.l"
 {
 			    /* end of object */
 			    return JSON_CLOSE_BRACE;
@@ -1062,7 +1060,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 148 "jparse.l"
+#line 149 "jparse.l"
 {
 			    /* start of array */
 			    return JSON_OPEN_BRACKET;
@@ -1070,7 +1068,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 152 "jparse.l"
+#line 153 "jparse.l"
 {
 			    /* end of array */
 			    return JSON_CLOSE_BRACKET;
@@ -1078,7 +1076,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 157 "jparse.l"
+#line 158 "jparse.l"
 {
 			    /* colon or 'equals' */
 			    return JSON_COLON;
@@ -1086,7 +1084,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 162 "jparse.l"
+#line 163 "jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    return JSON_COMMA;
@@ -1094,7 +1092,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 167 "jparse.l"
+#line 168 "jparse.l"
 {
 			    /* invalid token: any other character */
 			    warn(__func__, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
@@ -1130,10 +1128,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 200 "jparse.l"
+#line 201 "jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1085 "jparse.c"
+#line 1083 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2337,7 +2335,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 200 "jparse.l"
+#line 201 "jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */
@@ -2572,6 +2570,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  * given:
  *
+ *	filename    - filename or NULL for stdin
  *	ptr	    - pointer to start of json blob
  *	len	    - length of the json blob
  *	is_valid    - != NULL ==> set to true or false depending on json validity
@@ -2587,11 +2586,12 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * enough (or otherwise if this information is requested).
  */
 struct json *
-parse_json(char const *ptr, size_t len, bool *is_valid)
+parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     int ret = 0;			/* yyparse() return value */
     yyscan_t scanner;			/* scanner instance: is a void * */
+    struct json_extra extra;
 
     /*
      * We set *is_valid = true if is_valid != NULL so that the caller does not
@@ -2627,10 +2627,16 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
 	return tree;
     }
 
+    if (filename == NULL) {
+	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	filename = "-";	/* assume stdin */
+    }
+
     /*
      * initialise scanner
      */
-    yylex_init(&scanner);
+    extra.filename = filename;
+    yylex_init_extra(&extra, &scanner);
 
     /*
      * scan the blob
@@ -2726,6 +2732,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
  * then parse that data as if it were JSON.
  *
  * given:
+ *	filename    - name of file or NULL for stdin
  *	stream      - open file stream containing JSON data
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
@@ -2745,7 +2752,7 @@ parse_json(char const *ptr, size_t len, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_stream(FILE *stream, bool *is_valid)
+parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
 {
     struct json *node = NULL;		/* the JSON parse tree */
     char *data = NULL;			/* used to determine if there are NUL bytes in the file */
@@ -2786,6 +2793,11 @@ parse_json_stream(FILE *stream, bool *is_valid)
 	/* return a blank JSON tree */
 	node = json_alloc(JTYPE_UNSET);
 	return node;
+    }
+
+    if (filename == NULL) {
+	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	filename = "-";
     }
 
     /*
@@ -2851,7 +2863,7 @@ parse_json_stream(FILE *stream, bool *is_valid)
      * JSON parse the data from the file
      */
     json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
-    node = parse_json(data, len, is_valid);
+    node = parse_json(filename, data, len, is_valid);
 
     /* free data */
     if (data != NULL) {
@@ -2949,7 +2961,7 @@ parse_json_file(char const *name, bool *is_valid)
     } else {
 
 	/*
-	 * validate name
+	 * validate filename
 	 */
 	if (!exists(name)) {
 	    /* report missing file */
@@ -3021,7 +3033,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    node = parse_json_stream(stream, is_valid);
+    node = parse_json_stream(name, stream, is_valid);
 
     /*
      * return the JSON parse tree node

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2628,7 +2628,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
     }
 
     if (filename == NULL) {
-	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
 	filename = "-";	/* assume stdin */
     }
 
@@ -2796,7 +2796,7 @@ parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
     }
 
     if (filename == NULL) {
-	dbg(DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
 	filename = "-";
     }
 

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -599,7 +599,7 @@ YY_BUFFER_STATE bs;
  * locations in the file / json block
  */
 #define YY_USER_ACTION \
-			yylloc->filename = yyextra->filename; \
+			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line = yylineno; \
 			yylloc->first_column = yyget_column(yyscanner); \
 			yylloc->last_column = yyget_column(yyscanner)+yyget_leng(yyscanner)-1; \
@@ -2685,7 +2685,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
     ret = yyparse(&tree, scanner);
 
     /*
-     * scan and parse clean up
+     * free memory associated with bytes scanned by yy_scan_bytes()
      */
     yy_delete_buffer(bs, scanner);
     bs = NULL;

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2409,7 +2409,8 @@ void yyfree (void * ptr , yyscan_t yyscanner)
  *	nul_bytes   - pointer to set the number of NUL bytes found in
  *
  * return:
- *	true ==> data == NULL  OR  len <= 0 OR  one or more [\x00-\x08\x0e-\x1f] bytes are found
+ *	true ==> data == NULL  OR  len <= 0 OR  one or more [\x00-\x08\x0e-\x1f]
+ *		 bytes are found OR low_bytes == NULL OR nul_bytes == NULL
  *	false ==> data != NULL AND len > 0  AND no NUL [\x00-\x08\x0e-\x1f] bytes were found
  */
 static bool
@@ -2427,17 +2428,17 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
     if (data == NULL) {
 	werr(30, __func__, "data is NULL");
 	++num_errors;
-	return false;
+	return true;
     }
     if (len <= 0) {
 	werr(31, __func__, "len: %zu <= 0 ", len);
 	++num_errors;
-	return false;
+	return true;
     }
     if (low_bytes == NULL) {
 	werr(32, __func__, "low_bytes is NULL");
 	++num_errors;
-	return false;
+	return true;
     } else {
 	/* set *low_bytes to 0 */
 	*low_bytes = 0;
@@ -2445,7 +2446,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
     if (nul_bytes == NULL) {
 	werr(33, __func__, "nul_bytes is NULL"); /* nul_bytes is ironically NULL! :-) */
 	++num_errors;
-	return false;
+	return true;
     } else {
 	*nul_bytes = 0;
     }

--- a/jparse_main.c
+++ b/jparse_main.c
@@ -114,6 +114,18 @@ main(int argc, char **argv)
 	tree = parse_json_file(filename, &valid_json);
     }
 
+    if (tree == NULL) {
+	warn(program, "JSON parse tree is NULL");
+    }
+    /*
+     * free the JSON parse tree
+     */
+    else {
+	json_tree_free(tree, JSON_INFINITE_DEPTH);
+	free(tree);
+	tree = NULL;
+    }
+
     /*
      * firewall - JSON parser must have returned a valid JSON parse tree
      */
@@ -122,22 +134,7 @@ main(int argc, char **argv)
 	err(1, program, "invalid JSON"); /*ooo*/
 	not_reached();
     }
-    if (tree == NULL) {
-	warn(program, "JSON parse tree is NULL");
-    }
 
-    /*
-     * free the JSON parse tree
-     */
-    if (tree == NULL) {
-	json_tree_free(tree, JSON_INFINITE_DEPTH);
-	free(tree);
-	tree = NULL;
-    }
-
-    /*
-     *  exit based on JSON parse success or failure
-     */
     if (num_errors > 0) {
 	msg("invalid JSON");
 	exit(1); /*ooo*/

--- a/jparse_main.c
+++ b/jparse_main.c
@@ -99,9 +99,9 @@ main(int argc, char **argv)
     if (string_flag_used == true) {
 
 	/* parse arg as a block of json input */
-	dbg(DBG_HIGH, "Calling parse_json(\"%s\", %ju, &valid_json):",
+	dbg(DBG_HIGH, "Calling parse_json(NULL, \"%s\", %ju, &valid_json):",
 		      argv[argc-1], (uintmax_t)strlen(argv[argc-1]));
-	tree = parse_json(argv[argc-1], strlen(argv[argc-1]), &valid_json);
+	tree = parse_json(NULL, argv[argc-1], strlen(argv[argc-1]), &valid_json);
 
     /*
      * case: process file arg
@@ -110,8 +110,7 @@ main(int argc, char **argv)
 
 	/* parse arg as a json filename */
 	dbg(DBG_HIGH, "Calling parse_json_file(\"%s\", &valid_json):", argv[argc-1]);
-	filename = argv[argc-1];
-	tree = parse_json_file(filename, &valid_json);
+	tree = parse_json_file(argv[argc-1], &valid_json);
     }
 
     if (tree == NULL) {

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -198,9 +198,9 @@ main(int argc, char **argv)
     if (string_flag_used == true) {
 
 	/* parse arg as a block of json input */
-	dbg(DBG_HIGH, "Calling parse_json(\"%s\", %ju, &valid_json):",
+	dbg(DBG_HIGH, "Calling parse_json(NULL, \"%s\", %ju, &valid_json):",
 		      argv[argc-1], (uintmax_t)strlen(argv[argc-1]));
-	tree = parse_json(argv[argc-1], strlen(argv[argc-1]), &valid_json);
+	tree = parse_json(NULL, argv[argc-1], strlen(argv[argc-1]), &valid_json);
 
     /*
      * case: process file arg
@@ -209,8 +209,7 @@ main(int argc, char **argv)
 
 	/* parse arg as a json filename */
 	dbg(DBG_HIGH, "Calling parse_json_file(\"%s\", &valid_json):", argv[argc-1]);
-	filename = argv[argc-1];
-	tree = parse_json_file(filename, &valid_json);
+	tree = parse_json_file(argv[argc-1], &valid_json);
     }
 
     /*


### PR DESCRIPTION
Under macOS this problem did not show up but under linux it did. The problem is that chkentry also called clearerr_or_fclose() on the streams of the .info.json and .auth.json files but because the scanner also uses this it resulted in a double free. I'm not sure exactly why this did not happen before since it was always the same stream in the end but possibly because yyin was used it was in a different state. As I noted in either a commit log or a GitHub comment we can no longer use yyin due to complexities introduced with the re-entrant scanner wrt setting/getting yyin needing the scanner context (which we don't always have): specifically the function that opens the json stream (or stream that is supposed to be json) does not have the scanner. Instead the function that that function calls has the scanner context so we can't use yyin. We obviously have to close it in the scanner since at that point it'll always be reached but we don't always use chkentry so there would be a file descriptor leak.