### PR TITLE
Initial jprint code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ jparse.tab.c
 jparse.tab.h
 jparse.xml
 jparse/jparse
+jparse/jprint
 jparse/lex.yy.c
 jparse_test.log
 jsemtblgen

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -164,10 +164,10 @@ CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${LDFLAGS}
 # source files that are permanent (not made, nor removed)
 #
 C_SRC= jparse_main.c json_parse.c json_sem.c json_util.c \
-       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c
+       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c jprint.c
 H_SRC= jparse.h jparse_main.h jsemtblgen.h json_parse.h json_sem.h json_util.h \
        jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h \
-       jparse.tab.ref.h
+       jparse.tab.ref.h jprint.h
 
 # source files that do not conform to strict picky standards
 #
@@ -362,7 +362,7 @@ SH_TARGETS=
 
 # program targets to make by all, installed by install, and removed by clobber
 #
-PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode
+PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode jprint
 
 # include files NOT to removed by clobber
 #
@@ -455,6 +455,13 @@ jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
+
+jprint.o: jprint.c
+	${CC} ${CFLAGS} jprint.c -c
+
+jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+	${CC} ${CFLAGS} $^ -lm -o $@
+
 
 # How to create jparse.tab.c and jparse.tab.h
 #
@@ -948,6 +955,8 @@ jparse.tab.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h \
     json_util.h util.h
 jparse_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
     jparse_main.c jparse_main.h json_parse.h json_sem.h json_util.h util.h
+jprint.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jprint.c jprint.h \
+    util.h
 jsemtblgen.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../iocccsize.h jparse.h \
     jparse.tab.h jsemtblgen.c jsemtblgen.h json_parse.h json_sem.h \
     json_util.h util.h

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1,0 +1,33 @@
+/*
+ * jprint - JSON parser printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by:
+ *
+ *	Cody Boone Ferguson
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+#include "jprint.h"
+
+
+int main(int argc, char **argv)
+{
+    UNUSED_ARG(argc);
+    UNUSED_ARG(argv);
+
+    exit(0); /* for now do nothing but exit successfully */
+}

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -1,0 +1,34 @@
+/*
+ * jprint - JSON parser printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by:
+ *
+ *	Cody Boone Ferguson
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JPARSE_H)
+#    define  INCLUDE_JPARSE_H
+
+#include <stdlib.h>
+
+#include "jparse.h"
+
+#include "util.h"
+
+#endif


### PR DESCRIPTION
Right now it only links in the jparse, dynamic array and debug libraries and when run it exits 0.

The Makefile has been updated and make depend was run as well.

This tool will I believe take some time and careful thought and it definitely will be developed over many commits but now it should be possible to just start writing the code without having to worry about editing the Makefile etc. More editing of the Makefile will have to be done later - for instance when man pages are added or some dependency changes or if a new file has to be added but at this point I can start working on the code once I have a better idea of what is needed. This won't happen until a discussion is had on GitHub though I might be able to get some code in prior to that should I find the time and energy. I do hope to do a bit more on this later today.

Updated .gitignore: add jparse/jprint.