### PR TITLE
Various updates, enhancements and fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,7 +118,7 @@ Fixed obscure bug with bool typedef.
 
 ## Release 0.8.1 2022-11-19
 
-This is "roll-up" release was added so that it could be referenced
+This "roll-up" release was added so that it could be referenced
 in the https://www.ioccc.org/index.html news section.
 
 Updated legacy_clobber rule to remove older directories no longer used.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,192 @@
 
 *NOTE*: This code is currently under alpha-test.
 
+## HOW TO HELP TEST THIS REPO
+
+**IMPORTANT NOTE**: we currently are **NOT** _yet ready for this_. We will remove this
+note once we are ready.
+
+We first want to thank each and every person who helps us further test this repo
+under different platforms.
+
+In order to help you help us, we provide the following information.
+
+### Running the test suite
+
+Perhaps the most important thing you can do for us is run the `bug_report.sh`
+script with all information like:
+
+```sh
+make bug_report
+```
+
+This tool will run an exhaustive list of checks on your system, including the
+entire test suite, writing it to both stdout and a log file. If there are any
+issues found we encourage you (and thank you!) to post the entire log at the
+[GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues). Of
+course if it does not find any issues it does not necessarily mean there are no
+issues so you're certainly welcome to report other issues and are encouraged to
+do so.
+
+If the script does not report any issues you may delete the file safely (it will
+tell you the log file name). Alternatively you can run:
+
+```sh
+./bug_report -x
+```
+
+which will delete the log file for you if no issues are found.
+
+### Static analysis and dynamic analysis
+
+If you wish to run static analysis you may wish to see the file
+[test_ioccc/static_analsys.md](test_ioccc/static_analysis.md). For help on
+running with valgrind you may see the document
+[test_ioccc/dynamic_analysis.md](test_ioccc/dynamic_analysis.md).
+
+
+### Reviewing the tools
+
+For a list of tools that you may wish to look at in more detail, see the below
+list. 
+
+If at any stage you feel like you have an improvement you may open a new issue
+at the [GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues) or
+you may alternatively offer a fix and open a pull request.
+
+Finally we thank you once again in helping to make the IOCCC toolkit even better
+in order to improve the IOCCC itself!
+
+
+## The mkiocccentry toolkit
+
+
+### `mkiocccentry`
+
+Form an **IOCCC** entry as an XZ compressed tarball file.
+
+For examples and more information, try:
+
+
+```sh
+man ./soup/man/man1/mkiocccentry.1
+```
+
+
+### `iocccsize`
+
+The official **IOCCC** entry Rule 2b size tool.
+
+This code is based on code by *@SirWumpus* (**Anthony Howe**):
+
+[See @SirWumpus's iocccsize repo](https://github.com/SirWumpus/iocccsize)
+
+For more information and examples, try:
+
+```sh
+man ./soup/man/man1/iocccsize.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./iocccsize`.
+
+
+### `txzchk`
+
+The official **IOCCC** tarball validation tool.
+
+It is invoked by `mkiocccentry`; `txzchk` in turn uses `fnamchk` to make sure
+that the tarball was correctly named and formed (i.e. the `mkiocccentry` tool
+was used).
+
+`txzchk` verifies that the tarball does not have any feathers stuck in it (i.e.
+the tarball conforms to the IOCCC tarball rules). Invoked by `mkiocccentry`;
+`txzchk` in turn uses `fnamchk` to make sure that the tarball was correctly named
+and formed. In other words `txzchk` makes sure that the `mkiocccentry` tool was
+used and there was no screwing around with the resultant tarball.
+
+`txzchk` was written in 2022 by *@xexyl* (**Cody Boone Ferguson**). See
+[https://xexyl.net](https://xexyl.net) and
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net).
+
+For more information and examples, try:
+
+```sh
+man ./soup/man/man1/txzchk.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./txzchk`.
+
+###  `chkentry`
+
+The official **IOCCC** `.info.json` and `.auth.json` sanity checker tool.
+Invoked by `mkiocccentry` after the `.info.json` and `.auth.json` files have
+been created, it will attempt to validate the files. If it does not successfully
+validate the files there is a mismatch between what is expected and what is
+actually there and `mkiocccentry` will fail.
+
+As a stand-alone tool it will report whether the files are validly formed.
+
+This tool was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+
+For more information and examples, try:
+
+```sh
+man ./soup/man/man1/chkentry.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./chkentry`.
+
+
+###  `fnamchk`
+
+The official **IOCCC** XZ compressed tarball filename sanity checker tool.
+
+For more information and examples, try:
+
+```sh
+man ./test_ioccc/man/man1/fnamchk.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./test_ioccc/fnamchk`.
+
+
+### `bug_report.sh`
+
+Run a series of tests, collecting system information in the process, to help report bugs and issues.
+Without any arguments, this tool produces a bug report file of the form:
+
+```
+bug-report.YYYYMMDD.HHMMSS.txt
+```
+
+This bug report file is intended to be uploaded to a [mkiocccentry repo related bug report](https://github.com/ioccc-src/mkiocccentry/issues).
+
+This tool was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+For more information and examples, try:
+
+```sh
+man ./soup/man/man1/bug_report.1
+```
+
+NOTE: This tool may be found as: `./bug_report.sh`.
+
+
 
 ## HOW TO ENTER THE IOCCC
 
@@ -72,203 +258,3 @@ XXX - instructions TBD - XXX
 ```
 
 
-## The mkiocccentry toolkit
-
-
-### `mkiocccentry`
-
-Form an **IOCCC** entry as an XZ compressed tarball file.
-
-For examples and more information, try:
-
-
-```sh
-man ./soup/man/man1/mkiocccentry.1
-```
-
-
-### `iocccsize`
-
-The official **IOCCC** entry Rule 2b size tool.
-
-This code is based on code by *@SirWumpus* (**Anthony Howe**):
-
-[See @SirWumpus's iocccsize repo](https://github.com/SirWumpus/iocccsize)
-
-For more information and examples, try:
-
-```sh
-man ./soup/man/man1/iocccsize.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./iocccsize`.
-
-
-### `txzchk`
-
-The official **IOCCC** tarball validation tool.
-
-It is invoked by `mkiocccentry`; `txzchk` in turn uses `fnamchk` to make sure
-that the tarball was correctly named and formed (i.e. the `mkiocccentry` tool
-was used).
-
-`txzchk` verifies that the tarball does not have any feathers stuck in it (i.e.
-the tarball conforms to the IOCCC tarball rules). Invoked by `mkiocccentry`;
-`txzchk` in turn uses `fnamchk` to make sure that the tarball was correctly named
-and formed. In other words `txzchk` makes sure that the `mkiocccentry` tool was
-used and there was no screwing around with the resultant tarball.
-
-`txzchk` was written in 2022 by *@xexyl* (**Cody Boone Ferguson**). See
-[https://xexyl.net](https://xexyl.net) and
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net).
-
-For more information and examples, try:
-
-```sh
-man ./soup/man/man1/txzchk.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./txzchk`.
-
-
-###  `fnamchk`
-
-The official **IOCCC** XZ compressed tarball filename sanity checker tool.
-
-For more information and examples, try:
-
-```sh
-man ./test_ioccc/man/man1/fnamchk.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./test_ioccc/fnamchk`.
-
-
-###  `chkentry`
-
-The official **IOCCC** `.info.json` and `.auth.json` sanity checker tool.
-Invoked by `mkiocccentry` after the `.info.json` and `.auth.json` files have
-been created, it will attempt to validate the files. If it does not successfully
-validate the files there is a mismatch between what is expected and what is
-actually there and `mkiocccentry` will fail.
-
-As a stand-alone tool it will report whether the files are validly formed.
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-
-For more information and examples, try:
-
-```sh
-man ./soup/man/man1/chkentry.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./chkentry`.
-
-
-###  `jparse`
-
-The official **IOCCC** `JSON` parser written in C via `flex(1)` and `bison(1)`.
-
-It takes a block of memory from either a file (stdin or a text file) or a string
-(via `-s` option) and parses it as JSON, reporting if it is validly formed JSON
-or not.
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./jparse/man/man1/jparse.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./jparse/jparse`.
-
-
-### `jstrencode`
-
-Encode data.  This tool can converts data into JSON encoded strings according to the so-called
-[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./jparse/man/man1/jstrencode.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./jparse/jstrencode`.
-
-
-### `jstrdecode`
-
-Decode JSON encoded strings.  This tool converts JSON encoded strings to their original data according to the so-called
-[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./jparse/man/man1/jstrdecode.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./jparse/jstrdecode`.
-
-
-### `bug_report.sh`
-
-Run a series of tests, collecting system information in the process, to help report bugs and issues.
-Without any arguments, this tool produces a bug report file of the form:
-
-```
-bug-report.YYYYMMDD.HHMMSS.txt
-```
-
-This bug report file is intended to be uploaded to a [mkiocccentry repo related bug report](https://github.com/ioccc-src/mkiocccentry/issues).
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./soup/man/man1/bug_report.1
-```
-
-NOTE: This tool may be found as: `./bug_report.sh`.

--- a/dbg/man/man3/dbg.3
+++ b/dbg/man/man3/dbg.3
@@ -12,7 +12,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dbg 3  "22 January 2023" "dbg"
+.TH dbg 3  "23 January 2023" "dbg"
 .SH NAME
 .BR dbg(),
 .BR vdbg(),
@@ -79,6 +79,14 @@ As these are quite complex please refer to the \fBprintf(3)\fP man page for more
 .PP
 When \fBdbg_output_allowed == false\fP these functions will not print anything.
 If \fBlevel > verbosity_level\fP these functions will not print anything.
+.SS Version string
+The string
+.B dbg_version\c
+\&, which points to
+.B DBG_VERSION\c
+\&, is the current version of the
+.B dbg
+facility.
 .SH RETURN VALUE
 These functions return void.
 .SH NOTES

--- a/dyn_array/man/man3/dyn_array.3
+++ b/dyn_array/man/man3/dyn_array.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dyn_array 3  "22 January 2023" "dyn_array"
+.TH dyn_array 3  "23 January 2023" "dyn_array"
 .SH NAME
 .BR dyn_array_value(),
 .BR dyn_array_addr(),
@@ -31,7 +31,7 @@
 .sp
 \fB#define DYN_ARRAY_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fBextern const char *const dyn_array_version;	/* library version format: major.minor YYYY-MM-DD */\fP
+.B "extern const char *const dyn_array_version;	/* library version format: major.minor YYYY-MM-DD */"
 .sp
 .B "#define dyn_array_value(array, type, index) (((type *)(((struct dyn_array *)(array))->data))[(index)])"
 .br
@@ -170,6 +170,14 @@ struct dyn_array
 };
 .fi
 .in
+.SS Version string
+The string
+.B dyn_array_version\c
+\&, which points to
+.B DYN_ARRAY_VERSION\c
+\&, is the current version of the
+.B dyn_array
+facility.
 .SH RETURN VALUE
 .PP
 The function

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -219,7 +219,7 @@ ALL_OBJS= ${LIB_OBJS} ${OTHER_OBJS}
 
 # rule used by prep.sh and make clean via make clean_generated_obj
 #
-BUILT_OBJS= jparse.o jparse.tab.o jparse.tab.o
+BUILT_OBJS= jparse.o jparse.tab.o
 
 # RUN_O_FLAG - determine if the bison and flex backup files should be used
 #

--- a/jparse/README.md
+++ b/jparse/README.md
@@ -1,11 +1,51 @@
 # jparse - JSON parser written in C
 
-`jparse` is a JSON parser written in C with the help of `flex(1)` and
-`bison(1)`. It was co-developed by Cody Boone Ferguson and Landon Curt Noll (one
-of the IOCCC Judges) in support of the *IOCCC* (_International Obfuscated C Code
-Contest_), originally in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-# Synopsis
+`jparse` is a JSON parser (a stand-alone tool and a library) written in C with
+the help of `flex(1)` and `bison(1)`. It was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+
+in support of the **IOCCC** ([International Obfuscated C Code
+Contest](https://www.ioccc.org)), originally in the [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry), but we provide it here so that
+anyone may use it.
+
+As a stand-alone tool it is less useful, perhaps save for validating json
+documents and to see how it works. The library is much more useful because you
+can integrate it into your own applications and work with the parsed tree. More
+details on the library will be documented at a later date although we do give a
+bit of information below.
+
+We also have some additional tools, some of which will be documented later and
+some of which are documented below, namely `jstrencode` and `jstrdecode`.
+
+
+# Compiling
+
+We determine if you have a recent enough `flex(1)` and `bison(1)`. If you do not
+we use backup files. Either way, to compile you need only run:
+
+
+```sh
+make all
+```
+
+
+## Stand-alone tool
+
+As a tool by itself `jparse` takes a block of memory from either a file (stdin
+or a text file) or a string (via `-s` option) and parses it as JSON, reporting
+if it is validly formed JSON or not.
+
+### Synopsis
+
 
 ```sh
 ./jparse [-h] [-v level] [-J level] [-q] [-V] [-s] -- arg
@@ -21,10 +61,49 @@ to be a file.
 The options `-V` and `-h` show the version of the parser and the help or usage
 string, respectively.
 
-# Exit status
+
+### Exit status
 
 If the JSON is valid the exit status of `jparse` is 0. Different non-zero values
 are for different error conditions, or help or version string printed.
+
+
+## The jparse library
+
+As a library, `jparse` is much more useful as it allows one to parse JSON in
+their application and then interact with the parsed tree.
+
+
+### Linking the library into your own code
+
+To use you need to include `jparse.h` and then link in the `jparse.a` static
+library. This will be documented at a later date.
+
+
+### Example use of the library
+
+We currently do not have a short and simple example to go through. This will
+come at a later date when I (Cody) make this into a separate GitHub repo.
+Nevertheless one may check the library man page by:
+
+
+```sh
+man ./man/man3/jparse.3
+```
+
+which gives more information about the most important functions.
+
+### Re-entrancy
+
+Although the scanner and parser are both re-entrant, only one parse at one time
+in a process has been tested. The testing of more than one parse at the same
+time is way out of scope of this repo but will be tested more as I (@xexyl, Cody
+Boone Ferguson) move this to a separate repo.
+
+If it's not clear this means that having more than one parse active in the same
+process at the same time is not tested so even though it should be okay there
+might be some issues that have yet to be discovered.
+
 
 
 # History
@@ -37,25 +116,6 @@ the source code. If you do read the source code we **STRONGLY** recommend you
 read the `jparse.l` and `jparse.y` files and **NOT** the bison or flex generated
 code! This is because the generated code might give you nightmares and cause
 other horrible symptoms. :-) See `sorry.tm.ca.h` for more details.
-
-# Re-entrancy
-
-Although the scanner and parser are both re-entrant, only one parse at one time
-in a process has been tested. The testing of more than one parse at the same
-time is way out of scope of this repo but will be tested more as I (@xexyl, Cody
-Boone Ferguson) move this to a separate repo.
-
-If it's not clear this means that having more than one parse active in the same
-process at the same time is not tested so even though it should be okay there
-might be some issues that have yet to be discovered.
-
-# Compiling and using in your own code
-
-This won't be described until after the IOCCCMOCK contest and any changes are
-made based on what is learnt. After this I (Cody) will make a separate repo for
-the parser which will have an updated README. In there I will document how to
-use the tool in your own projects. The below section Examples will be updated at
-this point as well.
 
 # Examples
 
@@ -90,15 +150,65 @@ Run the `jparse_test.sh` script using the default `json_teststr.txt` file with v
 ```sh
 ./jparse_test.sh -v 5
 ```
-# See also
-       
-The following man pages might also be of value:
 
-- jparse(1)
-- jparse(3)
-- mkiocccentry(1)
-- jstrencode(1)
-- jstrdecode(1)
-- chkentry(1) (for the IOCCC reason the code exists in the first place)
-- flex(1)
-- bison(1)
+
+
+# See also
+
+For more information, try:
+
+```sh
+man ./man/man1/jparse.1
+man ./man/man3/jparse.3
+man ./man/man1/jstrencode.1
+man ./man/man1/jstrdecode.1
+```
+
+NOTE: the library man page currently has no example and this will not happen
+until later, possibly not until it's an actual repo.
+
+### `jstrencode`
+
+Encode data.  This tool can converts data into JSON encoded strings according to the so-called
+[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
+
+This tool was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+For more information and examples, try:
+
+```sh
+man ./man/man1/jstrencode.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./jstrencode`.
+
+
+### `jstrdecode`
+
+Decode JSON encoded strings.  This tool converts JSON encoded strings to their original data according to the so-called
+[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
+
+This tool was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+For more information and examples, try:
+
+```sh
+man ./man/man1/jstrdecode.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./jstrdecode`.
+

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -72,13 +72,14 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "0.13 2023-01-21"		/* format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "0.13 2023-01-21"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*
  * globals
  */
 extern const char *const json_parser_version;		/* library version format: major.minor YYYY-MM-DD */
+extern const char *const jparse_version;		/* jparse version format: major.minor YYYY-MM-DD */
 /* lexer and parser specific variables */
 extern int yydebug;
 

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -144,9 +144,10 @@ int yydebug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debug on 
  * JSON parser library version
  */
 const char *const json_parser_version = JSON_PARSER_VERSION;	/* library version format: major.minor YYYY-MM-DD */
+const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
 
 
-#line 99 "jparse.tab.c"
+#line 100 "jparse.tab.c"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -566,9 +567,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   164,   164,   222,   253,   284,   315,   346,   376,   406,
-     438,   469,   499,   533,   572,   608,   639,   669,   703,   741,
-     774,   806
+       0,   165,   165,   223,   254,   285,   316,   347,   377,   407,
+     439,   470,   500,   534,   573,   609,   640,   670,   704,   742,
+     775,   807
 };
 #endif
 
@@ -1531,7 +1532,7 @@ yyreduce:
     switch (yyn)
       {
   case 2: /* json: json_element  */
-#line 165 "./jparse.y"
+#line 166 "./jparse.y"
     {
 	/*
 	 * $$ = $json
@@ -1585,11 +1586,11 @@ yyreduce:
 					      "json: json_element");
 	}
     }
-#line 1538 "jparse.tab.c"
+#line 1539 "jparse.tab.c"
     break;
 
   case 3: /* json_value: json_object  */
-#line 223 "./jparse.y"
+#line 224 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1618,11 +1619,11 @@ yyreduce:
 					       "json_value: json_object");
 	}
     }
-#line 1571 "jparse.tab.c"
+#line 1572 "jparse.tab.c"
     break;
 
   case 4: /* json_value: json_array  */
-#line 254 "./jparse.y"
+#line 255 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1651,11 +1652,11 @@ yyreduce:
 					       "json_value: json_array");
 	}
     }
