### PR TITLE
Fix usage strings in jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,14 @@
 
 ## Release 1.0.5 2023-06-08
 
-`jprint` version now "0.0.7 2023-06-08". At this time I (Cody) believe all known
-checks for `jprint` options have been added!
+`jprint` version "0.0.8 2023-06-08". At this time I (Cody) believe all known
+checks for `jprint` options have been added. Also test functions for the number
+range code has been added and run successfully! To run test code pass in `-K` to
+`jprint`.
 
 The next step is to write some test functions (likely printing debug
-messages for different options and their option arguments).
+messages for different options and their option arguments). Currently (as of
+version 0.0.8) the number range test functions are successful.
 
 If all is OK the code to traverse the tree to look for simple matches (this does
 not mean the `JPRINT_TYPE_SIMPLE`) can be added. At first the tool will not

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ what the limit is, indicating that 0 is no limit and 256 is the default.
 bitvector but this might change as more is developed (bitvector was not the
 first thought).
 
+New `jprint` version "0.0.6 2023-06-07". It now parses all options and most test
+functions for options being set are added as well. This version is backdated to
+7 June because this was done on the 7th of June but the version was not updated.
 
 ## Release 1.0.4 2023-06-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Major changes to the IOCCC entry toolkit
 
+
+## Release 1.0.5 2023-06-08
+
+`jprint` version now "0.0.7 2023-06-08". At this time I (Cody) believe all known
+checks for `jprint` options have been added!
+
+The next step is to write some test functions (likely printing debug
+messages for different options and their option arguments).
+
+If all is OK the code to traverse the tree to look for simple matches (this does
+not mean the `JPRINT_TYPE_SIMPLE`) can be added. At first the tool will not
+check for the constraints but rather just print the name and value (even though
+the default is value (`JPRINT_PRINT_VALUE`) only I want to make sure that the
+ability to to print both is there).  This will help make sure that the
+traversing works okay before constraints are added. Prior to the following step,
+described below, the grep-like functionality, using `regex.h`, can be added (it
+might be better to instead add the grep-like functionality after the below - the
+constraints - are added but this will be determined at the time).
+
+Once the above is okay the constraints can be added. The tests should be easier
+to do than the traversing and following parts but my hope is that in the coming
+days more than tests can be added.
+
+Once this is all done a comprehensive test script can be added to the repo that
+is called by the entire test suite (including `bug_report.sh`) so that we can
+verify that `jprint` works as expected. Then any issues can be fixed and the
+tests can be run again. This might take more than a few days but hopefully
+things will move along nicely.
+
 ## Release 1.0.5 2023-06-05
 
 `jprint` now accepts a `-m max_depth` option to allow for one to specify maximum

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -459,10 +459,13 @@ json_sem.o: json_sem.c
 jprint_util.o: jprint_util.c jprint_util.h jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint_util.c -c
 
-jprint.o: jprint.c jparse.h jprint_util.o json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
+jprint_test.o: jprint_test.c jprint_util.o jprint_util.h jparse.h json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
+	${CC} ${CFLAGS} jprint_test.c -c
+
+jprint.o: jprint.c jparse.h jprint_util.o jprint_test.o json_parse.h json_util.h util.h ../dyn_array/dyn_array.h ../dbg/dbg.h
 	${CC} ${CFLAGS} jprint.c -c
 
-jprint: jprint.o jparse.a jprint_util.o ../dyn_array/dyn_array.a ../dbg/dbg.a
+jprint: jprint.o jparse.a jprint_util.o jprint_test.o ../dyn_array/dyn_array.a ../dbg/dbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 
@@ -959,8 +962,8 @@ jparse.tab.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h \
 jparse_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
     jparse_main.c jparse_main.h json_parse.h json_sem.h json_util.h util.h
 jprint.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
-    jprint.c jprint.h jprint_util.h json_parse.h json_sem.h json_util.h \
-    util.h
+    jprint.c jprint.h jprint_test.h jprint_util.h json_parse.h json_sem.h \
+    json_util.h util.h
 jsemtblgen.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../iocccsize.h jparse.h \
     jparse.tab.h jsemtblgen.c jsemtblgen.h json_parse.h json_sem.h \
     json_util.h util.h

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -161,8 +161,9 @@ int main(int argc, char **argv)
     bool encode_strings = false;	/* -e used */
     bool quote_strings = false;		/* -Q used */
     uintmax_t type = JPRINT_TYPE_SIMPLE;/* -t type used */
