### PR TITLE
Fix EXTERN_PROG in jparse/Makefile

### DIFF
--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -259,7 +259,7 @@ EXTERN_H= jparse.h
 EXTERN_O=
 EXTERN_MAN= ${ALL_MAN_TARGETS}
 EXTERN_LIBA= jparse.a
-EXTERN_PROG= jparse jsemtblgen jsemcgen.sh jstrdecode jstrencode
+EXTERN_PROG= jparse jsemtblgen jsemcgen.sh jnum_gen jstrdecode jstrencode
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
 #


### PR DESCRIPTION
It was missing jnum_gen which means that one would have to do make -C jparse before jnum_gen was built. This prevented bug_report.sh from working as it could not execute jparse/jnum_gen since it was not compiled.