### PR TITLE
Fix exit code for no name_arg specified in jprint

### DIFF
--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -462,7 +462,7 @@ jprint_util.o: jprint_util.c jprint_util.h jparse.h json_parse.h json_util.h uti
 jprint.o: jprint.c jparse.h jprint_util.o json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
-jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jprint: jprint.o jparse.a jprint_util.o ../dyn_array/dyn_array.a ../dbg/dbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -146,7 +146,6 @@ static const char * const usage_msg3 =
  * functions
  */
 static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
-static uintmax_t parse_types_option(char *optarg);
 
 int main(int argc, char **argv)
 {
@@ -213,7 +212,7 @@ int main(int argc, char **argv)
 	    quote_strings = true;
 	    break;
 	case 't':
-	    type = parse_types_option(optarg);
+	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
 	    if (!string_to_uintmax(optarg, &max_matches)) {
@@ -389,60 +388,6 @@ int main(int argc, char **argv)
 	 */
 	exit(1); /*ooo*/
     }
-}
-
-static uintmax_t
-parse_types_option(char *optarg)
-{
-    char *p = NULL;	    /* for strtok_r() */
-    char *saveptr = NULL;   /* for strtok_r() */
-
-    uintmax_t type = JPRINT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
-
-    if (optarg == NULL || !*optarg) {
-	/* NULL or empty optarg, assume simple */
-	return type;
-    }
-
-    /*
-     * Go through comma-separated list of types, setting each as a bitvector
-     *
-     * NOTE: the way this is done might change if it proves there is a better
-     * way (and there might be - I've thought of a number of ways already).
-     */
-    for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
-	if (!strcmp(p, "int")) {
-	    type |= JPRINT_TYPE_INT;
-	} else if (!strcmp(p, "float")) {
-	    type |= JPRINT_TYPE_FLOAT;
-	} else if (!strcmp(p, "exp")) {
-	    type |= JPRINT_TYPE_EXP;
-	} else if (!strcmp(p, "num")) {
-	    type |= JPRINT_TYPE_NUM;
-	} else if (!strcmp(p, "bool")) {
-	    type |= JPRINT_TYPE_BOOL;
-	} else if (!strcmp(p, "str")) {
-	    type |= JPRINT_TYPE_STR;
-	} else if (!strcmp(p, "null")) {
-	    type |= JPRINT_TYPE_NULL;
-	} else if (!strcmp(p, "object")) {
-	    type |= JPRINT_TYPE_OBJECT;
-	} else if (!strcmp(p, "array")) {
-	    type |= JPRINT_TYPE_ARRAY;
-	} else if (!strcmp(p, "simple")) {
-	    type |= JPRINT_TYPE_SIMPLE;
-	} else if (!strcmp(p, "compound")) {
-	    type |= JPRINT_TYPE_COMPOUND;
-	} else if (!strcmp(p, "any")) {
-	    type |= JPRINT_TYPE_ANY;
-	} else {
-	    /* unknown type */
-	    err(11, __func__, "unknown type '%s'", p);
-	    not_reached();
-	}
-    }
-
-    return type;
 }
 
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -134,7 +134,7 @@ static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
     "\tExit codes:\n"
-    "\t\t0\tall is OK, file is valid JSON, match(es) found or no name_arg given\n"
+    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given\n"
     "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
     "\t\t2\t-h and help string printed or -V and version string printed\n"
     "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
     /* free tree */
     json_tree_free(json_tree, max_depth);
 
