### PR TITLE
Change jprint -W to -o for output file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.13 2023-06-16
+
+New `jprint` version "0.0.19 2023-06-16" - will print entire file if no pattern
+specified OR the new option `-o` is specified but only if valid JSON (for both).
+A note that if `read_all()` fails to read in the entire file then there could be
+a problem but we only print the file if the data read is not NULL. This change
+is important as it means now all that needs to be done is add the handling of
+the JSON checker/semantics tool and then the compiling of regexps (if requested)
+and then printing for any matches found (the search routines have to be written
+too as does the code to traverse the tree - or 'climb down the tree' :-) ). In
+other words one of the features of the program is complete!
+
+
+
 ## Release 1.0.12 2023-06-15
 
 Change option letters of `jprint` a bit as described next.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ is important as it means now all that needs to be done is add the handling of
 the JSON checker/semantics tool and then the compiling of regexps (if requested)
 and then printing for any matches found (the search routines have to be written
 too as does the code to traverse the tree - or 'climb down the tree' :-) ). In
-other words one of the features of the program is complete!
+other words one of the features of the program is complete! Note that use of
+`-o` when a pattern is specified is a command line error.
 
 
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-Q] [-t type] [-q] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]} [-j] [-E] [-i] [-s] [-g] [-G regexp] [-c] [-m depth] [-K]\n"
-    "\t\t[-Y type:value] [-S path] [-A args] [-W] file.json [name_arg ...]\n\n"
+    "\t\t[-Y type:value] [-S path] [-A args] [-o] file.json [name_arg ...]\n\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
     "\t-v level\tVerbosity level (def: %d)\n"
@@ -153,7 +153,7 @@ static const char * const usage_msg3 =
     "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
     "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
     "\t\t\tNOTE: use of -A requires use of -S\n\n"
-    "\t-W\t\twrite entire file to stdout if valid JSON\n";
+    "\t-o\t\twrite entire file to stdout if valid JSON\n";
 
 /*
  * NOTE: this next one should be the last number; if any additional usage message strings
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:G:KY:sA:W")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:G:KY:sA:o")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jprint(jprint);
@@ -453,7 +453,7 @@ int main(int argc, char **argv)
 	    jprint->tool_args = optarg;
 	    dbg(DBG_NONE, "set tool args to %s", jprint->tool_args);
 	    break;
-	case 'W': /* -W, print entire file if valid JSON */
+	case 'o': /* -o, print entire file if valid JSON */
 	    jprint->print_entire_file = true;
 	    break;
 	case ':':   /* option requires an argument */
@@ -661,7 +661,7 @@ int main(int argc, char **argv)
 	 * so this check is only here for documentation purposes.
 	 */
     } else {
-	dbg(DBG_NONE,"no pattern requested or -W, will print entire file");
+	dbg(DBG_NONE,"no pattern requested or -o, will print entire file");
 	if (file_contents != NULL) {
 	    fpr(stdout, "jprint", "%s", file_contents);
 	}

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -153,7 +153,8 @@ static const char * const usage_msg3 =
     "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
     "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
     "\t\t\tNOTE: use of -A requires use of -S\n\n"
-    "\t-o\t\twrite entire file to stdout if valid JSON\n";
+    "\t-o\t\twrite entire file to stdout if valid JSON\n"
+    "\t\t\tNOTE: use of -o with patterns specified is an error.\n";
 
 /*
  * NOTE: this next one should be the last number; if any additional usage message strings
@@ -636,6 +637,12 @@ int main(int argc, char **argv)
 
     dbg(DBG_MED, "valid JSON");
 
+    if (jprint->patterns != NULL && jprint->print_entire_file) {
+	free_jprint(jprint);
+	jprint = NULL;
+	err(3, "jprint", "printing the entire file is incompatible with any patterns specified"); /*ooo*/
+	not_reached();
+    }
     if (jprint->patterns != NULL && !jprint->print_entire_file) {
 	/* TODO process name_args */
 	for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -651,6 +651,7 @@ int main(int argc, char **argv)
     /* free tree */
     json_tree_free(json_tree, jprint->max_depth);
 
+    /* All Done!!! -- Jessica Noll, Age 2 */
     if (jprint->match_found || !jprint->pattern_specified || jprint->print_entire_file) {
 	free_jprint(jprint);	/* free jprint struct */
 	jprint = NULL;	/* set jprint to NULL even though we're just about to exit */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-Q] [-t type] [-q] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]} [-j] [-E] [-i] [-s] [-g] [-G regexp] [-c] [-m depth] [-K]\n"
