### PR TITLE
Add test match types functions

### DIFF
--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -462,7 +462,7 @@ jprint_util.o: jprint_util.c jprint_util.h jparse.h json_parse.h json_util.h uti
 jprint.o: jprint.c jparse.h jprint_util.o json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
-jprint: jprint.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jprint: jprint.o jparse.a jprint_util.o ../dyn_array/dyn_array.a ../dbg/dbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -59,7 +59,7 @@ static const char * const usage_msg0 =
     "\t\t\t\tobject\t\tJSON objects\n"
     "\t\t\t\tarray\t\tJSON array\n"
     "\t\t\t\tcompound\talias for object,array\n"
-    "\t\t\t\tany\t\tany type of value\n\n";
+    "\t\t\t\tany\t\tany type of value\n";
 
 static const char * const usage_msg1 =
     "\t-q\t\tQuiet mode (def: print stuff to stdout)\n\n"
@@ -90,7 +90,7 @@ static const char * const usage_msg1 =
     "\t\t\tUse of -b {t,number} without -j or -p b has no effect.\n"
     "\t-b tab\t\tAlias for '-b t'.\n\n"
     "\t-L\t\tPrint JSON levels, followed by tab (def: do not print levels).\n"
-    "\t\t\tThe root (top) of the JSON document is defined as level 0.\n\n";
+    "\t\t\tThe root (top) of the JSON document is defined as level 0.\n";
 
 static const char * const usage_msg2 =
     "\t-T\t\tWhen printing '-j both', separate name/value by a : (colon) (def: do not)\n"

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -146,7 +146,6 @@ static const char * const usage_msg3 =
  * functions
  */
 static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
-static uintmax_t parse_types_option(char *optarg);
 
 int main(int argc, char **argv)
 {
@@ -213,7 +212,7 @@ int main(int argc, char **argv)
 	    quote_strings = true;
 	    break;
 	case 't':
-	    type = parse_types_option(optarg);
+	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
 	    if (!string_to_uintmax(optarg, &max_matches)) {
@@ -389,60 +388,6 @@ int main(int argc, char **argv)
 	 */
 	exit(1); /*ooo*/
     }
-}
-
-static uintmax_t
-parse_types_option(char *optarg)
-{
-    char *p = NULL;	    /* for strtok_r() */
-    char *saveptr = NULL;   /* for strtok_r() */
-
-    uintmax_t type = JPRINT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
-
-    if (optarg == NULL || !*optarg) {
-	/* NULL or empty optarg, assume simple */
-	return type;
-    }
-
-    /*
-     * Go through comma-separated list of types, setting each as a bitvector
-     *
-     * NOTE: the way this is done might change if it proves there is a better
-     * way (and there might be - I've thought of a number of ways already).
-     */
-    for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
-	if (!strcmp(p, "int")) {
-	    type |= JPRINT_TYPE_INT;
-	} else if (!strcmp(p, "float")) {
-	    type |= JPRINT_TYPE_FLOAT;
-	} else if (!strcmp(p, "exp")) {
-	    type |= JPRINT_TYPE_EXP;
-	} else if (!strcmp(p, "num")) {
-	    type |= JPRINT_TYPE_NUM;
-	} else if (!strcmp(p, "bool")) {
-	    type |= JPRINT_TYPE_BOOL;
-	} else if (!strcmp(p, "str")) {
-	    type |= JPRINT_TYPE_STR;
-	} else if (!strcmp(p, "null")) {
-	    type |= JPRINT_TYPE_NULL;
-	} else if (!strcmp(p, "object")) {
-	    type |= JPRINT_TYPE_OBJECT;
-	} else if (!strcmp(p, "array")) {
-	    type |= JPRINT_TYPE_ARRAY;
-	} else if (!strcmp(p, "simple")) {
-	    type |= JPRINT_TYPE_SIMPLE;
-	} else if (!strcmp(p, "compound")) {
-	    type |= JPRINT_TYPE_COMPOUND;
-	} else if (!strcmp(p, "any")) {
-	    type |= JPRINT_TYPE_ANY;
-	} else {
-	    /* unknown type */
-	    err(11, __func__, "unknown type '%s'", p);
-	    not_reached();
-	}
-    }
-
-    return type;
 }
 
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -134,7 +134,7 @@ static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
     "\tExit codes:\n"
