### PR TITLE
Move many jprint options to struct jprint_options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.8 2023-06-11
+
+Fix `jparse` column location calculations where error messages just showed the
+invalid token at column 1 even when the bad token is not on column 1.
+
+
 ## Release 1.0.7 2023-06-10
 
 Release `jprint` version "0.0.13 2023-06-10".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ the entire file will be printed once the printing code is implemented.
 
 It is an error to use `jprint -p {n,v,b}` and `jprint -j` together.
 
+Move the many options in `jprint`'s `main()` to `struct jprint_options` to
+organise them and to help with passing to necessary callbacks later on.
+
 ## Release 1.0.7 2023-06-10
 
 Release `jprint` version "0.0.13 2023-06-10".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@
 Fix `jparse` column location calculations where error messages just showed the
 invalid token at column 1 even when the bad token is not on column 1.
 
+Bumped `jprint` version to "0.0.14 2023-06-11".
+
+When no `name_arg` is passed to `jprint` it will print the entire file. It was
+never a condition that would cause anything but exit code 0 (assuming the json
+file is valid) but it is now more explicit in the code as of 11 June 2023 that
+the entire file will be printed once the printing code is implemented.
 
 ## Release 1.0.7 2023-06-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ never a condition that would cause anything but exit code 0 (assuming the json
 file is valid) but it is now more explicit in the code as of 11 June 2023 that
 the entire file will be printed once the printing code is implemented.
 
+It is an error to use `jprint -p {n,v,b}` and `jprint -j` together.
+
 ## Release 1.0.7 2023-06-10
 
 Release `jprint` version "0.0.13 2023-06-10".

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.1 2023-03-10"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.2 2023-06-11"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -54,10 +54,17 @@ static YY_BUFFER_STATE bs;
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
-			yylloc->first_line = yylloc->last_line = yylineno; \
-			yylloc->first_column = jparse_get_column(yyscanner); \
-			yylloc->last_column = jparse_get_column(yyscanner)+jparse_get_leng(yyscanner)-1; \
-			jparse_set_column(jparse_get_leng(yyscanner), yyscanner);
+			yylloc->first_line = yylloc->last_line + 1; \
+			yylloc->first_column = yylloc->last_column; \
+			for(int i = 0; yytext[i]; i++) { \
+			    if(yytext[i] == '\n') { \
+				yylloc->last_line++; \
+				yylloc->last_column = 1; \
+			    } \
+			    else { \
+				yylloc->last_column++; \
+			    } \
+			}
 %}
 
 /*

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -56,8 +56,8 @@ static YY_BUFFER_STATE bs;
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line + 1; \
 			yylloc->first_column = yylloc->last_column; \
-			for(int i = 0; yytext[i]; i++) { \
-			    if(yytext[i] == '\n') { \
+			for (char *p = yytext; *p; ++p) { \
+			    if (*p == '\n') { \
 				yylloc->last_line++; \
 				yylloc->last_column = 1; \
 			    } \

--- a/jparse/jparse.lex.ref.h
+++ b/jparse/jparse.lex.ref.h
@@ -777,7 +777,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 
 
 #line 732 "jparse.lex.h"

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -813,8 +813,8 @@ static YY_BUFFER_STATE bs;
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
 			yylloc->first_line = yylloc->last_line + 1; \
 			yylloc->first_column = yylloc->last_column; \
-			for(int i = 0; yytext[i]; i++) { \
-			    if(yytext[i] == '\n') { \
+			for (char *p = yytext; *p; ++p) { \
+			    if (*p == '\n') { \
 				yylloc->last_line++; \
 				yylloc->last_column = 1; \
 			    } \

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -811,11 +811,18 @@ static YY_BUFFER_STATE bs;
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \
-			yylloc->first_line = yylloc->last_line = yylineno; \
-			yylloc->first_column = jparse_get_column(yyscanner); \
-			yylloc->last_column = jparse_get_column(yyscanner)+jparse_get_leng(yyscanner)-1; \
-			jparse_set_column(jparse_get_leng(yyscanner), yyscanner);
-#line 767 "jparse.c"
+			yylloc->first_line = yylloc->last_line + 1; \
+			yylloc->first_column = yylloc->last_column; \
+			for(int i = 0; yytext[i]; i++) { \
+			    if(yytext[i] == '\n') { \
+				yylloc->last_line++; \
+				yylloc->last_column = 1; \
+			    } \
+			    else { \
+				yylloc->last_column++; \
+			    } \
+			}
+#line 774 "jparse.c"
 /*
  * Section 2: Patterns (regular expressions) and actions.
  */
