### PR TITLE
Fix the make all repeatedly compiling everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ TARGETS= mkiocccentry iocccsize txzchk chkentry ${SH_TARGETS}
 ######################################
 
 all: fast_hostchk just_all
+	@:
 
 # The original make all that bypasses running hostchk.sh
 #
@@ -358,8 +359,8 @@ hostchk_warning:
 # .PHONY list of rules that do not create files #
 #################################################
 
-.PHONY: all just_all fast_hostchk hostchk hostchk_warning all_ref all_ref_ptch mkchk_sem bug_report.sh build \
-	check_man clean clean_generated_obj clean_mkchk_sem clobber configure depend hostchk bug_report.sh \
+.PHONY: all just_all fast_hostchk hostchk hostchk_warning all_ref all_ref_ptch mkchk_sem bug_report build \
+	check_man clean clean_generated_obj clean_mkchk_sem clobber configure depend hostchk \
 	install test_ioccc legacy_clobber mkchk_sem parser parser-o picky prep prep_clobber \
         pull rebuild_jnum_test release seqcexit shellcheck tags test test-chkentry use_ref \
 	prep build release pull reset_min_timestamp \

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -27,7 +27,7 @@ export TOOLS="
     ./chkentry
     ./dbg/dbg_test
     ./fnamchk
-    ./hostchk.sh
+    ./soup/hostchk.sh
     ./iocccsize
     ./jparse/jnum_gen
     ./jparse/jparse
@@ -36,11 +36,11 @@ export TOOLS="
     ./jparse/jstrdecode
     ./jparse/jstrencode
     ./mkiocccentry
-    ./prep.sh
-    ./reset_tstamp.sh
+    ./test_ioccc/prep.sh
+    ./soup/reset_tstamp.sh
     ./jparse/run_bison.sh
     ./jparse/run_flex.sh
-    ./run_usage.sh
+    ./soup/run_usage.sh
     ./soup/all_ref.sh
     ./test_ioccc/chkentry_test.sh
     ./dyn_array/dyn_test
@@ -54,7 +54,7 @@ export TOOLS="
     ./test_ioccc/utf8_test
     ./txzchk
     ./jparse/verge
-    ./vermod.sh
+    ./soup/vermod.sh
     "
 
 export BUG_REPORT_VERSION="0.7 2022-11-10"
@@ -1125,7 +1125,7 @@ run_check 43 "make test"
 
 # hostchk.sh -v 3: we need to run some checks to make sure the system can
 # compile things and so on
-run_check 44 "./hostchk.sh -v 3"
+run_check 44 "./soup/hostchk.sh -v 3"
 
 echo "#-------------------------------------#" | tee -a -- "$LOG_FILE"
 echo "# SECTION 3 ABOVE: COMPILATION CHECKS $" | tee -a -- "$LOG_FILE"
@@ -1161,10 +1161,10 @@ get_version_optional "flex"
 # would mean the repo could not be used properly.
 #
 # run_bison.sh -v 7: check if bison will work
-run_check 45 "./jparse/run_bison.sh -v 7 -s ./jparse/sorry.tm.ca.h -g ./jparse/verge -l ./limit_ioccc.sh -D ./jparse"
+run_check 45 "./jparse/run_bison.sh -v 7 -s ./jparse/sorry.tm.ca.h -g ./jparse/verge -l ./soup/limit_ioccc.sh -D ./jparse"
 
 # run_flex.sh -v 7: check if flex will work
-run_check 46 "./jparse/run_flex.sh -v 7 -s ./jparse/sorry.tm.ca.h -g ./jparse/verge -l ./limit_ioccc.sh -D ./jparse"
+run_check 46 "./jparse/run_flex.sh -v 7 -s ./jparse/sorry.tm.ca.h -g ./jparse/verge -l ./soup/limit_ioccc.sh -D ./jparse"
 
 # run make all again: run_bison.sh and run_flex.sh will likely cause a need for
 # recompilation

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -255,8 +255,7 @@ all: ${TARGETS}
 	extern_include extern_objs extern_liba extern_man extern_prog extern_everything man/man3/dbg.3 \
 	man/man3/err.3 man/man3/msg.3 man/man3/warn.3 man/man3/werr.3 man/man3/printf_usage.3 man/man3/warn_or_err.3 \
 	test check_man prep_clean prep_clobber legacy_clean legacy_clobber \
