### PR TITLE
Finish parsing jprint options (-b, -I)

### DIFF
--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -161,8 +161,9 @@ int main(int argc, char **argv)
     bool encode_strings = false;	/* -e used */
     bool quote_strings = false;		/* -Q used */
     uintmax_t type = JPRINT_TYPE_SIMPLE;/* -t type used */
-    uintmax_t max_matches = 0;		/* -i count specified - don't show more than this many matches */
-    uintmax_t min_matches = 0;		/* -N count specified - minimum matches required */
+    struct jprint_number jprint_max_matches = { 0 }; /* -i count specified */
+    struct jprint_number jprint_min_matches = { 0 }; /* -N count specified */
+    struct jprint_number jprint_levels = { 0 }; /* -l level specified */
     uintmax_t print_type = JPRINT_PRINT_VALUE;	/* -p type specified */
     uintmax_t num_spaces = 0;		/* -b specified */
     bool print_json_levels = false;	/* -L specified */
@@ -182,7 +183,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:eQt:qj:i:N:p:b:LTCBI:jEISgcm:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qj:i:N:p:b:LTCBI:jEISgcm:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, program, "");	/*ooo*/
@@ -205,6 +206,9 @@ int main(int argc, char **argv)
 	     */
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
+	case 'l':
+	    jprint_parse_number_range(optarg, &jprint_levels);
+	    break;
 	case 'e':
 	    encode_strings = true;
 	    break;
@@ -215,25 +219,17 @@ int main(int argc, char **argv)
 	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
-	    if (!string_to_uintmax(optarg, &max_matches)) {
-		err(3, "jprint", "couldn't parse -i count"); /*ooo*/
-		not_reached();
-	    }
+	    jprint_parse_number_range(optarg, &jprint_max_matches);
 	    break;
 	case 'N':
-	    if (!string_to_uintmax(optarg, &min_matches)) {
-		err(3, "jprint", "couldn't parse -N count"); /*ooo*/
-		not_reached();
-	    }
+	    jprint_parse_number_range(optarg, &jprint_min_matches);
 	    break;
 	case 'p':
-	    /* XXX the type of this variable might have to change and in any
-	     * event must be parsed.
-	     */
 	    print_type = jprint_parse_print_option(optarg);
 	    break;
 	case 'b':
