### PR TITLE
Fix make[2]: `dbg.a' is up to date.

### DIFF
--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -274,7 +274,7 @@ fnamchk: fnamchk.o ../jparse/jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 #########################################################
 
 ../dbg/dbg.a: ../dbg/Makefile
-	@${MAKE} -C ../dbg dbg.a extern_liba
+	@${MAKE} -C ../dbg extern_liba
 
 ../dbg/dbg_test: ../dbg/Makefile
 	@${MAKE} -C ../dbg extern_prog


### PR DESCRIPTION
The problem was that in test_ioccc/Makefile the rule ../dbg/dbg.a did make -C ../dbg dbg.a extern_liba and extern_liba was all that was necessary as that rule itself runs the dbg.a rule. This silences make entirely after a successful make all.