### PR TITLE
Lower MAX_MASTODON_LEN

### DIFF
--- a/limit_ioccc.h
+++ b/limit_ioccc.h
@@ -57,8 +57,8 @@
 #define MAX_NAME_LEN (48)		/* max author name length */
 #define MAX_EMAIL_LEN (48)		/* max Email address length */
 #define MAX_URL_LEN (64)		/* max home URL length, including http:// or https:// */
-#define MAX_MASTODON_LEN (19+255)	/* max mastodon handle length, including the leading @ */
-#define MAX_GITHUB_LEN (16)		/* max GitHub account length, including the leading @, length */
+#define MAX_MASTODON_LEN (20+64)	/* max mastodon handle length, including both '@'s */
+#define MAX_GITHUB_LEN (16)		/* max GitHub account length, including the leading '@' */
 #define MAX_AFFILIATION_LEN (48)	/* max affiliation name length */
 #define MAX_TITLE_LEN (32)		/* maximum length of a title */
 #define MAX_ABSTRACT_LEN (64)		/* maximum length of an abstract */


### PR DESCRIPTION
Although technically correct at what it was, it was suggested to lower it. I actually thought of this as well so I went ahead and did it. A note on it though. The 255 to 64 does not really need an explanation as 64 is also the value of MAX_URL_LEN so it is a reasonable limit. If this is ever a problem for either it could of course be increased.

But the 20 instead of 19 is because unlike twitter, mastodon handles have two '@'s so the limit should allow for the same number of characters in twitter handles, as far as user names go, which was 18.