### PR TITLE
Add flexibility to jprint regexps/regular patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,15 @@ was `-s`.
 allowed and use of `-A` requires use of `-S`. The difference besides letters is
 that args now must not be empty though this might not be strictly necessary.
 
+Allow for both regular expressions and normal patterns via the `-G regexp`
+option. Does not conflict with `-s` because the regexp is added as a regexp but
+the `name_arg`s will allow substrings if `-s` specified - but not for the `-G`
+regexp. `-G` does not conflict with `-Y` as long as only `-G` is used only once
+and no additional `name_arg` is specified at the command line after `file.json`.
+
+Fix bug where the command line could be messed up and the file.json is thought
+to be a different arg specified.
+
 Updated `jprint` version to "0.0.18 2023-06-15".
 
 ## Release 1.0.11 2023-06-14

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.12 2023-06-15
+
+Change option letters of `jprint` a bit as described next.
+
+`-s` now means search substrings. Conflicts with `-g`. `-s` was `-M`.
+
+`-S` sets the path to the tool to run, which although in concept should be a
+semantics tool checker, it can actually be something else like `grep`. This option
+was `-s`.
+
+`-A` sets the args to the `-S path`. This option was `-S`. Empty args are not
+allowed and use of `-A` requires use of `-S`. The difference besides letters is
+that args now must not be empty though this might not be strictly necessary.
+
+Updated `jprint` version to "0.0.18 2023-06-15".
+
 ## Release 1.0.11 2023-06-14
 
 Minor fix in `jparse` error location reporting. When the erroneous token was at

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -41,16 +41,16 @@ static bool quiet = false;				/* true ==> quiet mode */
  */
 static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-Q] [-t type] [-q] [-n count]\n"
-    "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-T] [-C] [-B]\n"
-    "\t\t[-I <num>{[t|s]} [-j] [-E] [-i] [-M] [-g] [-c] [-m depth] [-K] [-Y type:value]\n"
-    "\t\t[-s path] [-S args] file.json [name_arg ...]\n\n"
+    "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
+    "\t\t[-I <num>{[t|s]} [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type:value]\n"
+    "\t\t[-S path] [-A args] file.json [name_arg ...]\n\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
     "\t-v level\tVerbosity level (def: %d)\n"
     "\t-J level\tJSON verbosity level (def: %d)\n"
     "\t-e\t\tPrint JSON strings as encoded strings (def: decode JSON strings)\n"
     "\t-Q\t\tPrint JSON strings surrounded by double quotes (def: do not)\n"
-    "\t-t type\t\tPrint only if JSON value matches one of the comma-separated\n"
+    "\t-t type\t\tPrint only if JSON value matches one of the comma-Separated\n"
     "\t\t\ttypes (def: simple):\n\n"
     "\t\t\t\tint\t\tinteger values\n"
     "\t\t\t\tfloat\t\tfloating point values\n"
@@ -102,7 +102,7 @@ static const char * const usage_msg1 =
     "\t-L tab\t\tAlias for '-L 1t'.\n";
 
 static const char * const usage_msg2 =
-    "\t-T\t\tWhen printing '-p both', separate name/value by a : (colon) (def: do not)\n"
+    "\t-P\t\tWhen printing '-p both', separate name/value by a : (colon) (def: do not)\n"
     "\t\t\tNOTE: When -C is used with -b {t,number}, the same number of spaces or tabs\n"
     "\t\t\tseparate the name from the : (colon) AND a number of spaces or tabs\n"
     "\t\t\tand separate : (colon) from the value by the same.\n\n"
@@ -123,12 +123,12 @@ static const char * const usage_msg2 =
     "\t\t\tNOTE: it is an error to use both -p and -j\n\n"
     "\t-E\t\tMatch the JSON encoded name (def: match the JSON decoded name).\n"
     "\t-i\t\tIgnore case of name (def: case matters).\n"
-    "\t-M\t\tSubstrings are used to match (def: the full name must match).\n\n"
+    "\t-s\t\tSubstrings are used to match (def: the full name must match).\n\n"
     "\t-g\t\tgrep-like extended regular expressions are used to match (def: name args are not regexps).\n"
     "\t\t\tTo match from the name beginning, start name_arg with '^'.\n"
     "\t\t\tTo match to the name end, end name_arg with '$'.\n"
     "\t\t\tTo match the entire name, enclose name_arg between '^' and '$'.\n"
-    "\t\t\tNOTE: Use of -g and -M is an error.\n\n"
+    "\t\t\tNOTE: Use of -g and -s is an error.\n\n"
     "\t-c\t\tOnly show count of matches found\n\n"
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
     "\t\t\tNOTE: 0 implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-).\n\n"
@@ -147,9 +147,9 @@ static const char * const usage_msg3 =
     "\t\t\t\tnull\tnull values\n"
     "\t\t\t\tsimple\talias for 'num,bool,str,null'\n\n"
     "\t\t\tNOTE: -Y Requires one and only one name_arg.\n\n"
