### PR TITLE
Add initial callback and calling code to jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ is not specified then you must specify one `name_arg`. If both `-G` and a
 `name_arg` are not specified it is also an error but there was a bug which
 required that `-G` was used.
 
+Don't show that substrings are ignored for patterns that are regexps.
 
 ## Release 1.0.13 2023-06-16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,13 @@ Don't show that substrings are ignored for patterns that are regexps (in
 
 Sequenced exit codes in `jprint`.
 
+Add callback function and calling code to `jprint`. Currently it does not check
+for any constraints and will print only json nodes which has a string as the
+name or value. The name is not ultimately desired without printing json as a
+whole but for now the name is printed. This means that both name and value might
+be printed. There are too many newlines printed as well. Much more needs to be
+done with these functions.
+
 ## Release 1.0.13 2023-06-16
 
 New `jprint` version "0.0.19 2023-06-16" - will print entire file if no pattern

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,10 @@ is not specified then you must specify one `name_arg`. If both `-G` and a
 `name_arg` are not specified it is also an error but there was a bug which
 required that `-G` was used.
 
-Don't show that substrings are ignored for patterns that are regexps.
+Don't show that substrings are ignored for patterns that are regexps (in
+`jprint`).
+
+Sequenced exit codes in `jprint`.
 
 ## Release 1.0.13 2023-06-16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.14 2023-06-17
+
+New `jprint` version at "0.0.20 2023-06-17".
+
+Fix special handling for -Y option wrt exactly one name arg. The idea behind the
+check is that if `-G` is specified then one cannot specify a `name_arg`. If it
+is not specified then you must specify one `name_arg`. If both `-G` and a
+`name_arg` are not specified it is also an error but there was a bug which
+required that `-G` was used.
+
+
 ## Release 1.0.13 2023-06-16
 
 New `jprint` version "0.0.19 2023-06-16" - will print entire file if no pattern

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -480,16 +480,6 @@ int main(int argc, char **argv)
 	jprint->print_entire_file = true;   /* technically this boolean is redundant */
     }
 
-    if (jprint->search_value && argv[1] != NULL && argv[2] != NULL) {
-	/*
-	 * special handling to make sure that if -Y is specified then only -G
-	 * foo or one arg is specified after the file
-	 */
-	free_jprint(&jprint);
-	err(19, "jprint", "-Y requires exactly one name_arg");
-	not_reached();
-    }
-
     for (i = 1; argv[i] != NULL; ++i) {
 	jprint->pattern_specified = true;
 
@@ -499,6 +489,17 @@ int main(int argc, char **argv)
 	    not_reached();
 	}
     }
