### PR TITLE
Make YY_USER_ACTION use char * not array access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.8 2023-06-11
+
+Fix `jparse` column location calculations where error messages just showed the
+invalid token at column 1 even when the bad token is not on column 1.
+
+
 ## Release 1.0.7 2023-06-10
 
 Release `jprint` version "0.0.13 2023-06-10".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@
 Fix `jparse` column location calculations where error messages just showed the
 invalid token at column 1 even when the bad token is not on column 1.
 
+Bumped `jprint` version to "0.0.14 2023-06-11".
+
+When no `name_arg` is passed to `jprint` it will print the entire file. It was
+never a condition that would cause anything but exit code 0 (assuming the json
+file is valid) but it is now more explicit in the code as of 11 June 2023 that
+the entire file will be printed once the printing code is implemented.
 
 ## Release 1.0.7 2023-06-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ never a condition that would cause anything but exit code 0 (assuming the json
 file is valid) but it is now more explicit in the code as of 11 June 2023 that
 the entire file will be printed once the printing code is implemented.
 
+It is an error to use `jprint -p {n,v,b}` and `jprint -j` together.
+
 ## Release 1.0.7 2023-06-10
 
 Release `jprint` version "0.0.13 2023-06-10".

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.1 2023-03-10"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.2 2023-06-11"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -54,10 +54,17 @@ static YY_BUFFER_STATE bs;
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
-			yylloc->first_line = yylloc->last_line = yylineno; \
-			yylloc->first_column = jparse_get_column(yyscanner); \
-			yylloc->last_column = jparse_get_column(yyscanner)+jparse_get_leng(yyscanner)-1; \
-			jparse_set_column(jparse_get_leng(yyscanner), yyscanner);
+			yylloc->first_line = yylloc->last_line + 1; \
+			yylloc->first_column = yylloc->last_column; \
+			for(int i = 0; yytext[i]; i++) { \
+			    if(yytext[i] == '\n') { \
+				yylloc->last_line++; \
+				yylloc->last_column = 1; \
+			    } \
+			    else { \
+				yylloc->last_column++; \
+			    } \
+			}
 %}
 
 /*

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -56,8 +56,8 @@ static YY_BUFFER_STATE bs;
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line + 1; \
 			yylloc->first_column = yylloc->last_column; \
-			for(int i = 0; yytext[i]; i++) { \
-			    if(yytext[i] == '\n') { \
+			for (char *p = yytext; *p; ++p) { \
+			    if (*p == '\n') { \
 				yylloc->last_line++; \
 				yylloc->last_column = 1; \
 			    } \

--- a/jparse/jparse.lex.ref.h
+++ b/jparse/jparse.lex.ref.h
@@ -777,7 +777,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 
 
 #line 732 "jparse.lex.h"

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -813,8 +813,8 @@ static YY_BUFFER_STATE bs;
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line + 1; \
 			yylloc->first_column = yylloc->last_column; \
-			for(int i = 0; yytext[i]; i++) { \
-			    if(yytext[i] == '\n') { \
+			for (char *p = yytext; *p; ++p) { \
+			    if (*p == '\n') { \
 				yylloc->last_line++; \
 				yylloc->last_column = 1; \
 			    } \

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -811,11 +811,18 @@ static YY_BUFFER_STATE bs;
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
-			yylloc->first_line = yylloc->last_line = yylineno; \
-			yylloc->first_column = jparse_get_column(yyscanner); \
-			yylloc->last_column = jparse_get_column(yyscanner)+jparse_get_leng(yyscanner)-1; \
-			jparse_set_column(jparse_get_leng(yyscanner), yyscanner);
-#line 767 "jparse.c"
+			yylloc->first_line = yylloc->last_line + 1; \
+			yylloc->first_column = yylloc->last_column; \
+			for(int i = 0; yytext[i]; i++) { \
+			    if(yytext[i] == '\n') { \
+				yylloc->last_line++; \
+				yylloc->last_column = 1; \
+			    } \
+			    else { \
+				yylloc->last_column++; \
+			    } \
+			}
+#line 774 "jparse.c"
 /*
  * Section 2: Patterns (regular expressions) and actions.
  */
@@ -836,7 +843,7 @@ static YY_BUFFER_STATE bs;
  *	    \"([^\n"]|\\\")*\"
  */
 /* Actions. */
-#line 788 "jparse.c"
+#line 795 "jparse.c"
 
 #define INITIAL 0
 
