### PR TITLE
Add remarks.example.md for authors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.3 2023-05-22
+
+Added [remarks.example.md](remarks.example.md) which has instructions for
+writing `remarks.md` files in the same vein as the
+[Makefile.example](Makefile.example).
+
 ## Release 1.0.2 2023-04-14
 
 Fix mkiocccentry to write past winner and author handle to the answer file. It

--- a/remarks.example.md
+++ b/remarks.example.md
@@ -1,0 +1,55 @@
+# PLEASE REMOVE THIS LINE THROUGH THE LINE THAT SAYS _END OF INSTRUCTIONS_
+
+First of all if you need help with markdown format please see this [helpful
+guide](https://www.markdownguide.org/basic-syntax/).
+
+## Sections and subsections
+
+For sections you should use heading levels i.e. lines that start with `#`
+followed by a space. Please start out at three (`###`). For subsections increase
+the number of `#`s up to a maximum of six.
+
+You may go down for new sections, increasing again for subsections.
+
+You need not start your remarks with a heading but you may if you wish.
+
+## What should you say?
+
+As much or as little as you wish.
+
+### What helps:
+
+- explaining what your entry does.
+
+- how to entice it to do what it is supposed to do.
+
+- what obfuscations are used.
+
+- what are the limitations of your entry in respect of portability and/or input
+data.
+
+- how it works (if you are really condescending :-) ).
+
+### What does not help:
+
+- admitting that your entry is not very obfuscated (you see, the contest is
+called the **IOCCC**, not the **INVOCCC** :-) ); but even if you do not admit
+it, not very obfuscated entries have a minuscule chance to win (although
+[2000/tomx](https://github.com/ioccc-src/temp-test-ioccc/tree/master/years.html#2000_tomx)
+is a notable counterexample).
+
+- mentioning your name or any identifying information in the remark section (or
+in the C code for that matter) - we like to be unbiased during the judging
+rounds; we look at the author name only if an entry wins. See the guidelines if
+this is not clear!
+
+- leaving the remark section empty.
+
+After doing the above you should rename the file _remarks.md_ and use the file
+as your `remarks.md` when packaging your entry with the `mkiocccentry` tool.
+
+Thank you!
+
+# END OF INSTRUCTIONS
+
+Your remarks should go here here.


### PR DESCRIPTION
This file gives instructions for writing a remarks.md file for IOCCC entries. This commit was supposed to be done quite a while ago but it slipped my mind and I haven't looked at the repo in a long while (or git status of the repo in a long while).

This file is of the same nature as the Makefile.example.

Updated CHANGES.md to note this addition.