### PR TITLE
Various enhancements, updates and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ just_all: ${ALL_SUBDIRS} ${TARGETS} build_man
 # fast build environment sanity check
 #
 fast_hostchk: test_ioccc/hostchk.sh
-	-${Q} ./test_ioccc/hostchk.sh -f -v 0; \
+	-${Q} ./test_ioccc/hostchk.sh -f -v 0 -Z .; \
 	EXIT_CODE="$$?"; \
 	if [ "$$EXIT_CODE" -ne 0 ]; then \
 	    ${MAKE} hostchk_warning; \
@@ -383,7 +383,7 @@ bug_report-txl: bug_report.sh
 # slower more verbose build environment sanity check
 #
 hostchk: test_ioccc/hostchk.sh
-	-${Q} ./test_ioccc/hostchk.sh -v 1; \
+	-${Q} ./test_ioccc/hostchk.sh -v 1 -Z .; \
 	EXIT_CODE="$$?"; \
 	if [ "$$EXIT_CODE" -ne 0 ]; then \
 	    ${MAKE} hostchk_warning; \

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -57,7 +57,7 @@ export TOOLS="
     ./txzchk
     "
 
-export BUG_REPORT_VERSION="0.10 2023-01-09"
+export BUG_REPORT_VERSION="0.11 2023-01-11"
 export FAILURE_SUMMARY=
 export WARNING_SUMMARY=
 export DBG_LEVEL="0"
@@ -355,7 +355,8 @@ STRINGS="$(type -P strings)" # this should always exist but we check anyway
 # NOTE: we don't want the path to the tool in this function as we try
 # determining that instead.
 #