@@ -836,7 +843,7 @@ static YY_BUFFER_STATE bs;
  *	    \"([^\n"]|\\\")*\"
  */
 /* Actions. */
-#line 788 "jparse.c"
+#line 795 "jparse.c"
 
 #define INITIAL 0
 
@@ -1116,9 +1123,9 @@ YY_DECL
 		}
 
 	{
-#line 101 "./jparse.l"
+#line 108 "./jparse.l"
 
-#line 1070 "jparse.c"
+#line 1077 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1189,7 +1196,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 102 "./jparse.l"
+#line 109 "./jparse.l"
 {
 			    /*
 			     * Whitespace excluding newlines
@@ -1209,14 +1216,14 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 118 "./jparse.l"
+#line 125 "./jparse.l"
 {
 			    yycolumn = 1;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 122 "./jparse.l"
+#line 129 "./jparse.l"
 {
 			    /* string */
 			    return JSON_STRING;
@@ -1224,7 +1231,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 127 "./jparse.l"
+#line 134 "./jparse.l"
 {
 			    /* number */
 			    return JSON_NUMBER;
@@ -1232,7 +1239,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 132 "./jparse.l"
+#line 139 "./jparse.l"
 {
 			    /* null object */
 			    return JSON_NULL;
@@ -1240,7 +1247,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 137 "./jparse.l"
+#line 144 "./jparse.l"
 {
 			    /* boolean: true */
 			    return JSON_TRUE;
@@ -1248,7 +1255,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 141 "./jparse.l"
+#line 148 "./jparse.l"
 {
 			    /* boolean: false */
 			    return JSON_FALSE;
@@ -1256,7 +1263,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 146 "./jparse.l"
+#line 153 "./jparse.l"
 {
 			    /* start of object */
 			    return JSON_OPEN_BRACE;
@@ -1264,7 +1271,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 150 "./jparse.l"
+#line 157 "./jparse.l"
 {
 			    /* end of object */
 			    return JSON_CLOSE_BRACE;
@@ -1272,7 +1279,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 155 "./jparse.l"
+#line 162 "./jparse.l"
 {
 			    /* start of array */
 			    return JSON_OPEN_BRACKET;
@@ -1280,7 +1287,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 159 "./jparse.l"
+#line 166 "./jparse.l"
 {
 			    /* end of array */
 			    return JSON_CLOSE_BRACKET;
@@ -1288,7 +1295,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 164 "./jparse.l"
+#line 171 "./jparse.l"
 {
 			    /* colon or 'equals' */
 			    return JSON_COLON;
@@ -1296,7 +1303,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 169 "./jparse.l"
+#line 176 "./jparse.l"
 {
 			    /* comma: name/value pair separator */
 			    return JSON_COMMA;
@@ -1304,7 +1311,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 174 "./jparse.l"
+#line 181 "./jparse.l"
 {
 			    /* invalid token: any other character */
 			    warn(__func__, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
@@ -1340,10 +1347,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1295 "jparse.c"
+#line 1302 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2505,7 +2512,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 207 "./jparse.l"
+#line 214 "./jparse.l"
 
 
 /* Section 3: Code that's copied to the generated scanner */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
     char const *program = NULL;		/* our name */
     extern char *optarg;
     extern int optind;
-    struct jprint_options options;	/* struct of all our options */
+    struct jprint options;	/* struct of all our options */
     FILE *json_file = NULL;		/* file pointer for json file */
     struct json *json_tree;		/* json tree */
     bool is_valid = false;		/* if file is valid json */
@@ -453,7 +453,11 @@ int main(int argc, char **argv)
 	     * XXX either change the debug level or remove this message once
 	     * processing is complete
 	     */
-	    dbg(DBG_NONE,"pattern requested: %s", argv[i]);
+	    if (options.use_regexps) {
+		dbg(DBG_NONE,"regex requested: %s", argv[i]);
+	    } else {
+		dbg(DBG_NONE,"pattern requested: %s", argv[i]);
+	    }
 	    /*
 	     * XXX if matches found we set the boolean match_found to true to
 	     * indicate exit code of 0 but currently no matches are checked. In

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -188,6 +188,7 @@ int main(int argc, char **argv)
     bool substrings_okay = false;	/* -S used, matching substrings okay */
     bool use_regexps = false;		/* -g used, allow grep-like regexps */
     bool count_only = false;		/* -c used, only show count */
+    bool print_entire_file = false;	/* no name_arg specified */
     uintmax_t max_depth = JSON_DEFAULT_MAX_DEPTH; /* max depth to traverse set by -m depth */
     int i;
 
@@ -393,35 +394,42 @@ int main(int argc, char **argv)
 		max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
 
     /* TODO process name_args */
-    for (i = 1; argv[i] != NULL; ++i) {
-	pattern_specified = true;
+    if (argv[1] == NULL) {
+	print_entire_file = true;   /* technically this boolean is redundant */
+    } else {
+	for (i = 1; argv[i] != NULL; ++i) {
+	    pattern_specified = true;
 
-	/*
-	 * XXX either change the debug level or remove this message once
-	 * processing is complete
-	 */
-	dbg(DBG_NONE,"pattern requested: %s", argv[i]);
-	/*
-	 * XXX if matches found we set the boolean match_found to true to
-	 * indicate exit code of 0 but currently no matches are checked. In
-	 * other words in the future this setting of match_found will not always
-	 * happen.
-	 */
-	match_found = true;
+	    /*
+	     * XXX either change the debug level or remove this message once
+	     * processing is complete
+	     */
+	    dbg(DBG_NONE,"pattern requested: %s", argv[i]);
+	    /*
+	     * XXX if matches found we set the boolean match_found to true to
+	     * indicate exit code of 0 but currently no matches are checked. In
+	     * other words in the future this setting of match_found will not always
+	     * happen.
+	     */
+	    match_found = true;
+	}
     }
 
     /*
      * XXX remove this informative message or change debug level once processing
      * is implemented.
+     *
+     * NOTE: if pattern_specified is false then print_entire_file will be true
+     * so this check is only here for documentation purposes.
      */
-    if (!pattern_specified) {
-	dbg(DBG_NONE,"no pattern requested");
+    if (!pattern_specified || print_entire_file) {
+	dbg(DBG_NONE,"no pattern requested, will print entire file");
     }
 
     /* free tree */
     json_tree_free(json_tree, max_depth);
 
-    if (match_found || !pattern_specified) {
+    if (match_found || !pattern_specified || print_entire_file) {
 	exit(0); /*ooo*/
     } else {
 	/*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -160,38 +160,73 @@ int main(int argc, char **argv)
     char const *program = NULL;		/* our name */
     extern char *optarg;
     extern int optind;
-    struct json *json_tree = NULL;	/* json tree */
-    bool is_stdin = false;		/* reading from stdin */
-    bool is_valid = true;		/* if file is valid json */
-    bool match_found = false;		/* true if a pattern is specified and there is a match */
-    bool case_insensitive = false;	/* true if -i, case-insensitive */
-    bool pattern_specified = false;	/* true if a pattern was specified */
+    struct jprint_options options;	/* struct of all our options */
     FILE *json_file = NULL;		/* file pointer for json file */
-    bool encode_strings = false;	/* -e used */
-    bool quote_strings = false;		/* -Q used */
-    uintmax_t type = JPRINT_TYPE_SIMPLE;/* -t type used */
-    struct jprint_number jprint_max_matches = { 0 }; /* -n count specified */
-    struct jprint_number jprint_min_matches = { 0 }; /* -N count specified */
-    struct jprint_number jprint_levels = { 0 }; /* -l level specified */
-    uintmax_t print_type = JPRINT_PRINT_VALUE;	/* -p type specified */
-    bool print_type_option = false;	/* -p explicitly used */
-    uintmax_t num_token_spaces = 0;	/* -b specified number of spaces or tabs */
-    bool print_token_tab = false;	/* -b tab (or -b <num>[t]) specified */
-    bool print_json_levels = false;	/* -L specified */
-    uintmax_t num_level_spaces = 0;	/* number of spaces or tab for -L */
-    bool print_level_tab = false;	/* -L tab option */
-    bool print_colons = false;		/* -T specified */
-    bool print_commas = false;		/* -C specified */
-    bool print_braces = false;		/* -B specified */
-    uintmax_t indent_level = 0;		/* -I specified */
-    bool indent_tab = false;		/* -I t{,ab} specified */
-    bool print_syntax = false;		/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
-    bool match_encoded = false;		/* -E used, match encoded name */
-    bool substrings_okay = false;	/* -S used, matching substrings okay */
-    bool use_regexps = false;		/* -g used, allow grep-like regexps */
-    bool count_only = false;		/* -c used, only show count */
-    bool print_entire_file = false;	/* no name_arg specified */
-    uintmax_t max_depth = JSON_DEFAULT_MAX_DEPTH; /* max depth to traverse set by -m depth */
+    struct json *json_tree;		/* json tree */
+    bool is_valid = false;		/* if file is valid json */
+
+    /* clear out options struct */
+    memset(&options, 0, sizeof options);
+
+    /* set things to proper and explicit values in options even after memset() */
+    options.is_stdin = false;			/* if it's stdin */
+    is_valid = true;			/* if file is valid json */
+    options.match_found = false;		/* true if a pattern is specified and there is a match */
+    options.case_insensitive = false;		/* true if -i, case-insensitive */
+    options.pattern_specified = false;		/* true if a pattern was specified */
+    options.encode_strings = false;		/* -e used */
+    options.quote_strings = false;		/* -Q used */
+    options.type = JPRINT_TYPE_SIMPLE;		/* -t type used */
+
+    /* number range options, see struct in jprint_util.h for details */
+
+    /* max matches number range */
+    options.jprint_max_matches.number = 0;
+    options.jprint_max_matches.exact = false;
+    options.jprint_max_matches.range.min = 0;
+    options.jprint_max_matches.range.max = 0;
+    options.jprint_max_matches.range.less_than_equal = false;
+    options.jprint_max_matches.range.greater_than_equal = false;
+    options.jprint_max_matches.range.inclusive = false;
+
+    /* min matches number range */
+    options.jprint_min_matches.number = 0;
+    options.jprint_min_matches.exact = false;
+    options.jprint_min_matches.range.min = 0;
+    options.jprint_min_matches.range.max = 0;
+    options.jprint_min_matches.range.less_than_equal = false;
+    options.jprint_min_matches.range.greater_than_equal = false;
+    options.jprint_min_matches.range.inclusive = false;
+
+    /* levels number range */
+    options.jprint_levels.number = 0;
+    options.jprint_levels.exact = false;
+    options.jprint_levels.range.min = 0;
+    options.jprint_levels.range.max = 0;
+    options.jprint_levels.range.less_than_equal = false;
+    options.jprint_levels.range.greater_than_equal = false;
+    options.jprint_levels.range.inclusive = false;
+
+    options.print_type = JPRINT_PRINT_VALUE;		/* -p type specified */
+    options. print_type_option = false;			/* -p explicitly used */
+    options.num_token_spaces = 0;			/* -b specified number of spaces or tabs */
+    options.print_token_tab = false;			/* -b tab (or -b <num>[t]) specified */
+    options.print_json_levels = false;			/* -L specified */
+    options.num_level_spaces = 0;			/* number of spaces or tab for -L */
+    options.print_level_tab = false;			/* -L tab option */
+    options.print_colons = false;			/* -T specified */
+    options.print_commas = false;			/* -C specified */
+    options.print_braces = false;			/* -B specified */
+    options.indent_level = 0;				/* -I specified */
+    options.indent_tab = false;				/* -I <num>[{t|s}] specified */
+    options.print_syntax = false;			/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+    options.match_encoded = false;			/* -E used, match encoded name */
+    options.substrings_okay = false;			/* -S used, matching substrings okay */
+    options.use_regexps = false;			/* -g used, allow grep-like regexps */
+    options.count_only = false;				/* -c used, only show count */
+    options.print_entire_file = false;			/* no name_arg specified */
+    options.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+
     int i;
 
     /*
@@ -222,79 +257,79 @@ int main(int argc, char **argv)
 	    json_verbosity_level = parse_verbosity(program, optarg);
 	    break;
 	case 'l':
-	    jprint_parse_number_range("-l", optarg, &jprint_levels);
+	    jprint_parse_number_range("-l", optarg, &options.jprint_levels);
 	    break;
 	case 'e':
-	    encode_strings = true;
+	    options.encode_strings = true;
 	    break;
 	case 'Q':
-	    quote_strings = true;
+	    options.quote_strings = true;
 	    break;
 	case 't':
-	    type = jprint_parse_types_option(optarg);
+	    options.type = jprint_parse_types_option(optarg);
 	    break;
 	case 'n':
-	    jprint_parse_number_range("-n", optarg, &jprint_max_matches);
+	    jprint_parse_number_range("-n", optarg, &options.jprint_max_matches);
 	    break;
 	case 'N':
-	    jprint_parse_number_range("-N", optarg, &jprint_min_matches);
+	    jprint_parse_number_range("-N", optarg, &options.jprint_min_matches);
 	    break;
 	case 'p':
-	    print_type_option = true;
-	    print_type = jprint_parse_print_option(optarg);
+	    options.print_type_option = true;
+	    options.print_type = jprint_parse_print_option(optarg);
 	    break;
 	case 'b':
-	    jprint_parse_st_tokens_option(optarg, &num_token_spaces, &print_token_tab);
+	    jprint_parse_st_tokens_option(optarg, &options.num_token_spaces, &options.print_token_tab);
 	    break;
 	case 'L':
-	    print_json_levels = true; /* print JSON levels */
-	    jprint_parse_st_level_option(optarg, &num_level_spaces, &print_level_tab);
+	    options.print_json_levels = true; /* print JSON levels */
+	    jprint_parse_st_level_option(optarg, &options.num_level_spaces, &options.print_level_tab);
 	    break;
 	case 'T':
-	    print_colons = true;
+	    options.print_colons = true;
 	    break;
 	case 'C':
-	    print_commas = true;
+	    options.print_commas = true;
 	    break;
 	case 'B':
-	    print_braces = true;
+	    options.print_braces = true;
 	    break;
 	case 'I':
-	    jprint_parse_st_indent_option(optarg, &indent_level, &indent_tab);
+	    jprint_parse_st_indent_option(optarg, &options.indent_level, &options.indent_tab);
 	    break;
 	case 'i':
-	    case_insensitive = true; /* make case cruel :-) */
+	    options.case_insensitive = true; /* make case cruel :-) */
 	    break;
 	case 'j':
-	    print_syntax = true;
-	    dbg(DBG_NONE, "implying -p both");
-	    print_type = jprint_parse_print_option("both");
-	    dbg(DBG_NONE, "implying -b 1");
-	    jprint_parse_st_tokens_option("1", &num_token_spaces, &print_token_tab);
-	    dbg(DBG_NONE, "implying -e -Q");
-	    encode_strings = true;
-	    quote_strings = true;
-	    dbg(DBG_NONE, "implying -t any");
-	    type = jprint_parse_types_option("any");
+	    options.print_syntax = true;
+	    dbg(DBG_NONE, "-j, implying -p both");
+	    options.print_type = jprint_parse_print_option("both");
+	    dbg(DBG_NONE, "-j, implying -b 1");
+	    jprint_parse_st_tokens_option("1", &options.num_token_spaces, &options.print_token_tab);
+	    dbg(DBG_NONE, "-j, implying -e -Q");
+	    options.encode_strings = true;
+	    options.quote_strings = true;
+	    dbg(DBG_NONE, "-j, implying -t any");
+	    options.type = jprint_parse_types_option("any");
 	    break;
 	case 'E':
-	    match_encoded = true;
+	    options.match_encoded = true;
 	    break;
 	case 'S':
-	    substrings_okay = true;
+	    options.substrings_okay = true;
 	    break;
 	case 'g':   /* allow grep-like ERE */
-	    use_regexps = true;
+	    options.use_regexps = true;
 	    break;
 	case 'c':
-	    count_only = true;
+	    options.count_only = true;
 	    break;
 	case 'q':
 	    quiet = true;
 	    msg_warn_silent = true;
 	    break;
 	case 'm': /* set maximum depth to traverse json tree */
-	    if (!string_to_uintmax(optarg, &max_depth)) {
+	    if (!string_to_uintmax(optarg, &options.max_depth)) {
 		err(3, "jprint", "couldn't parse -m depth"); /*ooo*/
 		not_reached();
 	    }
@@ -325,13 +360,13 @@ int main(int argc, char **argv)
      */
 
     /* use of -g conflicts with -S is an error */
-    if (use_regexps && substrings_okay) {
+    if (options.use_regexps && options.substrings_okay) {
 	err(3, "jprint", "cannot use both -g and -S"); /*ooo*/
 	not_reached();
     }
 
     /* check that if -b [num]t is used then both -p both */
-    if (print_token_tab && !jprint_print_name_value(print_type)) {
+    if (options.print_token_tab && !jprint_print_name_value(options.print_type)) {
 	err(3, "jparse", "use of -b [num]t cannot be used without -p both"); /*ooo*/
 	not_reached();
     }
@@ -343,7 +378,7 @@ int main(int argc, char **argv)
      * -j conflicts with it and since -j enables a number of options it is
      * easier to just make it an error.
      */
-    if (print_type_option && print_syntax) {
+    if (options.print_type_option && options.print_syntax) {
 	err(3, "jparse", "cannot use -j and explicit -p together"); /*ooo*/
 	not_reached();
     }
@@ -379,7 +414,7 @@ int main(int argc, char **argv)
 	    not_reached();
 	}
     } else { /* *argv[0] == '-', read from stdin */
-	is_stdin = true;
+	options.is_stdin = true;
 	json_file = stdin;
     }
 
@@ -404,15 +439,15 @@ int main(int argc, char **argv)
     msg("valid JSON");
 
     /* the debug level will be increased at a later time */
-    dbg(DBG_NONE, "maximum depth to traverse: %ju%s", max_depth, (max_depth == 0?" (no limit)":
-		max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
+    dbg(DBG_NONE, "maximum depth to traverse: %ju%s", options.max_depth, (options.max_depth == 0?" (no limit)":
+		options.max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
 
     /* TODO process name_args */
     if (argv[1] == NULL) {
-	print_entire_file = true;   /* technically this boolean is redundant */
+	options.print_entire_file = true;   /* technically this boolean is redundant */
     } else {
 	for (i = 1; argv[i] != NULL; ++i) {
-	    pattern_specified = true;
+	    options.pattern_specified = true;
 
 	    /*
 	     * XXX either change the debug level or remove this message once
@@ -425,7 +460,7 @@ int main(int argc, char **argv)
 	     * other words in the future this setting of match_found will not always
 	     * happen.
 	     */
-	    match_found = true;
+	    options.match_found = true;
 	}
     }
 
@@ -436,14 +471,14 @@ int main(int argc, char **argv)
      * NOTE: if pattern_specified is false then print_entire_file will be true
      * so this check is only here for documentation purposes.
      */
-    if (!pattern_specified || print_entire_file) {
+    if (!options.pattern_specified || options.print_entire_file) {
 	dbg(DBG_NONE,"no pattern requested, will print entire file");
     }
 
     /* free tree */
-    json_tree_free(json_tree, max_depth);
+    json_tree_free(json_tree, options.max_depth);
 
-    if (match_found || !pattern_specified || print_entire_file) {
+    if (options.match_found || !options.pattern_specified || options.print_entire_file) {
 	exit(0); /*ooo*/
     } else {
 	/*

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.13 2023-06-10"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
 
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,4 +68,40 @@
 #define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
 
 
+/*
+ * jprint_options - struct that holds all the options and other settings
+ */
+struct jprint_options
+{
+    bool is_stdin;				/* reading from stdin */
+    bool match_found;				/* true if a pattern is specified and there is a match */
+    bool case_insensitive;			/* true if -i, case-insensitive */
+    bool pattern_specified;			/* true if a pattern was specified */
+    bool encode_strings;			/* -e used */
+    bool quote_strings;				/* -Q used */
+    uintmax_t type;				/* -t type used */
+    struct jprint_number jprint_max_matches;	/* -n count specified */
+    struct jprint_number jprint_min_matches;	/* -N count specified */
+    struct jprint_number jprint_levels;		/* -l level specified */
+    uintmax_t print_type;			/* -p type specified */
+    bool print_type_option;			/* -p explicitly used */
+    uintmax_t num_token_spaces;			/* -b specified number of spaces or tabs */
+    bool print_token_tab;			/* -b tab (or -b <num>[t]) specified */
+    bool print_json_levels;			/* -L specified */
+    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
+    bool print_level_tab;			/* -L tab option */
+    bool print_colons;				/* -T specified */
+    bool print_commas;				/* -C specified */
+    bool print_braces;				/* -B specified */
+    uintmax_t indent_level;			/* -I specified */
+    bool indent_tab;				/* -I <num>[{t|s}] specified */
+    bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+    bool match_encoded;				/* -E used, match encoded name */
+    bool substrings_okay;			/* -S used, matching substrings okay */
+    bool use_regexps;				/* -g used, allow grep-like regexps */
+    bool count_only;				/* -c used, only show count */
+    bool print_entire_file;			/* no name_arg specified */
+    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
+};
+
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -69,9 +69,9 @@
 
 
 /*
- * jprint_options - struct that holds all the options and other settings
+ * jprint - struct that holds most of the options, other settings and other data
  */
-struct jprint_options
+struct jprint
 {
     bool is_stdin;				/* reading from stdin */
     bool match_found;				/* true if a pattern is specified and there is a match */

--- a/remarks.example.md
+++ b/remarks.example.md
@@ -3,6 +3,9 @@
 First of all if you need help with markdown format please see this [helpful
 guide](https://www.markdownguide.org/basic-syntax/).
 
+Second of all you should copy this file to a `remarks.md` file and edit that
+file.
+
 ## Sections and subsections
 
 For section titles you should use heading levels i.e. lines that start with `#`
@@ -46,10 +49,12 @@ this is not clear!
 
 - leaving the remark section empty.
 
-After doing the above you should rename the file _remarks.md_ and use the file
-as your `remarks.md` when packaging your entry with the `mkiocccentry` tool.
+### Submitting your entry
 
-Thank you!
+When packaging your entry please use the modified `remarks.md` file with the
+`mkiocccentry` tool.
+
+**Thank you!**
 
 # END OF INSTRUCTIONS
 


### PR DESCRIPTION

This is useful to help organise things and also because I think it's
going to be necessary to have a callback or possibly callbacks and since
there are many options / settings it will be helpful to have everything
in a single struct.

Not every variable is in the struct - only those specific to options. I
am still not completely satisfied with some of the variable names but 
this can be worried about another time.