### PR TITLE
Fix -Wmissing-variable-declarations in sanity.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1149,10 +1149,12 @@ iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
 mkiocccentry.o: dbg/dbg.h dyn_array/dyn_array.h iocccsize.h jparse/jparse.h \
     jparse/jparse.tab.h jparse/json_parse.h jparse/json_sem.h \
     jparse/json_util.h jparse/util.h mkiocccentry.c mkiocccentry.h \
-    soup/entry_util.h soup/limit_ioccc.h soup/location.h soup/sanity.h \
-    soup/utf8_posix_map.h soup/version.h
+    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
+    soup/entry_time.h soup/entry_util.h soup/limit_ioccc.h soup/location.h \
+    soup/sanity.h soup/soup.h soup/utf8_posix_map.h soup/version.h
 txzchk.o: dbg/dbg.h dyn_array/dyn_array.h jparse/jparse.h \
     jparse/jparse.tab.h jparse/json_parse.h jparse/json_sem.h \
-    jparse/json_util.h jparse/util.h soup/entry_util.h soup/limit_ioccc.h \
-    soup/location.h soup/sanity.h soup/utf8_posix_map.h soup/version.h \
-    txzchk.c txzchk.h
+    jparse/json_util.h jparse/util.h soup/chk_sem_auth.h \
+    soup/chk_sem_info.h soup/chk_validate.h soup/entry_time.h \
+    soup/entry_util.h soup/limit_ioccc.h soup/location.h soup/sanity.h \
+    soup/soup.h soup/utf8_posix_map.h soup/version.h txzchk.c txzchk.h

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -1548,6 +1548,7 @@ if [[ "$EXIT_CODE" -ne 0 ]]; then
     write_echo "instead email the Judges but you're encouraged to file a"
     write_echo "report instead. This is because not all tools were written by"
     write_echo "the Judges."
+    X_FLAG=""
 elif [[ -z "$X_FLAG" ]]; then
     write_echo "All tests PASSED"
     write_echo ""

--- a/dbg/man/man3/dbg.3
+++ b/dbg/man/man3/dbg.3
@@ -12,7 +12,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dbg 3  "21 January 2023" "dbg"
+.TH dbg 3  "22 January 2023" "dbg"
 .SH NAME
 .BR dbg(),
 .BR vdbg(),
@@ -25,7 +25,8 @@
 \fB#include "dbg.h"\fP
 .sp
 \fB#define DBG_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
-\fbextern const char *const dbg_version;	/* library version format: major.minor YYYY-MM-DD */\fP
+.br
+\fBextern const char *const dbg_version;	/* library version format: major.minor YYYY-MM-DD */\fP
 .sp
 .BI "extern int verbosity_level;		/* maximum debug level for debug messages */"
 .br

--- a/dyn_array/man/man3/dyn_array.3
+++ b/dyn_array/man/man3/dyn_array.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dyn_array 3  "17 January 2023" "dyn_array"
+.TH dyn_array 3  "22 January 2023" "dyn_array"
 .SH NAME
 .BR dyn_array_value(),
 .BR dyn_array_addr(),
@@ -30,6 +30,7 @@
 \fB#include "dyn_array.h"\fP
 .sp
 \fB#define DYN_ARRAY_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
+.br
 \fBextern const char *const dyn_array_version;	/* library version format: major.minor YYYY-MM-DD */\fP
 .sp
 .B "#define dyn_array_value(array, type, index) (((type *)(((struct dyn_array *)(array))->data))[(index)])"

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "17 January 2023" "jparse"
+.TH jparse 3  "22 January 2023" "jparse"
 .SH NAME
 .BR parse_json(),
 .BR parse_json_stream(),
@@ -22,9 +22,9 @@
 .SH SYNOPSIS
 \fB#include "jparse.h"\fP
 .sp