-    "\t\t0\tall is OK, file is valid JSON, match(es) found or no name_arg given\n"
+    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given\n"
     "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
     "\t\t2\t-h and help string printed or -V and version string printed\n"
     "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
     /* free tree */
     json_tree_free(json_tree, max_depth);
 
-    if (match_found) {
+    if (match_found || !pattern_specified) {
 	exit(0); /*ooo*/
     } else {
 	/*

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -50,7 +50,7 @@
 #include "json_util.h"
 
 /*
- * jprint_util - utilities we will need
+ * jprint_util - our utility functions, macros and variables
  */
 #include "jprint_util.h"
 
@@ -61,23 +61,6 @@
 
 /* jprint version string */
 #define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
-
-/* -t types */
-#define JPRINT_TYPE_NONE    (0)
-#define JPRINT_TYPE_INT	    (1)
-#define JPRINT_TYPE_FLOAT   (2)
-#define JPRINT_TYPE_EXP	    (4)
-#define JPRINT_TYPE_NUM	    (8)
-#define JPRINT_TYPE_BOOL    (16)
-#define JPRINT_TYPE_STR	    (32)
-#define JPRINT_TYPE_NULL    (64)
-#define JPRINT_TYPE_OBJECT  (128)
-#define JPRINT_TYPE_ARRAY   (256)
-#define JPRINT_TYPE_ANY	    (511) /* bitwise OR of the above values */
-/* JPRINT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
-#define JPRINT_TYPE_SIMPLE  (JPRINT_TYPE_NUM|JPRINT_TYPE_BOOL|JPRINT_TYPE_STR|JPRINT_TYPE_NULL)
-/* JPRINT_TYPE_COMPOUND is bitwise OR of object and array */
-#define JPRINT_TYPE_COMPOUND (JPRINT_TYPE_OBJECT|JPRINT_TYPE_ARRAY)
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -19,3 +19,59 @@
 
 
 #include "jprint_util.h"
+
+uintmax_t
+jprint_parse_types_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+
+    uintmax_t type = JPRINT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    }
+
+    /*
+     * Go through comma-separated list of types, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might be - I've thought of a number of ways already).
+     */
+    for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "int")) {
+	    type |= JPRINT_TYPE_INT;
+	} else if (!strcmp(p, "float")) {
+	    type |= JPRINT_TYPE_FLOAT;
+	} else if (!strcmp(p, "exp")) {
+	    type |= JPRINT_TYPE_EXP;
+	} else if (!strcmp(p, "num")) {
+	    type |= JPRINT_TYPE_NUM;
+	} else if (!strcmp(p, "bool")) {
+	    type |= JPRINT_TYPE_BOOL;
+	} else if (!strcmp(p, "str")) {
+	    type |= JPRINT_TYPE_STR;
+	} else if (!strcmp(p, "null")) {
+	    type |= JPRINT_TYPE_NULL;
+	} else if (!strcmp(p, "object")) {
+	    type |= JPRINT_TYPE_OBJECT;
+	} else if (!strcmp(p, "array")) {
+	    type |= JPRINT_TYPE_ARRAY;
+	} else if (!strcmp(p, "simple")) {
+	    type |= JPRINT_TYPE_SIMPLE;
+	} else if (!strcmp(p, "compound")) {
+	    type |= JPRINT_TYPE_COMPOUND;
+	} else if (!strcmp(p, "any")) {
+	    type |= JPRINT_TYPE_ANY;
+	} else {
+	    /* unknown type */
+	    err(11, __func__, "unknown type '%s'", p);
+	    not_reached();
+	}
+    }
+
+    return type;
+}
+
+

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -20,6 +20,191 @@
 
 #include "jprint_util.h"
 
