### PR TITLE
Print name, value or both depending on options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,15 @@ just like the others this will be changed.
 
 Stop extraneous newlines from being printed.
 
+Add initial support for searching by value or name (value via `-Y` option). This
+will only work for simple json files (or I have only tested simple json files at
+this time). If value is being searched we print the name. I'm not sure now if
+that's correct behaviour. If it is not then the check will have to be changed.
+
+Add checks of what to print - name, value or both. This is modified by the `-p`
+option. If `-Y` is specified it will print name but it can be changed by the
+`-p` option. Again this has only been tested for simple types.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.15 2023-06-18
+
+New `jprint` version at "0.0.21 2023-06-18". `jprint` now has a matches list per
+pattern. The tree traversal functions will search for matches and after that
+function finally returns the printing of matches will be found. This will
+require additional functions that figure out how to print based on the json type
+and jprint options along with the jprint type but for now it prints just the
+name and value. Currently everything is added to the list.
+
+Note that by 'everything is added to the list' mentioned above this means that
+name and value will be added as a value. This is something that will be fixed
+later but it's the way the tree is traversed that causes this. Be aware also
+that for _each_ pattern requested every member of currently supported types will
+be added so you can see duplicates. This is because no matching is done yet.
+
+New debug message added. The level is currently 0 so will always be printed but
+just like the others this will be changed.
+
+Stop extraneous newlines from being printed.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ pattern. The tree traversal functions will search for matches and after that
 function finally returns the printing of matches will be found. This will
 require additional functions that figure out how to print based on the json type
 and jprint options along with the jprint type but for now it prints just the
-name and value. Currently everything is added to the list.
+name and value.
 
 Note that by 'everything is added to the list' mentioned above this means that
 name and value will be added as a value. This is something that will be fixed

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -161,11 +161,11 @@ void jprint_print_matches(struct jprint *jprint);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* for finding matches and printing them */
-void jprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, ...);
-void vjprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, va_list ap);
+void jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
+void vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
-void jprint_json_tree_walk(struct jprint *jprint, struct json *node, unsigned int max_depth, unsigned int depth,
-		void (*vcallback)(struct jprint *, struct json *, unsigned int, va_list), va_list ap);
+void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
+		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
 
 
 /* sanity checks on environment for specific options */


### PR DESCRIPTION

If -Y is used by default it prints out the name of matches (though right
now no check of matches are done except for search by value or name i.e.
if it's not a value and we search by value it's not to be added). I am 
not clear if this is correct. If it's supposed to print out the value as
well then it will have to be changed. But -p modifies this behaviour 
anyway as noted below.

If -p both then print name and value. If -p v (default) then print only
value. If -p n print only the name. If one uses -Y they can still see 
the name and value.

This has only been tested for very simple JSON files and the behaviour 
in full might not be completely correct.