-
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
-\fbextern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */\fP
+.br
+\fBextern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */\fP
 .sp
 .B "extern struct json *parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid);"
 .br

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -811,8 +811,9 @@ rule_count.o: ../dbg/dbg.h ../iocccsize.h iocccsize_err.h limit_ioccc.h \
     rule_count.c version.h
 sanity.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
-    ../jparse/json_util.h ../jparse/util.h limit_ioccc.h location.h \
-    sanity.c sanity.h utf8_posix_map.h version.h
+    ../jparse/json_util.h ../jparse/util.h chk_sem_auth.h chk_sem_info.h \
+    chk_validate.h entry_time.h entry_util.h limit_ioccc.h location.h \
+    sanity.c sanity.h soup.h utf8_posix_map.h version.h
 utf8_posix_map.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_util.h ../jparse/util.h limit_ioccc.h utf8_posix_map.c \

--- a/soup/all_sem_ref.sh
+++ b/soup/all_sem_ref.sh
@@ -73,7 +73,7 @@ while getopts :hv:Vj:J: flag; do
     v)	V_FLAG="$OPTARG";
 	JSEMTBLGEN_ARGS="$JSEMTBLGEN_ARGS -v '$V_FLAG'";
 	;;
-    V)	echo "$ALL_SEM_REF_VERSION" 1>&2
+    V)	echo "$ALL_SEM_REF_VERSION"
 	exit 2
 	;;
     j)	JSEMTBLGEN="$OPTARG";

--- a/soup/sanity.h
+++ b/soup/sanity.h
@@ -9,6 +9,10 @@
 #if !defined(INCLUDE_SANITY_H)
 #    define  INCLUDE_SANITY_H
 
+/*
+ * soup - a big pot of soup for consumption :-)
+ */
+#include "soup.h"
 
 /*
  * jparse - the parser

--- a/soup/soup.h
+++ b/soup/soup.h
@@ -78,5 +78,11 @@
  */
 #include "version.h"
 
+/*
+ * global variables
+ *
+ * We put the soup.a version string here because we need to put it somewhere. :-)
+ */
+extern const char *const soup_version;
 
 #endif /* INCLUDE_SOUP_H */

--- a/soup/version.h
+++ b/soup/version.h
@@ -62,7 +62,7 @@
 
 
 /*
- * official soup version
+ * official soup version (aka recipe :-) )
  */
 #define SOUP_VERSION "1.0 2023-01-21"		/* format: major.minor YYYY-MM-DD */
 

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -17,7 +17,7 @@
 
 # setup
 #
-export IOCCC_TEST_VERSION="0.5 2022-11=04"
+export IOCCC_TEST_VERSION="0.5 2022-11-04"
 
 export USAGE="usage: $0 [-h] [-v level] [-J json_level] [-V] [-Z topdir]
 

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -54,7 +54,7 @@ while getopts :hv:J:VZ: flag; do
 	;;
     J)	J_FLAG="$OPTARG";
 	;;
-    V)	echo "$IOCCC_TEST_VERSION" 1>&2
+    V)	echo "$IOCCC_TEST_VERSION"
 	exit 2
 	;;
     Z)  TOPDIR="$OPTARG";


### PR DESCRIPTION
With the soup_version string in sanity.c but not in any header file it triggered a warning that there was no previous extern declaration for non-static variable:

    sanity.c:22:19: warning: no previous extern declaration for non-static variable 'soup_version' [-Wmissing-variable-declarations]
    const char *const soup_version = SOUP_VERSION;  /* library version format: major.minor YYYY-MM-DD */
		      ^
    sanity.c:22:7: note: declare 'static' if the variable is not intended to be used outside of this translation unit
    const char *const soup_version = SOUP_VERSION;  /* library version format: major.minor YYYY-MM-DD */
	  ^

Now it could have gone in sanity.h but I felt soup.h was more fitting. If there was a soup.c the version could have gone in there but it seems like making a soup.c just for that might be overkill - the soup.h already existed.

Make depend.