-    uintmax_t max_matches = 0;		/* -i count specified - don't show more than this many matches */
-    uintmax_t min_matches = 0;		/* -N count specified - minimum matches required */
+    struct jprint_number jprint_max_matches = { 0 }; /* -i count specified */
+    struct jprint_number jprint_min_matches = { 0 }; /* -N count specified */
+    struct jprint_number jprint_levels = { 0 }; /* -l level specified */
     uintmax_t print_type = JPRINT_PRINT_VALUE;	/* -p type specified */
     uintmax_t num_spaces = 0;		/* -b specified */
     bool print_json_levels = false;	/* -L specified */
@@ -182,7 +183,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:eQt:qj:i:N:p:b:LTCBI:jEISgcm:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qj:i:N:p:b:LTCBI:jEISgcm:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, program, "");	/*ooo*/
@@ -205,6 +206,9 @@ int main(int argc, char **argv)
 	     */
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
+	case 'l':
+	    jprint_parse_number_range(optarg, &jprint_levels);
+	    break;
 	case 'e':
 	    encode_strings = true;
 	    break;
@@ -215,25 +219,17 @@ int main(int argc, char **argv)
 	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
-	    if (!string_to_uintmax(optarg, &max_matches)) {
-		err(3, "jprint", "couldn't parse -i count"); /*ooo*/
-		not_reached();
-	    }
+	    jprint_parse_number_range(optarg, &jprint_max_matches);
 	    break;
 	case 'N':
-	    if (!string_to_uintmax(optarg, &min_matches)) {
-		err(3, "jprint", "couldn't parse -N count"); /*ooo*/
-		not_reached();
-	    }
+	    jprint_parse_number_range(optarg, &jprint_min_matches);
 	    break;
 	case 'p':
-	    /* XXX the type of this variable might have to change and in any
-	     * event must be parsed.
-	     */
 	    print_type = jprint_parse_print_option(optarg);
 	    break;
 	case 'b':
