### PR TITLE
Reorder parse_json and parse_json_stream args

### DIFF
--- a/chkentry.c
+++ b/chkentry.c
@@ -423,7 +423,7 @@ main(int argc, char *argv[])
      * parse .info.json if it is open
      */
     if (info_stream != NULL) {
-	info_tree = parse_json_stream(info_path, info_stream, &info_valid);
+	info_tree = parse_json_stream(info_stream, info_path, &info_valid);
 	if (info_valid == false || info_tree == NULL) {
 	    err(4, __func__, "failed to JSON parse of .info.json file: %s", info_path); /*ooo*/
 	    not_reached();
@@ -435,7 +435,7 @@ main(int argc, char *argv[])
      * parse .auth.json if it is open
      */
     if (auth_stream != NULL) {
-	auth_tree = parse_json_stream(auth_path, auth_stream, &auth_valid);
+	auth_tree = parse_json_stream(auth_stream, auth_path, &auth_valid);
 	if (auth_valid == false || auth_tree == NULL) {
 	    err(4, __func__, "failed to JSON parse of .auth.json file: %s", auth_path); /*ooo*/
 	    not_reached();

--- a/jparse.h
+++ b/jparse.h
@@ -91,8 +91,8 @@ extern void yyerror(YYLTYPE *yyltype, struct json **tree, yyscan_t scanner, char
 /*
  * function prototypes for jparse.l
  */
-extern struct json *parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid);
-extern struct json *parse_json_stream(char const *filename, FILE *stream, bool *is_valid);
+extern struct json *parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid);
+extern struct json *parse_json_stream(FILE *stream, char const *filename, bool *is_valid);
 extern struct json *parse_json_file(char const *name, bool *is_valid);
 
 

--- a/jparse.l
+++ b/jparse.l
@@ -432,9 +432,9 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  * given:
  *
- *	filename    - filename or NULL for stdin
  *	ptr	    - pointer to start of json blob
  *	len	    - length of the json blob
+ *	filename    - filename or NULL for stdin
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
  * return:
@@ -448,7 +448,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * enough (or otherwise if this information is requested).
  */
 struct json *
-parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
+parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     int ret = 0;			/* yyparse() return value */
@@ -594,8 +594,8 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
  * then parse that data as if it were JSON.
  *
  * given:
- *	filename    - name of file or NULL for stdin
  *	stream      - open file stream containing JSON data
+ *	filename    - name of file or NULL for stdin
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
  * return:
@@ -614,7 +614,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
+parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 {
     struct json *node = NULL;		/* the JSON parse tree */
     char *data = NULL;			/* used to determine if there are NUL bytes in the file */
@@ -725,7 +725,7 @@ parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
      * JSON parse the data from the file
      */
     json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
-    node = parse_json(filename, data, len, is_valid);
+    node = parse_json(data, len, filename, is_valid);
 
     /* free data */
     if (data != NULL) {
@@ -895,7 +895,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    node = parse_json_stream(name, stream, is_valid);
+    node = parse_json_stream(stream, name, is_valid);
 
     /*
      * return the JSON parse tree node

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -2570,9 +2570,9 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  * given:
  *
- *	filename    - filename or NULL for stdin
  *	ptr	    - pointer to start of json blob
  *	len	    - length of the json blob
+ *	filename    - filename or NULL for stdin
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
  * return:
@@ -2586,7 +2586,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * enough (or otherwise if this information is requested).
  */
 struct json *
-parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
+parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     int ret = 0;			/* yyparse() return value */
@@ -2732,8 +2732,8 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
  * then parse that data as if it were JSON.
  *
  * given:
- *	filename    - name of file or NULL for stdin
  *	stream      - open file stream containing JSON data
+ *	filename    - name of file or NULL for stdin
  *	is_valid    - != NULL ==> set to true or false depending on json validity
  *
  * return:
@@ -2752,7 +2752,7 @@ parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
+parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 {
     struct json *node = NULL;		/* the JSON parse tree */
     char *data = NULL;			/* used to determine if there are NUL bytes in the file */
@@ -2863,7 +2863,7 @@ parse_json_stream(char const *filename, FILE *stream, bool *is_valid)
      * JSON parse the data from the file
      */
     json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
-    node = parse_json(filename, data, len, is_valid);
+    node = parse_json(data, len, filename, is_valid);
 
     /* free data */
     if (data != NULL) {
@@ -3033,7 +3033,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    node = parse_json_stream(name, stream, is_valid);
+    node = parse_json_stream(stream, name, is_valid);
 
     /*
      * return the JSON parse tree node

--- a/jparse_main.c
+++ b/jparse_main.c
@@ -99,9 +99,9 @@ main(int argc, char **argv)
     if (string_flag_used == true) {
 
 	/* parse arg as a block of json input */
-	dbg(DBG_HIGH, "Calling parse_json(NULL, \"%s\", %ju, &valid_json):",
+	dbg(DBG_HIGH, "Calling parse_json(\"%s\", %ju, NULL, &valid_json):",
 		      argv[argc-1], (uintmax_t)strlen(argv[argc-1]));
-	tree = parse_json(NULL, argv[argc-1], strlen(argv[argc-1]), &valid_json);
+	tree = parse_json(argv[argc-1], strlen(argv[argc-1]), NULL, &valid_json);
 
     /*
      * case: process file arg

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -198,9 +198,9 @@ main(int argc, char **argv)
     if (string_flag_used == true) {
 
 	/* parse arg as a block of json input */
-	dbg(DBG_HIGH, "Calling parse_json(NULL, \"%s\", %ju, &valid_json):",
+	dbg(DBG_HIGH, "Calling parse_json(\"%s\", %ju, NULL, &valid_json):",
 		      argv[argc-1], (uintmax_t)strlen(argv[argc-1]));
-	tree = parse_json(NULL, argv[argc-1], strlen(argv[argc-1]), &valid_json);
+	tree = parse_json(argv[argc-1], strlen(argv[argc-1]), NULL, &valid_json);
 
     /*
      * case: process file arg


### PR DESCRIPTION
The diff for the parameter changes:

    -extern struct json *parse_json(char const *filename, char const *ptr, size_t len, bool *is_valid);
    -extern struct json *parse_json_stream(char const *filename, FILE *stream, bool *is_valid);
    +extern struct json *parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid);
    +extern struct json *parse_json_stream(FILE *stream, char const *filename, bool *is_valid);