### PR TITLE
Fix handling of -Y wrt name_arg count check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.14 2023-06-17
+
+New `jprint` version at "0.0.20 2023-06-17".
+
+Fix special handling for -Y option wrt exactly one name arg. The idea behind the
+check is that if `-G` is specified then one cannot specify a `name_arg`. If it
+is not specified then you must specify one `name_arg`. If both `-G` and a
+`name_arg` are not specified it is also an error but there was a bug which
+required that `-G` was used.
+
+
 ## Release 1.0.13 2023-06-16
 
 New `jprint` version "0.0.19 2023-06-16" - will print entire file if no pattern

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -480,16 +480,6 @@ int main(int argc, char **argv)
 	jprint->print_entire_file = true;   /* technically this boolean is redundant */
     }
 
-    if (jprint->search_value && argv[1] != NULL && argv[2] != NULL) {
-	/*
-	 * special handling to make sure that if -Y is specified then only -G
-	 * foo or one arg is specified after the file
-	 */
-	free_jprint(&jprint);
-	err(19, "jprint", "-Y requires exactly one name_arg");
-	not_reached();
-    }
-
     for (i = 1; argv[i] != NULL; ++i) {
 	jprint->pattern_specified = true;
 
@@ -499,6 +489,17 @@ int main(int argc, char **argv)
 	    not_reached();
 	}
     }
+
+    if (jprint->search_value && jprint->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only -G
+	 * foo or one arg is specified after the file
+	 */
+	free_jprint(&jprint);
+	err(19, "jprint", "-Y requires exactly one name_arg");
+	not_reached();
+    }
+
 
     /* run tool if -S used */
     if (tool_path != NULL) {

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.19 2023-06-16"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.20 2023-06-17"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_pattern - struct for a linked list of patterns requested, held in


### PR DESCRIPTION
New jprint version at "0.0.20 2023-06-17".

Fix special handling for -Y option wrt exactly one name arg. The idea behind the check is that if -G is specified then one cannot specify a name_arg. If it is not specified then you must specify one name_arg. If both -G and a name_arg are not specified it is also an error but there was a bug which required that -G was used.