### PR TITLE
Fix INSTALL variable in test_jparse/Makefile

### DIFF
--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -32,6 +32,7 @@ CMP= cmp
 CTAGS= ctags
 GREP= grep
 INDEPEND= independ
+INSTALL= install
 MAKE= make
 PICKY= picky
 RM= rm


### PR DESCRIPTION
This fixes a problem where make install would show:

    test_jparse: make install starting

    v -d -m 0775 /usr/local/bin
    bash: line 1: v: command not found
    make[2]: [install] Error 127 (ignored)
    v -m 0555  jnum_chk /usr/local/bin
    bash: line 1: v: command not found
    make[2]: [install] Error 127 (ignored)

    test_jparse: make install complete

It does not fix any other possible problem (that might or might not be in this subdirectory).