### PR TITLE
Rename some jprint functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,11 +25,10 @@ will only work for simple json files (or I have only tested simple json files at
 this time). If value is being searched we print the name. I'm not sure now if
 that's correct behaviour. If it is not then the check will have to be changed.
 
-Add checks of what to print - name, value or both. This is modified by the `-p`
-option. If `-Y` is specified it will print name but it can be changed by the
-`-p` option. Again this has only been tested for simple types and it is somewhat
-buggy depending on the options used. This has to do with the way the tree is
-traversed and what is added to the matches list.
+Checks for basic patterns are added! No regexp support yet. This does not mean
+that the printing of name and/or value is yet correct. This needs to be worked
+on. Right now a match can happen for either name or value even though it's
+supposed to be one or the other.
 
 ## Release 1.0.14 2023-06-17
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,9 @@ that's correct behaviour. If it is not then the check will have to be changed.
 
 Add checks of what to print - name, value or both. This is modified by the `-p`
 option. If `-Y` is specified it will print name but it can be changed by the
-`-p` option. Again this has only been tested for simple types.
+`-p` option. Again this has only been tested for simple types and it is somewhat
+buggy depending on the options used. This has to do with the way the tree is
+traversed and what is added to the matches list.
 
 ## Release 1.0.14 2023-06-17
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,15 @@ just like the others this will be changed.
 
 Stop extraneous newlines from being printed.
 
+Add initial support for searching by value or name (value via `-Y` option). This
+will only work for simple json files (or I have only tested simple json files at
+this time). If value is being searched we print the name. I'm not sure now if
+that's correct behaviour. If it is not then the check will have to be changed.
+
+Add checks of what to print - name, value or both. This is modified by the `-p`
+option. If `-Y` is specified it will print name but it can be changed by the
+`-p` option. Again this has only been tested for simple types.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.15 2023-06-18
+
+New `jprint` version at "0.0.21 2023-06-18". `jprint` now has a matches list per
+pattern. The tree traversal functions will search for matches and after that
+function finally returns the printing of matches will be found. This will
+require additional functions that figure out how to print based on the json type
+and jprint options along with the jprint type but for now it prints just the
+name and value. Currently everything is added to the list.
+
+Note that by 'everything is added to the list' mentioned above this means that
+name and value will be added as a value. This is something that will be fixed
+later but it's the way the tree is traversed that causes this. Be aware also
+that for _each_ pattern requested every member of currently supported types will
+be added so you can see duplicates. This is because no matching is done yet.
+
+New debug message added. The level is currently 0 so will always be printed but
+just like the others this will be changed.
+
+Stop extraneous newlines from being printed.
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ pattern. The tree traversal functions will search for matches and after that
 function finally returns the printing of matches will be found. This will
 require additional functions that figure out how to print based on the json type
 and jprint options along with the jprint type but for now it prints just the
-name and value. Currently everything is added to the list.
+name and value.
 
 Note that by 'everything is added to the list' mentioned above this means that
 name and value will be added as a value. This is something that will be fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ that the printing of name and/or value is yet correct. This needs to be worked
 on. Right now a match can happen for either name or value even though it's
 supposed to be one or the other.
 
+Rename some functions to match what they do better (they do not print but search
+for matches).
+
 ## Release 1.0.14 2023-06-17
 
 New `jprint` version at "0.0.20 2023-06-17".

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1237,8 +1237,6 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 
 		/*
 		 * if there is a match found add it to the matches list
-		 *
-		 * XXX - for now everything is added as no matching is done yet - XXX
 		 */
 		switch (node->type) {
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -609,7 +609,7 @@ int main(int argc, char **argv)
 	}
     }
 
-    jprint_json_tree_print(jprint, json_tree, jprint->max_depth);
+    jprint_json_tree_search(jprint, json_tree, jprint->max_depth);
     jprint_print_matches(jprint);
 
     /* free tree */