-    "\t-s path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
-    "\t-S args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
-    "\t\t\tNOTE: use of -S requires use of -s\n";
+    "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
+    "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
+    "\t\t\tNOTE: use of -A requires use of -S\n";
 /*
  * NOTE: this next one should be the last number; if any additional usage message strings
  * have to be added the first additional one should be the number this is and this one
@@ -245,14 +245,14 @@ int main(int argc, char **argv)
     jprint->print_json_levels = false;			/* -L specified */
     jprint->num_level_spaces = 0;			/* number of spaces or tab for -L */
     jprint->print_level_tab = false;			/* -L tab option */
-    jprint->print_colons = false;			/* -T specified */
+    jprint->print_colons = false;			/* -P specified */
     jprint->print_final_comma = false;			/* -C specified */
     jprint->print_braces = false;			/* -B specified */
     jprint->indent_level = 0;				/* -I specified */
     jprint->indent_tab = false;				/* -I <num>[{t|s}] specified */
     jprint->print_syntax = false;			/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
     jprint->match_encoded = false;			/* -E used, match encoded name */
-    jprint->substrings_okay = false;			/* -M used, matching substrings okay */
+    jprint->substrings_okay = false;			/* -s used, matching substrings okay */
     jprint->use_regexps = false;			/* -g used, allow grep-like regexps */
     jprint->count_only = false;				/* -c used, only show count */
     jprint->print_entire_file = false;			/* no name_arg specified */
@@ -260,8 +260,8 @@ int main(int argc, char **argv)
 
     jprint->search_value = false;			/* -Y search by value, not name. Uses print type */
 
-    jprint->tool_path = NULL;				/* -s path for check tool */
-    jprint->tool_args = NULL;				/* -S args for check tool */
+    jprint->tool_path = NULL;				/* -S path for check tool */
+    jprint->tool_args = NULL;				/* -A args for check tool */
     /* finally the linked list of patterns */
     jprint->patterns = NULL;
 
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:TCBI:jEiMgcm:KY:s:S:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:KY:sA:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jprint(jprint);
@@ -329,9 +329,9 @@ int main(int argc, char **argv)
 	    jprint->print_json_levels = true; /* print JSON levels */
 	    jprint_parse_st_level_option(optarg, &jprint->num_level_spaces, &jprint->print_level_tab);
 	    break;
-	case 'T':
+	case 'P':
 	    jprint->print_colons = true;
-	    dbg(DBG_NONE, "-T specified, will print colons");
+	    dbg(DBG_NONE, "-P specified, will print colons");
 	    break;
 	case 'C':
 	    jprint->print_final_comma = true;
@@ -364,9 +364,9 @@ int main(int argc, char **argv)
 	    jprint->match_encoded = true;
 	    dbg(DBG_NONE, "-E specified, will match encoded strings, not decoded strings");
 	    break;
-	case 'M':
+	case 's':
 	    jprint->substrings_okay = true;
-	    dbg(DBG_NONE, "-M specified, will match substrings");
+	    dbg(DBG_NONE, "-s specified, will match substrings");
 	    break;
 	case 'g':   /* allow grep-like ERE */
 	    jprint->use_regexps = true;
@@ -412,26 +412,28 @@ int main(int argc, char **argv)
 	    jprint->search_value = true;
 	    jprint->type = jprint_parse_value_type_option(optarg);
 	    break;
-	case 's':
+	case 'S':
 	    /*
-	     * -s path to tool
+	     * -S path to tool
 	     *
 	     * XXX it is currently unclear how this will be used as such so this
 	     * might need to be strdup()d but for now it's not.
 	     *
 	     */
 	    jprint->tool_path = optarg;
+	    dbg(DBG_NONE, "set tool path to %s", jprint->tool_path);
 	    break;
-	case 'S':
+	case 'A':
 	    /*
-	     * -S args to tool
+	     * -A args to tool
 	     *
-	     * Requires use of -s.
+	     * Requires use of -S.
 	     *
 	     * XXX it is currently unclear how this will be used as such so this
 	     * might need to be strdup()d but for now it's not.
 	     */
 	    jprint->tool_args = optarg;
+	    dbg(DBG_NONE, "set tool args to %s", jprint->tool_args);
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */
@@ -450,19 +452,19 @@ int main(int argc, char **argv)
      * the wrong number of arguments (if they do).
      */
 
-    /* use of -g conflicts with -M is an error */
+    /* use of -g conflicts with -s is an error */
     if (jprint->use_regexps && jprint->substrings_okay) {
 	free_jprint(jprint);
 	jprint = NULL;
-	err(3, "jprint", "cannot use both -g and -M"); /*ooo*/
+	err(3, "jprint", "cannot use both -g and -s"); /*ooo*/
 	not_reached();
     }
 
-    /* check that both -j and -M were not used */
+    /* check that both -j and -s were not used */
     if (jprint->print_syntax && jprint->substrings_okay) {
 	free_jprint(jprint);
 	jprint = NULL;
-	err(3, "jprint", "cannot use both -j and -M"); /*ooo*/
+	err(3, "jprint", "cannot use both -j and -s"); /*ooo*/
 	not_reached();
     }
 
@@ -488,16 +490,21 @@ int main(int argc, char **argv)
 	not_reached();
     }
 
