### PR TITLE
Update picky URL + improve URLs in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,12 @@ SLEEP= sleep
 TEE= tee
 TR= tr
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
 
 ####################
 # Makefile control #
@@ -646,18 +652,18 @@ seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${M} ${MAKE} ${MAKE_CD_Q} -C dbg $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C jparse $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C soup $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@
+	${M} ${MAKE} ${MAKE_CD_Q} SEQCEXIT_URL="${SEQCEXIT_URL}" -C dbg $@
+	${M} ${MAKE} ${MAKE_CD_Q} SEQCEXIT_URL="${SEQCEXIT_URL}" -C dyn_array $@
+	${M} ${MAKE} ${MAKE_CD_Q} SEQCEXIT_URL="${SEQCEXIT_URL}" -C jparse $@
+	${M} ${MAKE} ${MAKE_CD_Q} SEQCEXIT_URL="${SEQCEXIT_URL}" -C soup $@
+	${M} ${MAKE} ${MAKE_CD_Q} SEQCEXIT_URL="${SEQCEXIT_URL}" -C test_ioccc $@
 	${Q} HAVE_SEQCEXIT="`type -P ${SEQCEXIT}`"; if [[ -z "$$HAVE_SEQCEXIT" ]]; then \
 	    echo 'The seqcexit tool could not be found.' 1>&2; \
 	    echo 'The seqcexit tool is required for this rule.'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -672,18 +678,17 @@ picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${M} ${MAKE} ${MAKE_CD_Q} -C dbg $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C jparse $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C soup $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@
+	${M} ${MAKE} ${MAKE_CD_Q} PICKY_URL="${PICKY_URL}" -C dbg $@
+	${M} ${MAKE} ${MAKE_CD_Q} PICKY_URL="${PICKY_URL}" -C dyn_array $@
+	${M} ${MAKE} ${MAKE_CD_Q} PICKY_URL="${PICKY_URL}" -C jparse $@
+	${M} ${MAKE} ${MAKE_CD_Q} PICKY_URL="${PICKY_URL}" -C soup $@
+	${M} ${MAKE} ${MAKE_CD_Q} PICKY_URL="${PICKY_URL}" -C test_ioccc $@
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -746,11 +751,11 @@ check_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${M} ${MAKE} ${MAKE_CD_Q} -C dbg $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C jparse $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C soup $@
-	${M} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@
+	${M} ${MAKE} ${MAKE_CD_Q} CHECKNR_URL="${CHECKNR_URL}" -C dbg $@
+	${M} ${MAKE} ${MAKE_CD_Q} CHECKNR_URL="${CHECKNR_URL}" -C dyn_array $@
+	${M} ${MAKE} ${MAKE_CD_Q} CHECKNR_URL="${CHECKNR_URL}" -C jparse $@
+	${M} ${MAKE} ${MAKE_CD_Q} CHECKNR_URL="${CHECKNR_URL}" -C soup $@
+	${M} ${MAKE} ${MAKE_CD_Q} CHECKNR_URL="${CHECKNR_URL}" -C test_ioccc $@
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -52,6 +52,14 @@ SED= sed
 SEQCEXIT= seqcexit
 SHELL= bash
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
+
+
 
 ####################
 # Makefile control #
@@ -467,7 +475,7 @@ seqcexit: ${ALL_CSRC}
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -482,12 +490,11 @@ picky: ${ALL_SRC}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -522,9 +529,9 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo 'The checknr command could not be found.' 1>&2; \
 	    echo 'The checknr command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'The source code and install instructions for checknr are available from this GitHub repo:' 1>&2; \
+	    echo 'See the following GitHub repo for checknr:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/checknr' 1>&2; \
+	    echo '    ${CHECKNR_URL}' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI ${ALL_MAN_TARGETS}"; \

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -51,6 +51,14 @@ SED= sed
 SEQCEXIT= seqcexit
 SHELL= bash
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
+
+
 
 ####################
 # Makefile control #
@@ -423,7 +431,7 @@ seqcexit: ${ALL_CSRC}
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -438,12 +446,11 @@ picky: ${ALL_SRC}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -477,10 +484,10 @@ check_man: ${ALL_MAN_TARGETS}
 	-${Q} HAVE_CHECKNR="`type -P ${CHECKNR}`"; if [[ -z "$$HAVE_CHECKNR" ]]; then \
 	    echo 'The checknr command could not be found.' 1>&2; \
 	    echo 'The checknr command is required to run the $@ rule.' 1>&2; \