-    if (match_found) {
+    if (match_found || !pattern_specified) {
 	exit(0); /*ooo*/
     } else {
 	/*

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -50,7 +50,7 @@
 #include "json_util.h"
 
 /*
- * jprint_util - utilities we will need
+ * jprint_util - our utility functions, macros and variables
  */
 #include "jprint_util.h"
 
@@ -61,23 +61,6 @@
 
 /* jprint version string */
 #define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
-
-/* -t types */
-#define JPRINT_TYPE_NONE    (0)
-#define JPRINT_TYPE_INT	    (1)
-#define JPRINT_TYPE_FLOAT   (2)
-#define JPRINT_TYPE_EXP	    (4)
-#define JPRINT_TYPE_NUM	    (8)
-#define JPRINT_TYPE_BOOL    (16)
-#define JPRINT_TYPE_STR	    (32)
-#define JPRINT_TYPE_NULL    (64)
-#define JPRINT_TYPE_OBJECT  (128)
-#define JPRINT_TYPE_ARRAY   (256)
-#define JPRINT_TYPE_ANY	    (511) /* bitwise OR of the above values */
-/* JPRINT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
-#define JPRINT_TYPE_SIMPLE  (JPRINT_TYPE_NUM|JPRINT_TYPE_BOOL|JPRINT_TYPE_STR|JPRINT_TYPE_NULL)
-/* JPRINT_TYPE_COMPOUND is bitwise OR of object and array */
-#define JPRINT_TYPE_COMPOUND (JPRINT_TYPE_OBJECT|JPRINT_TYPE_ARRAY)
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -19,3 +19,59 @@
 
 
 #include "jprint_util.h"
+
+uintmax_t
+jprint_parse_types_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+
+    uintmax_t type = JPRINT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    }
+
+    /*
+     * Go through comma-separated list of types, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might be - I've thought of a number of ways already).
+     */
+    for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "int")) {
+	    type |= JPRINT_TYPE_INT;
+	} else if (!strcmp(p, "float")) {
+	    type |= JPRINT_TYPE_FLOAT;
+	} else if (!strcmp(p, "exp")) {
+	    type |= JPRINT_TYPE_EXP;
+	} else if (!strcmp(p, "num")) {
+	    type |= JPRINT_TYPE_NUM;
+	} else if (!strcmp(p, "bool")) {
+	    type |= JPRINT_TYPE_BOOL;
+	} else if (!strcmp(p, "str")) {
+	    type |= JPRINT_TYPE_STR;
+	} else if (!strcmp(p, "null")) {
+	    type |= JPRINT_TYPE_NULL;
+	} else if (!strcmp(p, "object")) {
+	    type |= JPRINT_TYPE_OBJECT;
+	} else if (!strcmp(p, "array")) {
+	    type |= JPRINT_TYPE_ARRAY;
+	} else if (!strcmp(p, "simple")) {
+	    type |= JPRINT_TYPE_SIMPLE;
+	} else if (!strcmp(p, "compound")) {
+	    type |= JPRINT_TYPE_COMPOUND;
+	} else if (!strcmp(p, "any")) {
+	    type |= JPRINT_TYPE_ANY;
+	} else {
+	    /* unknown type */
+	    err(11, __func__, "unknown type '%s'", p);
+	    not_reached();
+	}
+    }
+
+    return type;
+}
+
+

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -54,4 +54,27 @@
  */
 #include "jparse.h"
 
+/* defines */
+
+/* -t types */
+#define JPRINT_TYPE_NONE    (0)
+#define JPRINT_TYPE_INT	    (1)
+#define JPRINT_TYPE_FLOAT   (2)
+#define JPRINT_TYPE_EXP	    (4)
+#define JPRINT_TYPE_NUM	    (8)
+#define JPRINT_TYPE_BOOL    (16)
+#define JPRINT_TYPE_STR	    (32)
+#define JPRINT_TYPE_NULL    (64)
+#define JPRINT_TYPE_OBJECT  (128)
+#define JPRINT_TYPE_ARRAY   (256)
+#define JPRINT_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JPRINT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JPRINT_TYPE_SIMPLE  (JPRINT_TYPE_NUM|JPRINT_TYPE_BOOL|JPRINT_TYPE_STR|JPRINT_TYPE_NULL)
+/* JPRINT_TYPE_COMPOUND is bitwise OR of object and array */
+#define JPRINT_TYPE_COMPOUND (JPRINT_TYPE_OBJECT|JPRINT_TYPE_ARRAY)
+
+
+/* function prototypes */
+uintmax_t jprint_parse_types_option(char *optarg);
+
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION

The program is supposed to exit 0 if no name_arg is specified but it 
only exited 0 if one was specified and there was a match.

I also made a minor fix to the exit code wording in the usage string.