-	    /* XXX - is this the right idea ? - XXX */
+	    /* XXX this is incorrect as -b has two modes, tab and space count,
+	     * depending on optarg */
 	    if (!string_to_uintmax(optarg, &num_spaces)) {
 		err(3, "jprint", "couldn't parse -b spaces"); /*ooo*/
 		not_reached();

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'l':
-	    jprint_parse_number_range(optarg, &jprint_levels);
+	    jprint_parse_number_range("-l", optarg, &jprint_levels);
 	    break;
 	case 'e':
 	    encode_strings = true;
@@ -219,10 +219,10 @@ int main(int argc, char **argv)
 	    type = jprint_parse_types_option(optarg);
 	    break;
 	case 'i':
-	    jprint_parse_number_range(optarg, &jprint_max_matches);
+	    jprint_parse_number_range("-i", optarg, &jprint_max_matches);
 	    break;
 	case 'N':
-	    jprint_parse_number_range(optarg, &jprint_min_matches);
+	    jprint_parse_number_range("-N", optarg, &jprint_min_matches);
 	    break;
 	case 'p':
 	    print_type = jprint_parse_print_option(optarg);

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -229,12 +229,13 @@ int main(int argc, char **argv)
 	    print_type = jprint_parse_print_option(optarg);
 	    break;
 	case 'b':
-	    /* XXX this is incorrect as -b has two modes, tab and space count,
-	     * depending on optarg */
-	    if (!string_to_uintmax(optarg, &num_spaces)) {
+	    if (!strcmp(optarg, "t") || !strcmp(optarg, "tab"))
+		num_spaces = 8;
+	    else if (!string_to_uintmax(optarg, &num_spaces)) {
 		err(3, "jprint", "couldn't parse -b spaces"); /*ooo*/
 		not_reached();
 	    }
+	    dbg(DBG_NONE, "will print %zu spaces between name and value", num_spaces);
 	    break;
 	case 'L':
 	    print_json_levels = true;
@@ -249,10 +250,13 @@ int main(int argc, char **argv)
 	    print_braces = true;
 	    break;
 	case 'I':
-	    if (!string_to_uintmax(optarg, &indent_level)) {
+	    if (!strcmp(optarg, "t") || !strcmp(optarg, "tab"))
+		indent_level = 8;
+	    else if (!string_to_uintmax(optarg, &indent_level)) {
 		err(3, "jprint", "couldn't parse -I indent_level"); /*ooo*/
 		not_reached();
 	    }
+	    dbg(DBG_NONE, "indent level set to %ju spaces", indent_level);
 	    break;
 	case 'i':
 	    case_insensitive = true; /* make case cruel :-) */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -121,8 +121,8 @@ static const char * const usage_msg2 =
     "\t\t\tUse of -g conflicts with -S.\n"
     "\t-c\t\tOnly show count of matches found\n"
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
-    "\t-K\t\tRun tests on options parsed\n"
-    "\t\t\tNOTE: max_depth of 0 implies use of JSON_INFINITE_DEPTH: use this with extreme caution.\n";
+    "\t\t\tNOTE: max_depth of 0 implies use of JSON_INFINITE_DEPTH: use this with extreme caution.\n"
+    "\t-K\t\tRun tests on jprint constraints\n";
 
 /*
  * NOTE: this next one should be the last number; if any additional usage message strings

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -39,7 +39,7 @@ static bool quiet = false;				/* true ==> quiet mode */
 static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-Q] [-t type] [-q] [-j lvl] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b {t,number}] [-L] [-T] [-C] [-B] [-I {t,number}] [-j] [-E]\n"
-    "\t\t[-I] [-S] [-g] [-c] [-m depth] file.json [name_arg ...]\n\n"
+    "\t\t[-I] [-S] [-g] [-c] [-m depth] [-K] file.json [name_arg ...]\n\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
     "\t-v level\tVerbosity level (def: %d)\n"
@@ -121,6 +121,7 @@ static const char * const usage_msg2 =
     "\t\t\tUse of -g conflicts with -S.\n"
     "\t-c\t\tOnly show count of matches found\n"
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
+    "\t-K\t\tRun tests on options parsed\n"
     "\t\t\tNOTE: max_depth of 0 implies use of JSON_INFINITE_DEPTH: use this with extreme caution.\n";
 
 /*
@@ -184,7 +185,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qj:n:N:p:b:LTCBI:jEiSgcm:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qj:n:N:p:b:LTCBI:jEiSgcm:K")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    usage(2, program, "");	/*ooo*/
@@ -286,6 +287,9 @@ int main(int argc, char **argv)
 		err(3, "jprint", "couldn't parse -m depth"); /*ooo*/
 		not_reached();
 	    }
+	    break;
+	case 'K': /* run test code */
+	    return jprint_run_tests(); /*ooo*/
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -135,12 +135,13 @@ static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
     "\tExit codes:\n"
-    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given\n"
+    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
     "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
     "\t\t2\t-h and help string printed or -V and version string printed\n"
     "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
     "\t\t4\tfile does not exist, not a file, or unable to read the file\n"
-    "\t\t5\tfile contents is not valid JSON\n\n"
+    "\t\t5\tfile contents is not valid JSON\n"
+    "\t\t6\ttest mode failed\n\n"
     "jprint version: %s";
 
 /*
@@ -289,7 +290,12 @@ int main(int argc, char **argv)
 	    }
 	    break;
 	case 'K': /* run test code */
-	    return jprint_run_tests(); /*ooo*/
+	    if (!jprint_run_tests()) {
+		exit(6); /*ooo*/
+	    }
+	    else {
+		exit(0); /*ooo*/
+	    }
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -60,7 +60,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.5 2023-06-05"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.6 2023-06-07"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -60,7 +60,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.6 2023-06-07"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.7 2023-06-08"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -55,12 +55,17 @@
 #include "jprint_util.h"
 
 /*
+ * jprint_test - test functions
+ */
+#include "jprint_test.h"
+
+/*
  * jparse - JSON parser
  */
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.7 2023-06-08"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.8 2023-06-08"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint_test.c
+++ b/jparse/jprint_test.c
@@ -26,7 +26,7 @@
  *
  *	void	    - no args: this function is selfish :-)
  *
- * Returns true if any test failed. Will only return after all tests are run.
+ * Returns false if any test failed. Will only return after all tests are run.
  */
 bool
 jprint_run_tests(void)

