### PR TITLE
Formatting fix in txzchk -h

### DIFF
--- a/txzchk.h
+++ b/txzchk.h
@@ -179,6 +179,7 @@ static const char * const usage_msg =
     "\t\t\tfilename (def: %s)\n\n"
     "\t-T\t\tassume tarball_path is a text file with tar listing (for testing different formats)\n"
     "\t-E ext\t\tchange extension to test (def: txz)\n"
+    "\n"
     "\ttarball_path\tpath to an IOCCC compressed tarball\n"
     "\n"
     "Exit codes:\n"

--- a/txzchk.h
+++ b/txzchk.h
@@ -179,7 +179,7 @@ static const char * const usage_msg =
     "\t\t\tfilename (def: %s)\n\n"
     "\t-T\t\tassume tarball_path is a text file with tar listing (for testing different formats)\n"
     "\t-E ext\t\tchange extension to test (def: txz)\n"
-    "\ttarball_path\t\tpath to an IOCCC compressed tarball\n"
+    "\ttarball_path\tpath to an IOCCC compressed tarball\n"
     "\n"
     "Exit codes:\n"
     "     0   no feathers stuck in tarball  :-)\n"


### PR DESCRIPTION
Due to changing the txzpath to tarball_path the number of tabs in that line (as in \t) in the usage_msg string was incorrect.