-#line 1604 "jparse.tab.c"
+#line 1605 "jparse.tab.c"
     break;
 
   case 5: /* json_value: json_string  */
-#line 285 "./jparse.y"
+#line 286 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1684,11 +1685,11 @@ yyreduce:
 					       "json_value: json_string");
 	}
     }
-#line 1637 "jparse.tab.c"
+#line 1638 "jparse.tab.c"
     break;
 
   case 6: /* json_value: json_number  */
-#line 316 "./jparse.y"
+#line 317 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1717,11 +1718,11 @@ yyreduce:
 					       "json_value: json_number");
 	}
     }
-#line 1670 "jparse.tab.c"
+#line 1671 "jparse.tab.c"
     break;
 
   case 7: /* json_value: "true"  */
-#line 347 "./jparse.y"
+#line 348 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1749,11 +1750,11 @@ yyreduce:
 					       "json_value: JSON_TRUE");
 	}
     }
-#line 1702 "jparse.tab.c"
+#line 1703 "jparse.tab.c"
     break;
 
   case 8: /* json_value: "false"  */
-#line 377 "./jparse.y"
+#line 378 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1781,11 +1782,11 @@ yyreduce:
 					     "json_value: JSON_FALSE");
 	}
     }
-#line 1734 "jparse.tab.c"
+#line 1735 "jparse.tab.c"
     break;
 
   case 9: /* json_value: "null"  */
-#line 407 "./jparse.y"
+#line 408 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1813,11 +1814,11 @@ yyreduce:
 					       "json_value: JSON_NULL");
 	}
     }
-#line 1766 "jparse.tab.c"
+#line 1767 "jparse.tab.c"
     break;
 
   case 10: /* json_object: "{" json_members "}"  */
-#line 439 "./jparse.y"
+#line 440 "./jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1846,11 +1847,11 @@ yyreduce:
 					       "json_object: JSON_OPEN_BRACE json_members JSON_CLOSE_BRACE");
 	}
     }
-#line 1799 "jparse.tab.c"
+#line 1800 "jparse.tab.c"
     break;
 
   case 11: /* json_object: "{" "}"  */
-#line 470 "./jparse.y"
+#line 471 "./jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1876,11 +1877,11 @@ yyreduce:
 					       "json_object: JSON_OPEN_BRACE JSON_CLOSE_BRACE");
 	}
     }
-#line 1829 "jparse.tab.c"
+#line 1830 "jparse.tab.c"
     break;
 
   case 12: /* json_members: json_member  */
-#line 500 "./jparse.y"
+#line 501 "./jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -1912,11 +1913,11 @@ yyreduce:
 					      "json_members: json_member");
 	}
     }
-#line 1865 "jparse.tab.c"
+#line 1866 "jparse.tab.c"
     break;
 
   case 13: /* json_members: json_members "," json_member  */
-#line 534 "./jparse.y"
+#line 535 "./jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -1951,11 +1952,11 @@ yyreduce:
 					       "json_members: json_members JSON_COMMA json_member");
 	}
     }
-#line 1904 "jparse.tab.c"
+#line 1905 "jparse.tab.c"
     break;
 
   case 14: /* json_member: json_string ":" json_element  */
