### PR TITLE
Fix check of file arg '-' for stdin in jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.9 2023-06-12
+
+Make `jprint -h` exit codes formatting consistent with `jparse`.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ hold other information besides options including additional structs. Added
 `free_jprint(struct jprint *jprint)` function to completely free everything in
 it and then itself.
 
+Fix bug in `jprint` checking of `-` for stdin. It shouldn't be just checking the
+first char as being `-` but rather the entire arg. Without this it results in
+strange behaviour when say `-555` is the file arg.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,14 @@
 
 ## Release 1.0.9 2023-06-12
 
+New `jprint` version "0.0.15 2023-06-12".
+
 Make `jprint -h` exit codes formatting consistent with `jparse`.
+
+Make `struct jprint options` in jprint.c a `struct jprint *jprint` as it will
+hold other information besides options including additional structs. Added
+`free_jprint(struct jprint *jprint)` function to completely free everything in
+it and then itself.
 
 ## Release 1.0.8 2023-06-11
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -261,22 +261,11 @@ BISON_DIRS= \
 
 # Additional flags to pass to bison
 #
-# For --report all it will generate upon execution (if bison successfully
-# generates the code) the file jparse.output. With --report all --html it will
-# generate a html file which is easier to follow but I'm not sure how portable
-# this is; under CentOS (which does not have the right version but actually
-# normally generates code fine) the error:
-#
-#   jparse.y: error: xsltproc failed with status 127
-#
-# is thrown and since this could happen on other systems even with the
-# appropriate version I have not enabled this.
-#
 # For the -Wcounterexamples it gives counter examples if there are ever
 # shift/reduce conflicts in the grammar. The other warnings are of use as well.
 #
 BISON_FLAGS= -Werror -Wcounterexamples -Wmidrule-values -Wprecedence -Wdeprecated \
-	      --report all --header
+	      --header
 
 # the basename of flex (or lex) to look for
 #

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -140,14 +140,15 @@ static const char * const usage_msg2 =
 static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
-    "\tExit codes:\n"
-    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
-    "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
-    "\t\t2\t-h and help string printed or -V and version string printed\n"
-    "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
-    "\t\t4\tfile does not exist, not a file, or unable to read the file\n"
-    "\t\t5\tfile contents is not valid JSON\n"
-    "\t\t6\ttest mode failed\n\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n\n"
+    "    >=7\ttest mode failed\n\n"
     "jprint version: %s";
 
 /*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
 
 
     /* if *argv[0] != '-' we will attempt to read from a regular file */
-    if (*argv[0] != '-') {
+    if (!strcmp(argv[0], "-")) {
         /* check that first arg exists and is a regular file */
 	if (!exists(argv[0])) {
 	    free_jprint(jprint);

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.15 2023-06-12"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -103,5 +103,9 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
 };
+
+/* functions */
+
+void free_jprint(struct jprint *jprint);
 
 #endif /* !defined INCLUDE_JPRINT_H */


### PR DESCRIPTION

The check was

    if (*argv[0] == '-') { /* ... */ }

but this is incorrect because image if someone does:

    ./jprint -555

Now the entire argv[0] is checked via strcmp(). Why argv[0]? Because 
after options are parsed argv and argc are shifted.

Interestingly this was discovered as I was working on a (for now much
like jparse_test.sh) test script with the funny error in the log: 
 
     ... in file -555 ...

which is obviously very confusing and bogus. The test script has another
issue to be worked out but this is more important to get in as the tool
is not yet complete anyway.