### PR TITLE
Typo fix in soup/location.c

### DIFF
--- a/soup/location.c
+++ b/soup/location.c
@@ -475,7 +475,7 @@ check_location_table(void)
  * lookup_location_name - convert a ISO 3166-1 Alpha-2 into a location name
  *
  * Even though the ISO 3166-1 Alpha-2 code is only UPPER CASE, the
- * code is compared ion a case independent way.  That is, a non-canonical
+ * code is compared in a case independent way.  That is, a non-canonical
  * lower case code will match the canonical UPPER CASE ISO 3166-1 Alpha-2 code.
  *
  * given:


### PR DESCRIPTION
Although ions have their place when peroxide ions in particular combine with water and diluted acids it forms hydrogen peroxide which has ended up killing people when those unaware of the dangers misunderstand the request that someone would like a glass of H2O too. Thus we should get rid of stray ions in the repo and now have.

Yes there's a point (or actually two points) in the above. In order to help discern what they are you should start by looking at the diff.