-#line 573 "./jparse.y"
+#line 574 "./jparse.y"
     {
 	/*
 	 * $$ = $json_member
@@ -1987,11 +1988,11 @@ yyreduce:
 					       "json_member: json_string JSON_COLON json_element");
 	}
     }
-#line 1940 "jparse.tab.c"
+#line 1941 "jparse.tab.c"
     break;
 
   case 15: /* json_array: "[" json_elements "]"  */
-#line 609 "./jparse.y"
+#line 610 "./jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2020,11 +2021,11 @@ yyreduce:
 					       "json_array: JSON_OPEN_BRACKET json_elements JSON_CLOSE_BRACKET");
 	}
     }
-#line 1973 "jparse.tab.c"
+#line 1974 "jparse.tab.c"
     break;
 
   case 16: /* json_array: "[" "]"  */
-#line 640 "./jparse.y"
+#line 641 "./jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2050,11 +2051,11 @@ yyreduce:
 					       "json_array: JSON_OPEN_BRACKET JSON_CLOSE_BRACKET");
 	}
     }
-#line 2003 "jparse.tab.c"
+#line 2004 "jparse.tab.c"
     break;
 
   case 17: /* json_elements: json_element  */
-#line 670 "./jparse.y"
+#line 671 "./jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2086,11 +2087,11 @@ yyreduce:
 					       "json_elements: json_element");
 	}
     }
-#line 2039 "jparse.tab.c"
+#line 2040 "jparse.tab.c"
     break;
 
   case 18: /* json_elements: json_elements "," json_element  */
-#line 704 "./jparse.y"
+#line 705 "./jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2124,11 +2125,11 @@ yyreduce:
 					       "json_elements: json_elements JSON_COMMA json_element");
 	}
     }
-#line 2077 "jparse.tab.c"
+#line 2078 "jparse.tab.c"
     break;
 
   case 19: /* json_element: json_value  */