-    "\t\t[-Y type:value] [-S path] [-A args] file.json [name_arg ...]\n\n"
+    "\t\t[-Y type:value] [-S path] [-A args] [-W] file.json [name_arg ...]\n\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
     "\t-v level\tVerbosity level (def: %d)\n"
@@ -152,7 +152,9 @@ static const char * const usage_msg3 =
     "\t\t\tNOTE: -Y Requires one and only one name_arg\n\n"
     "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
     "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
-    "\t\t\tNOTE: use of -A requires use of -S\n";
+    "\t\t\tNOTE: use of -A requires use of -S\n\n"
+    "\t-W\t\twrite entire file to stdout if valid JSON\n";
+
 /*
  * NOTE: this next one should be the last number; if any additional usage message strings
  * have to be added the first additional one should be the number this is and this one
@@ -189,6 +191,8 @@ int main(int argc, char **argv)
     struct jprint *jprint = NULL;	/* struct of all our options and other things */
     struct jprint_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
     FILE *json_file = NULL;		/* file pointer for json file */
+    char *file_contents = NULL;		/* file contents in full */
+    size_t len = 0;			/* length of file contents */
     struct json *json_tree;		/* json tree */
     bool is_valid = false;		/* if file is valid json */
 
@@ -276,7 +280,7 @@ int main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:G:KY:sA:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:G:KY:sA:W")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jprint(jprint);
@@ -449,6 +453,9 @@ int main(int argc, char **argv)
 	    jprint->tool_args = optarg;
 	    dbg(DBG_NONE, "set tool args to %s", jprint->tool_args);
 	    break;
+	case 'W': /* -W, print entire file if valid JSON */
+	    jprint->print_entire_file = true;
+	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */
 	default:    /* anything else but should not actually happen */
@@ -567,26 +574,6 @@ int main(int argc, char **argv)
 	json_file = stdin;
     }
 
-    json_tree = parse_json_stream(json_file, argv[0], &is_valid);
-    if (!is_valid) {
-	if (json_file != stdin) {
-	    fclose(json_file);  /* close file prior to exiting */
-	    json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
-	}
-
-	/* free our jprint struct */
-	free_jprint(jprint);
-	jprint = NULL;
-	err(5, "jprint", "%s invalid JSON", argv[0]); /*ooo*/
-	not_reached();
-    } else if (json_file != stdin) {
-	/* close the JSON file if not stdin */
-	fclose(json_file);
-	json_file = NULL;
-    }
-
-    dbg(DBG_MED, "valid JSON");
-
     /* the debug level will be increased at a later time */
     dbg(DBG_NONE, "maximum depth to traverse: %ju%s", jprint->max_depth, (jprint->max_depth == 0?" (no limit)":
 		jprint->max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
@@ -620,32 +607,70 @@ int main(int argc, char **argv)
 	    not_reached();
 	}
     }
+    /*
+     * read in entire file BEFORE trying to parse it as json as the parser
+     * function will close the file
+     */
+    file_contents = read_all(json_file, &len);
+    if (file_contents == NULL) {
+	err(4, "jprint", "could not read in file: <%s>", argv[0]); /*ooo*/
+	not_reached();
+    }
+    /* clear EOF status and rewind for parse_json_stream() */
+    clearerr(json_file);
+    rewind(json_file);
 