-	    /* XXX - is this the right idea ? - XXX */
+	    /* XXX this is incorrect as -b has two modes, tab and space count,
+	     * depending on optarg */
 	    if (!string_to_uintmax(optarg, &num_spaces)) {
 		err(3, "jprint", "couldn't parse -b spaces"); /*ooo*/
 		not_reached();

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'l':
-	    jprint_parse_number_range(optarg, &jprint_levels);
+	    jprint_parse_number_range("-l", optarg, &jprint_levels);
 	    break;
 	case 'e':
 	    encode_strings = true;
@@ -219,10 +219,10 @@ int main(int argc, char **argv)
 	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
-	    jprint_parse_number_range(optarg, &jprint_max_matches);
+	    jprint_parse_number_range("-i", optarg, &jprint_max_matches);
 	    break;
 	case 'N':
-	    jprint_parse_number_range(optarg, &jprint_min_matches);
+	    jprint_parse_number_range("-N", optarg, &jprint_min_matches);
 	    break;
 	case 'p':
 	    print_type = jprint_parse_print_option(optarg);

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -229,12 +229,13 @@ int main(int argc, char **argv)
 	    print_type = jprint_parse_print_option(optarg);
 	    break;
 	case 'b':
-	    /* XXX this is incorrect as -b has two modes, tab and space count,
-	     * depending on optarg */
-	    if (!string_to_uintmax(optarg, &num_spaces)) {
+	    if (!strcmp(optarg, "t") || !strcmp(optarg, "tab"))
+		num_spaces = 8;
+	    else if (!string_to_uintmax(optarg, &num_spaces)) {
 		err(3, "jprint", "couldn't parse -b spaces"); /*ooo*/
 		not_reached();
 	    }
+	    dbg(DBG_NONE, "will print %zu spaces between name and value", num_spaces);
 	    break;
 	case 'L':
 	    print_json_levels = true;
@@ -249,10 +250,13 @@ int main(int argc, char **argv)
 	    print_braces = true;
 	    break;
 	case 'I':
-	    if (!string_to_uintmax(optarg, &indent_level)) {
+	    if (!strcmp(optarg, "t") || !strcmp(optarg, "tab"))
+		indent_level = 8;
+	    else if (!string_to_uintmax(optarg, &indent_level)) {
 		err(3, "jprint", "couldn't parse -I indent_level"); /*ooo*/
 		not_reached();
 	    }
+	    dbg(DBG_NONE, "indent level set to %ju spaces", indent_level);
 	    break;
 	case 'i':
 	    case_insensitive = true; /* make case cruel :-) */

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -277,11 +277,11 @@ jprint_parse_print_option(char *optarg)
     char *p = NULL;	    /* for strtok_r() */
     char *saveptr = NULL;   /* for strtok_r() */
 
-    uintmax_t print = JPRINT_PRINT_VALUE; /* default is to print values */
+    uintmax_t print_type = JPRINT_PRINT_VALUE; /* default is to print values */
 
     if (optarg == NULL || !*optarg) {
 	/* NULL or empty optarg, assume simple */
-	return print;
+	return print_type;
     }
 
     /*
@@ -292,11 +292,11 @@ jprint_parse_print_option(char *optarg)
      */
     for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
 	if (!strcmp(p, "v") || !strcmp(p, "value")) {
-	    print |= JPRINT_PRINT_VALUE;
+	    print_type |= JPRINT_PRINT_VALUE;
 	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
-	    print |= JPRINT_PRINT_NAME;
+	    print_type |= JPRINT_PRINT_NAME;
 	} else if (!strcmp(p, "both")) {
-	    print |= JPRINT_PRINT_BOTH;
+	    print_type |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
 	    err(12, __func__, "unknown keyword '%s'", p);
@@ -304,7 +304,38 @@ jprint_parse_print_option(char *optarg)
 	}
     }
 
-    return print;
+    return print_type;
 }
 
+/* jprint_parse_number_range	- parse a number range for options -l, -n, -i
+ *
+ * given:
+ *
+ *	optarg	    - the option argument
+ *	number	    - pointer to struct number
+ *
+ * Returns true if successfully parsed.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
+ *
+ * NOTE: this function is a work in progress and is currently incomplete. The
+ * structs might very well change too.
+ */
+bool
+jprint_parse_number_range(char *optarg, struct jprint_number *number)
+{
+    /* firewall */
+    if (number == NULL) {
+	err(15, __func__, "NULL number struct");
+	not_reached();
+    } else {
+	memset(number, 0, sizeof(struct jprint_number));
+    }
 
+    if (optarg == NULL || *optarg == '\0') {
+	warn(__func__, "NULL or empty optarg, ignoring");
+	return false;
+    }
+
+    return true;
+}

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -346,6 +346,14 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));
+
+	/* don't assume everything is 0 */
+	number->exact = false;
+	number->range.min = 0;
+	number->range.max = 0;
+	number->range.inclusive = false;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
     }
 
     if (optarg == NULL || *optarg == '\0') {

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -251,7 +251,7 @@ jprint_parse_types_option(char *optarg)
 	    type |= JPRINT_TYPE_ANY;
 	} else {
 	    /* unknown type */
-	    err(11, __func__, "unknown type '%s'", p);
+	    err(6, __func__, "unknown type '%s'", p);
 	    not_reached();
 	}
     }
@@ -299,7 +299,7 @@ jprint_parse_print_option(char *optarg)
 	    print_types |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
-	    err(12, __func__, "unknown keyword '%s'", p);
+	    err(7, __func__, "unknown keyword '%s'", p);
 	    not_reached();
 	}
     }
@@ -311,30 +311,93 @@ jprint_parse_print_option(char *optarg)
  *
  * given:
  *
