### PR TITLE
New jprint version 0.0.10 2023-06-09 - inclusive range fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.6 2023-06-09
+
+New `jprint` version "0.0.10 2023-06-09". This version now correctly handles the
+number ranges in the form of e.g. `-l 5:-3` where if there are 10 matches it
+will print the fifth match up through the third to last match.
+
+Fixed `seqcexit` and `picky` rules for jprint and sequenced exit codes.
+
+
 ## Release 1.0.5 2023-06-08
 
 `jprint` version "0.0.9 2023-06-08". At this time I (Cody) believe all known

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -164,10 +164,11 @@ CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${LDFLAGS}
 # source files that are permanent (not made, nor removed)
 #
 C_SRC= jparse_main.c json_parse.c json_sem.c json_util.c \
-       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c jprint.c
+       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c \
+       jprint.c jprint_util.c jprint_test.c
 H_SRC= jparse.h jparse_main.h jsemtblgen.h json_parse.h json_sem.h json_util.h \
        jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h \
-       jparse.tab.ref.h jprint.h
+       jparse.tab.ref.h jprint.h jprint_util.h jprint_test.h
 
 # source files that do not conform to strict picky standards
 #
@@ -964,6 +965,11 @@ jparse_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
 jprint.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
     jprint.c jprint.h jprint_test.h jprint_util.h json_parse.h json_sem.h \
     json_util.h util.h
+jprint_test.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
+    jprint_test.c jprint_test.h jprint_util.h json_parse.h json_sem.h \
+    json_util.h util.h
+jprint_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
+    jprint_util.c jprint_util.h json_parse.h json_sem.h json_util.h util.h
 jsemtblgen.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../iocccsize.h jparse.h \
     jparse.tab.h jsemtblgen.c jsemtblgen.h json_parse.h json_sem.h \
     json_util.h util.h

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -73,7 +73,7 @@ static const char * const usage_msg1 =
     "\t\t\tIf count is a number followed by : (e.g. '-n 3:'), matches must be >= number\n"
     "\t\t\tIf count is a : followed by a number (e.g. '-n :3'), matches must be <= number\n"
     "\t\t\tIf count is num:num (e.g. '-n 3:5'), matches must be inclusively in the range\n"
-    "\t\t\tNOTE: when number < 0 it refers to the instance from last: -1 is last, -2 second to last ...\n\n"
+    "\t\t\tNOTE: when number < 0 it refers to up through matches - the positive max\n\n"
     "\t-N num\t\tPrint only if there are only a given number of matches (def: do not limit)\n"
     "\t\t\tIf num is only a number (e.g. '-l 1'), there must be only that many matches\n"
     "\t\t\tIf num is a number followed by : (e.g. '-l 3:'), there must >= num matches\n"

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.9 2023-06-08"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.10 2023-06-09"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint_test.h
+++ b/jparse/jprint_test.h
@@ -56,12 +56,12 @@
 #include "jparse.h"
 
 /*
- * jprint_util - jprint utility functions 
+ * jprint_util - jprint utility functions
  */
 #include "jprint_util.h"
 
 bool jprint_run_tests(void);
-bool jprint_test_number_range_opts(bool expected, intmax_t number, struct jprint_number *range);
+bool jprint_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, struct jprint_number *range);
 bool jprint_test_bits(bool expected, uintmax_t set_bits, bool (*check_func)(uintmax_t), const char *name);
 
 #endif /* !defined INCLUDE_JPRINT_TEST_H */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -86,7 +86,7 @@ struct jprint_number_range
 {
     intmax_t min;   /* min in range */
     intmax_t max;   /* max in range */
-    
+
     bool less_than_equal;	/* true if number type must be <= min */
     bool greater_than_equal;	/* true if number type must be >= max */
     bool inclusive;		/* true if number type must be >= min && <= max */
@@ -126,6 +126,6 @@ bool jprint_print_name_value(uintmax_t types);
 
 /* for number range options: -l, -n, -n */
 bool jprint_parse_number_range(const char *option, char *optarg, struct jprint_number *number);
-bool jprint_number_in_range(intmax_t number, struct jprint_number *range);
+bool jprint_number_in_range(intmax_t number, intmax_t total_matches, struct jprint_number *range);
 
 #endif /* !defined INCLUDE_JPRINT_UTIL_H */


### PR DESCRIPTION
 
Fix handling of number range when the maximum is a negative number. This
fix involved the number range check functions to take a new parameter
which is the number of total matches.

There is one debug log that is problematic with this change but this can
be addressed at a later time, possibly by making more than one debug log
message depending on the range.
 
Sequenced exit codes.

Fix too long lines detected by make picky (previously undetected due to
the files missing in the variables in the Makefile fixed in commit 
3ffe7cf6bbcaa1ee727668f81ab6cd15fe4b9b4e which fixed not only make 
seqcexit as the log said but also make picky).

Updated CHANGES.md with new mkiocccentry release too as this seems like
a good place to do so as this is a very important change to the jprint
tool.