--- a/jparse/jprint_test.c
+++ b/jparse/jprint_test.c
@@ -1,0 +1,153 @@
+/*
+ * jprint_test - test functions for the jprint tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#include "jprint_test.h"
+
+/* jprint_run_tests	- run test functions
+ *
+ * given:
+ *
+ *	void	    - no args: this function is selfish :-)
+ *
+ * Returns true if any test failed. Will only return after all tests are run.
+ */
+bool
+jprint_run_tests(void)
+{
+    struct jprint_number number;    /* number range */
+    bool test = false;		    /* whether current test passes or fails */
+    bool okay = true;	    /* if any test fails set to true, is return value */
+
+    /* set up exact match of 5 */
+    jprint_parse_number_range("-l", "5", &number);
+
+    /* make sure number matches exactly */
+    test = jprint_test_number_range_opts(true, 5, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure number does NOT match */
+    test = jprint_test_number_range_opts(false, 6, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up inclusive range of >= 5 && <= 10 */
+    jprint_parse_number_range("-l", "5:10", &number);
+    /* make sure that number is in the range >= 5 && <= 10 */
+    test = jprint_test_number_range_opts(true, 6, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to >= max */
+    test = jprint_test_number_range_opts(false, 11, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jprint_test_number_range_opts(false, 4, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up minimum number */
+    jprint_parse_number_range("-l", "10:", &number);
+    /* make sure that number 10 is in the range >= 10 */
+    test = jprint_test_number_range_opts(true, 10, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 11 is in the range >= 10 */
+    test = jprint_test_number_range_opts(true, 11, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 9 is NOT >= 10 */
+    test = jprint_test_number_range_opts(false, 9, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up maximum number */
+    jprint_parse_number_range("-l", ":10", &number);
+    /* make sure that number 10 is in the range <= 10 */
+    test = jprint_test_number_range_opts(true, 10, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 9 is in the range <= 10 */
+    test = jprint_test_number_range_opts(true, 9, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 11 is NOT <= 10 */
+    test = jprint_test_number_range_opts(false, 11, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    return okay;
+}
+/* jprint_test_number_range_opts
+ *
+ * Test that the number range functionality works okay.
+ *
+ * given:
+ *
+ *	option	     	option that this is testing
+ *	expected     	whether test should return true or false
+ *	number		number to test
+ *	range		range to verify number against
+ *
+ * Returns true if test is okay.
+ *
+ * NOTE: this will not return on NULL pointers.
+ */
+bool
+jprint_test_number_range_opts(bool expected, intmax_t number, struct jprint_number *range)
+{
+    bool test = false;	    /* result of test */
+
+    if (range == NULL) {
+	err(15, __func__, "NULL range, cannot test");
+	not_reached();
+    }
+
+    test = jprint_number_in_range(number, range);
+    print("in function %s: expects %s: ", __func__, expected?"success":"failure");
+    if (range->exact) {
+	print("expect exact match for number %jd: ", number);
+    } else if (range->range.inclusive) {
+	print("expect number %jd to be >= %jd && <= %jd: ", number, range->range.min, range->range.max);
+    } else if (range->range.greater_than_equal) {
+	print("expect number %jd to be >= %ju: ", number, range->range.min);
+    } else if (range->range.less_than_equal) {
+	print("expect number %jd to be <= %jd: ", number, range->range.max);
+    }
+
+    if (expected == test) {
+	print("test %s\n", expected == test?"OK":"failed");
+    }
+
+    return expected == test;
+}

--- a/jparse/jprint_test.h
+++ b/jparse/jprint_test.h
@@ -1,0 +1,66 @@
+/* jprint_test - test functions for the jprint tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JPRINT_TEST_H)
+#    define  INCLUDE_JPRINT_TEST_H
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/*
+ * jprint_util - jprint utility functions 
+ */
+#include "jprint_util.h"
+
+bool jprint_run_tests(void);
+bool jprint_test_number_range_opts(bool expected, intmax_t number, struct jprint_number *range);
+
+#endif /* !defined INCLUDE_JPRINT_TEST_H */

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -472,3 +472,58 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 
     return true;
 }
+
+/* jprint_number_in_range   - check if number is in required range
+ *
+ * given:
+ *
+ *	number	    - number to check
+ *	range	    - pointer to struct jprint_number with range
+ *
+ * Returns true if the number is in range.
+ *
+ * NOTE: if range is NULL it will return false.
+ */
+bool
+jprint_number_in_range(intmax_t number, struct jprint_number *range)
+{
+    /* firewall check */
+    if (range == NULL) {
+	return false;
+    }
+
+    /* if exact is set and range->number == number then return true. */
+    if (range->exact && range->number == number) {
+	return true;
+    } else if (range->range.inclusive) {
+	/* if the number must be inclusive in range then we have to make sure
+	 * that number >= min and <= max.
+	 */
+	if (number >= range->range.min && number <= range->range.max) {
+	    return true;
+	} else {
+	    return false;
+	}
+    } else if (range->range.less_than_equal) {
+	/* if number has to be less than equal we check number <= the maximum
+	 * number (range->range.max).
+	 */
+	if (number <= range->range.max) {
+	    return true;
+	} else {
+	    return false;
+	}
+    } else if (range->range.greater_than_equal) {
+	/* if number has to be greater than or equal to the number then we check
+	 * that number >= minimum number (range->range.min).
+	 */
+	if (number >= range->range.min) {
+	    return true;
+	} else {
+	    return false;
+	}
+    }
+
+    return false; /* no match */
+
+}

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -277,11 +277,11 @@ jprint_parse_print_option(char *optarg)
     char *p = NULL;	    /* for strtok_r() */
     char *saveptr = NULL;   /* for strtok_r() */
 
-    uintmax_t print = JPRINT_PRINT_VALUE; /* default is to print values */
+    uintmax_t print_type = JPRINT_PRINT_VALUE; /* default is to print values */
 
     if (optarg == NULL || !*optarg) {
 	/* NULL or empty optarg, assume simple */
-	return print;
+	return print_type;
     }
 
     /*
@@ -292,11 +292,11 @@ jprint_parse_print_option(char *optarg)
      */
     for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
 	if (!strcmp(p, "v") || !strcmp(p, "value")) {
-	    print |= JPRINT_PRINT_VALUE;
+	    print_type |= JPRINT_PRINT_VALUE;
 	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
-	    print |= JPRINT_PRINT_NAME;
+	    print_type |= JPRINT_PRINT_NAME;
 	} else if (!strcmp(p, "both")) {
-	    print |= JPRINT_PRINT_BOTH;
+	    print_type |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
 	    err(12, __func__, "unknown keyword '%s'", p);
@@ -304,7 +304,38 @@ jprint_parse_print_option(char *optarg)
 	}
     }
 
-    return print;
+    return print_type;
 }
 
+/* jprint_parse_number_range	- parse a number range for options -l, -n, -i
+ *
+ * given:
+ *
+ *	optarg	    - the option argument
+ *	number	    - pointer to struct number
+ *
+ * Returns true if successfully parsed.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
+ *
+ * NOTE: this function is a work in progress and is currently incomplete. The
+ * structs might very well change too.
+ */
+bool
+jprint_parse_number_range(char *optarg, struct jprint_number *number)
+{
+    /* firewall */
+    if (number == NULL) {
+	err(15, __func__, "NULL number struct");
+	not_reached();
+    } else {
+	memset(number, 0, sizeof(struct jprint_number));
+    }
 
+    if (optarg == NULL || *optarg == '\0') {
+	warn(__func__, "NULL or empty optarg, ignoring");
+	return false;
+    }
+
+    return true;
+}

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -346,6 +346,14 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));
+
+	/* don't assume everything is 0 */
+	number->exact = false;
+	number->range.min = 0;
+	number->range.max = 0;
+	number->range.inclusive = false;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
     }
 
     if (optarg == NULL || *optarg == '\0') {

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -251,7 +251,7 @@ jprint_parse_types_option(char *optarg)
 	    type |= JPRINT_TYPE_ANY;
 	} else {
 	    /* unknown type */
-	    err(11, __func__, "unknown type '%s'", p);
+	    err(6, __func__, "unknown type '%s'", p);
 	    not_reached();
 	}
     }
@@ -299,7 +299,7 @@ jprint_parse_print_option(char *optarg)
 	    print_types |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
-	    err(12, __func__, "unknown keyword '%s'", p);
+	    err(7, __func__, "unknown keyword '%s'", p);
 	    not_reached();
 	}
     }
@@ -311,30 +311,93 @@ jprint_parse_print_option(char *optarg)
  *
  * given:
  *
+ *	option	    - option string (e.g. "-l"). Used for error and debug messages.
  *	optarg	    - the option argument
  *	number	    - pointer to struct number
  *
  * Returns true if successfully parsed.
  *
- * NOTE: this function does not return on syntax error or NULL number.
+ * The following rules apply:
  *
- * NOTE: this function is a work in progress and is currently incomplete. The
- * structs might very well change too.
+ * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
+ * (1) an inclusive range is <min>:<max> e.g. -l 5:10
+ *     (1a) the minimum must be <= the max
+ * (2) a minimum number, that is num >= minimum, is <num>:
+ * (3) a maximum number, that is num <= maximum, is :<num>
+ * (4) anything else is an error
+ *
+ * See also the structs jprint_number_range and jprint_number in jprint_util.h
+ * for more details.
+ *
+ * NOTE: currently (as of 7 June 2023) the numbers are signed. This might or
+ * might not change depending on what is needed.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
  */
 bool
-jprint_parse_number_range(char *optarg, struct jprint_number *number)
+jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number)
 {
+    intmax_t max = 0;
+    intmax_t min = 0;
+
     /* firewall */
     if (number == NULL) {
-	err(13, __func__, "NULL number struct");
+	err(8, __func__, "NULL number struct for option %s", option);
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));
     }
 
     if (optarg == NULL || *optarg == '\0') {
-	warn(__func__, "NULL or empty optarg, ignoring");
+	warn(__func__, "NULL or empty optarg for %s, ignoring", option);
 	return false;
+    }
+
+    if (!strchr(optarg, ':')) {
+	if (string_to_intmax(optarg, &number->number)) {
+	    number->exact = true;
+	    number->range.min = 0;
+	    number->range.max = 0;
+	    number->range.inclusive = false;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    dbg(DBG_NONE, "exact number required for option %s: %jd", option, number->number);
+	} else {
+	    err(9, __func__, "invalid number for option %s: <%s>", option, optarg);
+	    not_reached();
+	}
+    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
+	if (min > max) {
+	    err(10, __func__, "invalid inclusive range for option %s: min > max: %jd > %jd", option, min, max);
+	    not_reached();
+	}
+	number->range.min = min;
+	number->range.max = max;
+	number->range.inclusive = true;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
+	dbg(DBG_NONE, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min, number->range.max);
+    } else if (sscanf(optarg, "%jd:", &min) == 1) {
+	number->number = 0;
+	number->exact = false;
+	number->range.min = min;
+	number->range.max = number->range.min;
+	number->range.greater_than_equal = true;
+	number->range.less_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_NONE, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+    } else if (sscanf(optarg, ":%jd", &max) == 1) {
+	number->range.max = max;
+	number->range.min = number->range.max;
+	number->number = 0;
+	number->exact = false;
+	number->range.less_than_equal = true;
+	number->range.greater_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_NONE, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+    } else {
+	err(11, __func__, "number range syntax error for option %s: <%s>", option, optarg);
+	not_reached();
     }
 
     return true;

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -34,6 +34,7 @@ jprint_match_none(uintmax_t types)
 {
     return types == JPRINT_TYPE_NONE;
 }
