### PR TITLE
New jprint version - allow setting max tree depth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
-## Release 1.0.4 2023-06-05
+## Release 1.0.5 2023-06-05
+
+`jprint` now accepts a `-m max_depth` option to allow for one to specify maximum
+depth to traverse the json tree, assuming it's valid JSON. Defaults to
+`JSON_DEFAULT_MAX_DEPTH == 256`. With debug level `DBG_NONE` (this will change
+to a higher level once the tool is complete or closer to being complete) says
+what the limit is, indicating that 0 is no limit and 256 is the default.
+
+
+## Release 1.0.4 2023-06-04
 
 Split the location table into `soup/location_tbl.c` and
 the location table related utilities into c`soup/location_util.c`.

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -456,7 +456,7 @@ jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
 
-jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h
+jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
 jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'e':
-	    encode_strings = true; 
+	    encode_strings = true;
 	    break;
 	case 'Q':
 	    quote_strings = true;

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -24,12 +24,17 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <regex.h> /* for regular expression matching */
+#include <regex.h> /* for -g, regular expression matching */
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
 #include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
 
 /*
  * util - entry common utility functions for the IOCCC toolkit
@@ -52,6 +57,6 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.4 2023-06-04"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
 
 #endif /* !defined INCLUDE_JPRINT_H */


### PR DESCRIPTION

Specifying -m depth sets the maximum depth the tool will traverse in the
JSON tree. Used only if the json is valid.

Explicitly include dyn_array.h and update Makefile to be clear on this.

Updated CHANGES.md for new jprint version. Fixed date of previous 
release as well: it said it was 5 June but that's today, not yesterday.