-get_version_optional() {
+get_version_optional()
+{
 
     # parse args
     #
@@ -522,7 +523,8 @@ get_version_optional() {
 # NOTE: we don't want the path to the tool in this function as we try
 # determining that instead.
 #
-get_version() {
+get_version()
+{
 
     # parse args
     #
@@ -548,6 +550,49 @@ get_version() {
 	IS_EXEC=0
     fi
     write_echo "## VERSION CHECK FOR: $1"
+
+    # First check if this is bash. If it is we can do something special for
+    # version information.
+
+    if [[ "$(basename "${COMMAND}")" = "bash" ]]; then
+	write_echo "## RUNNING: echo \$BASH_VERSION"
+	exec_command "echo $BASH_VERSION"
+	write_echo "## \$BASH_VERSION ABOVE"
+	# get bash MAJOR version
+	write_echo "## RUNNING: echo \${BASH_VERSINFO[0]}"
+	exec_command "echo ${BASH_VERSINFO[0]}"
+	write_echo "## BASH MAJOR VERSION ABOVE"
+	# get bash MINOR version
+	write_echo "## RUNNING: echo \${BASH_VERSINFO[1]}"
+	exec_command "echo ${BASH_VERSINFO[1]}"
+	write_echo "## BASH MINOR VERSION ABOVE"
+	# get bash PATCH LEVEL
+	write_echo "## RUNNING: echo \${BASH_VERSINFO[2]}"
+	exec_command "echo ${BASH_VERSINFO[2]}"
+	write_echo "## BASH PATCH LEVEL ABOVE"
+	# get bash BUILD version
+	write_echo "## RUNNING: echo \${BASH_VERSINFO[3]}"
+	exec_command "echo ${BASH_VERSINFO[3]}"
+	write_echo "## BASH BUILD VERSION ABOVE"
+	# get bash RELEASE STATUS (e.g. beta)
+	write_echo "## RUNNING: echo \${BASH_VERSINFO[4]}"
+	exec_command "echo ${BASH_VERSINFO[4]}"
+	write_echo "## BASH RELEASE STATUS ABOVE"
+	# get MACHTYPE
+	#
+	# We use $MACHTYPE instead of ${BASH_VERSINFO[5]}. Why? Just in case
+	# some versions of bash do not have it and since it's meant to be the
+	# same value the name here can serve as additional documentation. Of
+	# course we could get that elsewhere but this is a bash variable so it
+	# seems fitting that it is put here.
+	write_echo "## RUNNING: echo \$MACHTYPE"
+	exec_command "echo $MACHTYPE"
+	write_echo "## \$MACHTYPE ABOVE: BASH SYSTEM TYPE"
+
+	# Don't return from this function even after all this because trying
+	# --version on bash might prove useful in some way even though we should
+	# have got the information above.
+    fi
 
     # try --version
     #
@@ -689,8 +734,8 @@ get_version() {
 #
 # NOTE: don't warn if we cannot get the version and don't use strings(1) either.
 #
-get_version_minimal() {
-
+get_version_minimal()
+{
     # parse args
     #
     if [[ $# -ne 1 ]]; then
@@ -797,8 +842,8 @@ get_version_minimal() {
 #
 #	command	    - check to run
 #
-run_optional_check() {
-
+run_optional_check()
+{
     # parse args
     #
     if [[ $# -ne 1 ]]; then
@@ -832,8 +877,8 @@ run_optional_check() {
 #
 #	command	    - check to run
 #
-run_check_warn() {
-
+run_check_warn()
+{
     # parse args
     #
     if [[ $# -ne 1 ]]; then
@@ -861,22 +906,23 @@ run_check_warn() {
 
 # get_shell - get the user shell :-)
 #
-get_shell() {
+get_shell()
+{
     write_echo "## RUNNING: echo \$SHELL"
     write_echo "$SHELL"
-    write_echo "## DEFAULT SHELL ABOVE"
+    write_echo "## USER SHELL ABOVE"
     write_echo ""
 }
 
 # get_path - get the user path :-)
 #
-get_path() {
+get_path()
+{
     write_echo "## RUNNING: echo \$PATH"
     write_echo "$PATH"
-    write_echo "## DEFAULT PATH ABOVE"
+    write_echo "## USER PATH ABOVE"
     write_echo ""
 }
-
 
 # run_check
 #
@@ -965,6 +1011,9 @@ get_shell
 
 # echo $PATH: we need to know their default path
 get_path
+
+# shopt -s: get shell options
+run_optional_check "shopt -s"
 
 # uname -a: get system information
 run_check 10 "uname -a"

--- a/dyn_array/dyn_array.c
+++ b/dyn_array/dyn_array.c
@@ -32,11 +32,6 @@
 /* exit code change of order - use new value in sequencing - coo */
 
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <inttypes.h>
-
 /*
  * dyn_array - dynamic array facility
  */

--- a/dyn_array/dyn_array.h
+++ b/dyn_array/dyn_array.h
@@ -33,6 +33,10 @@
 
 #include <stdint.h>
 #include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 
 
 /*

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -144,7 +144,7 @@ C_OPT= -O3 -g3
 
 # Compiler warnings
 #
-WARN_FLAGS= -pedantic -Wall -Wextra -Wno-unneeded-internal-declaration
+WARN_FLAGS= -pedantic -Wall -Wextra
 #WARN_FLAGS= -pedantic -Wall -Wextra -Werror
 
 # linker options
@@ -414,16 +414,16 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS} Makefile
 ####################################
 
 json_util.o: json_util.c json_util.h
-	${CC} ${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration json_util.c -c
+	${CC} ${CFLAGS} json_util.c -c
 
 jparse.tab.o: jparse.tab.c
-	${CC} ${CFLAGS} -Wno-unused-function -Wno-unneeded-internal-declaration jparse.tab.c -c
+	${CC} ${CFLAGS} jparse.tab.c -c
 
 jparse_main.o: jparse_main.c
 	${CC} ${CFLAGS} jparse_main.c -c
 
 jparse.o: jparse.c jparse.h
-	${CC} ${CFLAGS} -Wno-unused-but-set-variable -Wno-unused-function -Wno-unneeded-internal-declaration jparse.c -c
+	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -401,7 +401,7 @@ test:
 	    ./ioccc_test.sh; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
-		echo "${OUR_NAME}: ERROR: ioccc_test.s failed, error code: $$EXIT_CODE"; \
+		echo "${OUR_NAME}: ERROR: ioccc_test.sh failed, error code: $$EXIT_CODE"; \
 		exit "$$EXIT_CODE"; \
 	    else \
 		echo ${OUR_NAME}: "PASSED: ioccc_test.sh"; \

--- a/test_ioccc/hostchk.sh
+++ b/test_ioccc/hostchk.sh
@@ -62,7 +62,7 @@ if [[ -z $CC ]]; then
     CC="/usr/bin/cc"
 fi
 export HOSTCHK_VERSION="0.3 2022-10-27"
-export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w work_dir] [-f]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w work_dir] [-f] [-Z topdir]
 
     -h			    print help and exit
     -V			    print version and exit
@@ -72,6 +72,7 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w work_dir
     -w work_dir		    use an explicit work directory (def: use a temporary directory)
 				NOTE: The work_dir cannot exist
     -f			    faster check (def: run slower for better diagnostics)
+    -Z topdir		    top level build directory (def: try . or ..)
 
 Exit codes:
      0   all is well
@@ -82,6 +83,7 @@ Exit codes:
 
 $0 version: $HOSTCHK_VERSION"
 export EXIT_CODE=0
+export TOPDIR=
 
 # parse args
 #
@@ -89,7 +91,7 @@ export V_FLAG="0"
 export DBG_LEVEL="0"
 export F_FLAG=
 export W_FLAG=
-while getopts :hv:VD:c:w:f flag; do
+while getopts :hv:VD:c:w:fZ: flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -108,6 +110,8 @@ while getopts :hv:VD:c:w:f flag; do
 	;;
     f)	F_FLAG="true"
 	;;
+    Z)  TOPDIR="$OPTARG";
+        ;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
 	exit 3
 	;;
@@ -134,6 +138,45 @@ fi
 if [[ ! -x $CC ]]; then
     echo "$0: ERROR: cc not executable: $CC" 1>&2
     exit 12
+fi
+
+# change to the top level directory as needed
+#
+if [[ -n $TOPDIR ]]; then
+    if [[ ! -d $TOPDIR ]]; then
+	echo "$0: ERROR: -Z $TOPDIR given: not a directory: $TOPDIR" 1>&2
+	exit 3
+    fi
+    if [[ $V_FLAG -ge 1 ]]; then
+	echo "$0: debug[1]: -Z $TOPDIR given, about to cd $TOPDIR" 1>&2
+    fi
+    # warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
+    # shellcheck disable=SC2164
+    cd "$TOPDIR"
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: -Z $TOPDIR given: cd $TOPDIR exit code: $status" 1>&2
+	exit 3
+    fi
+elif [[ -f mkiocccentry.c ]]; then
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is .: $TOPDIR" 1>&2
+    fi
+elif [[ -f ../mkiocccentry.c ]]; then
+    cd ..
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: cd .. exit code: $status" 1>&2
+	exit 3
+    fi
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is ..: $TOPDIR" 1>&2
+    fi
+else
+    echo "$0: ERROR: cannot determine TOPDIR, use -Z topdir" 1>&2
+    exit 3
 fi
 
 # setup a working directory unless -w was given
@@ -189,7 +232,9 @@ if [[ -n $F_FLAG ]]; then
     #
     # NOTE: if your grep does not have -o this will fail. If this happens please
     # submit a bug report and we'll add a workaround.
-    printf "%s\\n%s\\n" "$(grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u)" "int main(void) { return 0; }" |
+    printf "%s\\n%s\\n" "$(grep -h -o '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] \
+	"$TOPDIR"/dyn_array/*.[hc] "$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hc] \
+	|sort -u)" "int main(void) { return 0; }" |
 	    "${CC}" -x c - -o "$PROG_FILE"
     status="$?"
     if [[ $status -ne 0 ]]; then
@@ -265,7 +310,8 @@ elif [[ -n $RUN_INCLUDE_TEST ]]; then
 
     # NOTE: if your grep does not have -o this will fail. If this happens please
     # submit a bug report and we'll add a workaround.
-    done < <(grep -h -o '#include.*<.*>' ./*.c ./*.h|sort -u)
+    done < <(grep -h -o '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] "$TOPDIR"/dyn_array/*.[hc] \
+	"$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hc] |sort -u)
 
 # case: neither -f nor run include tests one at a time
 #

--- a/test_ioccc/hostchk.sh
+++ b/test_ioccc/hostchk.sh
@@ -233,8 +233,8 @@ if [[ -n $F_FLAG ]]; then
     # NOTE: if your grep does not have -o this will fail. If this happens please
     # submit a bug report and we'll add a workaround.
     printf "%s\\n%s\\n" "$(grep -h -o '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] \
-	"$TOPDIR"/dyn_array/*.[hc] "$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hc] \
-	|sort -u)" "int main(void) { return 0; }" |
+	"$TOPDIR"/dyn_array/*.[hc] "$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hcly] \
+	"$TOPDIR"/jparse/test_jparse/*.[hc] |sort -u)" "int main(void) { return 0; }" |
 	    "${CC}" -x c - -o "$PROG_FILE"
     status="$?"
     if [[ $status -ne 0 ]]; then
@@ -311,7 +311,7 @@ elif [[ -n $RUN_INCLUDE_TEST ]]; then
     # NOTE: if your grep does not have -o this will fail. If this happens please
     # submit a bug report and we'll add a workaround.
     done < <(grep -h -o '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] "$TOPDIR"/dyn_array/*.[hc] \
-	"$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hc] |sort -u)
+	"$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hcly] "$TOPDIR"/jparse/test_jparse/*.[hc] |sort -u)
 
 # case: neither -f nor run include tests one at a time
 #

--- a/test_ioccc/man/man8/hostchk.8
+++ b/test_ioccc/man/man8/hostchk.8
@@ -9,11 +9,11 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH hostchk.sh 8 "09 January 2023" "hostchk.sh" "IOCCC tools"
+.TH hostchk.sh 8 "11 January 2023" "hostchk.sh" "IOCCC tools"
 .SH NAME
 hostchk.sh \- run a series of checks on your system to help determine if you can correctly use the mkiocccentry toolkit
 .SH SYNOPSIS
-\fBhostchk.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-c cc] [\-w work_dir] [\-f]
+\fBhostchk.sh\fP [\-h] [\-V] [\-v level] [\-D dbg_level] [\-c cc] [\-w work_dir] [\-f] [\-Z topdir]
 .SH DESCRIPTION
 \fBhostchk.sh\fP runs a series of checks to determine if you will be able to create an acceptable IOCCC entry tarball.
 If any step fails we recommend you use the \fBbug_report(1)\fP script to create a log file for filing a bug.
@@ -43,6 +43,21 @@ The \fIwork_dir\fP must not exist.
 Fast compile mode.
 Instead of testing one required system header file at a time it does it all at once.
 The default is not to use \fB\-f\fP because it will give more information to help identify the problem (and also let you know which files work).
+.TP
+\fB\-Z\fP \fItopdir\fP
+Declare the top level directory of this repository.
+The \fBtopdir\fP directory must contain the source file \fImkiocccentry.c\fP.
+By default, the source file \fImkiocccentry.c\fP is searched for in the current directory,
+and then the parent of current directory.
+.sp 1
+If \fB\-Z\fP \fItopdir\fP is used on the command line, then the source file \fImkiocccentry.c\fP need not exist
+in the \fBtopdir\fP directory.
+If \fB\-Z\fP \fItopdir\fP is not used on the command line, and the source file \fImkiocccentry.c\fP
+is not found in the current directory not the parent of current directory,
+then this command exits as if there was a command line error.
+.sp 1
+Once the \fBtopdir\fP directory is established,
+this command moves to that directory.
 .SH EXIT STATUS
 If no issues are detected the script will exit 0.
 Otherwise it will exit non\-zero.


### PR DESCRIPTION
We now collect shell options that are set (shopt -s).

When we're getting the bash version, if the basename is "bash", we get the values of the variables:

    $BASH_VERSION
    ${BASH_VERSINFO[0-4]} # as in each of the five indices
    $MACHTYPE

A note about the BASH_VERSINFO array. We do not string it up as one string but rather echo each element one at a time. This is a cosmetic choice as it would be a long line in the bug report. Additionally for each one the status is shown by not the element or array but what it stands for. For instance for ${BASH_VERSINFO[4]} we show something like:

    ## RUNNING: echo ${BASH_VERSINFO[4]}
    release
    ## BASH RELEASE STATUS ABOVE

The $MACHTYPE is the same value as ${BASH_VERSINFO[5]} but to be more clear we use $MACHTYPE. We still do it if it's the command passed to get_version is "bash" as it's a bash thing (though maybe other shells have it - I don't actually know now).

We still try --version after this just in case some or all of the above information could not be obtained.

An example output of the new information is as follows:

    ## RUNNING: shopt -s
    checkwinsize    on
    cmdhist         on
    complete_fullquote      on
    extquote        on
    force_fignore   on
    globasciiranges on
    globskipdots    on
    hostcomplete    on
    interactive_comments    on
    patsub_replacement      on
    progcomp        on
    promptvars      on
    sourcepath      on
    ## OUTPUT OF shopt -s ABOVE

    ## VERSION CHECK FOR: bash
    ## RUNNING: echo $BASH_VERSION
    5.2.9(1)-release
    ## $BASH_VERSION ABOVE
    ## RUNNING: echo ${BASH_VERSINFO[0]}
    5
    ## BASH MAJOR VERSION ABOVE
    ## RUNNING: echo ${BASH_VERSINFO[1]}
    2
    ## BASH MINOR VERSION ABOVE
    ## RUNNING: echo ${BASH_VERSINFO[2]}
    9
    ## BASH PATCH LEVEL ABOVE
    ## RUNNING: echo ${BASH_VERSINFO[3]}
    1
    ## BASH BUILD VERSION ABOVE
    ## RUNNING: echo ${BASH_VERSINFO[4]}
    release
    ## BASH RELEASE STATUS ABOVE
    ## RUNNING: echo $MACHTYPE
    aarch64-apple-darwin22.1.0
    ## $MACHTYPE ABOVE: BASH SYSTEM TYPE

Of course this is a lot more output but some of this might prove useful when trying to figure out a problem - even if we should normally get this information from bash --version (at least as far as the bash variables go).