### PR TITLE
Add string_to_uintmax + fix NULL pointer

### DIFF
--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -197,7 +197,12 @@ int main(int argc, char **argv)
     } else if (!is_file(argv[0])) {
 	err(5, "jprint", "%s: not a regular file", argv[0]); /*ooo*/
 	not_reached();
+    } else if (!is_read(argv[0])) {
+	err(6, "jprint", "%s: unreadable file", argv[0]); /*ooo*/
+	not_reached();
     }
+
+
 
     errno = 0; /* pre-clear errno for errp() */
     json_file = fopen(argv[0], "r");
@@ -211,7 +216,7 @@ int main(int argc, char **argv)
 	fclose(json_file);  /* close file prior to exiting */
 	json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
 
-	err(7, "jprint", "%s not valid JSON", argv[0]); /*ooo*/
+	err(7, "jprint", "%s invalid JSON", argv[0]); /*ooo*/
 	not_reached();
     }
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -205,6 +205,7 @@ extern void *read_all(FILE *stream, size_t *psize);
 extern bool is_string(char const * const ptr, size_t len);
 extern char const *strnull(char const * const str);
 extern bool string_to_intmax(char const *str, intmax_t *ret);
+extern bool string_to_uintmax(char const *str, uintmax_t *ret);
 extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_decimal(char const *ptr, size_t len);
 extern bool is_decimal_str(char const *str, size_t *retlen);

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -1,7 +1,7 @@
 .\" section 1 man page for location
 .\"
 .\" This man page was first written by Landon Curt Noll for the IOCCC
-.\" in 2023.
+.\" in 2023 with minor improvements and fixes by Cody Boone Ferguson.
 .\"
 .\" Location is relative. :-)
 .\"
@@ -111,7 +111,7 @@ Print the formal location name given ISO 3166 codes:
 The ISO 3166 codes may be in any case:
 .sp
 .RS
-.B ./location CX Gu um
+.B ./location CX us Gu
 .RE
 .sp
 .PP
@@ -173,7 +173,8 @@ for specifying an anonymous location,
 the formal name
 .B User-assigned code XX
 was renamed:
-.BR Anonymous location .
+.B Anonymous location\c
+\&.
 .sp
 We mean no offense by this list: we simply tried to
 include all ISO 3166 codes.

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -1,6 +1,6 @@
 .\" section 1 man page for location
 .\"
-.\" This man page was first written by Landon Curt Noll the IOCCC
+.\" This man page was first written by Landon Curt Noll for the IOCCC
 .\" in 2023.
 .\"
 .\" Location is relative. :-)
@@ -23,14 +23,11 @@
 .IR ... \|]
 .SH DESCRIPTION
 .B location
-without any arguments will print the entire table of
-ISO 3166 code, followed by a tab, followed by the formal location name
-for the given ISO 3166 code.
+without any arguments will print the entire table of ISO 3166 codes, followed by a tab, followed by the formal location name for the given ISO 3166 code.
 .sp 1
 Given arguments,
 .B location
-tool will assume the arguments are ISO 3166 code(s) and print with
-corresponding formal location name(s).
+tool will assume the arguments are ISO 3166 code(s) and print corresponding formal location name(s).
 .sp 1
 Arguments are case insensitive.
 .sp 1
@@ -183,4 +180,6 @@ include all ISO 3166 codes.
 Please pardon any typos.
 .SH SEE ALSO
 .PP
-.BR mkiocccentry (1).
+.BR mkiocccentry (1)
+.br
+.BR \<https://www.iso.org/iso-3166-country-codes.html\>

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -111,7 +111,7 @@ Print the formal location name given ISO 3166 codes:
 The ISO 3166 codes may be in any case:
 .sp
 .RS
-.B ./location CX us Gu
+.B ./location CX AU cA cz gb us Ie
 .RE
 .sp
 .PP


### PR DESCRIPTION

Added the function string_to_uintmax() in util.c. This will be needed
for jprint.

In string_to_intmax() there was a possible NULL pointer dereference.
'ret' was always dereferenced to set the return value of strtoimax() but
it was not checked for NULL.