### PR TITLE
Improve some of the test scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -231,10 +231,6 @@ The `make tags` now forms both local directory tags files by the name of
 .local.dir.tags as well as a tags file from the accumulation of tags from
 related source directories.
 
-Major updates to CHANGES.md. See
-[CHANGES.md](https://github.com/ioccc-src/mkiocccentry/blob/master/CHANGES.md)
-for details. :-)
-
 Changed `soup/vermod.sh` default JSON tree from "../test_ioccc/test_JSON" to "test_ioccc/test_JSON" and default limit.sh from "./limit_ioccc.sh" to "soup/limit_ioccc.sh" so that `soup/vermod.sh` may be executed from the top level source directory without the need for using `-d test_dir` nor `-i limit.sh`.
 
 Update versions prior to code freeze.
@@ -303,6 +299,20 @@ Fix `soup/Makefile` _clobber_ rule to remove the `soup/ref` tree.
 Have the `test_ioccc/Makefile` _clobber_ rule remove
 `test_iocccsize/`, `test_src/`, and `test_work/` directory
 trees from from under the `test_ioccc/` directory.
+
+Improved mkiocccentry_test.sh so that one can specify the path to various tools
+that mkiocccentry needs.
+Made txzchk_test.sh -t/-t consistent with mkiocccentry.
+Added option to ioccc_test.sh to let one specify path to tar.
+Changed IOCCC_TEST_VERSION from "1.0 2023-02-04" to "1.0.1 2023-02-05".
+Changed MKIOCCCENTRY_TEST_VERSION from "1.0 2023-02-04" to "1.0.1 2023-02-05".
+Changed TXZCHK_TEST_VERSION from "1.0 2023-02-04" to "1.0.1 2023-02-05".
+
+Fixed chkentry_test.sh so it will work when running it directly.
+
+Major updates to CHANGES.md. See
+[CHANGES.md](https://github.com/ioccc-src/mkiocccentry/blob/master/CHANGES.md)
+for details. :-)
 
 Version 1.0.0 code freeze.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -253,6 +253,10 @@ which does have such a tar or you can try downloading GNU Tar from
 the [GNU website](https://www.gnu.org/software/tar/) and after extracting it,
 compile it and then install it so that the tools may find it.
 
+Some systems have a `GNU tar` that you can use. For instance FreeBSD has a
+`gtar` command so if necessary you can use that. Note that you'll have to
+specify in the tools the `-t tar` option to make this work.
+
 
 ## 10. <a name="markdown">Where can I find help with formatting markdown files for my entry?</a>
 

--- a/Makefile
+++ b/Makefile
@@ -1093,6 +1093,7 @@ clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${RM} -rf .hostchk.work.*
 	${RM} -f .txzchk_test.*
 	${RM} -f .sorry.*
+	${RM} -f .build.*
 	${RM} -f answers.txt
 	${RM} -f ${TARGETS}
 	${RM} -rf man

--- a/dbg/man/man3/dbg.3
+++ b/dbg/man/man3/dbg.3
@@ -12,7 +12,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dbg 3  "30 January 2023" "dbg"
+.TH dbg 3  "05 February 2023" "dbg"
 .SH NAME
 .BR dbg() \|,
 .BR vdbg() \|,
@@ -207,7 +207,7 @@ main(void)
      *
      * with newlines as described.
      */
-    msg("NOTE: The next line should say: \\"Warning: %s: %s", __func__, "elephant is sky\-blue pink\\"");
+    msg("NOTE: The next line should say: \e"Warning: %s: %s", __func__, "elephant is sky\-blue pink\e"");
     warn(__func__, "elephant is sky\-blue pink\n");
 
     /* this will not print anything as verbosity_level 3 (DBG_MED) < 5 (DBG_HIGH): */
@@ -219,7 +219,7 @@ main(void)
      *
      *	    debug[3]: file: foo.bar has length: 7
      */
-    msg("NOTE: The next line should read: \\"debug[3]: file: %s has length: %ld\\"", filename, length);
+    msg("NOTE: The next line should read: \e"debug[3]: file: %s has length: %ld\e"", filename, length);
     dbg(DBG_MED, "file: %s has length: %ld\n", filename, length);
 
     /*

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "30 January 2023" "jstrencode" "IOCCC tools"
+.TH jstrencode 1 "05 February 2023" "jstrencode" "IOCCC tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -106,7 +106,7 @@ to encode):
 .RS
 .ft B
  ./jstrencode
- {"test\\"ing":false}
+ {"test\e"ing":false}
  ^D
 .ft R
 .RE

--- a/jparse/man/man8/verge.8
+++ b/jparse/man/man8/verge.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH verge 8 "30 January 2023" "verge" "IOCCC tools"
+.TH verge 8 "05 February 2023" "verge" "IOCCC tools"
 .SH NAME
 .B verge
 \- determine if first version >= second version
@@ -87,7 +87,7 @@ is \(>= the second version,
 .RS
 .ft B
  ./verge 1.1.3 1.1.4
- [[ $? \-eq 0 ]] && echo 'first version, 1.1.3, is >= second version, 1.1.4'
+ [[ $? \-eq 0 ]] && echo \(aqfirst version, 1.1.3, is >= second version, 1.1.4\(aq
 .ft R
 .RE
 .PP
@@ -101,7 +101,7 @@ is < the second version,
 .RS
 .ft B
  ./verge 1.1.3 1.1.4
- [[ $? \-eq 1 ]] && echo 'first version, 1.1.3, is < second version, 1.1.4'
+ [[ $? \-eq 1 ]] && echo \(aqfirst version, 1.1.3, is < second version, 1.1.4\(aq
 .ft R
 .RE
 .PP

--- a/soup/man/man1/iocccsize.1
+++ b/soup/man/man1/iocccsize.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH iocccsize 1 "29 January 2023" "iocccsize" "IOCCC tools"
+.TH iocccsize 1 "05 February 2023" "iocccsize" "IOCCC tools"
 .SH NAME
 .B iocccsize
 \- IOCCC Source Size Tool
@@ -40,7 +40,7 @@ The source's Rule 2b length is written to stdout; with
 option the Rule 2b length, gross (Rule 2a) length, and matched keyword count are written to stdout.
 .PP
 The size tool counts most C reserved words (keyword, secondary, and selected preprocessor keywords) as 1.
-The size tool counts all other octets as 1 excluding ASCII whitespace, and excluding any ';', '{' or '}' followed by ASCII whitespace, and excluding any ';', '{' or '}' octet immediately before the end of file.
+The size tool counts all other octets as 1 excluding ASCII whitespace, and excluding any \(aq;\(aq, \(aq{\(aq or \(aq}\(aq followed by ASCII whitespace, and excluding any \(aq;\(aq, \(aq{\(aq or \(aq}\(aq octet immediately before the end of file.
 .SH OPTIONS
 .TP
 .B \-h

--- a/soup/man/man8/all_sem_ref.8
+++ b/soup/man/man8/all_sem_ref.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH all_sem_ref.sh 8 "30 January 2023" "all_sem_ref.sh" "IOCCC tools"
+.TH all_sem_ref.sh 8 "05 February 2023" "all_sem_ref.sh" "IOCCC tools"
 .SH NAME
 .B all_sem_ref.sh
 \- form
@@ -203,10 +203,10 @@ to build the JSON semantic tables for
 .nf
 rm -rf ref
 mkdir ref
-\&./all_sem_ref.sh \-v 1 \-j ../jparse/jsemtblgen \-J ../jparse/jsemcgen.sh -- \\
-    chk.info.head.c chk.info.tail.c chk.info.head.h chk.info.tail.h \\
-    chk.auth.head.c chk.auth.tail.c chk.auth.head.h chk.auth.tail.h \\
-    ../test_ioccc/test_JSON/info.json/good \\
+\&./all_sem_ref.sh \-v 1 \-j ../jparse/jsemtblgen \-J ../jparse/jsemcgen.sh -- \e
+    chk.info.head.c chk.info.tail.c chk.info.head.h chk.info.tail.h \e
+    chk.auth.head.c chk.auth.tail.c chk.auth.head.h chk.auth.tail.h \e
+    ../test_ioccc/test_JSON/info.json/good \e
     ../test_ioccc/test_JSON/auth.json/good ref
 .fi
 .in -0.5i

--- a/soup/man/man8/vermod.8
+++ b/soup/man/man8/vermod.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH vermod 8 "29 January 2023" "vermod" "IOCCC tools"
+.TH vermod 8 "05 February 2023" "vermod" "IOCCC tools"
 .SH NAME
 .B vermod
 \- modify version strings (and others) under ./test_JSON/
@@ -51,7 +51,7 @@ Set verbosity level to
 (def: 0).
 .TP
 .BI \-d\  test_dir
-Set the directory where the '*.json' files are expected to
+Set the directory where the \(aq*.json\(aq files are expected to
 .IR test_dir .
 .TP
 .BI \-i\   limit.sh
@@ -134,7 +134,7 @@ show what files would change:
 .sp
 .RS
 .ft B
- ./vermod.sh \-l \-n '0.11 2022\-08\-23' '0.12 2022\-09\-22'
+ ./vermod.sh \-l \-n \(aq0.11 2022\-08\-23\(aq \(aq0.12 2022\-09\-22\(aq
 .ft R
 .RE
 .PP
@@ -142,7 +142,7 @@ After verifying that the above command is correct, run the script again to actua
 .sp
 .RS
 .ft B
- ./vermod.sh  '0.11 2022\-08\-23' '0.12 2022\-09\-22'
+ ./vermod.sh  \(aq0.11 2022\-08\-23\(aq \(aq0.12 2022\-09\-22\(aq
 .ft R
 .RE
 .SH SEE ALSO

--- a/soup/vermod.sh
+++ b/soup/vermod.sh
@@ -4,7 +4,7 @@
 #
 # "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
 #
-# The JSON scanner was co-developed in 2022 by:
+# The JSON parser was co-developed in 2022 by:
 #
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson

--- a/test_ioccc/chkentry_test.sh
+++ b/test_ioccc/chkentry_test.sh
@@ -37,7 +37,7 @@ export EXIT_CODE=0
 export INVALID_JSON_FOUND=""
 export UNEXPECTED_SEMANTIC_ERROR=""
 export SEMANTIC_ERROR_MISSED=""
-export JSON_TREE="./jparse/test_jparse/test_JSON"
+export JSON_TREE="./test_ioccc/test_JSON"
 
 export CHKENTRY_TEST_VERSION="1.0 2023-02-04"
 

--- a/test_ioccc/man/man8/ioccc_test.8
+++ b/test_ioccc/man/man8/ioccc_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH ioccc_test.sh 8 "30 January 2023" "ioccc_test.sh" "IOCCC tools"
+.TH ioccc_test.sh 8 "05 February 2023" "ioccc_test.sh" "IOCCC tools"
 .SH NAME
 .B ioccc_test.sh
 \- perform the complete suite of tests for the mkiocccentry repo
@@ -21,6 +21,8 @@
 .RB [\| \-J
 .IR level \|]
 .RB [\| \-V \|]
+.RB [\| \-t
+.IR tar \|]
 .RB [\| \-Z
 .IR topdir \|]
 .SH DESCRIPTION
@@ -57,6 +59,19 @@ Set JSON verbosity level to
 .TP
 .B \-V
 Print version and exit.
+.TP
+.BI \-t\  tar
+Set
+.B tar
+path to
+.IR tar .
+The
+.BR tar (1)
+command must support the
+.B \-J
+option and the
+.B v7
+format.
 .TP
 .BI \-Z\  topdir
 Declare the top level directory of this repository.

--- a/test_ioccc/man/man8/mkiocccentry_test.8
+++ b/test_ioccc/man/man8/mkiocccentry_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry_test.sh 8 "30 January 2023" "mkiocccentry_test.sh" "IOCCC tools"
+.TH mkiocccentry_test.sh 8 "05 February 2023" "mkiocccentry_test.sh" "IOCCC tools"
 .SH NAME
 .B mkiocccentry_test.sh
 \- run several invocations of
@@ -23,6 +23,16 @@ to test that it functions well
 .IR level \|]
 .RB [\| \-J
 .IR level \|]
+.RB [\| \-t
+.IR tar \|]
+.RB [\| \-T
+.IR txzchk \|]
+.RB [\| \-l
+.IR ls \|]
+.RB [\| \-c
+.IR cp \|]
+.RB [\| \-F
+.IR fnamchk \|]
 .RB [\| \-Z
 .IR topdir \|]
 .SH DESCRIPTION
@@ -46,6 +56,33 @@ Set verbosity level to
 .BI \-J\  level
 Set JSON verbosity level to
 .IR level .
+.TP
+.BI \-t\  tar
+Set path to
+.BR tar (1).
+The
+.BR tar (1)
+command must support the
+.B \-J
+option and the
+.B v7
+format.
+.TP
+.BI \-T\  txzchk
+Set path to
+.BR txzchk (1).
+.TP
+.BI \-l\  ls
+Set path to
+.BR ls (1).
+.TP
+.BI \-c\  cp
+Set path to
+.BR cp (1).
+.TP
+.BI \-F\  fnamchk
+Set path to
+.BR fnamchk (1).
 .TP
 .BI \-Z\  topdir
 Declare the top level directory of this repository.
@@ -97,7 +134,7 @@ not executable.
 error code.
 .SH BUGS
 .PP
-This script does not let one set the path to the needed tools like the other scripts do and so requires that one is in the clone of the repo directory to successfully run this script.
+This script does not let one set the path to some of the needed tools like the other scripts do and so requires that one is in the clone of the repo directory to successfully run this script.
 .SH SEE ALSO
 .BR ioccc_test (8),
 .BR iocccsize_test (8)

--- a/test_ioccc/man/man8/txzchk_test.8
+++ b/test_ioccc/man/man8/txzchk_test.8
@@ -26,7 +26,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH txzchk_test 8 "30 January 2023" "txzchk_test" "IOCCC tools"
+.TH txzchk_test 8 "05 February 2023" "txzchk_test" "IOCCC tools"
 .SH NAME
 .B txzchk_test.sh
 \- test suite for
@@ -38,9 +38,9 @@
 .RB [\| \-v
 .IR level \|]
 .RB [\| \-t
-.IR txzchk \|]
-.RB [\| \-T
 .IR tar \|]
+.RB [\| \-T
+.IR txzchk \|]
 .RB [\| \-F
 .IR fnamchk \|]
 .RB [\| \-d
@@ -51,7 +51,7 @@
 .SH DESCRIPTION
 .B txzchk_test.sh
 runs
-.B txzchk
+.BR txzchk (1)
 in text file mode on pseudo\-tar listings to make sure that bad tarballs are flagged with issues and good tarballs are not.
 For the bad files it checks that the issues reported are the same as expected.
 The script enforces that bad files have an associated error file to compare with the errors reported by
@@ -85,26 +85,33 @@ Set verbosity level to
 .I level
 (def: 0).
 .TP
-.BI \-t\  txzchk
+.BI \-T\  txzchk
 Set
-.B txzchk
+.BR txzchk (1)
 path to
 .IR txzchk .
 .TP
-.BI \-T\  tar
+.BI \-t\  tar
 Set
-.B tar
+.BR tar (1)
 path to
 .IR tar .
+The
+.BR tar (1)
+command must support the
+.B \-J
+option and the
+.B v7
+format.
 .TP
 .BI \-F\  fnamchk
 Set
 .B fnamchk
 path to
-.IR fnamchk .
-.B txzchk
+.IR fnamchk (1).
+.BR txzchk (1)
 uses
-.B fnamchk
+.BR fnamchk (1)
 to test if the tarball is validly named and if the files listed are in the correct directory.
 .TP
 .BI \-d\  txzchk_tree
@@ -179,7 +186,7 @@ It will be removed prior to each time the script is run to keep the state of the
 .RE
 .SH NOTES
 .PP
-.B txzchk
+.BR txzchk (1)
 was written by Cody Boone Ferguson after discussion with Landon Curt Noll (one of the IOCCC Judges) in support of IOCCCMOCK, IOCCC28 and beyond.
 In order to test different tarballs and tar listing formats Cody added the text file mode early on to help in development.
 That fact coupled with the fact there is the need to test that the tool works properly is what inspired him to create this script.
@@ -217,6 +224,9 @@ is supposed to check all issues this would have to be done differently from the 
 Additionally if this was done it would make it necessary to have only one issue in each test file which is not a good idea as it's easier to miss feathered tarballs by the simple fact that one has to be sure to have enough test files (there are a lot of checks that
 .BR txzchk (1)
 performs!).
+.PP
+When the minimum timestamp changes this script will fail unless the filenames of the good files are changed.
+This probably should be fixed or dealt with in some manner.
 .PP
 Perhaps there should be more tests done with the exit code of
 .BR txzchk (1)

--- a/test_ioccc/test_txzchk/README.md
+++ b/test_ioccc/test_txzchk/README.md
@@ -62,5 +62,5 @@ then do:
     git add ./test_txzchk/bad/*.txt ./test_txzchk/bad/*.err
 
 (assuming that there aren't any other files with those extensions that should
-not be there). We could have the `test_txzchk.sh` script do this but the problem
+not be there). We could have the `txzchk_test.sh` script do this but the problem
 is we need to manually inspect that the errors are correct.

--- a/test_ioccc/txzchk_test.sh
+++ b/test_ioccc/txzchk_test.sh
@@ -56,17 +56,17 @@ if [[ -z "$TAR" ]]; then
     TAR="/usr/bin/tar"
 fi
 
-export TXZCHK_TEST_VERSION="1.0 2023-02-04"
+export TXZCHK_TEST_VERSION="1.0.1 2023-02-05"
 export FNAMCHK="./test_ioccc/fnamchk"
 export TXZCHK="./txzchk"
 export TXZCHK_TREE="./test_ioccc/test_txzchk"
-export USAGE="usage: $0 [-h] [-V] [-v level] [-t txzchk] [-T tar] [-F fnamchk] [-d txzchk_tree] [-Z topdir] [-k]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-t tar] [-T txzchk] [-F fnamchk] [-d txzchk_tree] [-Z topdir] [-k]
 
     -h			    print help and exit
     -V			    print version and exit
     -v level		    set verbosity level for this script: (def level: 0)
-    -t txzchk		    path to txzchk executable (def: $TXZCHK)
-    -T tar		    path to tar that accepts -J option (def: $TAR)
+    -t tar		    path to tar that accepts -J option (def: $TAR)
+    -T txzchk		    path to txzchk executable (def: $TXZCHK)
     -F fnamchk	            path to fnamchk (def: $FNAMCHK)
 
     -d txzchk_tree	    tree where txzchk test files are to be found (def: $TXZCHK_TREE)
@@ -106,13 +106,13 @@ while getopts :hVv:t:d:T:F:Z:k flag; do
 	;;
     v)	V_FLAG="$OPTARG";
 	;;
-    t)	TXZCHK="$OPTARG";
+    t)	TAR="$OPTARG";
 	;;
     d)	TXZCHK_TREE="$OPTARG";
 	;;
     F)	FNAMCHK="$OPTARG";
 	;;
-    T)	TAR="$OPTARG";
+    T)	TXZCHK="$OPTARG";
 	;;
     Z)  TOPDIR="$OPTARG";
         ;;


### PR DESCRIPTION
In order to test other implementations of tar the txzchk_test.sh script has been enhanced to take an optional tar path. To make the tool more consistent with other tools (except in a way txzchk itself, see below) the script now is -t tar and -T txzchk. This is because in mkiocccentry that's the meaning of the options.

The mkiocccentry_test.sh and ioccc_test.sh scripts now also take -t tar and mkiocccentry_test.sh additionally takes an option for cp (-c cp), ls (-l ls), txzchk (-T txzchk) and fnamchk (-F fnamchk).

The way these changes are not consistent with txzchk is simply that txzchk takes a -T option to set text file (or if you prefer 'test') mode and -t for tar and additionally mkiocccentry takes a -T txzchk so the scripts that now take a -T that doesn't set txzchk won't match but then one would hope that txzchk does not need a path to itself! :-)

Updated man pages.