### PR TITLE
Fix warnings compiling jparse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.2 2023-04-14
+
+Fix mkiocccentry to write past winner and author handle to the answer file. It
+already read from these from the file but did not write them and therefore using
+a new answers file did not work at the point that these fields were added to the
+tool.
 
 ## Release 1.0.1 2023-02-14
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -145,7 +145,7 @@ C_OPT= -O3 -g3
 
 # Compiler warnings
 #
-WARN_FLAGS= -pedantic -Wall -Wextra
+WARN_FLAGS= -pedantic -Wall -Wextra -Wno-unused-but-set-variable
 #WARN_FLAGS= -pedantic -Wall -Wextra -Werror
 
 # linker options

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -126,7 +126,7 @@ json_dbg_allowed(int json_dbg_lvl)
  *	true ==> allowed, false ==> disabled
  */
 bool
-json_warn_allowed()
+json_warn_allowed(void)
 {
     /*
      * determine if a JSON warning message is allowed

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -2271,7 +2271,7 @@ is_decimal(char const *ptr, size_t len)
  *		    NULL or str is empty
  *
  * NOTE: This function calls is_decimal().  See that function for details on
- *	 what is or is not considered an integer.
+ *	 what is and is not considered an integer.
  */
 bool
 is_decimal_str(char const *str, size_t *retlen)
@@ -2318,7 +2318,7 @@ is_decimal_str(char const *str, size_t *retlen)
  *
  *		^[/0-9a-z][0-9a-z._+-]*$
  *
- *	   If lower_only is false, then the string must match:
+ *	    If lower_only is false, then the string must match:
  *
  *		^[/0-9A-Za-z][0-9A-Za-z._+-]*$
  *
@@ -2328,7 +2328,7 @@ is_decimal_str(char const *str, size_t *retlen)
  *
  *		^[/0-9a-z._+-]*$
  *
- *	   If lower_only is false, then the string must match:
+ *	    If lower_only is false, then the string must match:
  *
  *		^[/0-9A-Za-z._+-]*$
  *

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -614,7 +614,10 @@ main(int argc, char *argv[])
 		"%s\n"	/* alt_url */
 		"%s\n"	/* mastodon handle */
 		"%s\n"	/* GitHub */
-		"%s\n",	/* affiliation */
+		"%s\n"	/* affiliation */
+		"%s\n"  /* past winner */
+		"%s\n"  /* author_handle */
+		,
 		author_set[i].name,
 		author_set[i].location_code,
 		author_set[i].email,
@@ -622,9 +625,11 @@ main(int argc, char *argv[])
 		author_set[i].alt_url,
 		author_set[i].mastodon,
 		author_set[i].github,
-		author_set[i].affiliation);
+		author_set[i].affiliation,
+		author_set[i].past_winner?"y":"n",
+		author_set[i].author_handle);
 	    if (ret <= 0) {
-		warnp(__func__, "fprintf error printing author info the answers file");
+		warnp(__func__, "fprintf error printing author info to the answers file");
 		++answers_errors;
 	    }
 	}


### PR DESCRIPTION

Two warnings were being triggered under macOS: one about unused but set
variable (in generated code). That was solved by adding
-Wno-unused-but-set-variable to the WARN_FLAGS. Note that clang in some
platforms (like CentOS 7) do not have that option but it is not fatal so
this is okay (though in that platform it would generate additional
warnings).

The other was a more recent one:

    json_util.c:129:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    json_warn_allowed()
                     ^
                      void

The solution is to add void to the function arg list.

Aesthetic changes that don't really matter but were done and by accident
made in this commit (I already saved and quit - this is an emendation): 
off-by-one char in a comment and better wording of a comment as well.