+ *	option	    - option string (e.g. "-l"). Used for error and debug messages.
  *	optarg	    - the option argument
  *	number	    - pointer to struct number
  *
  * Returns true if successfully parsed.
  *
- * NOTE: this function does not return on syntax error or NULL number.
+ * The following rules apply:
  *
- * NOTE: this function is a work in progress and is currently incomplete. The
- * structs might very well change too.
+ * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
+ * (1) an inclusive range is <min>:<max> e.g. -l 5:10
+ *     (1a) the minimum must be <= the max
+ * (2) a minimum number, that is num >= minimum, is <num>:
+ * (3) a maximum number, that is num <= maximum, is :<num>
+ * (4) anything else is an error
+ *
+ * See also the structs jprint_number_range and jprint_number in jprint_util.h
+ * for more details.
+ *
+ * NOTE: currently (as of 7 June 2023) the numbers are signed. This might or
+ * might not change depending on what is needed.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
  */
 bool
-jprint_parse_number_range(char *optarg, struct jprint_number *number)
+jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number)
 {
+    intmax_t max = 0;
+    intmax_t min = 0;
+
     /* firewall */
     if (number == NULL) {
-	err(13, __func__, "NULL number struct");
+	err(8, __func__, "NULL number struct for option %s", option);
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));
     }
 
     if (optarg == NULL || *optarg == '\0') {
-	warn(__func__, "NULL or empty optarg, ignoring");
+	warn(__func__, "NULL or empty optarg for %s, ignoring", option);
 	return false;
+    }
+
+    if (!strchr(optarg, ':')) {
+	if (string_to_intmax(optarg, &number->number)) {
+	    number->exact = true;
+	    number->range.min = 0;
+	    number->range.max = 0;
+	    number->range.inclusive = false;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    dbg(DBG_NONE, "exact number required for option %s: %jd", option, number->number);
+	} else {
+	    err(9, __func__, "invalid number for option %s: <%s>", option, optarg);
+	    not_reached();
+	}
+    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
+	if (min > max) {
+	    err(10, __func__, "invalid inclusive range for option %s: min > max: %jd > %jd", option, min, max);
+	    not_reached();
+	}
+	number->range.min = min;
+	number->range.max = max;
+	number->range.inclusive = true;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
+	dbg(DBG_NONE, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min, number->range.max);
+    } else if (sscanf(optarg, "%jd:", &min) == 1) {
+	number->number = 0;
+	number->exact = false;
+	number->range.min = min;
+	number->range.max = number->range.min;
+	number->range.greater_than_equal = true;
+	number->range.less_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_NONE, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+    } else if (sscanf(optarg, ":%jd", &max) == 1) {
+	number->range.max = max;
+	number->range.min = number->range.max;
+	number->number = 0;
+	number->exact = false;
+	number->range.less_than_equal = true;
+	number->range.greater_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_NONE, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+    } else {
+	err(11, __func__, "number range syntax error for option %s: <%s>", option, optarg);
+	not_reached();
     }
 
     return true;

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -307,7 +307,7 @@ jprint_parse_print_option(char *optarg)
     return print_types;
 }
 
-/* jprint_parse_number_range	- parse a number range for options -l, -n, -i
+/* jprint_parse_number_range	- parse a number range for options -l, -N, -n
  *
  * given:
  *

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -277,11 +277,11 @@ jprint_parse_print_option(char *optarg)
     char *p = NULL;	    /* for strtok_r() */
     char *saveptr = NULL;   /* for strtok_r() */
 
-    uintmax_t print_type = JPRINT_PRINT_VALUE; /* default is to print values */
+    uintmax_t print_types = JPRINT_PRINT_VALUE; /* default is to print values */
 
     if (optarg == NULL || !*optarg) {
 	/* NULL or empty optarg, assume simple */
-	return print_type;
+	return print_types;
     }
 
     /*
@@ -292,11 +292,11 @@ jprint_parse_print_option(char *optarg)
      */
     for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
 	if (!strcmp(p, "v") || !strcmp(p, "value")) {
-	    print_type |= JPRINT_PRINT_VALUE;
+	    print_types |= JPRINT_PRINT_VALUE;
 	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
-	    print_type |= JPRINT_PRINT_NAME;
+	    print_types |= JPRINT_PRINT_NAME;
 	} else if (!strcmp(p, "both")) {
-	    print_type |= JPRINT_PRINT_BOTH;
+	    print_types |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
 	    err(12, __func__, "unknown keyword '%s'", p);
@@ -304,7 +304,7 @@ jprint_parse_print_option(char *optarg)
 	}
     }
 
