### PR TITLE
Bug fix + make bug_report.sh -l completely silent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,6 +523,7 @@ reset_min_timestamp: soup/Makefile
 prep: test_ioccc/prep.sh
 	${RM} -f ${BUILD_LOG}
 	@echo "./test_ioccc/prep.sh 2>&1 | ${TEE} ${BUILD_LOG}"
+	@#-./test_ioccc/prep.sh -l "${BUILD_LOG}"
 	@-./test_ioccc/prep.sh 2>&1 | ${TEE} "${BUILD_LOG}"; \
 	    EXIT_CODE="$${PIPESTATUS[0]}"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \

--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,9 @@ bug_report: bug_report.sh
 bug_report-tx: bug_report.sh
 	@-./bug_report.sh -t -x
 
+bug_report-txl: bug_report.sh
+	@-./bug_report.sh -t -x -l
+
 # slower more verbose build environment sanity check
 #
 hostchk: soup/hostchk.sh

--- a/Makefile
+++ b/Makefile
@@ -340,10 +340,16 @@ bug_report: bug_report.sh
 	@-./bug_report.sh -v 1
 
 bug_report-tx: bug_report.sh
+	@echo "${OUR_NAME}: make $@: starting test of bug_report.sh -t -x"
+	@echo
 	@-./bug_report.sh -t -x
+	@echo
+	@echo "${OUR_NAME}: finished test of bug_report.sh -t -x"
 
 bug_report-txl: bug_report.sh
+	@echo "${OUR_NAME}: make $@: starting test of bug_report.sh -t -x -l"
 	@-./bug_report.sh -t -x -l
+	@echo "${OUR_NAME}: finished test of bug_report.sh -t -x -l"
 
 # slower more verbose build environment sanity check
 #

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -1319,8 +1319,12 @@ if [[ -e "./makefile.local" ]]; then
 	write_echo "### WARNING: Found Makefile overriding file makefile.local:"
 	write_echo "cat ./makefile.local"
 	write_echo "--"
-	# tee -a -- "$LOG_FILE" < makefile.local
-	< makefile.local tee -a -- "$LOG_FILE"
+	if [[ -z "$L_FLAG" ]]; then
+	    # tee -a -- "$LOG_FILE" < makefile.local
+	    < makefile.local tee -a -- "$LOG_FILE"
+	else
+	    cat makefile.local >> "$LOG_FILE"
+	fi
 	write_echo "--"
     else
 	write_echo "### NOTICE: Found unreadable makefile.local"

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -54,7 +54,7 @@ SHELL= bash
 SHELLCHECK= shellcheck
 SLEEP= sleep
 TOUCH= touch
-
+TR= tr
 
 ####################
 # Makefile control #

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -116,14 +116,14 @@ fi
 
 # if -l logfile was specified, remove it and recreate it to start out empty
 #
-if [[ -n "$LOGFILE" ]]; then
-    rm -f "$LOGFILE"
-    touch "$LOGFILE"
-    if [[ ! -f "${LOGFILE}" ]]; then
+if [[ -n "$LOG_FILE" ]]; then
+    rm -f "$LOG_FILE"
+    touch "$LOG_FILE"
+    if [[ ! -f "${LOG_FILE}" ]]; then
 	echo "$0: ERROR: couldn't create log file" 1>&2
 	exit 4
     fi
-    if [[ ! -w "${LOGFILE}" ]]; then
+    if [[ ! -w "${LOG_FILE}" ]]; then
 	echo "$0: ERROR: log file not writable" 1>&2
 	exit 4
     fi
@@ -212,7 +212,7 @@ make_action 20 load_json_ref
 make_action 21 use_json_ref
 make_action 22 clean_generated_obj
 make_action 23 all
-make_action 24 bug_report-tx
+make_action 24 bug_report-txl
 make_action 25 shellcheck
 make_action 26 seqcexit
 make_action 27 picky


### PR DESCRIPTION
To do this required writing some new functions and reworking some things as well but with these changes bug_report.sh -l is now completely silent.

test_ioccc/prep.sh runs new Makefile rule bug_report-txl which runs bug_report.sh with -t -x -l which means to not run the make actions (prep.sh will have already done this), remove the log file if everything is okay and make the actions silent (respectively). Note though that prep.sh is still quite verbose. It does have an option for a log file but it's not yet used and I'm not even clear yet on the way it's supposed to work.

There were two bugs in bug_report.sh though one did not seem to be triggered always. The one that was not triggered in every case was that because the function exec_command() was empty it was a parse error (it might also be that I had done that at last and then didn't run it because nothing else was added).

The other bug was that in some cases a function (write_echo - which probably needs a better name) was called with too many arguments.  Now however it allows for more than one arg, printing everything passed to it.

In prep.sh I fixed a typo with a variable name (in some cases LOG_FILE was referred to as LOGFILE).