### PR TITLE
Add initial jprint_test.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ jparse/jparse
 jparse/jprint
 jparse/lex.yy.c
 jparse_test.log
+jprint_test.log
 jsemtblgen
 jstr_test.out
 jstr_test2.out

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.9 2023-06-12
+
+Make `jprint -h` exit codes formatting consistent with `jparse`.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ Fix bug in `jprint` checking of `-` for stdin. It shouldn't be just checking the
 first char as being `-` but rather the entire arg. Without this it results in
 strange behaviour when say `-555` is the file arg.
 
+Added initial `jprint_test.sh` test script. For now it is very much like
+`jparse_test.sh` except it doesn't test the strings file as `jprint` doesn't
+have an option to read args as a string. Whether it might be good to do this or
+to change the script so that it can read from stdin are questions to be answered
+at a later date. Something it additionally does is run `jprint -K` test mode.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ hold other information besides options including additional structs. Added
 `free_jprint(struct jprint *jprint)` function to completely free everything in
 it and then itself.
 
+Fix bug in `jprint` checking of `-` for stdin. It shouldn't be just checking the
+first char as being `-` but rather the entire arg. Without this it results in
+strange behaviour when say `-555` is the file arg.
+
 ## Release 1.0.8 2023-06-11
 
 Fix `jparse` column location calculations where error messages just showed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,14 @@
 
 ## Release 1.0.9 2023-06-12
 
+New `jprint` version "0.0.15 2023-06-12".
+
 Make `jprint -h` exit codes formatting consistent with `jparse`.
+
+Make `struct jprint options` in jprint.c a `struct jprint *jprint` as it will
+hold other information besides options including additional structs. Added
+`free_jprint(struct jprint *jprint)` function to completely free everything in
+it and then itself.
 
 ## Release 1.0.8 2023-06-11
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -261,22 +261,11 @@ BISON_DIRS= \
 
 # Additional flags to pass to bison
 #
-# For --report all it will generate upon execution (if bison successfully
-# generates the code) the file jparse.output. With --report all --html it will
-# generate a html file which is easier to follow but I'm not sure how portable
-# this is; under CentOS (which does not have the right version but actually
-# normally generates code fine) the error:
-#
-#   jparse.y: error: xsltproc failed with status 127
-#
-# is thrown and since this could happen on other systems even with the
-# appropriate version I have not enabled this.
-#
 # For the -Wcounterexamples it gives counter examples if there are ever
 # shift/reduce conflicts in the grammar. The other warnings are of use as well.
 #
 BISON_FLAGS= -Werror -Wcounterexamples -Wmidrule-values -Wprecedence -Wdeprecated \
-	      --report all --header
+	      --header
 
 # the basename of flex (or lex) to look for
 #

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -140,14 +140,15 @@ static const char * const usage_msg2 =
 static const char * const usage_msg3 =
     "\tfile.json\tJSON file to parse (- indicates stdin)\n"
     "\tname_arg\tJSON element to print\n\n"
-    "\tExit codes:\n"
-    "\t\t0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
-    "\t\t1\tfile is valid JSON, name_arg given but no matches found\n"
-    "\t\t2\t-h and help string printed or -V and version string printed\n"
-    "\t\t3\tinvalid command line, invalid option or option missing an argument\n"
-    "\t\t4\tfile does not exist, not a file, or unable to read the file\n"
-    "\t\t5\tfile contents is not valid JSON\n"
-    "\t\t6\ttest mode failed\n\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n\n"
+    "    >=7\ttest mode failed\n\n"
     "jprint version: %s";
 
 /*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
 
 
     /* if *argv[0] != '-' we will attempt to read from a regular file */
