### PR TITLE
Clarify last usage message number in jprint.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
-## Release 1.0.4 2023-06-05
+## Release 1.0.5 2023-06-05
+
+`jprint` now accepts a `-m max_depth` option to allow for one to specify maximum
+depth to traverse the json tree, assuming it's valid JSON. Defaults to
+`JSON_DEFAULT_MAX_DEPTH == 256`. With debug level `DBG_NONE` (this will change
+to a higher level once the tool is complete or closer to being complete) says
+what the limit is, indicating that 0 is no limit and 256 is the default.
+
+
+## Release 1.0.4 2023-06-04
 
 Split the location table into `soup/location_tbl.c` and
 the location table related utilities into c`soup/location_util.c`.

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -456,7 +456,7 @@ jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
 
-jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h
+jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
 jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'e':
-	    encode_strings = true; 
+	    encode_strings = true;
 	    break;
 	case 'Q':
 	    quote_strings = true;

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -125,6 +125,13 @@ static const char * const usage_msg2 =
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
     "\t\t\tNOTE: max_depth of 0 implies use of JSON_INFINITE_DEPTH: use this with extreme caution.\n";
 
+/*
+ * NOTE: this next one should be the last number; if any additional usage message strings
+ * have to be added the first additional one should be the number this is and this one
+ * should be changed to be the final string before this one + 1. Similarly if a
+ * string can be removed this one should have its number changed to be + 1 from
+ * the last one before it.
+ */
 static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -24,12 +24,17 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <regex.h> /* for regular expression matching */
+#include <regex.h> /* for -g, regular expression matching */
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
 #include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
 
 /*
  * util - entry common utility functions for the IOCCC toolkit
@@ -52,6 +57,6 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.4 2023-06-04"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
 
 #endif /* !defined INCLUDE_JPRINT_H */


### PR DESCRIPTION

The last usage string is for the end (how surprising :-) ) of the usage
message but if any additional strings have to be added (or removed) the
last number should be changed. Likely it'll be possible to remove one as
the string will be reduced in size once more is done with the tool (and
thus I don't need to see the usage as much) but this will be found out
later.