+
 /*
  * jprint_match_int	- if ints should match
  *
@@ -260,6 +261,50 @@ jprint_parse_types_option(char *optarg)
 }
 
 /*
+ * jprint_print_name	- if only names should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JPRINT_PRINT_NAME set.
+ */
+bool
+jprint_print_name(uintmax_t types)
+{
+    return (types & JPRINT_PRINT_NAME) && !(types & JPRINT_PRINT_VALUE);
+}
+/*
+ * jprint_print_value	- if only values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JPRINT_PRINT_VALUE set.
+ */
+bool
+jprint_print_value(uintmax_t types)
+{
+    return (types & JPRINT_PRINT_VALUE) && !(types & JPRINT_PRINT_NAME);
+}
+/*
+ * jprint_print_both	- if names AND values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types has JPRINT_PRINT_BOTH set.
+ */
+bool
+jprint_print_name_value(uintmax_t types)
+{
+    return types == JPRINT_PRINT_BOTH;
+}
+
+
+/*
  * jprint_parse_print_option	- parse -p option list
  *
  * given:
@@ -277,11 +322,11 @@ jprint_parse_print_option(char *optarg)
     char *p = NULL;	    /* for strtok_r() */
     char *saveptr = NULL;   /* for strtok_r() */
 
-    uintmax_t print_types = JPRINT_PRINT_VALUE; /* default is to print values */
+    uintmax_t print_types = 0; /* default is to print values */
 
     if (optarg == NULL || !*optarg) {
 	/* NULL or empty optarg, assume simple */
-	return print_types;
+	return JPRINT_PRINT_VALUE;
     }
 
     /*
@@ -295,7 +340,7 @@ jprint_parse_print_option(char *optarg)
 	    print_types |= JPRINT_PRINT_VALUE;
 	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
 	    print_types |= JPRINT_PRINT_NAME;
-	} else if (!strcmp(p, "both")) {
+	} else if (!strcmp(p, "b") || !strcmp(p, "both")) {
 	    print_types |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
@@ -304,6 +349,15 @@ jprint_parse_print_option(char *optarg)
 	}
     }
 
+    if (jprint_print_name_value(print_types)) {
+	dbg(DBG_NONE, "will print both name and value");
+    }
+    else if (jprint_print_name(print_types)) {
+	dbg(DBG_NONE, "will only print name");
+    }
+    else if (jprint_print_value(print_types)) {
+	dbg(DBG_NONE, "will only print value");
+    }
     return print_types;
 }
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -159,7 +159,7 @@ jprint_match_array(uintmax_t types)
 bool
 jprint_match_any(uintmax_t types)
 {
-    return types & JPRINT_TYPE_ANY;
+    return types == JPRINT_TYPE_ANY;
 }
 /*
  * jprint_match_simple	- if simple types should match

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -307,7 +307,7 @@ jprint_parse_print_option(char *optarg)
     return print_types;
 }
 
-/* jprint_parse_number_range	- parse a number range for options -l, -n, -i
+/* jprint_parse_number_range	- parse a number range for options -l, -N, -n
  *
  * given:
  *

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -277,11 +277,11 @@ jprint_parse_print_option(char *optarg)
     char *p = NULL;	    /* for strtok_r() */
     char *saveptr = NULL;   /* for strtok_r() */
 