-    if (*argv[0] != '-') {
+    if (!strcmp(argv[0], "-")) {
         /* check that first arg exists and is a regular file */
 	if (!exists(argv[0])) {
 	    free_jprint(jprint);

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
 
 
     /* if *argv[0] != '-' we will attempt to read from a regular file */
-    if (!strcmp(argv[0], "-")) {
+    if (strcmp(argv[0], "-")) {
         /* check that first arg exists and is a regular file */
 	if (!exists(argv[0])) {
 	    free_jprint(jprint);

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.14 2023-06-11"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.15 2023-06-12"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -103,5 +103,9 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
 };
+
+/* functions */
+
+void free_jprint(struct jprint *jprint);
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -380,6 +380,22 @@ test:
 	    fi; \
 	fi
 	${S} echo
+	${Q} if [[ ! -x ./jprint_test.sh ]]; then \
+	    echo "${OUR_NAME}: ERROR: executable not found: ./jprint_test.sh" 1>&2; \
+	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
+	    exit 1; \
+	else \
+	    echo "./jprint_test.sh -j ../jprint -d test_JSON -s . ./json_teststr.txt"; \
+	    ./jprint_test.sh -j ../jprint -d test_JSON -s . ./json_teststr.txt; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: jprint_test.sh failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo ${OUR_NAME}: "PASSED: jprint_test.sh"; \
+	    fi; \
+	fi
+	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes

--- a/jparse/test_jparse/jprint_test.sh
+++ b/jparse/test_jparse/jprint_test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# jprint_test.sh - test jprint tool on valid and invalid JSON files
+#
+# Run jprint on simple one-line JSON files or on whole JSON documents to test the
+# JSON parser.
+#
+# When used with "-d json_tree -s subdir", two directories are expected:
+#
+#	json_tree/tree/subdir/good
+#	json_tree/tree/subdir/bad
+#
+# All files under json_tree/tree/subdir/good must be valid JSON.  If any file under
+# that directory tests as an invalid JSON file, this script will exit non-zero.
+#
+# All files under json_tree/tree/subdir/bad must be valid JSON.  If any file under
+# that directory tests as a valid JSON file, this script will exit non-zero.
+#
+# Without "-d json_tree -s subdir" a list of files in the command line are
+# tested to see if they are valid JSON files.  With no arguments, or - the
+# contents of stdin is tested.
+#
+# "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+#
+# The JSON parser was co-developed in 2022 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# The jprint tool is being developed by Cody Boone Ferguson.
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# "Share and Enjoy!"
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+
+
+# setup
+#
+export JPRINT_TEST_VERSION="0.0.1 2023-06-12"
+export CHK_TEST_FILE="./jparse/test_jprint/json_teststr.txt"
+export JPRINT="./jparse/jprint"
+export JSON_TREE="./jprint/test_jprint/test_JSON"
+export SUBDIR="."
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jprint] [-d json_tree] [-s subdir] [file ..]
+
+    -h			print help and exit
+    -V			print version and exit
+    -v level		set verbosity level for this script: (def level: 0)
+    -D dbg_level	set verbosity level for tests (def: level: 0)
+    -J level		set JSON parser verbosity level (def level: 0)
+    -q			quiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)
+    -j /path/to/jprint	path to jprint tool (def: $JPRINT)
+    -d json_tree	read files under json_tree/subdir/good and json_tree/subdir/bad (def: $JSON_TREE)
+			    These subdirectories are expected:
+				json_tree/tree/subdir/bad
+				json_tree/tree/subdir/good
+    -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
+    [file ...]		read JSON documents, one per line, from these files, - means stdin (def: $CHK_TEST_FILE)
+			NOTE: To use stdin, end the command line with: -- -
+
+Exit codes:
+     0   all tests are OK
+     1   at least one test failed
+     2	 -h and help string printed or -V and version string printed
+     3   invalid command line
+     4	 jprint not a regular executable file
+     5	 couldn't create writable log file
+     6	 missing directory or directories
+     7	 missing JSON file
+  >= 10  internal error
+
+jprint_test.sh version: $JPRINT_TEST_VERSION"
+
+export V_FLAG="0"
+export DBG_LEVEL="0"
+export JSON_DBG_LEVEL="0"
+export Q_FLAG=""
+export LOGFILE="./jprint_test.log"
+export EXIT_CODE=0
+export FILE_FAILURE_SUMMARY=""
+
+# parse args
+#
+while getopts :hVv:D:J:qj:d:s: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$JPRINT_TEST_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    D)	DBG_LEVEL="$OPTARG";
+	;;
+    J)	JSON_DBG_LEVEL="$OPTARG";
+	;;
+    q)	Q_FLAG="-q";
+	;;
+    j)	JPRINT="$OPTARG";
+	;;
+    d)	JSON_TREE="$OPTARG"
+	;;
+    s)  SUBDIR="$OPTARG"
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    *)
+	;;
+    esac
+done
+if [[ $V_FLAG -ge 1 ]]; then
+    echo "$0: debug[1]: -v: $V_FLAG" 1>&2
+    echo "$0: debug[1]: -D: $DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -J: $JSON_DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -s: $SUBDIR" 1>&2
+    if [[ -z $Q_FLAG ]]; then
+	echo "$0: debug[1]: -q: false" 1>&2
+    else
+	echo "$0: debug[1]: -q: true" 1>&2
+    fi
+    echo "$0: debug[1]: jprint: $JPRINT" 1>&2
+fi
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+export JSON_GOOD_TREE="$JSON_TREE/$SUBDIR/good"
+export JSON_BAD_TREE="$JSON_TREE/$SUBDIR/bad"
+
+# firewall
+#
+if [[ ! -e $JPRINT ]]; then
+    echo "$0: ERROR: jprint not found: $JPRINT"
+    exit 4
+fi
+if [[ ! -f $JPRINT ]]; then
+    echo "$0: ERROR: jprint not a regular file: $JPRINT"
+    exit 4
+fi
+if [[ ! -x $JPRINT ]]; then
+    echo "$0: ERROR: jprint not executable: $JPRINT"
+    exit 4
+fi
+
+# check that json_tree is a readable directory
+#
+if [[ ! -e $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+
+# good tree
+#
+if [[ ! -e $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jprint directory not found: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jprint not a directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jprint not readable directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+
+# bad tree
+#
+if [[ ! -e $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jprint directory not found: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jprint not a directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jprint not readable directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+
+
+# remove logfile so that each run starts out with an empty file
+#
+rm -f "$LOGFILE"
+touch "$LOGFILE"
+if [[ ! -f "${LOGFILE}" ]]; then
+    echo "$0: ERROR: couldn't create log file" 1>&2
+    exit 5
+fi
+if [[ ! -w "${LOGFILE}" ]]; then
+    echo "$0: ERROR: log file not writable" 1>&2
+    exit 5
+fi
+
+# run_jprint_test_mode - run jprint -K test mode
+#
+# usage:
+#	run_jprint_test_mode jprint dbg_level json_dbg_level quiet_mode
+#
+run_jprint_test_mode()
+{
+    # parse args
+    #
+    if [[ $# -ne 4 ]]; then
+	echo "$0: ERROR: expected 4 args to run_jprint_test_mode, found $#" 1>&2
+	exit 10
+    fi
+    declare jprint="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_jprint_test_mode: jprint: $jprint" 1>&2
+	echo "$0: debug[9]: in run_jprint_test_mode: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jprint_test_mode: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jprint_test_mode: quiet_mode: $quiet_mode" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jprint -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jprint -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jprint" -v "$dbg_level" -J "$json_dbg_level" -K >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jprint -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jprint -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jprint" -v "$dbg_level" -J "$json_dbg_level" -q -K >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	    echo "$0: in test that must pass: jprint OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jprint OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+    else
+	if [[ $V_FLAG -ge 1 ]]; then
+	    echo "$0: in test that must pass: jprint FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: in run_jprint_test_mode: jprint exit code: $status" 1>&2 >> "${LOGFILE}"
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+
+# run_file_test - run a single jprint test on a file
+#
+# usage:
+#	run_file_test jprint dbg_level json_dbg_level quiet_mode json_doc_file pass|fail
+#
+#	jprint			path to the jprint program
+#	dbg_level		internal test debugging level to use as in: jprint -v dbg_level
+#	json_dbg_level		JSON parser debug level to use in: jprint -J json_dbg_level
+#	quiet_mode		quiet mode to use in: jprint -q
+#	json_doc_file		JSON document as a string to give to jprint
+#	pass|fail		string saying if jprint must return valid json or invalid json
+#
+run_file_test()
+{
+    # parse args
+    #
+    if [[ $# -ne 6 ]]; then
+	echo "$0: ERROR: expected 6 args to run_file_test, found $#" 1>&2
+	exit 11
+    fi
+    declare jprint="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+    declare json_doc_file="$5"
+    declare pass_fail="$6"
+
+    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
+	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
+	EXIT_CODE=12
+	return
+    fi
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_file_test: jprint: $jprint" 1>&2
+	echo "$0: debug[9]: in run_file_test: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: quiet_mode: $quiet_mode" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_doc_file: $json_doc_file" 1>&2
+	echo "$0: debug[9]: in run_file_test: pass_fail: $pass_fail" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jprint -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jprint -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jprint" -v "$dbg_level" -J "$json_dbg_level" -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jprint -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jprint -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jprint" -v "$dbg_level" -J "$json_dbg_level" -q -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	if [[ $pass_fail = pass ]]; then
+	    echo "$0: in test that must pass: jprint OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jprint OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jprint FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jprint exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	fi
+    else
+	if [[ $pass_fail = pass ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must pass: jprint FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jprint exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jprint OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jprint exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+# run tests that must pass
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jprint tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JPRINT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
+done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
+
+# run jprint test mode itself
+
+run_jprint_test_mode "$JPRINT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG"
+
+#
+# run tests that must fail
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jprint tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JPRINT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
+done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
+
+
+if [[ -n "$FILE_FAILURE_SUMMARY" ]]; then
+    echo "The following files failed: " | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+    echo "$FILE_FAILURE_SUMMARY" | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+fi
+
+# All Done!!! -- Jessica Noll, Age 2
+#
+if [[ $V_FLAG -ge 1 ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+	echo "$0: debug[1]: all tests PASSED" 1>&2
+	echo "$0: debug[1]: all tests PASSED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: see $LOGFILE for details" 1>&2
+    else
+	echo "$0: ERROR: debug[1]: some tests FAILED" 1>&2
+	echo "$0: ERROR: debug[1]: some tests FAILED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: Notice: see $LOGFILE for details" 1>&2
+    fi
+fi
+exit "$EXIT_CODE"


### PR DESCRIPTION

It is not much different from jparse_test.sh except that it does not
test the strings file (which has a json 'document' on each line). This
is because the tool does not allow a file arg to be a string from a
file. 

Something it also does do is run jprint -K test mode.

Whether string support should be added to the tool or whether the script 
should be modified so that the strings are faked as stdin are questions
that can be answered at another date.
