### PR TITLE
Fix writing of answers file (past winner, handle)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.2 2023-04-14
+
+Fix mkiocccentry to write past winner and author handle to the answer file. It
+already read from these from the file but did not write them and therefore using
+a new answers file did not work at the point that these fields were added to the
+tool.
 
 ## Release 1.0.1 2023-02-14
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -614,7 +614,10 @@ main(int argc, char *argv[])
 		"%s\n"	/* alt_url */
 		"%s\n"	/* mastodon handle */
 		"%s\n"	/* GitHub */
-		"%s\n",	/* affiliation */
+		"%s\n"	/* affiliation */
+		"%s\n"  /* past winner */
+		"%s\n"  /* author_handle */
+		,
 		author_set[i].name,
 		author_set[i].location_code,
 		author_set[i].email,
@@ -622,9 +625,11 @@ main(int argc, char *argv[])
 		author_set[i].alt_url,
 		author_set[i].mastodon,
 		author_set[i].github,
-		author_set[i].affiliation);
+		author_set[i].affiliation,
+		author_set[i].past_winner?"y":"n",
+		author_set[i].author_handle);
 	    if (ret <= 0) {
-		warnp(__func__, "fprintf error printing author info the answers file");
+		warnp(__func__, "fprintf error printing author info to the answers file");
 		++answers_errors;
 	    }
 	}


### PR DESCRIPTION
When the past winner and winner handle prompts were added to the mkiocccentry tool the tool was changed to read the values from the answers file but it did not write it to the answers file.

But why did the test script work? It's simply because the script (of course) does not run the interactive tool but merely reads from the answers file which the script itself creates.

Now one can use the -a/-A feature and expect -i to work.