### PR TITLE
Roll back 7d1c00 and 5fc50a + typo fix

### DIFF
--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -413,7 +413,7 @@ json_sem.o: json_sem.c Makefile
 # NOTE: The value of RUN_O_FLAG depends on what rule called this rule.
 jparse.tab.c jparse.tab.h bison: jparse.y jparse.h sorry.tm.ca.h run_bison.sh ../limit_ioccc.sh \
 	verge jparse.tab.ref.c jparse.tab.ref.h Makefile
-	./run_bison.sh -g ../verge -s ./sorry.tm.ca.h -l ../limit_ioccc.sh -b ${BISON_BASENAME} ${BISON_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- \
+	./run_bison.sh -g ./verge -s ./sorry.tm.ca.h -l ../limit_ioccc.sh -b ${BISON_BASENAME} ${BISON_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- \
 		       ${BISON_FLAGS}
 
 # How to create jparse.c and jparse.lex.h
@@ -425,7 +425,7 @@ jparse.tab.c jparse.tab.h bison: jparse.y jparse.h sorry.tm.ca.h run_bison.sh ..
 # NOTE: The value of RUN_O_FLAG depends on what rule called this rule.
 jparse.c jparse.lex.h flex: jparse.l jparse.h ./sorry.tm.ca.h jparse.tab.h ./run_flex.sh ../limit_ioccc.sh \
 	       verge jparse.ref.c jparse.lex.ref.h Makefile
-	./run_flex.sh -g ../verge -s ./sorry.tm.ca.h -l ../limit_ioccc.sh -f ${FLEX_BASENAME} ${FLEX_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- \
+	./run_flex.sh -g ./verge -s ./sorry.tm.ca.h -l ../limit_ioccc.sh -f ${FLEX_BASENAME} ${FLEX_DIRS} -p jparse -v 1 ${RUN_O_FLAG} -- \
 		      ${FLEX_FLAGS} -o jparse.c
 
 verge.o: verge.c verge.h Makefile

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -2,10 +2,10 @@
 #
 # jstr_test.sh - JSON string encoding and decoding test
 
-# setuo
+# setup
 #
-export JSTRENCODE="./jstrencode"
-export JSTRDECODE="./jstrdecode"
+export JSTRENCODE="./jparse/jstrencode"
+export JSTRDECODE="./jparse/jstrdecode"
 export TEST_FILE="./jparse/test_jparse/jstr_test.out"
 export TEST_FILE2="./jparse/test_jparse/jstr_test2.out"
 export JSTR_TEST_VERSION="0.4 2022-11-05"


### PR DESCRIPTION
Those two commits actually break make release / make prep and also bug_report.sh and actually will prevent successful compilation of the repo. The tool verge actually is compiled under jparse/ as are the other tools, jstrencode and jstrdecode. With this commit, running make test will show:

    PASSED: test_ioccc/iocccsize_test.sh
    PASSED: dbg_test
    PASSED: test_ioccc/mkiocccentry_test.sh
    PASSED: jparse/test_jparse/jstr_test.sh
    PASSED: jparse/test_jparse/jnum_chk
    PASSED: dyn_array/dyn_test
    PASSED: jparse/test_jparse/jparse_test.sh
    PASSED: test_ioccc/txzchk_test.sh
    test_ioccc/chkentry_test.sh: debug[1]: all tests PASSED
    PASSED: test_ioccc/chkentry_test.sh
    All tests PASSED
    =-=-= PASS: make test =-=-=
    =-=-=-=-= PASS: ./prep.sh =-=-=-=-=

but with those two commits none of this will work. In addition to those passing running bug_report will show:

    All tests PASSED

    A log of the above tests was saved to bug-report.20221217.044235.txt.
    If you feel everything is in order you may safely delete that file.
    Otherwise you may report the issue at the GitHub issue page:

	    https://github.com/ioccc-src/mkiocccentry/issues

    making sure to attach bug-report.20221217.044235.txt with your report. You may
    instead email the Judges but you're encouraged to file a
    report instead. This is because not all tools were written by
    the Judges.

    [...]

showing that indeed everything is in order. And to show that the files do compile under jparse/ and are no longer under the root directory:

    $ basename $(pwd)
    xexyl-mkiocccentry
    $ ls verge jstrdecode jstrencode
    ls: jstrdecode: No such file or directory
    ls: jstrencode: No such file or directory
    ls: verge: No such file or directory
    $ ls jparse/verge jparse/jstrdecode jparse/jstrencode
    jparse/jstrdecode* jparse/jstrencode* jparse/verge*

I also fixed a typo.