### PR TITLE
Fix make test on other systems (than mine)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1053,7 +1053,7 @@ install: all dbg/Makefile man/Makefile
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@echo

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -544,7 +544,7 @@ install: all
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@HAVE_INDEPEND="`type -P ${INDEPEND}`"; if [[ -z "$$HAVE_INDEPEND" ]]; then \

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -501,7 +501,7 @@ install: all
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@HAVE_INDEPEND="`type -P ${INDEPEND}`"; if [[ -z "$$HAVE_INDEPEND" ]]; then \

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -110,7 +110,7 @@ CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${LDFLAGS}
 # source files that are permanent (not made, nor removed)
 #
 C_SRC= jparse_main.c json_parse.c json_sem.c json_util.c jnum_gen.c jnum_header.c \
-       jsemtblgen.c jstrdecode.c jstrencode.c util.c
+       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c
 H_SRC= jparse.h jnum_gen.h jparse_main.h jsemtblgen.h json_parse.h json_sem.h json_util.h \
        jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h \
        jparse.tab.ref.h
@@ -146,7 +146,7 @@ LIB_OBJS= jparse.o jparse.tab.o jparse_main.o json_parse.o json_sem.o json_util.
 
 # NOTE: ${OTHER_OBJS} are objects NOT put into a library and removed by make clean
 #
-OTHER_OBJS=
+OTHER_OBJS= verge.o
 
 # all intermediate files and removed by make clean
 #
@@ -773,7 +773,7 @@ install: all test_jparse/Makefile
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	${MAKE} -C test_jparse $@
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
@@ -834,3 +834,5 @@ jstrencode.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
     ../dyn_array/dyn_array.h json_parse.h jstrencode.c jstrencode.h util.h
 util.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
     util.c util.h
+verge.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
+    ../soup/limit_ioccc.h ../soup/version.h util.h verge.c verge.h

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -471,7 +471,7 @@ install: all
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@HAVE_INDEPEND="`type -P ${INDEPEND}`"; if [[ -z "$$HAVE_INDEPEND" ]]; then \

--- a/jparse/test_jparse/test_JSON/bad/party.json
+++ b/jparse/test_jparse/test_JSON/bad/party.json
@@ -46,6 +46,20 @@
                         "RSVP_state" : "default accepted"
                 },
 		{
+                        "name" : "Sauron",
+                        "alias" : "(Second) Dark Lord",
+                        "alias" : "Annatar, the Lord of Gifts",
+			"alias" : "Gorthaur",
+			"alias" : "Aulendil",
+			"alias" : "Artano",
+			"alias" : "Thû",
+			"alias" : "the Necromancer",
+                        "RSVP_requested" : ,
+                        "attendance" : "denied",
+                        "like_level" : -1.0,
+                        "RSVP_state" : "'What are Hobbits?'"
+                },
+		{
                         "name" : "Gollum",
                         "alias" : "Precious",
 			"alias" : "Sméagol",

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -35,7 +35,7 @@
 /*
  * limit_ioccc - IOCCC size and rule related limitations
  */
-#include "../limit_ioccc.h"
+#include "../soup/limit_ioccc.h"
 
 
 /*

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -665,7 +665,7 @@ install: all
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@HAVE_INDEPEND="`type -P ${INDEPEND}`"; if [[ -z "$$HAVE_INDEPEND" ]]; then \

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -481,7 +481,7 @@ install: all
 # make depend #
 ###############
 
-depend: ${ALL_CSRC} all
+depend: ${ALL_CSRC}
 	@echo
 	@echo "${OUR_NAME}: make $@ starting"
 	@HAVE_INDEPEND="`type -P ${INDEPEND}`"; if [[ -z "$$HAVE_INDEPEND" ]]; then \


### PR DESCRIPTION
The reason make test did not fail for me is that I had made an empty directory bad/ under jparse/test_jparse/test_JSON but I forgot to add a file which means that the directory could not be found. Thus I have added a jparse/test_jparse/test_JSON/bad/party.json (to be in the theme of the good/party.json).

I also came to realise that diacritics are allowed in json so I changed the diacritics being escaped to diacritics. Perhaps though we should have some of the \u codes as well.

An aside for those who look at the party.json file and who are also interested in The Lord of the Rings. It is NOT an error to say that an alias of Gollum is Dígol. This is because in the earlier draft (see History of Middle-earth [HoMe] VI - The Return of the Shadow) there was no friend and it was ONLY Dígol. There was even at one point (immediately struck out) that he was a kind of goblin kind! Also, if we're going to go into history: in the first edition of The Hobbit Gollum was willing to give up the Ring and was seriously distressed when he could not find it. Bilbo let him off if he showed him the way out. This is because at that point it was only meant to be a literary device to make one invisible. When a sequel was called for the two obvious things that could be a plot point were the Ring and the Necromancer (which was originally just so that Gandalf would have to leave the Dwarves - NOT dwarfs - and Bilbo for a bit). But I've digressed into another love of mine: the point is Dígol is a valid alias for Gollum earlier on! :-)