### PR TITLE
Fix bug_report.sh

### DIFF
--- a/bug_report.sh
+++ b/bug_report.sh
@@ -27,7 +27,6 @@ export TOOLS="
     ./chkentry
     ./dbg
     ./fnamchk
-    ./have_timegm.sh
     ./hostchk.sh
     ./iocccsize
     ./jnum_gen


### PR DESCRIPTION
Since have_timegm.sh no longer exists bug_report.sh failed because it tried to run it along with all the other tools.