### PR TITLE
Makefiles clean up and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ jparse.tab.o: jparse.tab.c Makefile
 jparse_main.o: jparse_main.c Makefile
 	${CC} ${CFLAGS} jparse_main.c -c
 
-jparse: jparse/jparse.h jparse/jparse.l jparse/jparse.y jparse/Makefile
+jparse: jparse/jparse.h jparse/jparse.l jparse/jparse.y
 	@${MAKE} -C jparse CFLAGS="${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration"
 	@${CP} -f jparse/jparse.1 man/jparse.1
 	@${CP} -f jparse/jparse_test.8 man/jparse_test.8
@@ -806,7 +806,7 @@ legacy_clean:
 	${RM} -f jauthchk.o jinfochk.o
 
 clean: clean_generated_obj legacy_clean
-	${RM} -f ${OBJFILES}
+	${RM} -f ${OBJFILES} *.o
 	${RM} -f ${GENERATED_OBJ}
 	${RM} -f ${LESS_PICKY_OBJ}
 	${RM} -rf ${DSYMDIRS}
@@ -825,6 +825,7 @@ clobber: clean prep_clobber
 	${MAKE} -C dbg clobber
 	${MAKE} -C test_ioccc clobber
 	${MAKE} -C soup clobber
+	${MAKE} -C jparse clobber
 
 distclean nuke: clobber
 

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -46,10 +46,10 @@ soup:
 	fi
 
 clean:
-	${RM} -f *.o
+	${RM} *.o
 
 clobber: clean
-	${RM} -f .soup
+	${RM} .soup
 
 install: all
 	@${ECHO} "nothing to $@. Try eating the soup instead."

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -40,10 +40,10 @@ configure:
 	@echo nothing to $@
 
 clean:
-	${RM} -f *.o
+	${RM} *.o
 
 clobber: clean
-	${RM} -f ${TARGETS}
+	${RM} ${TARGETS}
 
 install: all
 	@echo nothing to $@


### PR DESCRIPTION
Fix 'No rule to make target `jparse/Makefile', needed by `jparse'' in Makefile.

Fix strange issue where running make clobber would pass to rm -f -f instead of just -f. I'm not even sure why this happened - I don't have the time or energy to try figuring it out. It seems odd because there's no reference to -f -f in any file. It did not occur with the dbg subdirectory but it does with soup and test_ioccc/. The fix was removing the single -f from the rm invocation in those Makefiles. It's very funny because even after removing the -f from the invocation in e.g. soup/Makefile if one does `cd soup; make clobber' you'll see that it does in fact run rm -f.