+	    echo 'See the following GitHub repo for checknr:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'The source code and install instructions for checknr are available from this GitHub repo:' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/checknr' 1>&2; \
+	    echo '    ${CHECKNR_URL}' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI ${ALL_MAN_TARGETS}"; \

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -41,6 +41,13 @@ SEQCEXIT= seqcexit
 SHELL= bash
 SHELLCHECK= shellcheck
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
+
 
 ####################
 # Makefile control #
@@ -636,7 +643,7 @@ seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -654,12 +661,11 @@ picky: ${ALL_SRC} test_jparse/Makefile
 	${S} echo
 	${M} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -720,9 +726,9 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo 'The checknr command could not be found.' 1>&2; \
 	    echo 'The checknr command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'The source code and install instructions for checknr are available from this GitHub repo:' 1>&2; \
+	    echo 'See the following GitHub repo for checknr:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/checknr' 1>&2; \
+	    echo '    ${CHECKNR_URL}' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI ${ALL_MAN_TARGETS}"; \

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -57,6 +57,14 @@ SLEEP= sleep
 TOUCH= touch
 TR= tr
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
+
+
 ####################
 # Makefile control #
 ####################
@@ -575,7 +583,7 @@ seqcexit: ${ALL_CSRC}
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -590,12 +598,11 @@ picky: ${ALL_SRC}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -655,9 +662,9 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo 'The checknr command could not be found.' 1>&2; \
 	    echo 'The checknr command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'The source code and install instructions for checknr are available from this GitHub repo:' 1>&2; \
+	    echo 'See the following GitHub repo for checknr:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/checknr' 1>&2; \
+	    echo '    ${CHECKNR_URL}' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI ${ALL_MAN_TARGETS}"; \

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -50,6 +50,13 @@ SEQCEXIT= seqcexit
 SHELL= bash
 SHELLCHECK= shellcheck
 
+######################
+# URLs for utilities #
+######################
+CHECKNR_URL = https://github.com/lcn2/checknr
+PICKY_URL= https://github.com/xexyl/picky
+SEQCEXIT_URL= https://github.com/lcn2/seqcexit
+
 
 ####################
 # Makefile control #
@@ -412,7 +419,7 @@ seqcexit: ${ALL_CSRC}
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for seqcexit:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/seqcexit'; 1>&2; \
+	    echo '    ${SEQCEXIT_URL}'; 1>&2; \
 	    echo ''; 1>&2; \
 	    exit 1; \
 	else \
@@ -427,12 +434,11 @@ picky: ${ALL_SRC}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
-	    echo "The picky tool could not be found." 1>&2; \
-	    echo "The picky tool is required for this rule." 1>&2; \
-	    echo "We recommend you install picky v2.6 or later" 1>&2; \
-	    echo "from this URL:" 1>&2; \
+	    echo 'The picky tool could not be found.' 1>&2; \
+	    echo 'The picky tool is required for this rule.' 1>&2; \
+	    echo 'See the following GitHub repo for picky:'; 1>&2; \
 	    echo 1>&2; \
-	    echo "http://grail.eecs.csuohio.edu/~somos/picky.html" 1>&2; \
+	    echo '    ${PICKY_URL}' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \
@@ -492,9 +498,9 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo 'The checknr command could not be found.' 1>&2; \
 	    echo 'The checknr command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'The source code and install instructions for checknr are available from this GitHub repo:' 1>&2; \
+	    echo 'See the following GitHub repo for checknr:'; 1>&2; \
 	    echo ''; 1>&2; \
-	    echo '    https://github.com/lcn2/checknr' 1>&2; \
+	    echo '    ${CHECKNR_URL}' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI ${ALL_MAN_TARGETS}"; \


### PR DESCRIPTION
A while back the original picky website was no longer online so I made a picky GitHub repo which is at https://github.com/xexyl/picky. The Makefiles now refer to this URL instead of the old one and I also made the text more consistent with some of the other rules that also refer to a URL (though it's not entirely finished - there are still some inconsistencies in text).

I also made _URL variables in the Makefiles for tools that we give a URL for. This is to make it easier to refer to in the Makefile without having to update the raw URL in every Makefile. Instead we simply update the variable and nothing else needs to be changed.