@@ -1086,7 +1086,7 @@ jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *too
 }
 
 /*
- * jprint_json_print
+ * jprint_json_search
  *
  * Print information about a JSON node, depending on the booleans in struct
  * jprint if the tree node matches the name or value in any pattern in the
@@ -1106,9 +1106,9 @@ jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *too
  *
  * Example use - print a JSON parse tree
  *
- *	jprint_json_print(node, true, depth, JSON_DBG_MED);
- *	jprint_json_print(node, false, depth, JSON_DBG_FORCED;
- *	jprint_json_print(node, false, depth, JSON_DBG_MED);
+ *	jprint_json_search(node, true, depth, JSON_DBG_MED);
+ *	jprint_json_search(node, false, depth, JSON_DBG_FORCED;
+ *	jprint_json_search(node, false, depth, JSON_DBG_MED);
  *
  * While the ... variable arg are ignored, we need to declare
  * then in order to be in vcallback form for use by json_tree_walk().
@@ -1119,7 +1119,7 @@ jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *too
  * NOTE: This function does nothing if jprint == NULL or node == NULL.
  */
 void
-jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...)
+jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...)
 {
     va_list ap;		/* variable argument list */
 
@@ -1136,7 +1136,7 @@ jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsig
     /*
      * call va_list argument list function
      */
-    vjprint_json_print(jprint, node, is_value, depth, ap);
+    vjprint_json_search(jprint, node, is_value, depth, ap);
 
     /*
      * stdarg variable argument list clean up
@@ -1147,15 +1147,15 @@ jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsig
 
 
 /*
- * vjprint_json_print
+ * vjprint_json_search
  *
- * Print information about a JSON node, depending on the booleans in struct
+ * Search for matches in a JSON node, depending on the booleans in struct
  * jprint if the tree node matches the name or value in any pattern in the
  * struct json.
  *
- * This is a variable argument list interface to jprint_json_print().
+ * This is a variable argument list interface to jprint_json_search().
  *
- * See jprint_json_tree_print() to go through the entire tree.
+ * See jprint_json_tree_search() to go through the entire tree.
  *
  * given:
  *	jprint	    pointer to our struct json
@@ -1177,7 +1177,7 @@ jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsig
  * problems will be fixed in a future commit.
  */
 void
-vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap)
+vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap)
 {
     FILE *stream = NULL;	/* stream to print on */
     int json_dbg_lvl = JSON_DBG_DEFAULT;	/* JSON debug level if json_dbg_used */
@@ -1233,11 +1233,6 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 	     * the matches list of that pattern. After that we can go through
 	     * the matches found and print out the matches as desired by the
 	     * user. We will not add matches if the constraints do not allow it.
-	     */
-
-	    /*
-	     * XXX - this does not check for matches nor any additional
-	     * constraints not noted above, just yet - XXX
 	     */
 
 		/*
@@ -1356,7 +1351,7 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 
 
 /*
- * jprint_json_tree_print - print lines for an entire JSON parse tree.
+ * jprint_json_tree_search - print lines for an entire JSON parse tree.
  *
  * This function uses the jprint_json_tree_walk() interface to walk
  * the JSON parse tree and print requested information about matching nodes.
@@ -1374,9 +1369,9 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
  *
  * Example uses - print an entire JSON parse tree
  *
- *	jprint_json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
- *	jprint_json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
- *	jprint_json_tree_print(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_MED);
+ *	jprint_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jprint_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jprint_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_MED);
  *
  * NOTE: If the pointer to allocated storage == NULL,
  *	 this function does nothing.
@@ -1387,10 +1382,10 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
  * NOTE: This function does nothing if the node type is invalid.
  *
  * NOTE: this function is a wrapper to jprint_json_tree_walk() with the callback
- * vjprint_json_print().
+ * vjprint_json_search().
  */
 void
-jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...)
+jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...)
 {
     va_list ap;		/* variable argument list */
 
@@ -1409,7 +1404,7 @@ jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int ma
     /*
      * walk the JSON parse tree
      */
-    jprint_json_tree_walk(jprint, node, max_depth, false, 0, vjprint_json_print, ap);
+    jprint_json_tree_walk(jprint, node, max_depth, false, 0, vjprint_json_search, ap);
 
     /*
      * stdarg variable argument list clean up

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1626,6 +1626,8 @@ jprint_print_matches(struct jprint *jprint)
 	    /* print the match if constraints allow it
 	     *
 	     * XXX - add final constraint checks
+	     *
+	     * XXX - This is buggy in some cases. This must be fixed.
 	     */
 	    if (jprint_print_name_value(jprint->print_type)) {
 		print("%s\n", match->name);

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1214,9 +1214,11 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
      * anyway so this might have to change but at this time for simple JSON
      * files using -Y will add only names and not using it will add only values.
      * The pattern should itself have the pattern that matched (though currently
-     * matching is not yet done) which is set to the name in the match (it might
-     * be that it should be renamed as it isn't necessarily always a name but
-     * this will be decided later).
+     * only basic matching is in - regexp not implemented yet) which is set to
+     * the name in the match (it might be that it should be renamed as it isn't
+     * necessarily always a name but this will be decided later). Note that this
+     * only prints the match found regardless of the -p option. That will be
+     * fixed later.
      */
     if ((jprint->search_value && is_value) || (!is_value && !jprint->search_value)) {
 	va_end(ap2); /* stdarg variable argument list clean up */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1252,9 +1252,11 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 		    {
 			struct json_number *item = &(node->item.number);
 
-			if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
-			    err(36, __func__, "adding match '%s' to pattern failed", item->as_str);
-			    not_reached();
+			if (!strcmp(pattern->pattern, item->as_str)) {
+			    if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
+				err(36, __func__, "adding match '%s' to pattern failed", item->as_str);
+				not_reached();
+			    }
 			}
 		    }
 		    break;
@@ -1263,9 +1265,11 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 		    {
 			struct json_string *item = &(node->item.string);
 
-			if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
-			    err(37, __func__, "adding match '%s' to pattern failed", item->as_str);
-			    not_reached();
+			if (!strcmp(pattern->pattern, item->as_str)) {
+			    if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
+				err(37, __func__, "adding match '%s' to pattern failed", item->as_str);
+				not_reached();
+			    }
 			}
 		    }
 		    break;