-#line 742 "./jparse.y"
+#line 743 "./jparse.y"
     {
 	/*
 	 * $$ = $json_element
@@ -2157,11 +2158,11 @@ yyreduce:
 					       "json_element: json_value");
 	}
     }
-#line 2110 "jparse.tab.c"
+#line 2111 "jparse.tab.c"
     break;
 
   case 20: /* json_string: JSON_STRING  */
-#line 775 "./jparse.y"
+#line 776 "./jparse.y"
     {
 	/*
 	 * $$ = $json_string
@@ -2189,11 +2190,11 @@ yyreduce:
 					       "json_string: JSON_STRING");
 	}
     }
-#line 2142 "jparse.tab.c"
+#line 2143 "jparse.tab.c"
     break;
 
   case 21: /* json_number: JSON_NUMBER  */
-#line 807 "./jparse.y"
+#line 808 "./jparse.y"
     {
 	/*
 	 * $$ = $json_number
@@ -2221,11 +2222,11 @@ yyreduce:
 					       "json_number: JSON_NUMBER");
 	}
     }
-#line 2174 "jparse.tab.c"
+#line 2175 "jparse.tab.c"
     break;
 
 
-#line 2178 "jparse.tab.c"
+#line 2179 "jparse.tab.c"
 
         default: break;
       }
@@ -2432,7 +2433,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 837 "./jparse.y"
+#line 838 "./jparse.y"
 
 
 

--- a/jparse/jparse.tab.ref.h
+++ b/jparse/jparse.tab.ref.h
@@ -96,7 +96,7 @@
 extern int yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 75 "./jparse.y"
+#line 76 "./jparse.y"
 
     #if !defined(YYLTYPE_IS_DECLARED)
     struct YYLTYPE

--- a/jparse/jparse.y
+++ b/jparse/jparse.y
@@ -69,6 +69,7 @@ int yydebug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debug on 
  * JSON parser library version
  */
 const char *const json_parser_version = JSON_PARSER_VERSION;	/* library version format: major.minor YYYY-MM-DD */
+const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
 
 %}
 

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "22 January 2023" "jparse"
+.TH jparse 3  "23 January 2023" "jparse"
 .SH NAME
 .BR parse_json(),
 .BR parse_json_stream(),
@@ -24,7 +24,11 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fBextern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */\fP
+\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+.br
+.B "extern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */"
+.br
+.B "extern const char *const jparse_version;		/* jparse version format: major.minor YYYY-MM-DD */"
 .sp
 .B "extern struct json *parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid);"
 .br
@@ -43,10 +47,6 @@
 The
 .B jparse
 library provides a way for C applications to parse JSON in a file (including stdin) or a string, returning a tree of the parsed JSON that one may then manipulate.
-The macro
-.B JPARSE_VERSION
-is a string that holds the current version of the parser.
-.sp
 The function
 .BR parse_json
 parses a JSON string
@@ -161,6 +161,8 @@ struct json
 {
     enum item_type type;		/* union item specifier */
     union json_union {
+.in +4n
+.nf
 	struct json_number number;	/* JTYPE_NUMBER - value is number (integer or floating point) */
 	struct json_string string;	/* JTYPE_STRING - value is a string */
 	struct json_boolean boolean;	/* JTYPE_BOOL - value is a JSON boolean */
@@ -169,15 +171,29 @@ struct json
 	struct json_object object;	/* JTYPE_OBJECT - value is a JSON { members } */
 	struct json_array array;	/* JTYPE_ARRAY - value is a JSON [ elements ] */
 	struct json_elements elements;	/* JTYPE_ELEMENTS - zero or more JSON values */
+.in
     } item;
 
     /*
      * JSON parse tree links
      */
     struct json *parent;	/* parent node in the JSON parse tree, or NULL if tree root or unlinked */
-};
 .fi
 .in
+};
+.SS Version strings
+The string
+.B jparse_version\c
+\&, which points to
+.B JPARSE_VERSION\c
+\&, is the current version of the
+.B jparse
+tool.
+The string
+.B json_parser_version\c
+\&, which points to
+.B JSON_PARSER_VERSION\c
+\&, is the current version of the parser itself.
 .SH RETURN VALUE
 .PP
 The functions

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -2341,6 +2341,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     char *line;			/* Makefile line to parse */
     int rulenum = 0;		/* current rule number */
     char *p;
+    char *saveptr = NULL;	/* for strtok_r */
 
     /*
      * firewall
@@ -2423,7 +2424,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 	/*
 	 * split the line into whitespace separated tokens
 	 */
-	for (p = strtok(line, " \t"); p != NULL; p = strtok(NULL, ":")) {
+	for (p = strtok_r(line, " \t", &saveptr); p != NULL; p = strtok_r(NULL, ":", &saveptr)) {
 
 	    /*
 	     * detect all rule

--- a/soup/man/man1/txzchk.1
+++ b/soup/man/man1/txzchk.1
@@ -26,16 +26,16 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH txzchk 1 "13 November 2022" "txzchk" "IOCCC tools"
+.TH txzchk 1 "23 January 2023" "txzchk" "IOCCC tools"
 .SH NAME
 txzchk \- sanity checker tool used on IOCCC compressed tarballs
 .SH SYNOPSIS
-\fBtxzchk\fP [\-h] [\-v level] [\-q] [\-w] [\-V] [\-t tar] [\-F fnamchk] [\-T] [\-E ext] txzpath
+\fBtxzchk\fP [\-h] [\-v level] [\-q] [\-w] [\-V] [\-t tar] [\-F fnamchk] [\-T] [\-E ext] tarball_path
 .SH DESCRIPTION
 \fBtxzchk\fP runs a series of sanity tests on IOCCC compressed tarballs.
 It is invoked by \fBmkiocccentry(1)\fP after the tarball is formed, reporting any feathers stuck in the tarball (i.e. issues found) and exiting the program accordingly; if \fBtxzchk\fP does not return 0, \fBmkiocccentry\fP will exit with an error.
 .PP
-The program runs \fBtar \-tJvf\fP on the \fItxzpath\fP and parses the output of the command, performing a variety of tests on the tarball.
+The program runs \fBtar \-tJvf\fP on the \fItarball_path\fP and parses the output of the command, performing a variety of tests on the tarball.
 As a side effect it will show the user the contents of the tarball.
 The tarball is \fBNOT\fP extracted.
 \fBtxzchk\fP also runs the IOCCC tool \fBfnamchk(1)\fP on the file, verifying that the tarball is properly named (this is also how it gets the directory name that the files should be in).
@@ -71,7 +71,7 @@ Specify path to the IOCCC \fBfnamchk(1)\fP tool.
 If this option is not specified the program looks under the current working directory and \fI/usr/local/bin\fP.
 .TP
 \fB\-T\fP
-Assume txzpath is a text file: use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
+Assume tarball_path is a text file: use \fBfopen(3)\fP and \fBfclose(3)\fP instead of \fBpopen(3)\fP and \fBpclose(3)\fP and don't require \fBtar\fP program.
 .TP
 \fB\-E \fIext\fP\fP
 Change extension for \fBfnamchk(1)\fP to validate (don't include the dot).

--- a/test_ioccc/dynamic_analysis.md
+++ b/test_ioccc/dynamic_analysis.md
@@ -71,7 +71,7 @@ the problem is resolved.
 
 ### See also
 
-Fixed in commit 66f539b70c2fa2a54dd39cd8645bc7166b93b5b7.
+Fixed in commit 5eb62121b6298e5ecc5324c6c1fd13a7f904ee0b.
 
 
 ## Issue: memory leaks in txzchk.c
@@ -113,7 +113,7 @@ function.
 
 ### See also
 
-Fixed in commit b10e2e2747bfb6cb5d76effd4bb17ab12f525c07.
+Fixed in commit 290963a459b707cc6b22374cc20dbd76e9f5db6d.
 
 ## Issue: memory leaks in jstrencode.c and jstredecode.c
 ### Status: partially fixed
@@ -216,7 +216,7 @@ Add missing call to the cap_tbl_name variable.
 
 ### See also
 
-Fixed in commit 693c929355608f0cd316c31dc71d943e6641c213: Fix memory leak in
+Fixed in commit fa9eca1c273fdd138d338a93875f462f62b0bc5b: Fix memory leak in
 jsemtblgen.c.
 
 Note that there are other memory leaks in the json parser itself. Whether these
@@ -248,7 +248,7 @@ function that frees memory did not free everything but there it is.
 
 ### See also
 
-Fixed in commit f46114885ad81198163823ff9b58b5c676d826f9: Plug memory leaks in
+Fixed in commit 6c4138d788614f138013f4497b2ea1631923ab5b: Plug memory leaks in
 dyn_{array,test}.c.
 
 

--- a/test_ioccc/dynamic_analysis.md
+++ b/test_ioccc/dynamic_analysis.md
@@ -194,7 +194,7 @@ For reference: these were detected via valgrind in the `jstr_test.sh` script.
 
 ### See also
 
-Commit 6c746ed9fee496d303a2ba75bb3f199dc4a986be.
+Fixed in commit 670dc207b58dbeb0f0afd24e2f63fa7bf609daa2.
 
 
 ## Issue: memory leak in jsemtblgen.c

--- a/test_ioccc/fnamchk.c
+++ b/test_ioccc/fnamchk.c
@@ -79,6 +79,7 @@ main(int argc, char *argv[])
     int i;
     bool test_mode = false;	/* true ==> force check to test if it's a test entry filename */
     bool uuid_mode = false;	/* true ==> force check to test if it's a UUID entry filename */
+    char *saveptr = NULL;	/* for strtok_r() */
 
 
     /*
@@ -145,9 +146,9 @@ main(int argc, char *argv[])
     /*
      * first '.' separated token must be entry
      */
-    entry = strtok(filename, ".");
+    entry = strtok_r(filename, ".", &saveptr);
     if (entry == NULL) {
-	err(10, __func__, "first strtok() returned NULL");
+	err(10, __func__, "first strtok_r() returned NULL");
 	not_reached();
     }
     if (strcmp(entry, "entry") != 0) {
@@ -159,7 +160,7 @@ main(int argc, char *argv[])
     /*
      * second '.' separated token must be test or a UUID
      */
-    uuid = strtok(NULL, ".");
+    uuid = strtok_r(NULL, ".", &saveptr);
     if (uuid == NULL) {
 	err(12, __func__, "nothing found after \"entry.\"");
 	not_reached();
@@ -251,7 +252,7 @@ main(int argc, char *argv[])
     /*
      * third '.' separated token must be a valid timestamp
      */
-    timestamp_str = strtok(NULL, ".");
+    timestamp_str = strtok_r(NULL, ".", &saveptr);
     if (timestamp_str == NULL) {
 	err(23, __func__, "nothing found after second '.' separated token of entry number");
 	not_reached();
@@ -270,7 +271,7 @@ main(int argc, char *argv[])
     /*
      * fourth .-separated token must be the filename extension
      */
-    extension = strtok(NULL, ".");
+    extension = strtok_r(NULL, ".", &saveptr);
     if (extension == NULL) {
 	err(26, __func__, "nothing found after third '.' separated token of timestamp");
 	not_reached();

--- a/test_ioccc/txzchk_test.sh
+++ b/test_ioccc/txzchk_test.sh
@@ -350,7 +350,7 @@ if [[ ! -w "$TMP_STDERR_FILE" ]]; then
     exit 36
 fi
 
-# remove or key temporary files
+# remove or keep (some) temporary files
 #
 if [[ -z $K_FLAG ]]; then
     trap "rm -f \$TARBALL \$TEST_FILE \$TAR_ERROR \$TMP_STDERR_FILE; exit" 0 1 2 3 15

--- a/txzchk.c
+++ b/txzchk.c
@@ -68,9 +68,9 @@ static intmax_t count_check;			/* negative of previous count */
 
 static bool quiet = false;				/* true ==> quiet mode */
 
-static char const *txzpath_path = NULL;		/* the current tarball being checked */
+static char const *tarball_path = NULL;		/* the current tarball being checked */
 static char const *program = NULL;		/* our name */
-static bool read_from_text_file = false;	/* true ==> assume txzpath_path is a text file */
+static bool read_from_text_file = false;	/* true ==> assume tarball_path is a text file */
 static char const *ext = "txz";			/* force extension in fnamchk to be this value */
 static char const *tok_sep = " \t";		/* token separators for strtok_r */
 static bool always_show_warnings = false;	/* true ==> show warnings even if -q */
@@ -140,8 +140,8 @@ main(int argc, char **argv)
 	usage(3, "wrong number of arguments", program); /*ooo*/
 	not_reached();
     }
-    txzpath_path = argv[optind];
-    dbg(DBG_LOW, "txzpath: %s", txzpath_path);
+    tarball_path = argv[optind];
+    dbg(DBG_LOW, "tarball path: %s", tarball_path);
 
     if (always_show_warnings) {
 	warn_output_allowed = true;
@@ -200,7 +200,7 @@ main(int argc, char **argv)
     if (!quiet && !tarball.total_feathers) {
 	para("No feathers stuck in tarball.", NULL);
     }
-    show_tarball_info(txzpath_path);
+    show_tarball_info(tarball_path);
 
     /*
      * All Done!!! - Jessica Noll, age 2
@@ -217,17 +217,17 @@ main(int argc, char **argv)
  *
  * given:
  *
- *	txzpath	    - path to tarball we checked
+ *	tarball_path	    - path to tarball we checked
  *
  * Returns void. Does not return on error.
  */
 static void
-show_tarball_info(char const *txzpath)
+show_tarball_info(char const *tarball_path)
 {
     /*
      * firewall
      */
-    if (txzpath == NULL) {
+    if (tarball_path == NULL) {
 	err(10, __func__, "passed NULL arg");
 	not_reached();
     }
@@ -237,50 +237,50 @@ show_tarball_info(char const *txzpath)
 	para("", "The following information about the tarball was collected:", NULL);
 
 
-	dbg(DBG_MED, "%s %s a .info.json", txzpath, has_does_not_have(tarball.has_info_json));
-	dbg(DBG_HIGH, "%s %s an empty .info.json", txzpath, has_does_not_have(tarball.empty_info_json));
-	dbg(DBG_HIGH, "%s .info.json size is %jd", txzpath, (intmax_t)tarball.info_json_size);
-	dbg(DBG_MED, "%s %s a .auth.json", txzpath, has_does_not_have(tarball.has_auth_json));
-	dbg(DBG_HIGH, "%s %s an empty .auth.json", txzpath, has_does_not_have(tarball.empty_auth_json));
-	dbg(DBG_HIGH, "%s .auth.json size is %jd", txzpath, (intmax_t)tarball.auth_json_size);
-	dbg(DBG_MED, "%s %s a prog.c", txzpath, has_does_not_have(tarball.has_prog_c));
-	dbg(DBG_HIGH, "%s %s an empty prog.c", txzpath, has_does_not_have(tarball.empty_prog_c));
-	dbg(DBG_HIGH, "%s prog.c size is %jd", txzpath, (intmax_t)tarball.prog_c_size);
-	dbg(DBG_MED, "%s %s a remarks.md", txzpath, has_does_not_have(tarball.has_remarks_md));
-	dbg(DBG_HIGH, "%s %s an empty remarks.md", txzpath, has_does_not_have(tarball.empty_remarks_md));
-	dbg(DBG_HIGH, "%s remarks.md size is %jd", txzpath, (intmax_t)tarball.remarks_md_size);
-	dbg(DBG_MED, "%s %s a Makefile", txzpath, has_does_not_have(tarball.has_Makefile));
-	dbg(DBG_HIGH, "%s %s an empty Makefile", txzpath, has_does_not_have(tarball.empty_Makefile));
-	dbg(DBG_HIGH, "%s Makefile size is %jd", txzpath, (intmax_t)tarball.Makefile_size);
-	dbg(DBG_MED, "%s tarball size is %jd according to stat(2)", txzpath, (intmax_t)tarball.size);
-	dbg(DBG_MED, "%s total file size is %jd", txzpath, (intmax_t)tarball.files_size);
-	dbg(DBG_HIGH, "%s shrunk in files size %ju time%s", txzpath, tarball.files_size_shrunk,
+	dbg(DBG_MED, "%s %s a .info.json", tarball_path, has_does_not_have(tarball.has_info_json));
+	dbg(DBG_HIGH, "%s %s an empty .info.json", tarball_path, has_does_not_have(tarball.empty_info_json));
+	dbg(DBG_HIGH, "%s .info.json size is %jd", tarball_path, (intmax_t)tarball.info_json_size);
+	dbg(DBG_MED, "%s %s a .auth.json", tarball_path, has_does_not_have(tarball.has_auth_json));
+	dbg(DBG_HIGH, "%s %s an empty .auth.json", tarball_path, has_does_not_have(tarball.empty_auth_json));
+	dbg(DBG_HIGH, "%s .auth.json size is %jd", tarball_path, (intmax_t)tarball.auth_json_size);
+	dbg(DBG_MED, "%s %s a prog.c", tarball_path, has_does_not_have(tarball.has_prog_c));
+	dbg(DBG_HIGH, "%s %s an empty prog.c", tarball_path, has_does_not_have(tarball.empty_prog_c));
+	dbg(DBG_HIGH, "%s prog.c size is %jd", tarball_path, (intmax_t)tarball.prog_c_size);
+	dbg(DBG_MED, "%s %s a remarks.md", tarball_path, has_does_not_have(tarball.has_remarks_md));
+	dbg(DBG_HIGH, "%s %s an empty remarks.md", tarball_path, has_does_not_have(tarball.empty_remarks_md));
+	dbg(DBG_HIGH, "%s remarks.md size is %jd", tarball_path, (intmax_t)tarball.remarks_md_size);
+	dbg(DBG_MED, "%s %s a Makefile", tarball_path, has_does_not_have(tarball.has_Makefile));
+	dbg(DBG_HIGH, "%s %s an empty Makefile", tarball_path, has_does_not_have(tarball.empty_Makefile));
+	dbg(DBG_HIGH, "%s Makefile size is %jd", tarball_path, (intmax_t)tarball.Makefile_size);
+	dbg(DBG_MED, "%s tarball size is %jd according to stat(2)", tarball_path, (intmax_t)tarball.size);
+	dbg(DBG_MED, "%s total file size is %jd", tarball_path, (intmax_t)tarball.files_size);
+	dbg(DBG_HIGH, "%s shrunk in files size %ju time%s", tarball_path, tarball.files_size_shrunk,
 		singular_or_plural(tarball.files_size_shrunk));
-	dbg(DBG_HIGH, "%s went below 0 in all files size %ju time%s", txzpath, tarball.negative_files_size,
+	dbg(DBG_HIGH, "%s went below 0 in all files size %ju time%s", tarball_path, tarball.negative_files_size,
 		singular_or_plural(tarball.negative_files_size));
-	dbg(DBG_HIGH, "%s went above max files size %ju %ju time%s", txzpath,
+	dbg(DBG_HIGH, "%s went above max files size %ju %ju time%s", tarball_path,
 		(uintmax_t)MAX_SUM_FILELEN, (uintmax_t)tarball.files_size_too_big,
 		singular_or_plural(tarball.files_size_too_big));
-	dbg(DBG_MED, "%s has %ju file%s", txzpath, tarball.total_files-tarball.abnormal_files,
+	dbg(DBG_MED, "%s has %ju file%s", tarball_path, tarball.total_files-tarball.abnormal_files,
 		tarball.total_files-tarball.abnormal_files == 1?"":"s");
 
 	if (tarball.correct_directory < tarball.total_files) {
-	    dbg(DBG_MED, "%s has %ju incorrect director%s", txzpath, tarball.total_files - tarball.correct_directory,
+	    dbg(DBG_MED, "%s has %ju incorrect director%s", tarball_path, tarball.total_files - tarball.correct_directory,
 		    tarball.total_files - tarball.correct_directory == 1 ? "y":"ies");
 	} else {
-	    dbg(DBG_MED, "%s has 0 incorrect directories", txzpath);
+	    dbg(DBG_MED, "%s has 0 incorrect directories", tarball_path);
 	}
 
-	dbg(DBG_MED, "%s has %ju invalid dot file%s", txzpath, tarball.invalid_dot_files,
+	dbg(DBG_MED, "%s has %ju invalid dot file%s", tarball_path, tarball.invalid_dot_files,
 		singular_or_plural(tarball.invalid_dot_files));
-	dbg(DBG_MED, "%s has %ju file%s named '.'", txzpath, tarball.named_dot, singular_or_plural(tarball.named_dot));
-	dbg(DBG_MED, "%s has %ju file%s with at least one unsafe char", txzpath, tarball.unsafe_chars,
+	dbg(DBG_MED, "%s has %ju file%s named '.'", tarball_path, tarball.named_dot, singular_or_plural(tarball.named_dot));
+	dbg(DBG_MED, "%s has %ju file%s with at least one unsafe char", tarball_path, tarball.unsafe_chars,
 		singular_or_plural(tarball.unsafe_chars));
 	if (tarball.total_feathers > 0) {
-	    dbg(DBG_VHIGH, "%s has %ju feather%s stuck in tarball :-(", txzpath, tarball.total_feathers,
+	    dbg(DBG_VHIGH, "%s has %ju feather%s stuck in tarball :-(", tarball_path, tarball.total_feathers,
 		    singular_or_plural(tarball.total_feathers));
 	} else {
-	    dbg(DBG_VHIGH, "%s has 0 feathers stuck in tarball :-)", txzpath);
+	    dbg(DBG_VHIGH, "%s has 0 feathers stuck in tarball :-)", tarball_path);
 	}
     }
 }
@@ -346,7 +346,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
     /*
      * firewall
      */
-    if ((tar == NULL && !read_from_text_file) || fnamchk == NULL || txzpath_path == NULL) {
+    if ((tar == NULL && !read_from_text_file) || fnamchk == NULL || tarball_path == NULL) {
 	err(11, __func__, "called with NULL arg(s)");
 	not_reached();
     }
@@ -457,46 +457,46 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
 
 
     /*
-     * txzpath must be readable
+     * tarball_path must be readable
      */
-    if (!exists(txzpath_path)) {
+    if (!exists(tarball_path)) {
 	fpara(stderr,
 	      "",
 	      "The tarball path specified does not exist. Perhaps you made a typo?",
 	      "Please check the path and try again."
 	      "",
-	      "    txzchk [options] <txzpath>"
+	      "    txzchk [options] <tarball_path>"
 	      "",
 	      NULL);
-	err(18, __func__, "txzpath does not exist: %s", txzpath_path);
+	err(18, __func__, "tarball_path does not exist: %s", tarball_path);
 	not_reached();
     }
 
-    if (!is_file(txzpath_path)) {
+    if (!is_file(tarball_path)) {
 	fpara(stderr,
 	      "",
 	      "The file specified, while it exists, is not a regular file.",
 	      "",
 	      "Perhaps you need to use another path:",
 	      "",
-	      "    txzchk [...] <txzpath>",
+	      "    txzchk [...] <tarball_path>",
 	      "",
 	      NULL);
-	err(19, __func__, "txzpath is not a regular file: %s", txzpath_path);
+	err(19, __func__, "tarball_path is not a regular file: %s", tarball_path);
 	not_reached();
     }
 
-    if (!is_read(txzpath_path)) {
+    if (!is_read(tarball_path)) {
 	fpara(stderr,
 	      "",
 	      "The tarball path, while it is a file, is not readable.",
 	      "",
 	      "We suggest you check the permissions on the path or use another path:",
 	      "",
-	      "    txzchk [...] <txzpath>"
+	      "    txzchk [...] <tarball_path>"
 	      "",
 	      NULL);
-	err(20, __func__, "txzpath is not readable: %s", txzpath_path);
+	err(20, __func__, "tarball_path is not readable: %s", tarball_path);
 	not_reached();
     }
 
@@ -509,7 +509,7 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
  *
  * given:
  *
- *	txzpath		- the tarball (or text file) we're processing
+ *	tarball_path	- the tarball (or text file) we're processing
  *	dir_name	- the directory name (if fnamchk passed - else NULL)
  *	file		- file structure
  *
@@ -519,14 +519,14 @@ txzchk_sanity_chks(char const *tar, char const *fnamchk)
  *
  */
 static void
-check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
+check_txz_file(char const *tarball_path, char const *dir_name, struct txz_file *file)
 {
     bool allowed_dot_file = false;	/* true ==> basename is an allowed '.' file */
 
     /*
      * firewall
      */
-    if (txzpath == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
+    if (tarball_path == NULL || file == NULL || file->basename == NULL || file->filename == NULL) {
 	err(21, __func__, "passed NULL arg(s)");
 	not_reached();
     }
@@ -557,7 +557,7 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 	++tarball.total_feathers; /* report it once and consider it only one feather */
 	++tarball.unsafe_chars;
 	warn(__func__, "%s: file does not match regexp ^[/0-9a-z][/0-9a-z._+-]*$: %s",
-		       txzpath, file->filename);
+		       tarball_path, file->filename);
     }
 
     /*
@@ -575,14 +575,14 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 	if (*(file->basename) == '.') {
 	    ++tarball.total_feathers;
 	    warn("txzchk", "%s: found non %s and %s dot file %s",
-			   txzpath, AUTH_JSON_FILENAME, INFO_JSON_FILENAME, file->basename);
+			   tarball_path, AUTH_JSON_FILENAME, INFO_JSON_FILENAME, file->basename);
 	    tarball.invalid_dot_files++;
 
 	    /* check for files called '.' without anything after the dot */
 	    if (file->basename[1] == '\0') {
 		++tarball.total_feathers;
 		++tarball.named_dot;
-		warn("txzchk", "%s: found file called '.' in path %s", txzpath, file->filename);
+		warn("txzchk", "%s: found file called '.' in path %s", tarball_path, file->filename);
 	    }
 	}
 
@@ -593,12 +593,12 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
 	    ++tarball.total_feathers; /* report it once and consider it only one feather */
 	    ++tarball.unsafe_chars;
 	    warn(__func__, "%s: file basename does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$: %s",
-			   txzpath, file->basename);
+			   tarball_path, file->basename);
 	}
     }
 
     /* check the dirs in the path */
-    check_directories(file, dir_name, txzpath);
+    check_directories(file, dir_name, tarball_path);
 }
 
 
@@ -607,7 +607,7 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
  *
  * given:
  *
- *	txzpath		- the tarball (or text file) we're checking
+ *	tarball_path	- the tarball (or text file) we're checking
  *	size		- size of the file
  *	file		- the struct txz_file we're checking
  *
@@ -616,13 +616,13 @@ check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file)
  * Does not return on error (NULL pointers passed in).
  */
 static void
-check_file_size(char const *txzpath, off_t size, struct txz_file *file)
+check_file_size(char const *tarball_path, off_t size, struct txz_file *file)
 {
     /*
      * firewall
      */
 
-    if (txzpath == NULL || file == NULL) {
+    if (tarball_path == NULL || file == NULL) {
 	err(22, __func__, "called with NULL arg(s)");
 	not_reached();
     } else if (file->basename == NULL || file->filename == NULL) {
@@ -633,20 +633,20 @@ check_file_size(char const *txzpath, off_t size, struct txz_file *file)
     if (size == 0) {
 	if (!strcmp(file->basename, AUTH_JSON_FILENAME)) {
 	    ++tarball.total_feathers;
-	    warn("txzchk", "%s: found empty %s file", txzpath, AUTH_JSON_FILENAME);
+	    warn("txzchk", "%s: found empty %s file", tarball_path, AUTH_JSON_FILENAME);
 	    tarball.empty_auth_json = true;
 	} else if (!strcmp(file->basename, INFO_JSON_FILENAME)) {
 	    ++tarball.total_feathers;
 	    tarball.empty_info_json = true;
-	    warn("txzchk", "%s: found empty %s file", txzpath, INFO_JSON_FILENAME);
+	    warn("txzchk", "%s: found empty %s file", tarball_path, INFO_JSON_FILENAME);
 	} else if (!strcmp(file->basename, "remarks.md")) {
 	    ++tarball.total_feathers;
 	    tarball.empty_remarks_md = true;
-	    warn("txzchk", "%s: found empty remarks.md", txzpath);
+	    warn("txzchk", "%s: found empty remarks.md", tarball_path);
 	} else if (!strcmp(file->basename, "Makefile")) {
 	    ++tarball.total_feathers;
 	    tarball.empty_Makefile = true;
-	    warn("txzchk", "%s: found empty Makefile", txzpath);
+	    warn("txzchk", "%s: found empty Makefile", tarball_path);
 	} else if (!strcmp(file->basename, "prog.c")) {
 	    /* this is NOT a feather: it's only for informational purposes! */
 	    tarball.empty_prog_c = true;
@@ -716,13 +716,13 @@ check_all_txz_files(char const *dir_name)
 
 	if (dir_name != NULL && tarball.correct_directory) {
 	    if (strncmp(file->filename, dir_name, strlen(dir_name))) {
-		warn("txzchk", "%s: found directory change in filename %s", txzpath_path, file->filename);
+		warn("txzchk", "%s: found directory change in filename %s", tarball_path, file->filename);
 		++tarball.total_feathers;
 	    }
 	}
 
 	if (file->count > 1) {
-	    warn("txzchk", "%s: found a total of %ju files with the name %s", txzpath_path, file->count, file->basename);
+	    warn("txzchk", "%s: found a total of %ju files with the name %s", tarball_path, file->count, file->basename);
 	    tarball.total_feathers += file->count - 1;
 	}
     }
@@ -730,27 +730,27 @@ check_all_txz_files(char const *dir_name)
     /* determine if the required files are there */
     if (!tarball.has_info_json) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: no .info.json found", txzpath_path);
+	warn("txzchk", "%s: no .info.json found", tarball_path);
     }
     if (!tarball.has_auth_json) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: no .auth.json found", txzpath_path);
+	warn("txzchk", "%s: no .auth.json found", tarball_path);
     }
     if (!tarball.has_prog_c) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: no prog.c found", txzpath_path);
+	warn("txzchk", "%s: no prog.c found", tarball_path);
     }
     if (!tarball.has_Makefile) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: no Makefile found", txzpath_path);
+	warn("txzchk", "%s: no Makefile found", tarball_path);
     }
     if (!tarball.has_remarks_md) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: no remarks.md found", txzpath_path);
+	warn("txzchk", "%s: no remarks.md found", tarball_path);
     }
     if (tarball.correct_directory < tarball.total_files) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: not all files in correct directory", txzpath_path);
+	warn("txzchk", "%s: not all files in correct directory", tarball_path);
     }
 
     /*
@@ -760,7 +760,7 @@ check_all_txz_files(char const *dir_name)
      */
     if (tarball.invalid_dot_files > 0) {
 	warn("txzchk", "%s: found a total of %ju invalidly named dot file%s",
-		       txzpath_path, tarball.invalid_dot_files, tarball.invalid_dot_files==1?"":"s");
+		       tarball_path, tarball.invalid_dot_files, tarball.invalid_dot_files==1?"":"s");
     }
 
     /*
@@ -768,7 +768,7 @@ check_all_txz_files(char const *dir_name)
      */
     if (tarball.total_feathers > 0) {
 	warn("txzchk", "%s: found %ju feather%s stuck in the tarball",
-		       txzpath_path, tarball.total_feathers, tarball.total_feathers==1?"":"s");
+		       tarball_path, tarball.total_feathers, tarball.total_feathers==1?"":"s");
     }
 }
 
@@ -780,7 +780,7 @@ check_all_txz_files(char const *dir_name)
  *
  *	file		- file structure
  *	dir_name	- the directory expected (or NULL if fnamchk fails)
- *	txzpath		- the tarball path
+ *	tarball_path	- the tarball path
  *
  * Issues a warning for every violation specific to directories (and
  * subdirectories).
@@ -788,7 +788,7 @@ check_all_txz_files(char const *dir_name)
  * Does not return on error.
  */
 static void
-check_directories(struct txz_file *file, char const *dir_name, char const *txzpath)
+check_directories(struct txz_file *file, char const *dir_name, char const *tarball_path)
 {
     uintmax_t dir_count = 0; /* number of directories in the path */
     int prev = '\0';
@@ -798,14 +798,14 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
     /*
      * firewall
      */
-    if (txzpath == NULL || file == NULL || file->filename == NULL) {
+    if (tarball_path == NULL || file == NULL || file->filename == NULL) {
 	err(26, __func__, "passed NULL arg(s)");
 	not_reached();
     }
 
     /* check that there is a directory */
     if (strchr(file->filename, '/') == NULL && strcmp(file->filename, ".")) {
-	warn("txzchk", "%s: no directory found in filename %s", txzpath, file->filename);
+	warn("txzchk", "%s: no directory found in filename %s", tarball_path, file->filename);
 	++tarball.total_feathers;
     }
     if (strstr(file->filename, "..")) /* check for '..' in path */ {
@@ -815,11 +815,11 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
 	 * is okay.
 	 */
 	++tarball.total_feathers;
-	warn("txzchk", "%s: found file with '..' in the path: %s", txzpath, file->filename);
+	warn("txzchk", "%s: found file with '..' in the path: %s", tarball_path, file->filename);
     }
     if (*(file->filename) == '/') {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: found absolute path %s", txzpath, file->filename);
+	warn("txzchk", "%s: found absolute path %s", tarball_path, file->filename);
     }
 
     /*
@@ -868,7 +868,7 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
 
     if (dir_count > 1) {
 	++tarball.total_feathers;
-	warn("txzchk", "%s: found more than one directory in path %s", txzpath, file->filename);
+	warn("txzchk", "%s: found more than one directory in path %s", tarball_path, file->filename);
     }
 
     /*
@@ -881,7 +881,7 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
     if (dir_name != NULL && *dir_name != '\0')
     {
 	if (strncmp(file->filename, dir_name, strlen(dir_name))) {
-	    warn("txzchk", "%s: found incorrect directory in filename %s", txzpath, file->filename);
+	    warn("txzchk", "%s: found incorrect directory in filename %s", tarball_path, file->filename);
 	    ++tarball.total_feathers;
 	} else {
 	    /* This file is in the right directory */
@@ -900,7 +900,7 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
  *	linep		- the line we're parsing
  *	line_dup	- duplicated line
  *	dir_name	- directory name retrieved from fnamchk or NULL if it failed
- *	txzpath		- the tarball path
+ *	tarball_path	- the tarball path
  *	saveptr		- pointer to char * to save context between each strtok_r() call
  *	normal_file	- true ==> normal file, check size and number of files
  *	sum		- pointer to sum for sum_and_count() (which we use in count_and_sum())
@@ -913,8 +913,8 @@ check_directories(struct txz_file *file, char const *dir_name, char const *txzpa
  * This function does not return on error.
  */
 static void
-parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr,
-		    bool normal_file, intmax_t *sum, intmax_t *count)
+parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
+	char const *tarball_path, char **saveptr, bool normal_file, intmax_t *sum, intmax_t *count)
 {
     intmax_t length = 0; /* file size */
     struct txz_file *file = NULL;   /* allocated struct of file info */
@@ -924,7 +924,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     /*
      * firewall
      */
-    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || saveptr == NULL ||
+    if (p == NULL || linep == NULL || line_dup == NULL || tarball_path == NULL || saveptr == NULL ||
 	sum == NULL || count == NULL) {
 	err(27, __func__, "called with NULL arg(s)");
 	not_reached();
@@ -959,7 +959,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     }
     p = strtok_r(NULL, tok_sep, saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
@@ -967,7 +967,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 
     test = string_to_intmax2(p, &length);
     if (!test) {
-	warn("txzchk", "%s: trying to parse file size in on line: <%s>: token: <%s>", txzpath, line_dup, p);
+	warn("txzchk", "%s: trying to parse file size in on line: <%s>: token: <%s>", tarball_path, line_dup, p);
 	++tarball.total_feathers;
 
 	/*
@@ -975,7 +975,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 	 * next line but only if it's a normal file
 	 */
 	if (normal_file) {
-	    count_and_sum(txzpath, sum, count, length);
+	    count_and_sum(tarball_path, sum, count, length);
 	}
 	msg("skipping to next line due to inability to parse file size");
 	return;
@@ -983,7 +983,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
 
     /* add to total number of files and total size if it's a normal file */
     if (normal_file) {
-	count_and_sum(txzpath, sum, count, length);
+	count_and_sum(tarball_path, sum, count, length);
     }
 
     /*
@@ -993,7 +993,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     for (i = 0; i < 3; ++i) {
 	p = strtok_r(NULL, tok_sep, saveptr);
 	if (p == NULL) {
-	    warn("txzchk", "%s: NULL pointer trying to parse line", txzpath);
+	    warn("txzchk", "%s: NULL pointer trying to parse line", tarball_path);
 	    msg("skipping to next line");
 	    ++tarball.total_feathers;
 	    return;
@@ -1010,7 +1010,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
     do {
 	p = strtok_r(NULL, tok_sep, saveptr);
 	if (p != NULL) {
-	    warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
+	    warn("txzchk", "%s: bogus field found after filename: %s", tarball_path, p);
 	    ++tarball.total_feathers;
 	}
     } while (p != NULL);
@@ -1020,10 +1020,10 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
      * add_txz_file_to_list() function doesn't add the same file (basename) more
      * than once: it simply increments the times it's been seen.
      */
-    check_file_size(txzpath, length, file);
+    check_file_size(tarball_path, length, file);
 
     /* checks on this specific file */
-    check_txz_file(txzpath, dir_name, file);
+    check_txz_file(tarball_path, dir_name, file);
 
     add_txz_file_to_list(file);
 }
@@ -1034,21 +1034,21 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
  *
  * given:
  *
- *	txzpath		- path to the tarball being checked for feathers
+ *	tarball_path	- path to the tarball being checked for feathers
  *	sum		- corresponds to the sum pointer in sum_and_count()
  *	count		- corresponds to the count pointer in sum_and_count()
  *	length		- corresponds to the length in sum_and_count()
  */
 static void
-count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t length)
+count_and_sum(char const *tarball_path, intmax_t *sum, intmax_t *count, intmax_t length)
 {
     bool test = false;	    /* status of various tests */
 
     /*
      * firewall
      */
-    if (txzpath == NULL) {
-	err(29, __func__, "txzpath is NULL");
+    if (tarball_path == NULL) {
+	err(29, __func__, "tarball_path is NULL");
 	not_reached();
     } else if (sum == NULL) {
 	err(30, __func__, "sum is NULL");
@@ -1073,10 +1073,10 @@ count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t leng
     if (*sum < 0) {
 	++tarball.total_feathers;
 	++tarball.negative_files_size;
-	warn("txzchk", "%s: total file size went below 0: %jd", txzpath, *sum);
+	warn("txzchk", "%s: total file size went below 0: %jd", tarball_path, *sum);
 	if (*sum < tarball.previous_files_size) {
 	    ++tarball.files_size_shrunk;
-	    warn("txzchk", "%s: total files size %jd < previous file size %jd", txzpath, *sum,
+	    warn("txzchk", "%s: total files size %jd < previous file size %jd", tarball_path, *sum,
 		    (intmax_t)tarball.previous_files_size);
 	}
     }
@@ -1084,7 +1084,7 @@ count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t leng
     if (*sum > MAX_SUM_FILELEN) {
 	++tarball.total_feathers;
 	++tarball.files_size_too_big;
-	warn("txzchk", "%s: total file size too big: %jd > %jd", txzpath, *sum, (intmax_t)MAX_SUM_FILELEN);
+	warn("txzchk", "%s: total file size too big: %jd > %jd", tarball_path, *sum, (intmax_t)MAX_SUM_FILELEN);
     }
     /* update the previous files size */
     tarball.previous_files_size = *sum;
@@ -1093,13 +1093,13 @@ count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t leng
     if (*count <= 0) {
 	++tarball.total_feathers;
 	++tarball.invalid_files_count;
-	warn("txzchk", "%s: files count <= 0: %jd", txzpath, *count);
+	warn("txzchk", "%s: files count <= 0: %jd", tarball_path, *count);
     }
     /* check for too many files */
     if (*count - (intmax_t)tarball.abnormal_files > MAX_FILE_COUNT) {
 	++tarball.total_feathers;
 	++tarball.invalid_files_count;
-	warn("txzchk", "%s: too many files: %jd > %jd", txzpath,
+	warn("txzchk", "%s: too many files: %jd > %jd", tarball_path,
 		*count - (intmax_t)tarball.abnormal_files, (intmax_t)MAX_FILE_COUNT);
     }
 }
@@ -1114,7 +1114,7 @@ count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t leng
  *	linep		- the line we're parsing
  *	line_dup	- duplicated line
  *	dir_name	- directory name retrieved from fnamchk or NULL if it failed
- *	txzpath		- the tarball path
+ *	tarball_path	- the tarball path
  *	saveptr		- pointer to char * to save context between each strtok_r() call
  *	normal_file	- true ==> normal file, check size and number of files
  *	sum		- pointer to sum for sum_and_count() (which we use in count_and_sum())
@@ -1127,7 +1127,8 @@ count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t leng
  * This function does not return on error.
  */
 static void
-parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr,
+parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name,
+	char const *tarball_path, char **saveptr,
 		    bool normal_file, intmax_t *sum, intmax_t *count)
 {
     intmax_t length = 0; /* file size */
@@ -1138,7 +1139,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     /*
      * firewall
      */
-    if (p == NULL || linep == NULL || line_dup == NULL || txzpath == NULL || saveptr == NULL ||
+    if (p == NULL || linep == NULL || line_dup == NULL || tarball_path == NULL || saveptr == NULL ||
 	sum == NULL || count == NULL) {
 	err(32, __func__, "called with NULL arg(s)");
 	not_reached();
@@ -1146,7 +1147,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 
     p = strtok_r(NULL, tok_sep, saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
@@ -1161,7 +1162,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     }
 
     if (*p) {
-	warn("txzchk", "%s: found non-numerical UID in file in line %s", txzpath, line_dup);
+	warn("txzchk", "%s: found non-numerical UID in file in line %s", tarball_path, line_dup);
 	++tarball.total_feathers;
     }
 
@@ -1170,7 +1171,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
      */
     p = strtok_r(NULL, tok_sep, saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
@@ -1180,13 +1181,13 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     }
 
     if (*p) {
-	warn("txzchk", "%s: found non-numerical GID in file in line: %s", txzpath, line_dup);
+	warn("txzchk", "%s: found non-numerical GID in file in line: %s", tarball_path, line_dup);
 	++tarball.total_feathers;
     }
 
     p = strtok_r(NULL, tok_sep, saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
@@ -1194,7 +1195,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 
     test = string_to_intmax2(p, &length);
     if (!test) {
-	warn("txzchk", "%s: trying to parse file size in on line: <%s>: token: <%s>", txzpath, line_dup, p);
+	warn("txzchk", "%s: trying to parse file size in on line: <%s>: token: <%s>", tarball_path, line_dup, p);
 	++tarball.total_feathers;
 
 	/*
@@ -1202,7 +1203,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 	 * next line but only if it's a normal file
 	 */
 	if (normal_file) {
-	    count_and_sum(txzpath, sum, count, length);
+	    count_and_sum(tarball_path, sum, count, length);
 	}
 	msg("skipping to next line due to inability to parse file size");
 	return;
@@ -1210,7 +1211,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
 
     /* add to total number of files and total size if it's a normal file */
     if (normal_file) {
-	count_and_sum(txzpath, sum, count, length);
+	count_and_sum(tarball_path, sum, count, length);
     }
 
     /*
@@ -1220,7 +1221,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     for (i = 0; i < 4; ++i) {
 	p = strtok_r(NULL, tok_sep, saveptr);
 	if (p == NULL) {
-	    warn("txzchk", "%s: NULL pointer trying to parse line", txzpath);
+	    warn("txzchk", "%s: NULL pointer trying to parse line", tarball_path);
 	    msg("skipping to next line");
 	    ++tarball.total_feathers;
 	    return;
@@ -1237,7 +1238,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
     do {
 	p = strtok_r(NULL, tok_sep, saveptr);
 	if (p != NULL) {
-	    warn("txzchk", "%s: bogus field found after filename: %s", txzpath, p);
+	    warn("txzchk", "%s: bogus field found after filename: %s", tarball_path, p);
 	    ++tarball.total_feathers;
 	}
     } while (p != NULL);
@@ -1247,10 +1248,10 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
      * add_txz_file_to_list() function doesn't add the same file (basename) more
      * than once: it simply increments the times it's been seen.
      */
-    check_file_size(txzpath, length, file);
+    check_file_size(tarball_path, length, file);
 
     /* checks on this specific file */
-    check_txz_file(txzpath, dir_name, file);
+    check_txz_file(tarball_path, dir_name, file);
 
     add_txz_file_to_list(file);
 }
@@ -1264,7 +1265,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
  *	linep		-   line to parse
  *	line_dup	-   pointer to the duplicated line
  *	dir_name	-   the dir name reported by fnamchk or NULL if it failed
- *	txzpath		-   the tarball path
+ *	tarball_path	-   the tarball path
  *	dir_count	-   pointer to dir_count (from check_tarball())
  *	sum		-   corresponds to sum pointer in sum_and_count()
  *	count		-   corresponds to count pointer in sum_and_count()
@@ -1274,7 +1275,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dir_name, c
  *  Function does not return on error.
  */
 static void
-parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count,
+parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tarball_path, int *dir_count,
 	       intmax_t *sum, intmax_t *count)
 {
     char *p = NULL; /* each field in the line extracted from strtok_r() */
@@ -1285,7 +1286,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
      * firewall
      */
 
-    if (linep == NULL || line_dup == NULL || txzpath == NULL || dir_count == NULL ||
+    if (linep == NULL || line_dup == NULL || tarball_path == NULL || dir_count == NULL ||
 	    sum == NULL || count == NULL) {
 	err(34, __func__, "called with NULL arg(s)");
 	not_reached();
@@ -1297,7 +1298,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
     if (*linep == 'd') {
 	++(*dir_count);
 	if (*dir_count > 1) {
-	    warn("txzchk", "%s: found more than one directory entry: %s", txzpath, linep);
+	    warn("txzchk", "%s: found more than one directory entry: %s", tarball_path, linep);
 	    ++tarball.total_feathers;
 	}
 	++tarball.abnormal_files; /* we need this for the sum_and_count() checks on total number of files */
@@ -1305,7 +1306,7 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
      * look for non-directory non-regular non-hard-linked items
      */
     } else if (*linep != '-') {
-	warn("txzchk", "%s: found a non-directory non-regular non-hard-linked item: %s", txzpath, linep);
+	warn("txzchk", "%s: found a non-directory non-regular non-hard-linked item: %s", tarball_path, linep);
 	++tarball.total_feathers;
 	++tarball.abnormal_files; /* we need this for the sum_and_count() checks on total number of files */
     } else {
@@ -1315,14 +1316,14 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
     /* extract each field, one at a time, to do various tests */
     p = strtok_r(linep, tok_sep, &saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
     }
 
     if (has_special_bits(p)) {
-	warn("txzchk", "%s: found special bits on line: %s", txzpath, line_dup);
+	warn("txzchk", "%s: found special bits on line: %s", tarball_path, line_dup);
 	++tarball.total_feathers;
     }
 
@@ -1332,17 +1333,17 @@ parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tx
      */
     p = strtok_r(NULL, tok_sep, &saveptr);
     if (p == NULL) {
-	warn("txzchk", "%s: NULL pointer encountered trying to parse line", txzpath);
+	warn("txzchk", "%s: NULL pointer encountered trying to parse line", tarball_path);
 	msg("skipping to next line");
 	++tarball.total_feathers;
 	return;
     }
     if (strchr(p, '/') != NULL) {
 	/* found linux output */
-	parse_linux_txz_line(p, linep, line_dup, dir_name, txzpath, &saveptr, normal_file, sum, count);
+	parse_linux_txz_line(p, linep, line_dup, dir_name, tarball_path, &saveptr, normal_file, sum, count);
     } else {
 	/* assume macOS/BSD output */
-	parse_bsd_txz_line(p, linep, line_dup, dir_name, txzpath, &saveptr, normal_file, sum, count);
+	parse_bsd_txz_line(p, linep, line_dup, dir_name, tarball_path, &saveptr, normal_file, sum, count);
     }
 }
 
@@ -1379,7 +1380,7 @@ check_tarball(char const *tar, char const *fnamchk)
     /*
      * firewall
      */
-    if ((!read_from_text_file && tar == NULL) || fnamchk == NULL || txzpath_path == NULL)
+    if ((!read_from_text_file && tar == NULL) || fnamchk == NULL || tarball_path == NULL)
     {
 	err(35, __func__, "called with NULL arg(s)");
 	not_reached();
@@ -1404,16 +1405,16 @@ check_tarball(char const *tar, char const *fnamchk)
      * would tell it to expect the extension txt instead of txz).
      */
     if (dbg_allowed(DBG_HIGH)) {
-	dbg(DBG_MED, "about to execute: %s -v 5 -E %s -- %s", fnamchk, ext, txzpath_path);
+	dbg(DBG_MED, "about to execute: %s -v 5 -E %s -- %s", fnamchk, ext, tarball_path);
 	errno = 0;			/* pre-clear errno for errp() */
-	exit_code = shell_cmd(__func__, true, "% -v 5 -E % -- %", fnamchk, ext, txzpath_path);
+	exit_code = shell_cmd(__func__, true, "% -v 5 -E % -- %", fnamchk, ext, tarball_path);
     } else {
-	dbg(DBG_MED, "about to execute: %s -E %s -- %s >/dev/null", fnamchk, ext, txzpath_path);
+	dbg(DBG_MED, "about to execute: %s -E %s -- %s >/dev/null", fnamchk, ext, tarball_path);
 	errno = 0;			/* pre-clear errno for errp() */
-	exit_code = shell_cmd(__func__, true, "% -E % -- % >/dev/null", fnamchk, ext, txzpath_path);
+	exit_code = shell_cmd(__func__, true, "% -E % -- % >/dev/null", fnamchk, ext, tarball_path);
     }
     if (exit_code != 0) {
-	warn("txzchk", "%s: %s %s failed with exit code: %d", txzpath_path, fnamchk, txzpath_path, WEXITSTATUS(exit_code));
+	warn("txzchk", "%s: %s %s failed with exit code: %d", tarball_path, fnamchk, tarball_path, WEXITSTATUS(exit_code));
 	++tarball.total_feathers;
     } else {
 	fnamchk_okay = true;
@@ -1434,9 +1435,9 @@ check_tarball(char const *tar, char const *fnamchk)
 	/*
 	 * form pipe to the fnamchk command
 	 */
-	fnamchk_stream = pipe_open(__func__, true, "% -E % -- %", fnamchk, ext, txzpath_path);
+	fnamchk_stream = pipe_open(__func__, true, "% -E % -- %", fnamchk, ext, tarball_path);
 	if (fnamchk_stream == NULL) {
-	    err(36, __func__, "popen for reading failed for: %s -- %s", fnamchk, txzpath_path);
+	    err(36, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
 	    not_reached();
 	}
 
@@ -1445,7 +1446,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	 */
 	readline_len = readline(&dir_name, fnamchk_stream);
 	if (readline_len < 0) {
-	    warn("txzchk", "%s: unexpected EOF from fnamchk", txzpath_path);
+	    warn("txzchk", "%s: unexpected EOF from fnamchk", tarball_path);
 	}
 
 	/*
@@ -1454,22 +1455,22 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;		/* pre-clear errno for warnp() */
 	ret = pclose(fnamchk_stream);
 	if (ret < 0) {
-	    warnp(__func__, "%s: pclose error on fnamchk stream", txzpath_path);
+	    warnp(__func__, "%s: pclose error on fnamchk stream", tarball_path);
 	}
 
 	fnamchk_stream = NULL;
 
 	if (dir_name == NULL || *dir_name == '\0') {
-	    err(37, __func__, "txzchk: unexpected NULL pointer from fnamchk -- %s", txzpath_path);
+	    err(37, __func__, "txzchk: unexpected NULL pointer from fnamchk -- %s", tarball_path);
 	    not_reached();
 	}
     }
 
     /* determine size of tarball */
-    tarball.size = file_size(txzpath_path);
+    tarball.size = file_size(tarball_path);
     /* report size if too big or !quiet */
     if (tarball.size < 0) {
-	err(38, __func__, "%s: impossible error: txzchk_sanity_chks() found tarball but file_size() did not", txzpath_path);
+	err(38, __func__, "%s: impossible error: txzchk_sanity_chks() found tarball but file_size() did not", tarball_path);
 	not_reached();
     } else if (tarball.size > MAX_TARBALL_LEN) {
 	++tarball.total_feathers;
@@ -1479,28 +1480,28 @@ check_tarball(char const *tar, char const *fnamchk)
 	      "",
 	      NULL);
 	err(39, __func__, "%s: The compressed tarball size %jd > %jd",
-		 txzpath_path, (intmax_t)tarball.size, (intmax_t)MAX_TARBALL_LEN);
+		 tarball_path, (intmax_t)tarball.size, (intmax_t)MAX_TARBALL_LEN);
 	not_reached();
     } else if (!quiet) {
 	errno = 0;		/* pre-clear errno for warnp() */
-	ret = printf("txzchk: %s size of %jd bytes OK\n", txzpath_path, (intmax_t) tarball.size);
+	ret = printf("txzchk: %s size of %jd bytes OK\n", tarball_path, (intmax_t) tarball.size);
 	if (ret <= 0)
-	    warnp("txzchk", "unable to tell user how big the tarball %s is", txzpath_path);
+	    warnp("txzchk", "unable to tell user how big the tarball %s is", tarball_path);
     }
-    dbg(DBG_MED, "txzchk: %s size in bytes: %jd", txzpath_path, (intmax_t)tarball.size);
+    dbg(DBG_MED, "txzchk: %s size in bytes: %jd", tarball_path, (intmax_t)tarball.size);
 
     if (read_from_text_file) {
-	input_stream = fopen(txzpath_path, "r");
+	input_stream = fopen(tarball_path, "r");
 	errno = 0;
 	if (input_stream == NULL)
 	{
-	    errp(40, __func__, "fopen of %s failed", txzpath_path);
+	    errp(40, __func__, "fopen of %s failed", tarball_path);
 	    not_reached();
 	}
 	errno = 0;		/* pre-clear errno for warnp() */
 	ret = setvbuf(input_stream, (char *)NULL, _IOLBF, 0);
 	if (ret != 0)
-	    warnp(__func__, "setvbuf failed for %s", txzpath_path);
+	    warnp(__func__, "setvbuf failed for %s", tarball_path);
 
     } else {
 	/*
@@ -1513,18 +1514,18 @@ check_tarball(char const *tar, char const *fnamchk)
 	 * first execute the tar command
 	 */
 	errno = 0;			/* pre-clear errno for errp() */
-	exit_code = shell_cmd(__func__, true, "% -tJvf %", tar, txzpath_path);
+	exit_code = shell_cmd(__func__, true, "% -tJvf %", tar, tarball_path);
 	if (exit_code != 0) {
 	    errp(41, __func__, "%s -tJvf %s failed with exit code: %d",
-			      tar, txzpath_path, WEXITSTATUS(exit_code));
+			      tar, tarball_path, WEXITSTATUS(exit_code));
 	    not_reached();
 	}
 
 	/* now open a pipe to tar command (tar -tJvf) to read from */
-	input_stream = pipe_open(__func__, true, "% -tJvf %", tar, txzpath_path);
+	input_stream = pipe_open(__func__, true, "% -tJvf %", tar, tarball_path);
 	if (input_stream == NULL) {
 	    err(42, __func__, "popen for reading failed for: %s -tJvf %s",
-			      tar, txzpath_path);
+			      tar, tarball_path);
 	    not_reached();
 	}
     }
@@ -1545,10 +1546,10 @@ check_tarball(char const *tar, char const *fnamchk)
 	 */
 	readline_len = readline(&linep, input_stream);
         if (readline_len < 0) {
-	    dbg(DBG_HIGH, "reached EOF of tarball %s", txzpath_path);
+	    dbg(DBG_HIGH, "reached EOF of tarball %s", tarball_path);
 	    break;
 	} else if (readline_len == 0) {
-	    dbg(DBG_HIGH, "found empty line in tarball %s", txzpath_path);
+	    dbg(DBG_HIGH, "found empty line in tarball %s", tarball_path);
 	    continue;
 	}
 
@@ -1607,7 +1608,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	ret = pclose(input_stream);
     }
     if (ret < 0) {
-	warnp(__func__, "%s: %s error on tar stream", txzpath_path, read_from_text_file?"fclose":"pclose");
+	warnp(__func__, "%s: %s error on tar stream", tarball_path, read_from_text_file?"fclose":"pclose");
     }
     input_stream = NULL;
 
@@ -1616,7 +1617,7 @@ check_tarball(char const *tar, char const *fnamchk)
      * now parse the lines, reporting any feathers stuck in the tarball that
      * have to be detected while parsing
      */
-    parse_all_txz_lines(dir_name, txzpath_path);
+    parse_all_txz_lines(dir_name, tarball_path);
 
     /*
      * check files list and report any additional feathers stuck in the tarball
@@ -1723,16 +1724,16 @@ add_txz_line(char const *str, uintmax_t line_num)
  *
  * given:
  *
- *	dir_name    - directory name as reported by fnamchk (can be NULL if
- *		      fnamchk failed to validate directory)
- *	txzpath	    - the tarball that is being read
+ *	dir_name	- directory name as reported by fnamchk (can be NULL if
+ *			  fnamchk failed to validate directory)
+ *	tarball_path	- the tarball that is being read
  *
  * This function returns void.
  *
  * This function does not return on error.
  */
 static void
-parse_all_txz_lines(char const *dir_name, char const *txzpath)
+parse_all_txz_lines(char const *dir_name, char const *tarball_path)
 {
     struct txz_line *line = NULL;	/* for txz_lines list */
     char *line_dup = NULL;	/* strdup()d line */
@@ -1743,7 +1744,7 @@ parse_all_txz_lines(char const *dir_name, char const *txzpath)
     /*
      * firewall
      */
-    if (txzpath == NULL) {
+    if (tarball_path == NULL) {
 	err(47, __func__, "passed NULL arg");
 	not_reached();
     }
@@ -1757,11 +1758,11 @@ parse_all_txz_lines(char const *dir_name, char const *txzpath)
 
 	line_dup = strdup(line->line);
 	if (line_dup == NULL) {
-	    err(48, __func__, "%s: duplicating %s failed", txzpath, line->line);
+	    err(48, __func__, "%s: duplicating %s failed", tarball_path, line->line);
 	    not_reached();
 	}
 
-	parse_txz_line(line->line, line_dup, dir_name, txzpath, &dir_count, &sum, &count);
+	parse_txz_line(line->line, line_dup, dir_name, tarball_path, &dir_count, &sum, &count);
 	free(line_dup);
 	line_dup = NULL;
     }
@@ -1832,20 +1833,20 @@ alloc_txz_file(char const *path, intmax_t length)
     errno = 0;
     file = calloc(1, sizeof *file);
     if (file == NULL) {
-	errp(50, __func__, "%s: unable to allocate a struct txz_file *", txzpath_path);
+	errp(50, __func__, "%s: unable to allocate a struct txz_file *", tarball_path);
 	not_reached();
     }
 
     errno = 0;
     file->filename = strdup(path);
     if (!file->filename) {
-	errp(51, __func__, "%s: unable to strdup filename %s", txzpath_path, path);
+	errp(51, __func__, "%s: unable to strdup filename %s", tarball_path, path);
 	not_reached();
     }
 
     file->basename = base_name(path);
     if (!file->basename || *(file->basename) == '\0') {
-	err(52, __func__, "%s: unable to strdup basename of filename %s", txzpath_path, path);
+	err(52, __func__, "%s: unable to strdup basename of filename %s", tarball_path, path);
 	not_reached();
     }
 

--- a/txzchk.h
+++ b/txzchk.h
@@ -113,7 +113,7 @@ struct tarball
     uintmax_t total_feathers;		    /* number of total feathers stuck in tarball (i.e. issues found) */
 };
 
-static struct tarball tarball;	    /* all the information collected from txzpath */
+static struct tarball tarball;	    /* all the information collected from tarball_path */
 
 /*
  * txz_file - struct for each file
@@ -165,7 +165,7 @@ static struct txz_line *txz_lines;	/* all the lines read */
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-w] [-V] [-t tar] [-F fnamchk] [-T] [-E ext] txzpath\n"
+    "usage: %s [-h] [-v level] [-q] [-w] [-V] [-t tar] [-F fnamchk] [-T] [-E ext] tarball_path\n"
     "\n"
     "\t-h\t\tprint help message and exit\n"
     "\t-v level\tset verbosity level: (def level: %d)\n"
@@ -175,11 +175,11 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\n"
     "\t-t tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
-    "\t-F fnamchk\tpath to tool that checks if txzpath is a valid compressed tarball name\n"
+    "\t-F fnamchk\tpath to tool that checks if tarball_path is a valid compressed tarball name\n"
     "\t\t\tfilename (def: %s)\n\n"
-    "\t-T\t\tassume txzpath is a text file with tar listing (for testing different formats)\n"
+    "\t-T\t\tassume tarball_path is a text file with tar listing (for testing different formats)\n"
     "\t-E ext\t\tchange extension to test (def: txz)\n"
-    "\ttxzpath\t\tpath to an IOCCC compressed tarball\n"
+    "\ttarball_path\t\tpath to an IOCCC compressed tarball\n"
     "\n"
     "Exit codes:\n"
     "     0   no feathers stuck in tarball  :-)\n"
@@ -196,22 +196,22 @@ static const char * const usage_msg =
  */
 static void usage(int exitcode, char const *name, char const *str) __attribute__((noreturn));
 static void txzchk_sanity_chks(char const *tar, char const *fnamchk);
-static void parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *txzpath, int *dir_count,
+static void parse_txz_line(char *linep, char *line_dup, char const *dir_name, char const *tarball_path, int *dir_count,
 			   intmax_t *sum, intmax_t *count);
-static void parse_linux_txz_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr,
-		    bool normal_file, intmax_t *sum, intmax_t *count);
-static void parse_bsd_txz_line(char *p, char *line, char *line_dup, char const *dir_name, char const *txzpath, char **saveptr,
-		    bool normal_file, intmax_t *sum, intmax_t *count);
+static void parse_linux_txz_line(char *p, char *line, char *line_dup, char const *dir_name,
+	char const *tarball_path, char **saveptr, bool normal_file, intmax_t *sum, intmax_t *count);
+static void parse_bsd_txz_line(char *p, char *line, char *line_dup, char const *dir_name, char const *tarball_path,
+	char **saveptr, bool normal_file, intmax_t *sum, intmax_t *count);
 static uintmax_t check_tarball(char const *tar, char const *fnamchk);
-static void show_tarball_info(char const *txzpath);
-static void check_file_size(char const *txzpath, off_t size, struct txz_file *file);
-static void count_and_sum(char const *txzpath, intmax_t *sum, intmax_t *count, intmax_t length);
-static void check_txz_file(char const *txzpath, char const *dir_name, struct txz_file *file);
+static void show_tarball_info(char const *tarball_path);
+static void check_file_size(char const *tarball_path, off_t size, struct txz_file *file);
+static void count_and_sum(char const *tarball_path, intmax_t *sum, intmax_t *count, intmax_t length);
+static void check_txz_file(char const *tarball_path, char const *dir_name, struct txz_file *file);
 static void check_all_txz_files(char const *dir_name);
-static void check_directories(struct txz_file *file, char const *dir_name, char const *txzpath);
+static void check_directories(struct txz_file *file, char const *dir_name, char const *tarball_path);
 static bool has_special_bits(char const *str);
 static void add_txz_line(char const *str, uintmax_t line_num);
-static void parse_all_txz_lines(char const *dir_name, char const *txzpath);
+static void parse_all_txz_lines(char const *dir_name, char const *tarball_path);
 static void free_txz_lines(void);
 static struct txz_file *alloc_txz_file(char const *path, intmax_t length);
 static void add_txz_file_to_list(struct txz_file *file);


### PR DESCRIPTION
With commit b5fc2a3658e8eeea711eb908a2fd6c6806b58bae the txzpath was changed to txzpath_path which seems like it might not be what was intended. In any case it seems clearer as tarball_path so that's what it now is called in all cases including the man page and usage message.