### PR TITLE
Fix comments for json_tree_print()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ is not specified then you must specify one `name_arg`. If both `-G` and a
 `name_arg` are not specified it is also an error but there was a bug which
 required that `-G` was used.
 
+Don't show that substrings are ignored for patterns that are regexps.
 
 ## Release 1.0.13 2023-06-16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.14 2023-06-17
+
+New `jprint` version at "0.0.20 2023-06-17".
+
+Fix special handling for -Y option wrt exactly one name arg. The idea behind the
+check is that if `-G` is specified then one cannot specify a `name_arg`. If it
+is not specified then you must specify one `name_arg`. If both `-G` and a
+`name_arg` are not specified it is also an error but there was a bug which
+required that `-G` was used.
+
+
 ## Release 1.0.13 2023-06-16
 
 New `jprint` version "0.0.19 2023-06-16" - will print entire file if no pattern

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -480,16 +480,6 @@ int main(int argc, char **argv)
 	jprint->print_entire_file = true;   /* technically this boolean is redundant */
     }
 
-    if (jprint->search_value && argv[1] != NULL && argv[2] != NULL) {
-	/*
-	 * special handling to make sure that if -Y is specified then only -G
-	 * foo or one arg is specified after the file
-	 */
-	free_jprint(&jprint);
-	err(19, "jprint", "-Y requires exactly one name_arg");
-	not_reached();
-    }
-
     for (i = 1; argv[i] != NULL; ++i) {
 	jprint->pattern_specified = true;
 
@@ -499,6 +489,17 @@ int main(int argc, char **argv)
 	    not_reached();
 	}
     }
+
+    if (jprint->search_value && jprint->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only -G
+	 * foo or one arg is specified after the file
+	 */
+	free_jprint(&jprint);
+	err(19, "jprint", "-Y requires exactly one name_arg");
+	not_reached();
+    }
+
 
     /* run tool if -S used */
     if (tool_path != NULL) {

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -586,9 +586,14 @@ int main(int argc, char **argv)
 		 */
 		jprint->match_found = true;
 
-		dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+		if (pattern->use_regexp) {
+		dbg(DBG_NONE, "searching for %s regexp '%s'", pattern->use_value?"value":"name",
+			pattern->pattern);
+		} else {
+		    dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
 			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
 			pattern->use_substrings?"OK":"ignored");
+		}
 	    }
 	}
     } else {

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.19 2023-06-16"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.20 2023-06-17"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_pattern - struct for a linked list of patterns requested, held in

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1782,14 +1782,11 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  *		json_dbg_lvl   print message if JSON_DBG_FORCED
  *			       OR if <= json_verbosity_level
  *
- * Example use - free an entire JSON parse tree
+ * Example use - print an entire JSON parse tree
  *
  *	len = json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stderr, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stdout, JSON_DBG_MED);
- *
- * NOTE: This function will free the internals of a JSON parser tree node.
- *	 It is up to the caller to free the top level struct json if needed.
  *
  * NOTE: If the pointer to allocated storage == NULL,
  *	 this function does nothing.
@@ -1797,6 +1794,9 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  * NOTE: This function does nothing if node == NULL.
  *
  * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is a wrapper to vjson_tree_walk() with the callback
+ * vjson_fprint().
  */
 void
 json_tree_print(struct json *node, unsigned int max_depth, ...)

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1782,9 +1782,9 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  *		json_dbg_lvl   print message if JSON_DBG_FORCED
  *			       OR if <= json_verbosity_level
  *
- * Example use - print an entire JSON parse tree
+ * Example uses - print an entire JSON parse tree
  *
- *	len = json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
+ *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stderr, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stdout, JSON_DBG_MED);
  *

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1344,7 +1344,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
     }
 
     /*
-     * print debug leader
+     * print debug header
      */
     if (json_dbg_lvl != JSON_DBG_FORCED) {
 	fprint(stream, "JSON tree[%d]:\t", json_dbg_lvl);


### PR DESCRIPTION

The comments suggested it frees the json tree but instead it (as the
name implies) prints the entire tree. Probably the 'yank paste and 
forget to update' problem.