-    /* TODO process name_args */
-    for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {
-	if (pattern->pattern != NULL && *pattern->pattern) {
-	    /*
-	     * XXX if matches found we set the boolean match_found to true to
-	     * indicate exit code of 0 but currently no matches are checked. In
-	     * other words in the future this setting of match_found will not always
-	     * happen.
-	     */
-	    jprint->match_found = true;
+    json_tree = parse_json_stream(json_file, argv[0], &is_valid);
+    if (!is_valid) {
+	if (json_file != stdin) {
+	    fclose(json_file);  /* close file prior to exiting */
+	    json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
+	}
 
-	    dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
-		    pattern->use_regexp?"regexp":"pattern", pattern->pattern,
-		    pattern->use_substrings?"OK":"ignored");
+	/* free our jprint struct */
+	free_jprint(jprint);
+	jprint = NULL;
+	err(5, "jprint", "%s invalid JSON", argv[0]); /*ooo*/
+	not_reached();
+    }
+
+    dbg(DBG_MED, "valid JSON");
+
+    if (jprint->patterns != NULL && !jprint->print_entire_file) {
+	/* TODO process name_args */
+	for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {
+	    if (pattern->pattern != NULL && *pattern->pattern) {
+		/*
+		 * XXX if matches found we set the boolean match_found to true to
+		 * indicate exit code of 0 but currently no matches are checked. In
+		 * other words in the future this setting of match_found will not always
+		 * happen.
+		 */
+		jprint->match_found = true;
+
+		dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
+			pattern->use_substrings?"OK":"ignored");
+	    }
+	}
+	/*
+	 * XXX remove this informative message or change debug level once processing
+	 * is implemented.
+	 *
+	 * NOTE: if pattern_specified is false then print_entire_file will be true
+	 * so this check is only here for documentation purposes.
+	 */
+    } else {
+	dbg(DBG_NONE,"no pattern requested or -W, will print entire file");
+	if (file_contents != NULL) {
+	    fpr(stdout, "jprint", "%s", file_contents);
 	}
     }
-    /*
-     * XXX remove this informative message or change debug level once processing
-     * is implemented.
-     *
-     * NOTE: if pattern_specified is false then print_entire_file will be true
-     * so this check is only here for documentation purposes.
-     */
-    if (!jprint->pattern_specified || jprint->print_entire_file) {
-	dbg(DBG_NONE,"no pattern requested, will print entire file");
+
+    /* close the JSON file if not stdin */
+    if (json_file != stdin) {
+	fclose(json_file);
+	json_file = NULL;
     }
 
     /* free tree */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.18 2023-06-15"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.19 2023-06-16"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_pattern - struct for a linked list of patterns requested, held in

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1097,52 +1097,49 @@ pipe_open(char const *name, char const *mode, bool abort_on_error, char const *f
 	}
     }
 
