### PR TITLE
Remove external sanity checks in txzchk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -963,10 +963,10 @@ iocccsize.o: iocccsize.c iocccsize_err.h iocccsize.h
 fnamchk.o: fnamchk.c fnamchk.h dbg/dbg.h jparse/jparse.h jparse/../dbg/dbg.h jparse/util.h \
 	jparse/../dyn_array/dyn_array.h jparse/../dyn_array/../dbg/dbg.h jparse/json_parse.h \
 	jparse/json_util.h jparse/json_sem.h jparse/jparse.tab.h limit_ioccc.h version.h utf8_posix_map.h
-txzchk.o: txzchk.c txzchk.h jparse/jparse.h jparse/../dbg/dbg.h jparse/util.h \
+txzchk.o: txzchk.c txzchk.h dbg/dbg.h sanity.h jparse/jparse.h jparse/../dbg/dbg.h jparse/util.h \
 	jparse/../dyn_array/dyn_array.h jparse/../dyn_array/../dbg/dbg.h jparse/json_parse.h \
-	jparse/json_util.h jparse/json_sem.h jparse/jparse.tab.h dbg/dbg.h sanity.h location.h \
-	utf8_posix_map.h limit_ioccc.h version.h entry_util.h
+	jparse/json_util.h jparse/json_sem.h jparse/jparse.tab.h location.h utf8_posix_map.h limit_ioccc.h \
+	version.h entry_util.h
 chkentry.o: chkentry.c chkentry.h dbg/dbg.h jparse/jparse.h jparse/../dbg/dbg.h jparse/util.h \
 	jparse/../dyn_array/dyn_array.h jparse/../dyn_array/../dbg/dbg.h jparse/json_parse.h \
 	jparse/json_util.h jparse/json_sem.h jparse/jparse.tab.h soup/soup.h soup/../entry_util.h \

--- a/txzchk.c
+++ b/txzchk.c
@@ -487,9 +487,6 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
 	not_reached();
     }
 
-    /* we also check that all the tables across the IOCCC toolkit are sane */
-    ioccc_sanity_chks();
-
     return;
 }
 

--- a/txzchk.h
+++ b/txzchk.h
@@ -42,17 +42,12 @@
 
 
 /*
- * jparse - the parser
- */
-#include "jparse/jparse.h"
-
-/*
  * dbg - info, debug, warning, error, and usage message facility
  */
 #include "dbg/dbg.h"
 
 /*
- * sanity - perform common IOCCC sanity checks
+ * sanity - perform common IOCCC sanity checks + find utils we need
  */
 #include "sanity.h"
 


### PR DESCRIPTION
Remove inclusion of jparse/jparse.h in txzchk.h. This is an artefact from a long time ago where the tool ran all the sanity checks including the old (manual) parsing of .info.json and .auth.json (then as .author.json) files. Some of the functions it called no longer exist and the json sanity checks were not being done by txzchk since ages.

I also removed the call to ioccc_sanity_chks() as it's not strictly needed. The rationale was similar for the json checks - that if something is wrong with the core then we should not proceed. But mkiocccentry does call the function and also calls txzchk. Since no other tool uses the function I don't think txzchk needs to either. It probably never did.

Make depend due to no longer including jparse/jparse.h in txzchk.h.