+/*
+ * match_none	- if no types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types == 0.
+ */
+bool
+match_none(uintmax_t types)
+{
+    return types == JPRINT_TYPE_NONE;
+}
+/*
+ * match_int	- if ints should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_INT set.
+ */
+bool
+match_int(uintmax_t types)
+{
+    return types & JPRINT_TYPE_INT;
+}
+/*
+ * match_float	- if floats should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_FLOAT set.
+ */
+bool
+match_float(uintmax_t types)
+{
+    return types & JPRINT_TYPE_FLOAT;
+}
+/*
+ * match_exp	- if exponents should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_EXP set.
+ */
+bool
+match_exp(uintmax_t types)
+{
+    return types & JPRINT_TYPE_EXP;
+}
+/*
+ * match_bool	- if booleans should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_BOOL set.
+ */
+bool
+match_bool(uintmax_t types)
+{
+    return types & JPRINT_TYPE_BOOL;
+}
+/*
+ * match_string	    - if strings should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_STR set.
+ */
+bool
+match_string(uintmax_t types)
+{
+    return types & JPRINT_TYPE_STR;
+}
+/*
+ * match_null	- if null should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_NULL set.
+ */
+bool
+match_null(uintmax_t types)
+{
+    return types & JPRINT_TYPE_NULL;
+}
+/*
+ * match_object	    - if objects should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_OBJECT set.
+ */
+bool
+match_object(uintmax_t types)
+{
+    return types & JPRINT_TYPE_OBJECT;
+}
+/*
+ * match_array	    - if arrays should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JPRINT_TYPE_ARRAY set.
+ */
+bool
+match_array(uintmax_t types)
+{
+    return types & JPRINT_TYPE_ARRAY;
+}
+/*
+ * match_any	- if any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has any type set.
+ */
+bool
+match_any(uintmax_t types)
+{
+    return types & JPRINT_TYPE_ANY;
+}
+/*
+ * match_simple	- if simple types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Simple is defined as a number, a bool, a string or a null.
+ *
+ * Returns true if types has JPRINT_TYPE_SIMPLE set.
+ */
+bool
+match_simple(uintmax_t types)
+{
+    return types & JPRINT_TYPE_SIMPLE;
+}
+/*
+ * match_compound   - if compounds should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * A compound is defined as an object or array.
+ *
+ * Returns true if types has JPRINT_TYPE_COMPOUND set.
+ */
+bool
+match_compound(uintmax_t types)
+{
+    return types & JPRINT_TYPE_COMPOUND;
+}
+
+/*
+ * jprint_parse_types_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JPRINT_TYPE_SIMPLE (as if '-t simple').
+ */
 uintmax_t
 jprint_parse_types_option(char *optarg)
 {

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -76,5 +76,19 @@
 
 /* function prototypes */
 uintmax_t jprint_parse_types_option(char *optarg);
+bool match_none(uintmax_t types);
+bool match_int(uintmax_t types);
+bool match_float(uintmax_t types);
+bool match_exp(uintmax_t types);
+bool match_bool(uintmax_t types);
+bool match_string(uintmax_t types);
+bool match_null(uintmax_t types);
+bool match_object(uintmax_t types);
+bool match_array(uintmax_t types);
+bool match_any(uintmax_t types);
+bool match_simple(uintmax_t types);
+bool match_compound(uintmax_t types);
+
+
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -54,4 +54,27 @@
  */
 #include "jparse.h"
 
+/* defines */
+
+/* -t types */
+#define JPRINT_TYPE_NONE    (0)
+#define JPRINT_TYPE_INT	    (1)
+#define JPRINT_TYPE_FLOAT   (2)
+#define JPRINT_TYPE_EXP	    (4)
+#define JPRINT_TYPE_NUM	    (8)
+#define JPRINT_TYPE_BOOL    (16)
+#define JPRINT_TYPE_STR	    (32)
+#define JPRINT_TYPE_NULL    (64)
+#define JPRINT_TYPE_OBJECT  (128)
+#define JPRINT_TYPE_ARRAY   (256)
+#define JPRINT_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JPRINT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JPRINT_TYPE_SIMPLE  (JPRINT_TYPE_NUM|JPRINT_TYPE_BOOL|JPRINT_TYPE_STR|JPRINT_TYPE_NULL)
+/* JPRINT_TYPE_COMPOUND is bitwise OR of object and array */
+#define JPRINT_TYPE_COMPOUND (JPRINT_TYPE_OBJECT|JPRINT_TYPE_ARRAY)
+
+
+/* function prototypes */
+uintmax_t jprint_parse_types_option(char *optarg);
+
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION

In other words whether or not a type should be matched. The following
functions were added:

    bool match_none(uintmax_t types);
    bool match_int(uintmax_t types);
    bool match_float(uintmax_t types);
    bool match_exp(uintmax_t types);
    bool match_bool(uintmax_t types);
    bool match_string(uintmax_t types);
    bool match_null(uintmax_t types);
    bool match_object(uintmax_t types);
    bool match_array(uintmax_t types);
    bool match_any(uintmax_t types);
    bool match_simple(uintmax_t types);
    bool match_compound(uintmax_t types);

but as noted yesterday it might be that something else is devised to do
this instead but bits at this time seem like a simple approach 
especially with these functions.