-	configure clean clobber install depend \
-	dbg.a
+	configure clean clobber install depend
 
 
 ####################################

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -252,8 +252,7 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS}
 .PHONY: all \
 	extern_include extern_objs extern_liba extern_man extern_prog extern_everything man/man3/dyn_array.3 \
 	test check_man tags prep_clean prep_clobber legacy_clean legacy_clobber \
-	configure clean clobber install depend \
-	dyn_array.a
+	configure clean clobber install depend
 
 
 ####################################

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -332,8 +332,7 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS} Makefile
 .PHONY: all \
 	extern_include extern_objs extern_liba extern_man extern_prog extern_everything man/man1/jparse.1 man/man8/jparse_test.8 \
 	parser parser-o use_ref bison flex test tags check_man prep_clean prep_clobber legacy_clean legacy_clobber \
-	configure clean clobber install depend \
-	util.o
+	configure clean clobber install depend
 
 
 ####################################

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -191,7 +191,7 @@ EXTERN_H= chk_sem_info.h chk_sem_auth.h
 EXTERN_O=
 EXTERN_MAN= ${ALL_MAN_TARGETS}
 EXTERN_LIBA= soup.a
-EXTERN_PROG= hostchk.sh run_usage.sh vermod.sh reset_tstamp.sh limit_ioccc.sh
+EXTERN_PROG= hostchk.sh run_usage.sh vermod.sh reset_tstamp.sh
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
 #
@@ -219,7 +219,7 @@ H_SRC_TARGETS=
 
 # shell targets to make by all and removed by clobber
 #
-SH_TARGETS= limit_ioccc.sh
+SH_TARGETS= 
 
 # what to make by all but NOT to removed by clobber (because they are not files)
 #
@@ -252,6 +252,7 @@ TARGETS= ${LIBA_TARGETS} ${SH_TARGETS}
 ######################################
 
 all: ${TARGETS}
+	@:
 
 
 #################################################
@@ -262,9 +263,7 @@ all: ${TARGETS}
 	depend soup eat eating eat_soup eating_soup prep_clean prep_clobber legacy_clean legacy_clobber \
 	configure clean clobber install depend \
 	prep build release pull reset_min_timestamp \
-	../jparse/jsemcgen.sh hostchk.sh \
-	../jparse/test_jparse/test_JSON/info.json/good/info.reference.json \
-	../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json
+	hostchk.sh limit_ioccc.sh
 
 
 ####################################
@@ -308,29 +307,32 @@ soup.a: ${LIB_OBJS}
 
 chk_sem_info.c: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../jparse/test_jparse/test_JSON/info.json/good/info.reference.json \
 		chk.info.head.c chk.info.ptch.c chk.info.tail.c
-	@${RM} -f $@
+	${RM} -f $@
 	../jparse/jsemcgen.sh -N sem_info -P chk -j ../jparse/jsemtblgen -- \
 	    ../jparse/test_jparse/test_JSON/info.json/good/info.reference.json chk.info.head.c \
 	    chk.info.ptch.c chk.info.tail.c $@
 
+chk.info.head.c chk.info.ptch.c chk.info.tail.c:
+	@:
+
 chk_sem_info.h: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../jparse/test_jparse/test_JSON/info.json/good/info.reference.json \
 		chk.info.head.h chk.info.ptch.h chk.info.tail.h
