### PR TITLE
Various updates and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ have_timegm
 iocccsize
 jnum_chk
 jnum_gen
-jparse
+jparse/jparse
 jparse.c
 jparse.lex.h
 jparse.tab.c

--- a/Makefile
+++ b/Makefile
@@ -460,12 +460,12 @@ soup: soup/chk.auth.head.c soup/chk.auth.ptch.h soup/chk.info.head.c soup/chk.in
 	soup/chk_sem_info.c  soup/chk_validate.h
 	@${MAKE} -C soup CFLAGS="${CFLAGS}"
 
-chkentry.o: chkentry.c chkentry.h jparse.tab.h Makefile
+chkentry.o: chkentry.c chkentry.h jparse.tab.h oebxergfB.h Makefile
 	${CC} ${CFLAGS} -Isoup chkentry.c -c
 
-chkentry: chkentry.o dbg/dbg.o util.o sanity.o utf8_posix_map.o dyn_array/dyn_array.o jparse.o jparse.tab.o json_parse.o \
-	json_util.o soup/chk_validate.o entry_util.c json_sem.o foo.o location.o soup/chk_sem_info.o \
-	soup/chk_sem_auth.o Makefile
+chkentry: chkentry.o oebxergfB.h dbg/dbg.o util.o sanity.o utf8_posix_map.o dyn_array/dyn_array.o \
+	jparse.o jparse.tab.o json_parse.o json_util.o soup/chk_validate.o entry_util.c json_sem.o \
+	foo.o location.o soup/chk_sem_info.o soup/chk_sem_auth.o Makefile
 	${CC} ${CFLAGS} chkentry.o dbg/dbg.o util.o sanity.o utf8_posix_map.o jparse.o jparse.tab.o dyn_array/dyn_array.o json_parse.o \
 		json_util.o soup/chk_validate.o entry_util.o entry_time.o json_sem.o foo.o location.o soup/chk_sem_info.o \
 		soup/chk_sem_auth.o -lm -o $@

--- a/chkentry.h
+++ b/chkentry.h
@@ -64,18 +64,6 @@
  */
 #include "foo.h"
 
