### PR TITLE
Fix bug in bug_report.sh wrt cat version

### DIFF
--- a/bug_report.sh
+++ b/bug_report.sh
@@ -605,7 +605,7 @@ get_version_minimal() {
     command "${COMMAND}" --version >/dev/null 2>&1
     status=$?
     if [[ "$status" -eq 0 ]]; then
-	exec_command "${COMMAND}"
+	exec_command "${COMMAND}" --version
 	write_echo "## OUTPUT OF $COMMAND --version ABOVE"
 	write_echo ""
 	return


### PR DESCRIPTION
The problem was that the script first checks the return value of cat --version and if all is good it then ran not cat --version but just cat which means that it was blocking, waiting for input on stdin, thus hanging. Why this did not show itself under macOS I do not know but this should fix the problem under linux.