### PR TITLE
Note that -Y / -p is somewhat buggy in some cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,9 @@ that's correct behaviour. If it is not then the check will have to be changed.
 
 Add checks of what to print - name, value or both. This is modified by the `-p`
 option. If `-Y` is specified it will print name but it can be changed by the
-`-p` option. Again this has only been tested for simple types.
+`-p` option. Again this has only been tested for simple types and it is somewhat
+buggy depending on the options used. This has to do with the way the tree is
+traversed and what is added to the matches list.
 
 ## Release 1.0.14 2023-06-17
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,15 @@ just like the others this will be changed.
 
 Stop extraneous newlines from being printed.
 
+Add initial support for searching by value or name (value via `-Y` option). This
+will only work for simple json files (or I have only tested simple json files at
+this time). If value is being searched we print the name. I'm not sure now if
+that's correct behaviour. If it is not then the check will have to be changed.
+
+Add checks of what to print - name, value or both. This is modified by the `-p`
+option. If `-Y` is specified it will print name but it can be changed by the
+`-p` option. Again this has only been tested for simple types.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.15 2023-06-18
+
+New `jprint` version at "0.0.21 2023-06-18". `jprint` now has a matches list per
+pattern. The tree traversal functions will search for matches and after that
+function finally returns the printing of matches will be found. This will
+require additional functions that figure out how to print based on the json type
+and jprint options along with the jprint type but for now it prints just the
+name and value. Currently everything is added to the list.
+
+Note that by 'everything is added to the list' mentioned above this means that
+name and value will be added as a value. This is something that will be fixed
+later but it's the way the tree is traversed that causes this. Be aware also
+that for _each_ pattern requested every member of currently supported types will
+be added so you can see duplicates. This is because no matching is done yet.
+
+New debug message added. The level is currently 0 so will always be printed but
+just like the others this will be changed.
+
+Stop extraneous newlines from being printed.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ pattern. The tree traversal functions will search for matches and after that
 function finally returns the printing of matches will be found. This will
 require additional functions that figure out how to print based on the json type
 and jprint options along with the jprint type but for now it prints just the
-name and value. Currently everything is added to the list.
+name and value.
 
 Note that by 'everything is added to the list' mentioned above this means that
 name and value will be added as a value. This is something that will be fixed

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1626,6 +1626,8 @@ jprint_print_matches(struct jprint *jprint)
 	    /* print the match if constraints allow it
 	     *
 	     * XXX - add final constraint checks
+	     *
+	     * XXX - This is buggy in some cases. This must be fixed.
 	     */
 	    if (jprint_print_name_value(jprint->print_type)) {
 		print("%s\n", match->name);

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -161,11 +161,11 @@ void jprint_print_matches(struct jprint *jprint);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* for finding matches and printing them */
-void jprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, ...);
-void vjprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, va_list ap);
+void jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
+void vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
-void jprint_json_tree_walk(struct jprint *jprint, struct json *node, unsigned int max_depth, unsigned int depth,
-		void (*vcallback)(struct jprint *, struct json *, unsigned int, va_list), va_list ap);
+void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
+		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
 
 
 /* sanity checks on environment for specific options */


### PR DESCRIPTION

In some cases the use of the two options is problematic. This is due to
the way the traversal of the tree is done where the pattern name is 
added to the match list being incorrect. It ends up where one can have 
the wrong things printed.

This might have been a simple error on my part as I believe I initially
had it. This will have to be fixed in a future commit.