### PR TITLE
Make struct jprint options a struct jprint *jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.9 2023-06-12
+
+Make `jprint -h` exit codes formatting consistent with `jparse`.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,14 @@
 
 ## Release 1.0.9 2023-06-12
 
+New `jprint` version "0.0.15 2023-06-12".
+
 Make `jprint -h` exit codes formatting consistent with `jparse`.
+
+Make `struct jprint options` in jprint.c a `struct jprint *jprint` as it will
+hold other information besides options including additional structs. Added
+`free_jprint(struct jprint *jprint)` function to completely free everything in
+it and then itself.
 
 ## Release 1.0.8 2023-06-11
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -261,22 +261,11 @@ BISON_DIRS= \
 
 # Additional flags to pass to bison
 #
-# For --report all it will generate upon execution (if bison successfully
-# generates the code) the file jparse.output. With --report all --html it will
-# generate a html file which is easier to follow but I'm not sure how portable
-# this is; under CentOS (which does not have the right version but actually
-# normally generates code fine) the error:
-#
-#   jparse.y: error: xsltproc failed with status 127
-#
-# is thrown and since this could happen on other systems even with the
-# appropriate version I have not enabled this.
-#
 # For the -Wcounterexamples it gives counter examples if there are ever
 # shift/reduce conflicts in the grammar. The other warnings are of use as well.
 #
 BISON_FLAGS= -Werror -Wcounterexamples -Wmidrule-values -Wprecedence -Wdeprecated \
-	      --report all --header
+	      --header
 
 # the basename of flex (or lex) to look for
 #

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -140,14 +140,15 @@ static const char * const usage_msg2 =
 static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
-    "\tExit codes:\n"
-    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
-    "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
-    "\t\t2\t-h and help string printed or -V and version string printed\n"
-    "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
-    "\t\t4\tfile does not exist, not a file, or unable to read the file\n"
-    "\t\t5\tfile contents is not valid JSON\n"
-    "\t\t6\ttest mode failed\n\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n\n"
+    "    >=7\ttest mode failed\n\n"
     "jprint version: %s";
 
 /*

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.15 2023-06-12"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -103,5 +103,9 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
 };
+
+/* functions */
+
+void free_jprint(struct jprint *jprint);
 
 #endif /* !defined INCLUDE_JPRINT_H */


### PR DESCRIPTION

New version of jprint - 0.0.15 2023-06-12.

The struct jprint will hold other information besides the options 
including additional structs.

In this commit the msg("valid JSON"); call has been made a dbg() call to
match the formatting of the other dbg() calls.

A note on the level DBG_NONE just to be clear. None of these dbg() calls 
will keep the DBG_NONE level. It's only this way for now as I don't want
to have to always specify the -v num option every time I am testing
something but I do want to always have this information during
development. To be entirely clear on this point: all messages currently
are subject to change or being deleted. Messages added later will also 
be subject to change or being deleted and this holds until the tool is
more fully developed where it would be a problem to always have the 
output. It'll probably start to change once matches are shown or 
possibly even the entire file (no name\_arg).