### PR TITLE
Parse -t type in jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
-## Release 1.0.4 2023-06-05
+## Release 1.0.5 2023-06-05
+
+`jprint` now accepts a `-m max_depth` option to allow for one to specify maximum
+depth to traverse the json tree, assuming it's valid JSON. Defaults to
+`JSON_DEFAULT_MAX_DEPTH == 256`. With debug level `DBG_NONE` (this will change
+to a higher level once the tool is complete or closer to being complete) says
+what the limit is, indicating that 0 is no limit and 256 is the default.
+
+
+## Release 1.0.4 2023-06-04
 
 Split the location table into `soup/location_tbl.c` and
 the location table related utilities into c`soup/location_util.c`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ depth to traverse the json tree, assuming it's valid JSON. Defaults to
 to a higher level once the tool is complete or closer to being complete) says
 what the limit is, indicating that 0 is no limit and 256 is the default.
 
+`jprint` now parses the `-t type` comma-separated option. Currently is a
+bitvector but this might change as more is developed (bitvector was not the
+first thought).
+
 
 ## Release 1.0.4 2023-06-04
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -456,7 +456,10 @@ jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
 
-jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
+jprint_util.o: jprint_util.c jprint_util.h jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
+	${CC} ${CFLAGS} jprint_util.c -c
+
+jprint.o: jprint.c jparse.h jprint_util.o json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
 jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
@@ -956,7 +959,8 @@ jparse.tab.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h \
 jparse_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
     jparse_main.c jparse_main.h json_parse.h json_sem.h json_util.h util.h
 jprint.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
-    jprint.c jprint.h json_parse.h json_sem.h json_util.h util.h
+    jprint.c jprint.h jprint_util.h json_parse.h json_sem.h json_util.h \
+    util.h
 jsemtblgen.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../iocccsize.h jparse.h \
     jparse.tab.h jsemtblgen.c jsemtblgen.h json_parse.h json_sem.h \
     json_util.h util.h

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -456,7 +456,7 @@ jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
 
-jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h
+jprint.o: jprint.c jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
 jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -104,7 +104,7 @@ static const char * const usage_msg2 =
     "\t-B\t\tWhen printing JSON syntax, start with a { line and end with a } line\n"
     "\t\t\tUse of -B without -j has no effect.\n\n"
     "\t-I {t,number}\tWhen printing JSON syntax, indent levels (i.e. '-I 4') (def: do not indent i.e. '-I 0')\n"
-    "\t\t\tIndent levels by tab or spaces (i.e. '-t 4').\n"
+    "\t\t\tIndent levels by tab or spaces (i.e. '-I 4').\n"
     "\t\t\tUse of -I {t,number} without -j has no effect.\n"
     "\t-I tab\t\tAlias for '-I t'.\n\n"
     "\t-j\t\tPrint using JSON syntax (def: do not).\n"

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -8,8 +8,6 @@
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
- * and:
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * The JSON parser was co-developed in 2022 by Cody and Landon.
  *

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'e':
-	    encode_strings = true; 
+	    encode_strings = true;
 	    break;
 	case 'Q':
 	    quote_strings = true;

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -361,7 +361,7 @@ int main(int argc, char **argv)
 	 * processing is complete
 	 */
 	dbg(DBG_NONE,"pattern requested: %s", argv[i]);
-	/*
+	/*\n"
 	 * XXX if matches found we set the boolean match_found to true to
 	 * indicate exit code of 0 but currently no matches are checked. In
 	 * other words in the future this setting of match_found will not always

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -125,6 +125,13 @@ static const char * const usage_msg2 =
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
     "\t\t\tNOTE: max_depth of 0 implies use of JSON_INFINITE_DEPTH: use this with extreme caution.\n";
 
+/*
+ * NOTE: this next one should be the last number; if any additional usage message strings
+ * have to be added the first additional one should be the number this is and this one
+ * should be changed to be the final string before this one + 1. Similarly if a
+ * string can be removed this one should have its number changed to be + 1 from
+ * the last one before it.
+ */
 static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -7,8 +7,6 @@
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
- * and:
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * The JSON parser was co-developed in 2022 by Cody and Landon.
  *

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -62,4 +62,22 @@
 /* jprint version string */
 #define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
 
+/* -t types */
+#define JPRINT_TYPE_NONE    (0)
+#define JPRINT_TYPE_INT	    (1)
+#define JPRINT_TYPE_FLOAT   (2)
+#define JPRINT_TYPE_EXP	    (4)
+#define JPRINT_TYPE_NUM	    (8)
+#define JPRINT_TYPE_BOOL    (16)
+#define JPRINT_TYPE_STR	    (32)
+#define JPRINT_TYPE_NULL    (64)
+#define JPRINT_TYPE_OBJECT  (128)
+#define JPRINT_TYPE_ARRAY   (256)
+#define JPRINT_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JPRINT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JPRINT_TYPE_SIMPLE  (JPRINT_TYPE_NUM|JPRINT_TYPE_BOOL|JPRINT_TYPE_STR|JPRINT_TYPE_NULL)
+/* JPRINT_TYPE_COMPOUND is bitwise OR of object and array */
+#define JPRINT_TYPE_COMPOUND (JPRINT_TYPE_OBJECT|JPRINT_TYPE_ARRAY)
+
+
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -24,12 +24,17 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <regex.h> /* for regular expression matching */
+#include <regex.h> /* for -g, regular expression matching */
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
 #include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
 
 /*
  * util - entry common utility functions for the IOCCC toolkit
@@ -52,6 +57,6 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.4 2023-06-04"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -8,8 +8,6 @@
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
- * and:
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * The JSON parser was co-developed in 2022 by Cody and Landon.
  *

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -1,0 +1,23 @@
+/*
+ * jprint_util - utility functions for JSON printer jprint
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#include "jprint_util.h"

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -7,8 +7,6 @@
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
- * and:
- *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * The JSON parser was co-developed in 2022 by Cody and Landon.
  *

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -1,4 +1,4 @@
-/* jprint - JSON printer
+/* jprint_util - utility functions for JSON printer jprint
  *
  * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
  *
@@ -19,8 +19,8 @@
  */
 
 
-#if !defined(INCLUDE_JPRINT_H)
-#    define  INCLUDE_JPRINT_H
+#if !defined(INCLUDE_JPRINT_UTIL_H)
+#    define  INCLUDE_JPRINT_UTIL_H
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -52,16 +52,8 @@
 #include "json_util.h"
 
 /*
- * jprint_util - utilities we will need
- */
-#include "jprint_util.h"
-
-/*
  * jparse - JSON parser
  */
 #include "jparse.h"
 
-/* jprint version string */
-#define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
-
-#endif /* !defined INCLUDE_JPRINT_H */
+#endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION

This is currently done with a bitvector and it might change if it's 
discovered that a better way exists. But that won't be known until more
is developed. This was not even the first way I thought of. What will
stay the same is the loop going through the comma-separated optarg but
whether the keeping track and checking of types will be done differently
is TBD later.

Other comma-separated lists in the options will also likely be done in a
similar way but how the information is stored is unknown at this time.

Updated CHANGES.md.