-    if (!strcmp(mode, "r")) {
-	/*
-	 * pre-flush stdout to avoid popen() buffered stdio issues
-	 */
-	clearerr(stdout);		/* pre-clear ferror() status */
-	errno = 0;			/* pre-clear errno for errp() */
-	ret = fflush(stdout);
-	if (ret < 0) {
-	    /* free allocated command storage */
-	    if (cmd != NULL) {
-		free(cmd);
-		cmd = NULL;
-	    }
-	    /* exit or error return depending on abort_on_error */
-	    if (abort_on_error) {
-		errp(122, name, "fflush(stdout): error code: %d", ret);
-		not_reached();
-	    } else {
-		dbg(DBG_MED, "called from %s: fflush(stdout) failed: %s", name, strerror(errno));
-		va_end(ap);		/* stdarg variable argument list cleanup */
-		return NULL;
-	    }
+    /*
+     * pre-flush stdout to avoid popen() buffered stdio issues
+     */
+    clearerr(stdout);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stdout);
+    if (ret < 0) {
+	/* free allocated command storage */
+	if (cmd != NULL) {
+	    free(cmd);
+	    cmd = NULL;
+	}
+	/* exit or error return depending on abort_on_error */
+	if (abort_on_error) {
+	    errp(122, name, "fflush(stdout): error code: %d", ret);
+	    not_reached();
+	} else {
+	    dbg(DBG_MED, "called from %s: fflush(stdout) failed: %s", name, strerror(errno));
+	    va_end(ap);		/* stdarg variable argument list cleanup */
+	    return NULL;
 	}
     }
-    if (!strcmp(mode, "w")) {
-	/*
-	 * pre-flush stdin to avoid popen() buffered stdio issues
-	 */
-	clearerr(stdin);		/* pre-clear ferror() status */
-	errno = 0;			/* pre-clear errno for errp() */
-	ret = fflush(stdin);
-	if (ret < 0) {
-	    /* free allocated command storage */
-	    if (cmd != NULL) {
-		free(cmd);
-		cmd = NULL;
-	    }
-	    /* exit or error return depending on abort_on_error */
-	    if (abort_on_error) {
-		errp(123, name, "fflush(stdin): error code: %d", ret);
-		not_reached();
-	    } else {
-		dbg(DBG_MED, "called from %s: fflush(stdin) failed: %s", name, strerror(errno));
-		va_end(ap);		/* stdarg variable argument list cleanup */
-		return NULL;
-	    }
+
+    /*
+     * pre-flush stdin to avoid popen() buffered stdio issues
+     */
+    clearerr(stdin);		/* pre-clear ferror() status */
+    errno = 0;			/* pre-clear errno for errp() */
+    ret = fflush(stdin);
+    if (ret < 0) {
+	/* free allocated command storage */
+	if (cmd != NULL) {
+	    free(cmd);
+	    cmd = NULL;
+	}
+	/* exit or error return depending on abort_on_error */
+	if (abort_on_error) {
+	    errp(123, name, "fflush(stdin): error code: %d", ret);
+	    not_reached();
+	} else {
+	    dbg(DBG_MED, "called from %s: fflush(stdin) failed: %s", name, strerror(errno));
+	    va_end(ap);		/* stdarg variable argument list cleanup */
+	    return NULL;
 	}
     }
 

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1007,6 +1007,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
  *
  * given:
  *	name		- name of the calling function
+ *	mode		- string of the mode arg to popen()
  *	abort_on_error	- false ==> return FILE * stream for open pipe to shell, or
  *			    return NULL on failure
  *			  true ==> return FILE * stream for open pipe to shell, or
@@ -1023,7 +1024,7 @@ shell_cmd(char const *name, bool abort_on_error, char const *format, ...)
  *	FILE * stream for open pipe to shell, or NULL ==> error
  */
 FILE *
-pipe_open(char const *name, bool abort_on_error, char const *format, ...)
+pipe_open(char const *name, char const *mode, bool abort_on_error, char const *format, ...)
 {
     va_list ap;			/* variable argument list */
     char *cmd = NULL;		/* e.g. cp prog.c entry_dir/prog.c */
@@ -1043,10 +1044,29 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
 	    return NULL;
 	}
     }
+    if (mode == NULL) {
+	/* exit or error return depending on abort */
+	if (abort_on_error) {
+	    err(118, __func__, "function mode is NULL");
+	    not_reached();
+	} else {
+	    dbg(DBG_MED, "called with NULL mode, returning NULL");
+	    return NULL;
+	}
+    } else if (strcmp(mode, "r") && strcmp(mode, "w")) {
+	/* exit or error return depending on abort */
+	if (abort_on_error) {
+	    err(119, __func__, "invalid mode, is neither: \"r\" nor \"w\": <%s>", mode);
+	    not_reached();
+	} else {
+	    dbg(DBG_MED, "invalid mode, is neither: \"r\" nor \"w\": <%s>", mode);
+	    return NULL;
+	}
+    }
     if (format == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    err(118, name, "called with NULL format");
+	    err(120, name, "called with NULL format");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called with NULL format, returning NULL");
@@ -1067,7 +1087,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     if (cmd == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    errp(119, name, "calloc failed in vcmdprintf()");
+	    errp(121, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s returning: %d < 0",
@@ -1077,26 +1097,52 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
 	}
     }
 
-    /*
-     * pre-flush stdout to avoid popen() buffered stdio issues
-     */
-    clearerr(stdout);		/* pre-clear ferror() status */
-    errno = 0;			/* pre-clear errno for errp() */
-    ret = fflush(stdout);
-    if (ret < 0) {
-	/* free allocated command storage */
-	if (cmd != NULL) {
-	    free(cmd);
-	    cmd = NULL;
+    if (!strcmp(mode, "r")) {
+	/*
+	 * pre-flush stdout to avoid popen() buffered stdio issues
+	 */
+	clearerr(stdout);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stdout);
+	if (ret < 0) {
+	    /* free allocated command storage */
+	    if (cmd != NULL) {
+		free(cmd);
+		cmd = NULL;
+	    }
+	    /* exit or error return depending on abort_on_error */
+	    if (abort_on_error) {
+		errp(122, name, "fflush(stdout): error code: %d", ret);
+		not_reached();
+	    } else {
+		dbg(DBG_MED, "called from %s: fflush(stdout) failed: %s", name, strerror(errno));
+		va_end(ap);		/* stdarg variable argument list cleanup */
+		return NULL;
+	    }
 	}
-	/* exit or error return depending on abort_on_error */
-	if (abort_on_error) {
-	    errp(120, name, "fflush(stdout): error code: %d", ret);
-	    not_reached();
-	} else {
-	    dbg(DBG_MED, "called from %s: fflush(stdout) failed: %s", name, strerror(errno));
-	    va_end(ap);		/* stdarg variable argument list cleanup */
-	    return NULL;
+    }
+    if (!strcmp(mode, "w")) {
+	/*
+	 * pre-flush stdin to avoid popen() buffered stdio issues
+	 */
+	clearerr(stdin);		/* pre-clear ferror() status */
+	errno = 0;			/* pre-clear errno for errp() */
+	ret = fflush(stdin);
+	if (ret < 0) {
+	    /* free allocated command storage */
+	    if (cmd != NULL) {
+		free(cmd);
+		cmd = NULL;
+	    }
+	    /* exit or error return depending on abort_on_error */
+	    if (abort_on_error) {
+		errp(123, name, "fflush(stdin): error code: %d", ret);
+		not_reached();
+	    } else {
+		dbg(DBG_MED, "called from %s: fflush(stdin) failed: %s", name, strerror(errno));
+		va_end(ap);		/* stdarg variable argument list cleanup */
+		return NULL;
+	    }
 	}
     }
 
@@ -1114,7 +1160,7 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
 	}
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(121, name, "fflush(stderr): error code: %d", ret);
+	    errp(124, name, "fflush(stderr): error code: %d", ret);
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: fflush(stderr) failed: %s", name, strerror(errno));
@@ -1126,16 +1172,16 @@ pipe_open(char const *name, bool abort_on_error, char const *format, ...)
     /*
      * establish the open pipe to the shell command
      */
-    dbg(DBG_HIGH, "about to perform: popen(%s, \"r\")", cmd);
+    dbg(DBG_HIGH, "about to perform: popen(%s, \"%s\")", cmd, mode);
     errno = 0;			/* pre-clear errno for errp() */
-    stream = popen(cmd, "r");
+    stream = popen(cmd, mode);
     if (stream == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(122, name, "error calling popen(%s, \"r\")", cmd);
+	    errp(125, name, "error calling popen(%s, \"%s\")", cmd, mode);
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called from %s: error calling popen(%s, \"r\"): %s", name, cmd, strerror(errno));
+	    dbg(DBG_MED, "called from %s: error calling popen(%s, \"%s\"): %s", name, cmd, mode, strerror(errno));
 	    va_end(ap);		/* stdarg variable argument list cleanup */
 	    /* free allocated command storage */
 	    if (cmd != NULL) {
@@ -1208,7 +1254,7 @@ para(char const *line, ...)
      * firewall
      */
     if (stdout == NULL) {
-	err(123, __func__, "stdout is NULL");
+	err(126, __func__, "stdout is NULL");
 	not_reached();
     }
     clearerr(stdout);		/* pre-clear ferror() status */
@@ -1218,7 +1264,7 @@ para(char const *line, ...)
      */
     fd = fileno(stdout);
     if (fd < 0) {
-	errp(124, __func__, "fileno on stdout returned: %d < 0", fd);
+	errp(128, __func__, "fileno on stdout returned: %d < 0", fd);
 	not_reached();
     }
     clearerr(stdout);		/* paranoia */
@@ -1237,13 +1283,13 @@ para(char const *line, ...)
 	ret = fputs(line, stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(125, __func__, "error writing paragraph to a stdout");
+		errp(129, __func__, "error writing paragraph to a stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(126, __func__, "EOF while writing paragraph to a stdout");
+		err(130, __func__, "EOF while writing paragraph to a stdout");
 		not_reached();
 	    } else {
-		errp(128, __func__, "unexpected fputs error writing paragraph to stdout");
+		errp(131, __func__, "unexpected fputs error writing paragraph to stdout");
 		not_reached();
 	    }
 	}
@@ -1256,13 +1302,13 @@ para(char const *line, ...)
 	ret = fputc('\n', stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(129, __func__, "error writing newline to stdout");
+		errp(132, __func__, "error writing newline to stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(130, __func__, "EOF while writing newline to stdout");
+		err(133, __func__, "EOF while writing newline to stdout");
 		not_reached();
 	    } else {
-		errp(131, __func__, "unexpected fputc error writing newline to stdout");
+		errp(134, __func__, "unexpected fputc error writing newline to stdout");
 		not_reached();
 	    }
 	}
@@ -1287,13 +1333,13 @@ para(char const *line, ...)
     ret = fflush(stdout);
     if (ret == EOF) {
 	if (ferror(stdout)) {
-	    errp(132, __func__, "error flushing stdout");
+	    errp(135, __func__, "error flushing stdout");
 	    not_reached();
 	} else if (feof(stdout)) {
-	    err(133, __func__, "EOF while flushing stdout");
+	    err(136, __func__, "EOF while flushing stdout");
 	    not_reached();
 	} else {
-	    errp(134, __func__, "unexpected fflush error while flushing stdout");
+	    errp(137, __func__, "unexpected fflush error while flushing stdout");
 	    not_reached();
 	}
     }
@@ -1336,7 +1382,7 @@ fpara(FILE * stream, char const *line, ...)
      * firewall
      */
     if (stream == NULL) {
-	err(135, __func__, "stream is NULL");
+	err(138, __func__, "stream is NULL");
 	not_reached();
     }
 
@@ -1347,7 +1393,7 @@ fpara(FILE * stream, char const *line, ...)
     errno = 0;			/* pre-clear errno for errp() */
     fd = fileno(stream);
     if (fd < 0) {
-	errp(136, __func__, "fileno on stream returned: %d < 0", fd);
+	errp(139, __func__, "fileno on stream returned: %d < 0", fd);
 	not_reached();
     }
     clearerr(stream);		/* paranoia */
@@ -1366,13 +1412,13 @@ fpara(FILE * stream, char const *line, ...)
 	ret = fputs(line, stream);
 	if (ret == EOF) {
 	    if (ferror(stream)) {
-		errp(137, __func__, "error writing paragraph to stream");
+		errp(140, __func__, "error writing paragraph to stream");
 		not_reached();
 	    } else if (feof(stream)) {
-		err(138, __func__, "EOF while writing paragraph to stream");
+		err(141, __func__, "EOF while writing paragraph to stream");
 		not_reached();
 	    } else {
-		errp(139, __func__, "unexpected fputs error writing paragraph to stream");
+		errp(142, __func__, "unexpected fputs error writing paragraph to stream");
 		not_reached();
 	    }
 	}
@@ -1385,13 +1431,13 @@ fpara(FILE * stream, char const *line, ...)
 	ret = fputc('\n', stream);
 	if (ret == EOF) {
 	    if (ferror(stream)) {
-		errp(140, __func__, "error writing newline to stream");
+		errp(143, __func__, "error writing newline to stream");
 		not_reached();
 	    } else if (feof(stream)) {
-		err(141, __func__, "EOF while writing newline to stream");
+		err(144, __func__, "EOF while writing newline to stream");
 		not_reached();
 	    } else {
-		errp(142, __func__, "unexpected fputc error writing newline to stream");
+		errp(145, __func__, "unexpected fputc error writing newline to stream");
 		not_reached();
 	    }
 	}
@@ -1416,13 +1462,13 @@ fpara(FILE * stream, char const *line, ...)
     ret = fflush(stream);
     if (ret == EOF) {
 	if (ferror(stream)) {
-	    errp(143, __func__, "error flushing stream");
+	    errp(146, __func__, "error flushing stream");
 	    not_reached();
 	} else if (feof(stream)) {
-	    err(144, __func__, "EOF while flushing stream");
+	    err(147, __func__, "EOF while flushing stream");
 	    not_reached();
 	} else {
-	    errp(145, __func__, "unexpected fflush error while flushing stream");
+	    errp(148, __func__, "unexpected fflush error while flushing stream");
 	    not_reached();
 	}
     }
@@ -1615,7 +1661,7 @@ readline(char **linep, FILE * stream)
      * firewall
      */
     if (linep == NULL || stream == NULL) {
-	err(146, __func__, "called with NULL arg(s)");
+	err(149, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1630,10 +1676,10 @@ readline(char **linep, FILE * stream)
 	    dbg(DBG_VVHIGH, "EOF detected in getline");
 	    return -1; /* EOF found */
 	} else if (ferror(stream)) {
-	    errp(147, __func__, "getline() error");
+	    errp(150, __func__, "getline() error");
 	    not_reached();
 	} else {
-	    errp(148, __func__, "unexpected getline() error");
+	    errp(151, __func__, "unexpected getline() error");
 	    not_reached();
 	}
     }
@@ -1641,7 +1687,7 @@ readline(char **linep, FILE * stream)
      * paranoia
      */
     if (*linep == NULL) {
-	err(149, __func__, "*linep is NULL after getline()");
+	err(152, __func__, "*linep is NULL after getline()");
 	not_reached();
     }
 
@@ -1697,7 +1743,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
      * firewall
      */
     if (linep == NULL || stream == NULL) {
-	err(150, __func__, "called with NULL arg(s)");
+	err(153, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -1719,7 +1765,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
     errno = 0;			/* pre-clear errno for errp() */
     ret = calloc((size_t)len+1+1, sizeof(char));
     if (ret == NULL) {
-	errp(151, __func__, "calloc of read line of %jd bytes failed", (intmax_t)len+1+1);
+	errp(154, __func__, "calloc of read line of %jd bytes failed", (intmax_t)len+1+1);
 	not_reached();
     }
     memcpy(ret, *linep, (size_t)len);
@@ -1822,7 +1868,7 @@ read_all(FILE *stream, size_t *psize)
      * firewall
      */
     if (stream == NULL) {
-	err(152, __func__, "called with NULL stream");
+	err(155, __func__, "called with NULL stream");
 	not_reached();
     }
 
@@ -2523,7 +2569,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
      * firewall
      */
     if (str == NULL || slash == NULL || posix_safe == NULL || first_alphanum == NULL || upper == NULL) {
-	err(153, __func__, "called with NULL arg(s)");
+	err(156, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3604,7 +3650,7 @@ calloc_path(char const *dirname, char const *filename)
      * firewall
      */
     if (filename == NULL) {
-	err(154, __func__, "filename is NULL");
+	err(157, __func__, "filename is NULL");
 	not_reached();
     }
 
@@ -3621,7 +3667,7 @@ calloc_path(char const *dirname, char const *filename)
 	errno = 0;		/* pre-clear errno for errp() */
 	buf = strdup(filename);
 	if (buf == NULL) {
-	    errp(155, __func__, "strdup of filename failed: %s", filename);
+	    errp(158, __func__, "strdup of filename failed: %s", filename);
 	    not_reached();
 	}
 
@@ -3639,7 +3685,7 @@ calloc_path(char const *dirname, char const *filename)
 	buf = calloc(len+1, sizeof(char));	/* + 1 for paranoia padding */
 	errno = 0;		/* pre-clear errno for errp() */
 	if (buf == NULL) {
-	    errp(156, __func__, "calloc of %ju bytes failed", (uintmax_t)len);
+	    errp(159, __func__, "calloc of %ju bytes failed", (uintmax_t)len);
 	    not_reached();
 	}
 
@@ -3649,7 +3695,7 @@ calloc_path(char const *dirname, char const *filename)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = snprintf(buf, len, "%s/%s", dirname, filename);
 	if (ret < 0) {
-	    errp(157, __func__, "snprintf returned: %zu < 0", len);
+	    errp(160, __func__, "snprintf returned: %zu < 0", len);
 	    not_reached();
 	}
     }
@@ -3658,7 +3704,7 @@ calloc_path(char const *dirname, char const *filename)
      * return malloc path
      */
     if (buf == NULL) {
-	errp(158, __func__, "function attempted to return NULL");
+	errp(161, __func__, "function attempted to return NULL");
 	not_reached();
     }
     return buf;
@@ -3685,7 +3731,7 @@ count_char(char const *str, int ch)
      * firewall
      */
     if (str == NULL) {
-	err(159, __func__, "given NULL str");
+	err(162, __func__, "given NULL str");
 	not_reached();
     }
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -189,7 +189,7 @@ extern off_t file_size(char const *path);
 extern char *cmdprintf(char const *format, ...);
 extern char *vcmdprintf(char const *format, va_list ap);
 extern int shell_cmd(char const *name, bool abort_on_error, char const *format, ...);
-extern FILE *pipe_open(char const *name, bool abort_on_error, char const *format, ...);
+extern FILE *pipe_open(char const *name, char const *mode, bool abort_on_error, char const *format, ...);
 extern void para(char const *line, ...);
 extern void fpara(FILE * stream, char const *line, ...);
 extern void vfpr(FILE *stream, char const *name, char const *fmt, va_list ap);

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -4538,7 +4538,7 @@ verify_entry_dir(char const *entry_dir, char const *ls)
      * open pipe to the ls command
      */
     dbg(DBG_HIGH, "about to popen: cd -- %s && %s -lak .", entry_dir, ls);
-    ls_stream = pipe_open(__func__, true, "cd -- % && % -lak .", entry_dir, ls);
+    ls_stream = pipe_open(__func__, "r", true, "cd -- % && % -lak .", entry_dir, ls);
     if (ls_stream == NULL) {
 	err(137, __func__, "popen filed for: cd -- %s && %s -lak .", entry_dir, ls);
 	not_reached();

--- a/txzchk.c
+++ b/txzchk.c
@@ -1484,7 +1484,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	/*
 	 * form pipe to the fnamchk command
 	 */
-	fnamchk_stream = pipe_open(__func__, true, "% -E % -- %", fnamchk, ext, tarball_path);
+	fnamchk_stream = pipe_open(__func__, "r", true, "% -E % -- %", fnamchk, ext, tarball_path);
 	if (fnamchk_stream == NULL) {
 	    err(36, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
 	    not_reached();
@@ -1571,7 +1571,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	}
 
 	/* now open a pipe to tar command (tar -tJvf) to read from */
-	input_stream = pipe_open(__func__, true, "% -tJvf %", tar, tarball_path);
+	input_stream = pipe_open(__func__, "r", true, "% -tJvf %", tar, tarball_path);
 	if (input_stream == NULL) {
 	    err(42, __func__, "popen for reading failed for: %s -tJvf %s",
 			      tar, tarball_path);


### PR DESCRIPTION

This seems like a better letter to use. The issue of whether or not it 
should be a command line error if -o and any patterns are specified has
not been addressed but my suspicion is it should be an error and 
probably will be made into one. This is TBD at a later point in time, 
perhaps rather soon.