### PR TITLE
Fix up to date issues in make parser rule

### DIFF
--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -560,10 +560,12 @@ man/man8/jparse_test.8:
 #
 parser: jparse.y jparse.l
 	${RM} -f jparse.tab.c jparse.tab.h
-	${E} ${MAKE} jparse.tab.c jparse.tab.h
+	@# make jparse.tab.c implies make jparse.tab.h too
+	${E} ${MAKE} jparse.tab.c
 	${E} ${MAKE} jparse.tab.o
 	${RM} -f jparse.c jparse.lex.h
-	${E} ${MAKE} jparse.c jparse.lex.h
+	@# make jparse.c implies make jparse.lex.h too
+	${E} ${MAKE} jparse.c
 	${E} ${MAKE} jparse.o
 	${RM} -f jparse.tab.ref.c
 	${CP} -f -v jparse.tab.c jparse.tab.ref.c


### PR DESCRIPTION
An annoying problem was in jparse/Makefile when running make parser that made it appear that the scripts were not running. There are two parts to this.

First the script was set to 0 verbosity level and I did not realise this so it seemed as it was not running (only obscure hints that it was). The second part is that the make parser rule had the lines:

	${E} ${MAKE} jparse.tab.c jparse.tab.h
	${E} ${MAKE} jparse.c jparse.lex.h

and the problem with that is that the first of each implies the second so we would get the messages:

    make[2]: `jparse.tab.h' is up to date.

    make[2]: `jparse.lex.h' is up to date.

This made me believe that the problem I was facing was the scripts were not running but instead it's that the rule was run twice which is unnecessary. Thus a comment above each one notes that the rule implies the other and no longer runs both.