-    uintmax_t print_type = JPRINT_PRINT_VALUE; /* default is to print values */
+    uintmax_t print_types = JPRINT_PRINT_VALUE; /* default is to print values */
 
     if (optarg == NULL || !*optarg) {
 	/* NULL or empty optarg, assume simple */
-	return print_type;
+	return print_types;
     }
 
     /*
@@ -292,11 +292,11 @@ jprint_parse_print_option(char *optarg)
      */
     for (p = strtok_r(optarg, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
 	if (!strcmp(p, "v") || !strcmp(p, "value")) {
-	    print_type |= JPRINT_PRINT_VALUE;
+	    print_types |= JPRINT_PRINT_VALUE;
 	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
-	    print_type |= JPRINT_PRINT_NAME;
+	    print_types |= JPRINT_PRINT_NAME;
 	} else if (!strcmp(p, "both")) {
-	    print_type |= JPRINT_PRINT_BOTH;
+	    print_types |= JPRINT_PRINT_BOTH;
 	} else {
 	    /* unknown keyword */
 	    err(12, __func__, "unknown keyword '%s'", p);
@@ -304,7 +304,7 @@ jprint_parse_print_option(char *optarg)
 	}
     }
 
-    return print_type;
+    return print_types;
 }
 
 /* jprint_parse_number_range	- parse a number range for options -l, -n, -i
@@ -326,7 +326,7 @@ jprint_parse_number_range(char *optarg, struct jprint_number *number)
 {
     /* firewall */
     if (number == NULL) {
-	err(15, __func__, "NULL number struct");
+	err(13, __func__, "NULL number struct");
 	not_reached();
     } else {
 	memset(number, 0, sizeof(struct jprint_number));

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -154,7 +154,15 @@ jprint_match_array(uintmax_t types)
  *
  *	types	- types set
  *
- * Returns true if types has any type set.
+ * Returns true if types is equal to JPRINT_TYPE_ANY.
+ *
+ * Why does it have to equal JPRINT_TYPE_ANY if it checks for any type? Because
+ * the point is that if JPRINT_TYPE_ANY is set it can be any type but not
+ * specific types. For the specific types those bits have to be set instead. If
+ * JPRINT_TYPE_ANY is set then any type can be set but if types is say
+ * JPRINT_TYPE_INT then checking for JPRINT_TYPE_INT & JPRINT_TYPE_ANY would be
+ * != 0 (as it's a bitwise OR Of all the types) which would suggest that any
+ * type is okay even if JPRINT_TYPE_INT was the only type.
  */
 bool
 jprint_match_any(uintmax_t types)

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -82,21 +82,20 @@
 /* structs for various options */
 
 /* number ranges for the options -l, -i and -n */
-/* XXX - that these two structs are works in progress - XXX */
 struct jprint_number_range
 {
     intmax_t min;   /* min in range */
     intmax_t max;   /* max in range */
     
-    bool less_than_equal;	/* if number type must be <= min */
-    bool greater_than_equal;	/* if number type must be >= max */
-    bool inclusive;		/* if number type must be >= min && <= max */
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
 };
 struct jprint_number
 {
     /* exact number if >= 0 */
-    intmax_t number;		/* for exact number (must be >= 0) */
-    bool exact;			/* if an exact match must be found and number != -1 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
 
     /* for number ranges */
     struct jprint_number_range range;	/* for ranges */
@@ -123,6 +122,6 @@ bool jprint_match_compound(uintmax_t types);
 uintmax_t jprint_parse_print_option(char *optarg);
 
 /* for number range options: -l, -n, -i */
-bool jprint_parse_number_range(char *optarg, struct jprint_number *number);
+bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -120,6 +120,9 @@ bool jprint_match_compound(uintmax_t types);
 
 /* what to print - -p option */
 uintmax_t jprint_parse_print_option(char *optarg);
+bool jprint_print_name(uintmax_t types);
+bool jprint_print_value(uintmax_t types);
+bool jprint_print_name_value(uintmax_t types);
 
 /* for number range options: -l, -n, -n */
 bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -126,5 +126,6 @@ bool jprint_print_name_value(uintmax_t types);
 
 /* for number range options: -l, -n, -n */
 bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
+bool jprint_number_in_range(intmax_t number, struct jprint_number *range);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
@@ -78,6 +79,29 @@
 #define JPRINT_PRINT_VALUE  (2)
 #define JPRINT_PRINT_BOTH   (JPRINT_PRINT_NAME | JPRINT_PRINT_VALUE)
 
+/* structs for various options */
+
+/* number ranges for the options -l, -i and -n */
+/* XXX - that these two structs are works in progress - XXX */
+struct jprint_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+    
+    bool less_than_equal;	/* if number type must be <= min */
+    bool greater_than_equal;	/* if number type must be >= max */
+    bool inclusive;		/* if number type must be >= min && <= max */
+};
+struct jprint_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* for exact number (must be >= 0) */
+    bool exact;			/* if an exact match must be found and number != -1 */
+
+    /* for number ranges */
+    struct jprint_number_range range;	/* for ranges */
+};
+
 /* function prototypes */
 
 /* JSON types - -t option*/
@@ -97,5 +121,8 @@ bool jprint_match_compound(uintmax_t types);
 
 /* what to print - -p option */
 uintmax_t jprint_parse_print_option(char *optarg);
+
+/* for number range options: -l, -n, -i */
+bool jprint_parse_number_range(char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -81,7 +81,7 @@
 
 /* structs for various options */
 
-/* number ranges for the options -l, -i and -n */
+/* number ranges for the options -l, -n and -n */
 struct jprint_number_range
 {
     intmax_t min;   /* min in range */
@@ -121,7 +121,7 @@ bool jprint_match_compound(uintmax_t types);
 /* what to print - -p option */
 uintmax_t jprint_parse_print_option(char *optarg);
 
-/* for number range options: -l, -n, -i */
+/* for number range options: -l, -n, -n */
 bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION

By accident I had put the -K option description in the middle of the -m
and note about that option.

Also it doesn't test the options parsed but rather constraints whether 
they were passed prior to the -K or not (even if any were passed it 
won't use those) so the description was fixed.