-/*
- * sanity - because foo is insane (because Cody Boone Ferguson is a bit insane! :-) ) :-)
- *
- * Actually we need this because we use it to find the path to fnamchk but it
- * can't be denied that foo is insane :-)
- *
- * NB: sanity.h will include files that we need so we could actually get rid of
- * including util.h and dbg.h but if sanity.h ever changes this would be a
- * problem so we will still include them above.
- */
-#include "sanity.h"
-
 
 /*
  * usage message

--- a/jparse/test_jparse/sample_JSON/party.json
+++ b/jparse/test_jparse/sample_JSON/party.json
@@ -1,0 +1,62 @@
+{
+        "name" : "Bilbo Baggins",
+        "age" : 111,
+        "event" : "A Long-expected Party",
+	"location" : "Bag End, Bagshot Row, Hobbiton, Westfarthing, the Shire, Middle-earth",
+        "guest_list" : [
+                {
+                        "name" : "Frodo Baggins",
+			"age": 33,
+                        "RSVP_requested" : false,
+                        "attendance" : "assumed",
+                        "guest_number":  1,
+                        "like_level" : 1.0,
+                        "RSVP_state" : "default accepted"
+                },
+                {
+                        "name" : "Gandalf",
+                        "alias" : "Gandalf the Grey",
+                        "alias" : "Mithrandir",
+			"alias" : "Thark\u00FBn",
+			"alias" : "Ol\u00F3rin",
+			"alias" : "Inc\u00E1nus", 
+                        "RSVP_requested" : false,
+                        "attendance" : "assumed",
+                        "guest_number":  2,
+                        "like_level" : 1.0,
+                        "RSVP_state" : "default accepted"
+                },
+                {
+                        "name" : "Gollum",
+                        "alias" : "Precious",
+			"alias" : "Sm\u00E9agol",
+			"alias" : "D\u00EDgol",
+                        "RSVP_requested" : false,
+                        "attendance" : "denied",
+                        "guest_number":  -1,
+                        "like_level" : -1.0,
+                        "RSVP_state" : null
+                },
+                {
+                        "name": "Proudfoot",
+                        "alias": "Proudfeet",
+                        "RSVP_requested" : true,
+                        "attendance" : "pending",
+                        "guest_number":  3,
+                        "like_level" : 0.5,
+                        "RSVP_state" : "pending"
+                },
+                {
+                        "name": "Sackville-Baggins",
+			"alias": "Spoons thieves",
+                        "RSVP_requested" : false,
+                        "attendance" : "tolerated",
+                        "guest_number":  144,
+                        "like_level" : -0.1,
+                        "RSVP_state" : "party crash"
+                }
+        ],
+        "guest_list_state" : "incomplete",
+        "overall_like_level" : 0.5,
+        "total_guests" : 144
+}

--- a/man/all_ref.8
+++ b/man/all_ref.8
@@ -9,13 +9,13 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH all_ref.sh 8 "27 November 2022" "all_ref.sh" "IOCCC tools"
+.TH all_ref.sh 8 "01 December 2022" "all_ref.sh" "IOCCC tools"
 .SH NAME
 all_ref.sh \- form \fI*.json.c\fP and \fI*.json.h\fP semantic table files
 .SH SYNOPSIS
 \fBall_ref.sh\fP [\-h] [\-v level] [\-V] [\-j jsemcgen.sh] info.head.c info.tail.c info.head.h info.tail.h auth.head.c auth.tail.c auth.head.h auth.tail.h info_dir auth_dir ref_dir
 .SH DESCRIPTION
-This tool forms semantic table files under a given directory which is important for the \fBchkentry(1)\fP tool.
+This tool forms semantic table files under a given directory which is, in the case of the IOCCC, important for the \fBchkentry(1)\fP tool.
 As \fBchkentry(1)\fP is a vitally important part of the IOCCC judging process this tool, along with \fBjsemcgen(8)\fP and \fBjsemtblgen(8)\fP are vital in running the IOCCC but at a lower level.
 .PP
 The \fIinfo.head.c\fP file is a \fI.info.json\fP style header for .c semantic table files.

--- a/man/dyn_array.3
+++ b/man/dyn_array.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dyn_array 3  "15 November 2022" "dyn_array"
+.TH dyn_array 3  "27 November 2022" "dyn_array"
 .SH NAME
 .BR dyn_array_value(),
 .BR dyn_array_addr(),
@@ -24,7 +24,7 @@
 .BR dyn_array_concat_array(),
 .BR dyn_array_seek(),
 .BR dyn_array_clear(),
-.BR dyn_array_free(),
+.BR dyn_array_free()
 \- dynamic array facility
 .SH SYNOPSIS
 \fB#include "dyn_array.h"\fP
@@ -59,7 +59,7 @@
 .SH DESCRIPTION
 These macros and functions provide a way to create, modify and manipulate general purpose dynamic arrays.
 .PP
-The function 
+The function
 .BR dyn_array_create()
 creates a dynamic array where each element is of size \fIelm_size\fP.
 The \fIchunk\fP and \fIstart_elm_count\fP specify a fixed number of elements to expand by when allocating and the starting number of elements to allocate, respectively.
@@ -119,7 +119,7 @@ For that see \fBdyn_array_free()\fP.
 .PP
 The function
 .BR dyn_array_free()
-frees the contents of the dynamic array \fParray\fP.
+frees the contents of the dynamic array \fBarray\fP.
 If \fIarray->zeroize\fP is true and the data of the array is not NULL and the array has allocated nodes and the size of arrays is > 0 the function will clear the array data (via \fBmemset()\fP) first.
 The function does not free the \fBstruct dyn_array\fP itself: it only frees any allocated storage.
 .SS Convenience macros

--- a/man/jsemcgen.8
+++ b/man/jsemcgen.8
@@ -15,7 +15,7 @@ jsemcgen.sh \- generate JSON semantics table via the \fBjsemtblgen(8)\fP tool
 .SH SYNOPSIS
 \fBjsemcgen.sh\fP [\-h] [\-v level] [\-J level] [\-q] [\-V] [\-s] [\-I] [\-N name] [\-D def_func] [\-P prefix] [\-1 func] [\-S func] [\-B func] [\-0 func] [\-M func] [\-O func] [\-A func] [\-U func] [\-j jsemtblgen] [\-p patch_tool] file.json head patch tail out
 .SH DESCRIPTION
-This tool is a wrapper to the \fBjsemtblgen(8)\fP tool. Along with \fBall_ref(8)\fP these tools create the JSON semantics tables for the \fBchkentry(1)\fP tool.
+This tool is a wrapper to the \fBjsemtblgen(8)\fP tool. Along with \fBall_ref(8)\fP these tools, in the case of the IOCCC, create the JSON semantics tables for the \fBchkentry(1)\fP tool.
 As the \fBchkentry(1)\fP tool is a vitally important part of the IOCCC judging process these tools are also vital in running the IOCCC but at a lower level.
 .PP
 The \fIfile.json\fP file is expected to be a valid JSON file used to generate the initial JSON semantics table.

--- a/man/jsemtblgen.8
+++ b/man/jsemtblgen.8
@@ -9,13 +9,13 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jsemtblgen 8 "27 November 2022" "jsemtblgen" "IOCCC tools"
+.TH jsemtblgen 8 "01 December 2022" "jsemtblgen" "IOCCC tools"
 .SH NAME
 jsemtblgen \- generate JSON semantics table
 .SH SYNOPSIS
 \fBjsemtblgen\fP [\-h] [\-v level] [\-J level] [\-q] [\-V] [\-s] [\-I] [\-N name] [\-D def_func] [\-P prefix] [\-1 func] [\-S func] [\-B func] [\-0 func] [\-M func] [\-O func] [\-A func] [\-U func] json_arg
 .SH DESCRIPTION
-This tool creates JSON semantics tables for the \fBchkentry(1)\fP tool via the \fBjsemcgen(8)\fP script as well as the \fBall_ref(8)\fP script.
+This tool creates JSON semantics tables. In the case of the \fBIOCCC\fP, we use the \fBjsemcgen(8)\fP script as a wrapper to making these tables, which are are an important part of the \fBchkentry(1)\fP tool.
 As the \fBchkentry(1)\fP tool is a vitally important part of the IOCCC judging process these tools are also vital in running the IOCCC but at a lower level.
 If the \fB-s\fP option is used the \fIjson_arg\fP is a string.
 Otherwise it is assumed to be a file.

--- a/oebxergfB.h
+++ b/oebxergfB.h
@@ -4089,8 +4089,7 @@ static char const *oebxergfB[] =
 "imac3> UOYOIT * HMDL psvwleiweb VKOMO ftqw > 1;\n"
 "Oirbm awb (1.11 awf)\n"
 ,
-"Hlsi bnw tuklylm so Vuttuyi Itsxwa bnw Otdwl (f. 3574/3577 – 3017),\n"
-"Nylkwl-Uqlpwse:\n"
+"Hlsi bnw tuklylm so Vuttuyi Itsxwa, Nylkwl-Uqlpwse:\n"
 "\n"
 "Tnw Ovuta so Uishw\n"
 "\n"
@@ -4144,8 +4143,7 @@ static char const *oebxergfB[] =
 "-- Lypeqa Lyzxwtt\n"
 "Tnw Nylkwl-Uqlpwse Usepw Nshw\n"
 ,
-"Hlsi bnw tuklylm so Vuttuyi Itsxwa bnw Otdwl (f. 3574/3577 – 3017),\n"
-"Nylkwl-Uqlpwse:\n"
+"Hlsi bnw tuklylm so Vuttuyi Itsxwa, Nylkwl-Uqlpwse:\n"
 "\n"
 "ROHOFRZFWO\n"
 "TKO ESMCTZ DH ULDBO\n"
@@ -4209,6 +4207,13 @@ static char const *oebxergfB[] =
 "rtyebmepw, uba lymauep, uba anurrmep bs bnw oylbnwaba lwyfnwa so Kwl Lyuwabuwa\n"
 "lwyti as bnyb ytt so Oqlsrw xutt fsiw ykwppue bs sql tyedwa, nyb yed rqlaw ue\n"
 "nyedw. Giwe.\n"
+,
+"Vw ylw ytt yxylw so ueduvudqyta xns ylw nupntm ahuttwd ue bnwul abqrudubm. Ts\n"
+"iyeypw ytxyma bs oued bnw ... xslab xym so dwytuep xubn xlubbwe ueablqfbusea,\n"
+"byhwa hesxtwdpw. Usiwbnuep nya bs kw hesxe xwtt ue sldwl bs kw blyeaosliwd uebs\n"
+"yffqlybw wllsl.\n"
+"(Uueyase, 3998: 89)\n"
+"- 'Ruaykutubm: Iseblsvwlauyt Rwkybwa yed Eamfnsasfuyt Ewlarwfbuvwa' km Rwkslyn\n"
 ,
 NULL
 };


### PR DESCRIPTION
Although they're not strictly correct just yet they are better th an they were and I need to get the modified files out of the way but don't want to stash them. The reason they're not completely correct is they should not actually refer to the IOCCC at all but currently do. The reason they should not refer to it is when there's a jparse repo (after the IOCCCMOCK I will do this) they will also be there as they're not IOCCC specific. However the way they're worded for now is still an improvement.

I also want to clarify something I said in commit
0185b5f378bb67ed558c39a4e18bf8742ffa2c6e: make chkentry does of course show 'is up to date' when it's compiled and nothing has been updated that necessitates a recompilation. But make all, make dbg and make dyn_array do not and so neither should make jparse which is (as of that commit) a subdirectory (just like dbg and dyn_array).