### PR TITLE
Fix bug in jstr_test.sh - resolves #407

### DIFF
--- a/entry_util.c
+++ b/entry_util.c
@@ -1680,7 +1680,7 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 
 
 /*
- * form_tar_filename - return an malloced tarball filename
+ * form_tar_filename - return a malloced tarball filename
  *
  * given:
  *	IOCCC_contest_id	IOCCC contest UUID or test

--- a/json_sem.c
+++ b/json_sem.c
@@ -1287,7 +1287,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
  * and if it is a JTYPE_NUMBER (JSON number), return a pointer to a time_t
  * or return NULL on error or invalid input.
  *
- * If the JTYPE_NUMBER (JSON number) cannot be returned as an time_t, NULL is returned.
+ * If the JTYPE_NUMBER (JSON number) cannot be returned as a time_t, NULL is returned.
  *
  * given:
  *	node	JSON parse node being checked
@@ -1298,7 +1298,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
  *		NULL ==> do not report a JSON semantic validation error
  *
  * returns:
- *	!= NULL ==> decoded JTYPE_NUMBER as an time_t from the value part of JTYPE_MEMBER
+ *	!= NULL ==> decoded JTYPE_NUMBER as a time_t from the value part of JTYPE_MEMBER
  *	    The val_err arg is ignored
  *	NULL ==> invalid arguments or JSON conversion error
  *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_sem_val_err)

--- a/test/jstr_test.sh
+++ b/test/jstr_test.sh
@@ -204,16 +204,26 @@ echo "cat \$SRC_SET | $JSTRENCODE -v $V_FLAG -n | $JSTRDECODE -v $V_FLAG -n > $T
 # note: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
 # shellcheck disable=SC2002
 cat $SRC_SET | "$JSTRENCODE" -v "$V_FLAG" -n | "$JSTRDECODE" -v "$V_FLAG" -n > "$TEST_FILE"
-# We cannot double quote "$SRC_SET" because it would make the shell think it's a
-# single file which of course does not exist by that name as it's actually a
-# list of files. Thus we disable shellcheck check SC2086.
-# shellcheck disable=SC2086
-cat $SRC_SET > "$TEST_FILE2"
-if cmp -s "$TEST_FILE2" "$TEST_FILE"; then
-    echo "$0: test #3 passed"
-else
+STATUS="$?"
+if [[ "$STATUS" -ne 0 ]]; then
     echo "$0: test #3 failed" 1>&2
     EXIT_CODE=45
+else
+    # We cannot double quote "$SRC_SET" because it would make the shell think it's a
+    # single file which of course does not exist by that name as it's actually a
+    # list of files. Thus we disable shellcheck check SC2086.
+    # shellcheck disable=SC2086
+    cat $SRC_SET > "$TEST_FILE2"
+    STATUS="$?"
+    if [[ "$STATUS" -ne 0 ]]; then
+	echo "$0: test #3 failed" 1>&2
+	EXIT_CODE=45
+    elif cmp -s "$TEST_FILE2" "$TEST_FILE"; then
+	echo "$0: test #3 passed"
+    else
+	echo "$0: test #3 failed" 1>&2
+	EXIT_CODE=45
+    fi
 fi
 
 # All Done!!! -- Jessica Noll, Age 2

--- a/txzchk.c
+++ b/txzchk.c
@@ -191,7 +191,7 @@ main(int argc, char **argv)
 
 
 /*
- * show_txz_info    - show information about tarball (if verbosity is >= medium)
+ * show_txz_info    - show information about tarball (if verbosity is >= DBG_MED)
  *
  * given:
  *
@@ -762,7 +762,7 @@ check_all_txz_files(char const *dir_name)
  *	dir_name	- the directory expected (or NULL if fnamchk fails)
  *	txzpath		- the tarball path
  *
- * Issues a warning for every violations specific to directories (and
+ * Issues a warning for every violation specific to directories (and
  * subdirectories).
  *
  * Does not return on error.

--- a/util.c
+++ b/util.c
@@ -3496,7 +3496,7 @@ fprint_line_buf(FILE *stream, void *buf, size_t len, int start, int end)
     }
 
     /*
-     * if we had an print error, report the last errno that was observed
+     * if we had a print error, report the last errno that was observed
      */
     if (delayed_errno != 0) {
 	warn(__func__, "last write errno: %d (%s)", delayed_errno, strerror(delayed_errno));


### PR DESCRIPTION
Now the script checks for failure of test 3. I'm not sure if there are any conditions that might not be picked up. For example if another part of the pipeline fails it might not be detected but at least if one of the files does not exist (or cannot be found) the test will fail.