### PR TITLE
Typo fix jprint.c comment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ functionality is limited to:
 - checks that first arg exists and is a regular file and if so it tries to parse
 it as a JSON file. Depending on status of whether it's valid or json it will
 report an error or report valid json.
+- parsing options except that only the basic option arguments are parsed.
+- note that `jprint` will make use of the `regex(3)` library.
 
 Updated [jparse/README.md](jparse/README.md) to note the `jprint` tool.
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -197,7 +197,12 @@ int main(int argc, char **argv)
     } else if (!is_file(argv[0])) {
 	err(5, "jprint", "%s: not a regular file", argv[0]); /*ooo*/
 	not_reached();
+    } else if (!is_read(argv[0])) {
+	err(6, "jprint", "%s: unreadable file", argv[0]); /*ooo*/
+	not_reached();
     }
+
+
 
     errno = 0; /* pre-clear errno for errp() */
     json_file = fopen(argv[0], "r");
@@ -211,7 +216,7 @@ int main(int argc, char **argv)
 	fclose(json_file);  /* close file prior to exiting */
 	json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
 
-	err(7, "jprint", "%s not valid JSON", argv[0]); /*ooo*/
+	err(7, "jprint", "%s invalid JSON", argv[0]); /*ooo*/
 	not_reached();
     }
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
 	}
     }
 
-    /* must have the exact required number of args */
+    /* must have at least REQUIRED_ARGS args */
     if (argc - optind < REQUIRED_ARGS) {
 	usage(3, program, "wrong number of arguments"); /*ooo*/
 	not_reached();

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -86,7 +86,7 @@ static const char * const usage_msg1 =
     "\t\t\tthen the key, value or both are not printed.\n"
     "\t-p name\t\tAlias for '-p n'.\n"
     "\t-p value\tAlias for '-p v'.\n"
-    "\t-p both\t\tAlias '-p v'.\n\n"
+    "\t-p both\t\tAlias for '-p n,v'.\n\n"
     "\t-b {t,number}\tprint between name and value (def: 1)\n"
     "\t\t\tprint a tab or spaces (i.e. '-b 4') between the name and value.\n"
     "\t\t\tUse of -b {t,number} without -j or -p b has no effect.\n"

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <regex.h> /* for regular expression matching */
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
@@ -51,6 +52,6 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.3 2023-06-03"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.4 2023-06-04"		/* format: major.minor YYYY-MM-DD */
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -205,6 +205,7 @@ extern void *read_all(FILE *stream, size_t *psize);
 extern bool is_string(char const * const ptr, size_t len);
 extern char const *strnull(char const * const str);
 extern bool string_to_intmax(char const *str, intmax_t *ret);
+extern bool string_to_uintmax(char const *str, uintmax_t *ret);
 extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_decimal(char const *ptr, size_t len);
 extern bool is_decimal_str(char const *str, size_t *retlen);

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -1,7 +1,7 @@
 .\" section 1 man page for location
 .\"
 .\" This man page was first written by Landon Curt Noll for the IOCCC
-.\" in 2023.
+.\" in 2023 with minor improvements and fixes by Cody Boone Ferguson.
 .\"
 .\" Location is relative. :-)
 .\"
@@ -111,7 +111,7 @@ Print the formal location name given ISO 3166 codes:
 The ISO 3166 codes may be in any case:
 .sp
 .RS
-.B ./location CX Gu um
+.B ./location CX us Gu
 .RE
 .sp
 .PP
@@ -173,7 +173,8 @@ for specifying an anonymous location,
 the formal name
 .B User-assigned code XX
 was renamed:
-.BR Anonymous location .
+.B Anonymous location\c
+\&.
 .sp
 We mean no offense by this list: we simply tried to
 include all ISO 3166 codes.

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -1,6 +1,6 @@
 .\" section 1 man page for location
 .\"
-.\" This man page was first written by Landon Curt Noll the IOCCC
+.\" This man page was first written by Landon Curt Noll for the IOCCC
 .\" in 2023.
 .\"
 .\" Location is relative. :-)
@@ -23,14 +23,11 @@
 .IR ... \|]
 .SH DESCRIPTION
 .B location
-without any arguments will print the entire table of
-ISO 3166 code, followed by a tab, followed by the formal location name
-for the given ISO 3166 code.
+without any arguments will print the entire table of ISO 3166 codes, followed by a tab, followed by the formal location name for the given ISO 3166 code.
 .sp 1
 Given arguments,
 .B location
-tool will assume the arguments are ISO 3166 code(s) and print with
-corresponding formal location name(s).
+tool will assume the arguments are ISO 3166 code(s) and print corresponding formal location name(s).
 .sp 1
 Arguments are case insensitive.
 .sp 1
@@ -183,4 +180,6 @@ include all ISO 3166 codes.
 Please pardon any typos.
 .SH SEE ALSO
 .PP
-.BR mkiocccentry (1).
+.BR mkiocccentry (1)
+.br
+.BR \<https://www.iso.org/iso-3166-country-codes.html\>

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -111,7 +111,7 @@ Print the formal location name given ISO 3166 codes:
 The ISO 3166 codes may be in any case:
 .sp
 .RS
-.B ./location CX us Gu
+.B ./location CX AU cA cz gb us Ie
 .RE
 .sp
 .PP


### PR DESCRIPTION

I also want to say a couple things that were not mentioned in the
previous commit that were added or changed.

Most importantly one can now specify more than one name arg.

Also the -c option to jprint was changed to -T and -c was given the same 
meaning as grep -c.