-    return print_type;
+    return print_types;
 }
 
 /* jprint_parse_number_range	- parse a number range for options -l, -n, -i
@@ -326,7 +326,7 @@ jprint_parse_number_range(char *optarg, struct jprint_number *number)
 {
     /* firewall */
     if (number == NULL) {
-	err(15, __func__, "NULL number struct");
+	err(13, __func__, "NULL number struct");
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -82,21 +82,20 @@
 /* structs for various options */
 
 /* number ranges for the options -l, -i and -n */
-/* XXX - that these two structs are works in progress - XXX */
 struct jprint_number_range
 {
     intmax_t min;   /* min in range */
     intmax_t max;   /* max in range */
     
-    bool less_than_equal;	/* if number type must be <= min */
-    bool greater_than_equal;	/* if number type must be >= max */
-    bool inclusive;		/* if number type must be >= min && <= max */
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
 };
 struct jprint_number
 {
     /* exact number if >= 0 */
-    intmax_t number;		/* for exact number (must be >= 0) */
-    bool exact;			/* if an exact match must be found and number != -1 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
 
     /* for number ranges */
     struct jprint_number_range range;	/* for ranges */
@@ -123,6 +122,6 @@ bool jprint_match_compound(uintmax_t types);
 uintmax_t jprint_parse_print_option(char *optarg);
 
 /* for number range options: -l, -n, -i */
-bool jprint_parse_number_range(char *optarg, struct jprint_number *number);
+bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
@@ -78,6 +79,29 @@
 #define JPRINT_PRINT_VALUE  (2)
 #define JPRINT_PRINT_BOTH   (JPRINT_PRINT_NAME | JPRINT_PRINT_VALUE)
 
+/* structs for various options */
+
+/* number ranges for the options -l, -i and -n */
+/* XXX - that these two structs are works in progress - XXX */
+struct jprint_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+    
+    bool less_than_equal;	/* if number type must be <= min */
+    bool greater_than_equal;	/* if number type must be >= max */
+    bool inclusive;		/* if number type must be >= min && <= max */
+};
+struct jprint_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* for exact number (must be >= 0) */
+    bool exact;			/* if an exact match must be found and number != -1 */
+
+    /* for number ranges */
+    struct jprint_number_range range;	/* for ranges */
+};
+
 /* function prototypes */
 
 /* JSON types - -t option*/
@@ -97,5 +121,8 @@ bool jprint_match_compound(uintmax_t types);
 
 /* what to print - -p option */
 uintmax_t jprint_parse_print_option(char *optarg);
+
+/* for number range options: -l, -n, -i */
+bool jprint_parse_number_range(char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -81,7 +81,7 @@
 
 /* structs for various options */
 
-/* number ranges for the options -l, -i and -n */
+/* number ranges for the options -l, -n and -n */
 struct jprint_number_range
 {
     intmax_t min;   /* min in range */
@@ -121,7 +121,7 @@ bool jprint_match_compound(uintmax_t types);
 /* what to print - -p option */
 uintmax_t jprint_parse_print_option(char *optarg);
 
-/* for number range options: -l, -n, -i */
+/* for number range options: -l, -n, -n */
 bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION

Since '\t' is 8 spaces and since the other mode for the options is 
number of spaces if optarg is "t" or "tab" set the variable to 8.
Otherwise attempt to parse as a number. If it fails to parse it's an
error.

This completes at least for now the parsing of all options if I'm not
very much mistaken. As long as I did not miss any in the long list this
is done. Once I start adding functionality (the purpose of the tool
itself) some of the options might very well change.