-	@${RM} -f $@
-	@../jparse/jsemcgen.sh -N sem_info -P chk -I -j ../jparse/jsemtblgen -- \
+	${RM} -f $@
+	../jparse/jsemcgen.sh -N sem_info -P chk -I -j ../jparse/jsemtblgen -- \
 	    ../jparse/test_jparse/test_JSON/info.json/good/info.reference.json chk.info.head.h \
 	    chk.info.ptch.h chk.info.tail.h $@
 
 chk_sem_auth.c: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json \
 		chk.auth.head.c chk.auth.ptch.c chk.auth.tail.c
-	@${RM} -f $@
+	${RM} -f $@
 	../jparse/jsemcgen.sh -N sem_auth -P chk -j ../jparse/jsemtblgen -- \
 	    ../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json chk.auth.head.c \
 	    chk.auth.ptch.c chk.auth.tail.c $@
 
 chk_sem_auth.h: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json \
 		chk.auth.head.h chk.auth.ptch.h chk.auth.tail.h
-	@${RM} -f $@
-	@../jparse/jsemcgen.sh -N sem_auth -P chk -I -j ../jparse/jsemtblgen -- \
+	${RM} -f $@
+	../jparse/jsemcgen.sh -N sem_auth -P chk -I -j ../jparse/jsemtblgen -- \
 	    ../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json chk.auth.head.h \
 	    chk.auth.ptch.h chk.auth.tail.h $@
 
@@ -339,16 +341,16 @@ chk_sem_auth.h: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../jparse/test_jparse
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../jparse/jsemtblgen: ../jparse/Makefile
+../jparse/jsemtblgen:
 	@${MAKE} -C ../jparse extern_prog
 
-../jparse/jsemcgen.sh: ../jparse/Makefile
+../jparse/jsemcgen.sh:
 	@${MAKE} -C ../jparse extern_prog
 
-../jparse/test_jparse/test_JSON/info.json/good/info.reference.json: ../jparse/Makefile
+../jparse/test_jparse/test_JSON/info.json/good/info.reference.json:
 	@${MAKE} -C ../jparse test_jparse/test_JSON/info.json/good/info.reference.json
 
-../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json: ../jparse/Makefile
+../jparse/test_jparse/test_JSON/auth.json/good/auth.reference.json:
 	@${MAKE} -C ../jparse test_jparse/test_JSON/auth.json/good/auth.reference.json
 
 ####################################

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -237,6 +237,7 @@ TARGETS= utf8_test fnamchk ${SH_TARGETS}
 ######################################
 
 all: ${TARGETS} ${EXTERN_PROG}
+	@:
 
 
 #################################################
@@ -273,7 +274,7 @@ fnamchk: fnamchk.o ../jparse/jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 #########################################################
 
 ../dbg/dbg.a: ../dbg/Makefile
-	@${MAKE} -C ../dbg dbg extern_liba
+	@${MAKE} -C ../dbg dbg.a extern_liba
 
 ../dbg/dbg_test: ../dbg/Makefile
 	@${MAKE} -C ../dbg extern_prog


### PR DESCRIPTION
There might still be some issues but at least now running make all more
than once will try recompiling everything. This is on a different branch
because of some problems I had some of which I'm not sure entirely of
the source.

Specifically one to do with permissions. This was very possibly because
of earlier on trying to do make && sudo make install but then the make
install as root actually compiling the object files again - but it might
not be because make clobber all sometimes (not always) resulted in the
problem again.

Sometimes I got an error trying to link dbg but that was because, it
appears, that a Makefile (not in dbg/) did make dbg instead of dbg.o or
dbg.a. I changed it to dbg.a but in retrospect it might need to be
dbg.o: I'm not sure but noting this in case it is a problem. In
particular it's in test_ioccc/Makefile:

     ../dbg/dbg.a: ../dbg/Makefile
    -       @${MAKE} -C ../dbg dbg extern_liba
    +       @${MAKE} -C ../dbg dbg.a extern_liba

Given that it's extern_liba it probably is okay for dbg.a but just in
case I'm noting it (I didn't see the extern_liba until now as I was
focused on the actual problem).

Some objects were added to .PHONY rules and some were removed. Some
rules ('all') had a no-op @: added to them to silence make when nothing
was to be done.
