### PR TITLE
Remove lex.jparse_.c - resolves #518

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.3 2023-05-22
+
+Added [remarks.example.md](remarks.example.md) which has instructions for
+writing `remarks.md` files in the same vein as the
+[Makefile.example](Makefile.example).
+
 ## Release 1.0.2 2023-04-14
 
 Fix mkiocccentry to write past winner and author handle to the answer file. It

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Added [remarks.example.md](remarks.example.md) which has instructions for
 writing `remarks.md` files in the same vein as the
 [Makefile.example](Makefile.example).
 
+Fix `bug_report.sh` and `make clobber` (in `jparse/`) to remove bogus file
+`jparse/lex.jparse_.c` after completion of one of the steps.
+
+
 ## Release 1.0.2 2023-04-14
 
 Fix mkiocccentry to write past winner and author handle to the answer file. It

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -90,7 +90,7 @@ export SUBDIRS="
     ./test_ioccc
     "
 
-export BUG_REPORT_VERSION="1.0 2023-02-04"
+export BUG_REPORT_VERSION="1.0.1 2023-05-22"
 export FAILURE_SUMMARY=
 export NOTICE_SUMMARY=
 export DBG_LEVEL="0"
@@ -1761,7 +1761,7 @@ fi
 
 # final cleanup
 #
-rm -f jparse/lex.yy.c
+rm -f jparse/lex.yy.c jparse/lex.jparse_.c
 
 # All Done!!! -- Jessica Noll, Age 2
 #

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -880,7 +880,7 @@ clobber: legacy_clobber clean
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@
 	${RM} -f ${TARGETS}
-	${RM} -f jparse.output lex.yy.c jparse.c
+	${RM} -f jparse.output lex.yy.c jparse.c lex.jparse_.c
 	${RM} -f jsemcgen.out.*
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo

--- a/remarks.example.md
+++ b/remarks.example.md
@@ -1,0 +1,55 @@
+# PLEASE REMOVE THIS LINE THROUGH THE LINE THAT SAYS _END OF INSTRUCTIONS_
+
+First of all if you need help with markdown format please see this [helpful
+guide](https://www.markdownguide.org/basic-syntax/).
+
+## Sections and subsections
+
+For sections you should use heading levels i.e. lines that start with `#`
+followed by a space. Please start out at three (`###`). For subsections increase
+the number of `#`s up to a maximum of six.
+
+You may go down for new sections, increasing again for subsections.
+
+You need not start your remarks with a heading but you may if you wish.
+
+## What should you say?
+
+As much or as little as you wish.
+
+### What helps:
+
+- explaining what your entry does.
+
+- how to entice it to do what it is supposed to do.
+
+- what obfuscations are used.
+
+- what are the limitations of your entry in respect of portability and/or input
+data.
+
+- how it works (if you are really condescending :-) ).
+
+### What does not help:
+
+- admitting that your entry is not very obfuscated (you see, the contest is
+called the **IOCCC**, not the **INVOCCC** :-) ); but even if you do not admit
+it, not very obfuscated entries have a minuscule chance to win (although
+[2000/tomx](https://github.com/ioccc-src/temp-test-ioccc/tree/master/years.html#2000_tomx)
+is a notable counterexample).
+
+- mentioning your name or any identifying information in the remark section (or
+in the C code for that matter) - we like to be unbiased during the judging
+rounds; we look at the author name only if an entry wins. See the guidelines if
+this is not clear!
+
+- leaving the remark section empty.
+
+After doing the above you should rename the file _remarks.md_ and use the file
+as your `remarks.md` when packaging your entry with the `mkiocccentry` tool.
+
+Thank you!
+
+# END OF INSTRUCTIONS
+
+Your remarks should go here here.


### PR DESCRIPTION

After make clobber (under jparse/) the bogus file created by
bug_report.sh, lex.jparse_.c, is removed.

bug_report.sh also removes this file in the clean up stage.

Updated README.md with this bug fix.