-    /* if -S is specified, -s must also be specified */
+    /* if -A is specified, -S must also be specified */
     if (jprint->tool_args != NULL && jprint->tool_path == NULL) {
 	free_jprint(jprint);
 	jprint = NULL;
-	err(3, "jparse", "use of -S args requires use of -s path"); /*ooo*/
+	err(3, "jparse", "use of -A args requires use of -S path"); /*ooo*/
+	not_reached();
+    } else if (jprint->tool_args != NULL && *jprint->tool_args == '\0') {
+	free_jprint(jprint);
+	jprint = NULL;
+	err(3, "jparse", "-A requires non empty args list"); /*ooo*/
 	not_reached();
     }
 
     /*
-     * TODO if -s path is specified, verify that it exists, is a regular file
+     * TODO if -S path is specified, verify that it exists, is a regular file
      * and is executable.
      */
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -74,8 +74,9 @@
 struct jprint_pattern
 {
     char *pattern;		    /* the actual pattern or regexp string */
-    bool regexp;		    /* whether -g was used */
-    bool value;			    /* whether -Y was used, implying to search values */
+    bool use_regexp;		    /* whether -g was used */
+    bool use_value;		    /* whether -Y was used, implying to search values */
+    bool use_substrings;	    /* if -s was used */
 
     struct jprint_pattern *next;    /* the next in the list */
 };
@@ -111,20 +112,22 @@ struct jprint
     bool match_encoded;				/* -E used, match encoded name */
     bool substrings_okay;			/* -s used, matching substrings okay */
     bool use_regexps;				/* -g used, allow grep-like regexps */
+    bool explicit_regexp;			/* -G used, will not allow -Y */
     bool count_only;				/* -c used, only show count */
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
-    bool search_value;				/* search for value, not name (-Y) */
+    bool search_value;				/* -Y used, search for value, not name */
     char *tool_path;				/* -S path specified */
     char *tool_args;				/* -A args for -S path specified */
 
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */
+    uintmax_t number_of_patterns;		/* patterns specified */
 };
 
 /* functions */
 void free_jprint(struct jprint *jprint);
-struct jprint_pattern *add_jprint_pattern(struct jprint *jprint, char *str);
+struct jprint_pattern *add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, char *str);
 void free_jprint_patterns_list(struct jprint *jprint);
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.17 2023-06-14"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.18 2023-06-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_pattern - struct for a linked list of patterns requested, held in
@@ -102,21 +102,21 @@ struct jprint
     bool print_json_levels;			/* -L specified */
     uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
     bool print_level_tab;			/* -L tab option */
-    bool print_colons;				/* -T specified */
+    bool print_colons;				/* -P specified */
     bool print_final_comma;			/* -C specified */
     bool print_braces;				/* -B specified */
     uintmax_t indent_level;			/* -I specified */
     bool indent_tab;				/* -I <num>[{t|s}] specified */
     bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
     bool match_encoded;				/* -E used, match encoded name */
-    bool substrings_okay;			/* -M used, matching substrings okay */
+    bool substrings_okay;			/* -s used, matching substrings okay */
     bool use_regexps;				/* -g used, allow grep-like regexps */
     bool count_only;				/* -c used, only show count */
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     bool search_value;				/* search for value, not name (-Y) */
-    char *tool_path;				/* -s path specified */
-    char *tool_args;				/* -S args for -s path specified */
+    char *tool_path;				/* -S path specified */
+    char *tool_args;				/* -A args for -S path specified */
 
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */


### PR DESCRIPTION
NOTE: to see more rationale behind this see comment https://github.com/ioccc-src/mkiocccentry/issues/523#issuecomment-1593134282.

NOTE: it should not cause problems with substrings unless `-g` is specified. Then it's a command line error. Special care was made so that it can still be used with `-Y` as long as only one name arg is specified, either via `-G` or after the file.json arg. 

NOTE: I have taken special care to avoid problems with option conflicts but if I missed something please let me know and I'll happily fix it!

The way this works is that each pattern now has a boolean to indicate the type: regexp, regular, substring (conflicts with regexp) and also if it should be searching by value or name.

The commit log is below:

--

With -G regexp one can explicitly enable a search for a regexp pattern
without conflicting with the normal patterns (name_args) or -s. But how
does this work so it's not in conflict?

The patterns struct has booleans to indicate what was specified so that
when -G is specified that specific pattern will be added as a regexp but
after the command line if -g was not specified it will be a regular
pattern. If -s is specified -g is still an error. -G can be used with -Y
but the name_arg will be instead the regexp explicitly specified. This
means that the following two commands would result in the same
functionality with respect to -Y:

    jprint .. -Y int -G foo file.json
    jprint .. -Y int -g file.json foo

Without either -G or -g the -Y would search value without regexps
enabled. If however -G foo and file.json foo is used or more than one -G
foo is used or file.json foo foo is used it is an error. This requires a
special additional check in main() to verify this.

In making the above enhancements I discovered and fixed a bug that 
caused the file.json arg to be the wrong argv element depending on 
options specified.

This feature allows more flexibility in looking for patterns.