@@ -1116,9 +1123,9 @@ YY_DECL
 		}
 
 	{
-#line 101 "./jparse.l"
+#line 108 "./jparse.l"
 
-#line 1070 "jparse.c"
+#line 1077 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1189,7 +1196,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 102 "./jparse.l"
+#line 109 "./jparse.l"
 {
 			    /*
 			     * Whitespace excluding newlines
@@ -1209,14 +1216,14 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 118 "./jparse.l"
+#line 125 "./jparse.l"
 {
 			    yycolumn = 1;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 122 "./jparse.l"
+#line 129 "./jparse.l"
 {
 			    /* string */
 			    return JSON_STRING;
@@ -1224,7 +1231,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 127 "./jparse.l"
+#line 134 "./jparse.l"
 {
 			    /* number */
 			    return JSON_NUMBER;
@@ -1232,7 +1239,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 132 "./jparse.l"
+#line 139 "./jparse.l"
 {
 			    /* null object */
 			    return JSON_NULL;
@@ -1240,7 +1247,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 137 "./jparse.l"
+#line 144 "./jparse.l"
 {
 			    /* boolean: true */
 			    return JSON_TRUE;
@@ -1248,7 +1255,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 141 "./jparse.l"
+#line 148 "./jparse.l"
 {
 			    /* boolean: false */
 			    return JSON_FALSE;
@@ -1256,7 +1263,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 146 "./jparse.l"
+#line 153 "./jparse.l"
 {
 			    /* start of object */
 			    return JSON_OPEN_BRACE;
@@ -1264,7 +1271,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 150 "./jparse.l"
+#line 157 "./jparse.l"
 {
 			    /* end of object */
 			    return JSON_CLOSE_BRACE;
@@ -1272,7 +1279,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 155 "./jparse.l"
+#line 162 "./jparse.l"
 {
 			    /* start of array */
 			    return JSON_OPEN_BRACKET;
@@ -1280,7 +1287,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 159 "./jparse.l"
+#line 166 "./jparse.l"
 {
 			    /* end of array */
 			    return JSON_CLOSE_BRACKET;
@@ -1288,7 +1295,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 164 "./jparse.l"
+#line 171 "./jparse.l"
 {
 			    /* colon or 'equals' */
 			    return JSON_COLON;
@@ -1296,7 +1303,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 169 "./jparse.l"
+#line 176 "./jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    return JSON_COMMA;
@@ -1304,7 +1311,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 174 "./jparse.l"
+#line 181 "./jparse.l"
 {
 			    /* invalid token: any other character */
 			    warn(__func__, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
@@ -1340,10 +1347,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1295 "jparse.c"
+#line 1302 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2505,7 +2512,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -188,6 +188,7 @@ int main(int argc, char **argv)
     bool substrings_okay = false;	/* -S used, matching substrings okay */
     bool use_regexps = false;		/* -g used, allow grep-like regexps */
     bool count_only = false;		/* -c used, only show count */
+    bool print_entire_file = false;	/* no name_arg specified */
     uintmax_t max_depth = JSON_DEFAULT_MAX_DEPTH; /* max depth to traverse set by -m depth */
     int i;
 
@@ -393,35 +394,42 @@ int main(int argc, char **argv)
 		max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
 
     /* TODO process name_args */
-    for (i = 1; argv[i] != NULL; ++i) {
-	pattern_specified = true;
+    if (argv[1] == NULL) {
+	print_entire_file = true;   /* technically this boolean is redundant */
+    } else {
+	for (i = 1; argv[i] != NULL; ++i) {
+	    pattern_specified = true;
 
-	/*
-	 * XXX either change the debug level or remove this message once
-	 * processing is complete
-	 */
-	dbg(DBG_NONE,"pattern requested: %s", argv[i]);
-	/*
-	 * XXX if matches found we set the boolean match_found to true to
-	 * indicate exit code of 0 but currently no matches are checked. In
-	 * other words in the future this setting of match_found will not always
-	 * happen.
-	 */
-	match_found = true;
+	    /*
+	     * XXX either change the debug level or remove this message once
+	     * processing is complete
+	     */
+	    dbg(DBG_NONE,"pattern requested: %s", argv[i]);
+	    /*
+	     * XXX if matches found we set the boolean match_found to true to
+	     * indicate exit code of 0 but currently no matches are checked. In
+	     * other words in the future this setting of match_found will not always
+	     * happen.
+	     */
+	    match_found = true;
+	}
     }
 
     /*
      * XXX remove this informative message or change debug level once processing
      * is implemented.
+     *
+     * NOTE: if pattern_specified is false then print_entire_file will be true
+     * so this check is only here for documentation purposes.
      */
-    if (!pattern_specified) {
-	dbg(DBG_NONE,"no pattern requested");
+    if (!pattern_specified || print_entire_file) {
+	dbg(DBG_NONE,"no pattern requested, will print entire file");
     }
 
     /* free tree */
     json_tree_free(json_tree, max_depth);
 
-    if (match_found || !pattern_specified) {
+    if (match_found || !pattern_specified || print_entire_file) {
 	exit(0); /*ooo*/
     } else {
 	/*

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.13 2023-06-10"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/remarks.example.md
+++ b/remarks.example.md
@@ -3,6 +3,9 @@
 First of all if you need help with markdown format please see this [helpful
 guide](https://www.markdownguide.org/basic-syntax/).
 
+Second of all you should copy this file to a `remarks.md` file and edit that
+file.
+
 ## Sections and subsections
 
 For section titles you should use heading levels i.e. lines that start with `#`
@@ -46,10 +49,12 @@ this is not clear!
 
 - leaving the remark section empty.
 
-After doing the above you should rename the file _remarks.md_ and use the file
-as your `remarks.md` when packaging your entry with the `mkiocccentry` tool.
+### Submitting your entry
 
-Thank you!
+When packaging your entry please use the modified `remarks.md` file with the
+`mkiocccentry` tool.
+
+**Thank you!**
 
 # END OF INSTRUCTIONS
 


### PR DESCRIPTION

It probably doesn't matter much but using code like

    for (char *p = text; *p; ++p) { }

is more beautiful in my eyes perhaps because it's a standard C idiom.

The 'char *p' inside the start of the for loop is because it's in a
macro.

Everything checks out okay.