+
+    if (jprint->search_value && jprint->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only -G
+	 * foo or one arg is specified after the file
+	 */
+	free_jprint(&jprint);
+	err(19, "jprint", "-Y requires exactly one name_arg");
+	not_reached();
+    }
+
 
     /* run tool if -S used */
     if (tool_path != NULL) {

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -484,7 +484,7 @@ int main(int argc, char **argv)
 	jprint->pattern_specified = true;
 
 	if (add_jprint_pattern(jprint, jprint->use_regexps, jprint->substrings_okay, argv[i]) == NULL) {
-	    err(20, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
+	    err(19, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
 		    jprint->substrings_okay?"OK":"ignored", argv[i]);
 	    not_reached();
 	}
@@ -496,7 +496,7 @@ int main(int argc, char **argv)
 	 * foo or one arg is specified after the file
 	 */
 	free_jprint(&jprint);
-	err(19, "jprint", "-Y requires exactly one name_arg");
+	err(20, "jprint", "-Y requires exactly one name_arg");
 	not_reached();
     }
 
@@ -587,8 +587,7 @@ int main(int argc, char **argv)
 		jprint->match_found = true;
 
 		if (pattern->use_regexp) {
-		dbg(DBG_NONE, "searching for %s regexp '%s'", pattern->use_value?"value":"name",
-			pattern->pattern);
+		dbg(DBG_NONE, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
 		} else {
 		    dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
 			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
@@ -637,7 +636,7 @@ alloc_jprint(void)
 
     /* verify jprint != NULL */
     if (jprint == NULL) {
-	err(15, "jprint", "failed to allocate jprint struct");
+	err(21, "jprint", "failed to allocate jprint struct");
 	not_reached();
     }
 
@@ -742,11 +741,11 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
      * firewall
      */
     if (jprint == NULL) {
-	err(21, __func__, "passed NULL jprint struct");
+	err(22, __func__, "passed NULL jprint struct");
 	not_reached();
     }
     if (str == NULL) {
-	err(22, __func__, "passed NULL str");
+	err(23, __func__, "passed NULL str");
 	not_reached();
     }
 
@@ -772,14 +771,14 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     errno = 0; /* pre-clear errno for errp() */
     pattern = calloc(1, sizeof *pattern);
     if (pattern == NULL) {
-	errp(23, __func__, "unable to allocate struct jprint_pattern *");
+	errp(24, __func__, "unable to allocate struct jprint_pattern *");
 	not_reached();
     }
 
     errno = 0;
     pattern->pattern = strdup(str);
     if (pattern->pattern == NULL) {
-	errp(24, __func__, "unable to strdup string '%s' for patterns list", str);
+	errp(25, __func__, "unable to strdup string '%s' for patterns list", str);
 	not_reached();
     }
 
@@ -822,7 +821,7 @@ free_jprint_patterns_list(struct jprint *jprint)
     struct jprint_pattern *next_pattern = NULL; /* next in list */
 
     if (jprint == NULL) {
-	err(25, __func__, "passed NULL jprint struct");
+	err(26, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
@@ -889,7 +888,7 @@ jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *too
 {
     /* firewall */
     if (jprint == NULL) {
-	err(26, __func__, "NULL jprint");
+	err(27, __func__, "NULL jprint");
 	not_reached();
     }
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -586,9 +586,14 @@ int main(int argc, char **argv)
 		 */
 		jprint->match_found = true;
 
-		dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+		if (pattern->use_regexp) {
+		dbg(DBG_NONE, "searching for %s regexp '%s'", pattern->use_value?"value":"name",
+			pattern->pattern);
+		} else {
+		    dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
 			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
 			pattern->use_substrings?"OK":"ignored");
+		}
 	    }
 	}
     } else {

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -128,5 +128,10 @@ void free_jprint(struct jprint **jprint);
 struct jprint_pattern *add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, char *str);
 void free_jprint_patterns_list(struct jprint *jprint);
 void jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *tool_args);
+void jprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, ...);
+void vjprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, va_list ap);
+void jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
+void jprint_json_tree_walk(struct jprint *jprint, struct json *node, unsigned int max_depth, unsigned int depth,
+		void (*vcallback)(struct jprint *, struct json *, unsigned int, va_list), va_list ap);
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.19 2023-06-16"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.20 2023-06-17"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_pattern - struct for a linked list of patterns requested, held in

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1782,14 +1782,11 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  *		json_dbg_lvl   print message if JSON_DBG_FORCED
  *			       OR if <= json_verbosity_level
  *
- * Example use - free an entire JSON parse tree
+ * Example use - print an entire JSON parse tree
  *
  *	len = json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stderr, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stdout, JSON_DBG_MED);
- *
- * NOTE: This function will free the internals of a JSON parser tree node.
- *	 It is up to the caller to free the top level struct json if needed.
  *
  * NOTE: If the pointer to allocated storage == NULL,
  *	 this function does nothing.
@@ -1797,6 +1794,9 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  * NOTE: This function does nothing if node == NULL.
  *
  * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is a wrapper to vjson_tree_walk() with the callback
+ * vjson_fprint().
  */
 void
 json_tree_print(struct json *node, unsigned int max_depth, ...)

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1782,9 +1782,9 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
  *		json_dbg_lvl   print message if JSON_DBG_FORCED
  *			       OR if <= json_verbosity_level
  *
- * Example use - print an entire JSON parse tree
+ * Example uses - print an entire JSON parse tree
  *
- *	len = json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
+ *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, NULL, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stderr, JSON_DBG_FORCED);
  *	json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, stdout, JSON_DBG_MED);
  *

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1344,7 +1344,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
     }
 
     /*
-     * print debug leader
+     * print debug header
      */
     if (json_dbg_lvl != JSON_DBG_FORCED) {
 	fprint(stream, "JSON tree[%d]:\t", json_dbg_lvl);

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1220,7 +1220,7 @@ json_tree_free(struct json *node, unsigned int max_depth, ...)
  *	JSON tree node:
  *
  * given:
- *	node	pointer to a JSON parser tree node to free
+ *	node	pointer to a JSON parser tree node to print
  *	depth	current tree depth (0 ==> top of tree)
  *	...	extra args are ignored, required extra args:
  *				OR if <= json_verbosity_level


### PR DESCRIPTION

Much more needs to be done here but the initial callback is added and 
the code to call it is added and also called itself. Right now no 
constraints on what to print (type, name, value, level etc.) have been 
added and one might see both name and value printed. Not all types are
printed as it's not clear yet how to print all types. The functions are 
definitely incomplete but this is a great start that will help when
actually implementing those constraints and then the right way to print
what is requested.