@@ -1274,9 +1278,11 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 		    {
 			struct json_boolean *item = &(node->item.boolean);
 
-			if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
-			    err(38, __func__, "adding match '%s' to pattern failed", item->as_str);
-			    not_reached();
+			if (!strcmp(pattern->pattern, item->as_str)) {
+			    if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
+				err(38, __func__, "adding match '%s' to pattern failed", item->as_str);
+				not_reached();
+			    }
 			}
 		    }
 		    break;
@@ -1285,9 +1291,11 @@ vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsi
 		    {
 			struct json_null *item = &(node->item.null);
 
-			if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
-			    err(39, __func__, "adding match '%s' to pattern failed", item->as_str);
-			    not_reached();
+			if (!strcmp(pattern->pattern, item->as_str)) {
+			    if (add_jprint_match(jprint, pattern, item->as_str, depth) == NULL) {
+				err(39, __func__, "adding match '%s' to pattern failed", item->as_str);
+				not_reached();
+			    }
 			}
 		    }
 		    break;

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -161,11 +161,11 @@ void jprint_print_matches(struct jprint *jprint);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* for finding matches and printing them */
-void jprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, ...);
-void vjprint_json_print(struct jprint *jprint, struct json *node, unsigned int depth, va_list ap);
+void jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
+void vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
-void jprint_json_tree_walk(struct jprint *jprint, struct json *node, unsigned int max_depth, unsigned int depth,
-		void (*vcallback)(struct jprint *, struct json *, unsigned int, va_list), va_list ap);
+void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
+		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
 
 
 /* sanity checks on environment for specific options */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -161,9 +161,9 @@ void jprint_print_matches(struct jprint *jprint);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* for finding matches and printing them */
-void jprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
-void vjprint_json_print(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
-void jprint_json_tree_print(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
+void jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
+void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
+void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
 void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
 		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
 


### PR DESCRIPTION

The functions that traverse the json tree do not print but rather search
for matches so they now suggest this in name.