### PR TITLE
Process write only pipe if -S tool specified

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.17 2023-06-20
+
+New `jprint` version "0.0.23 2023-06-20".
+
+Process write only pipe if -S tool specified. To see details check git log and
+search for 'Process write only pipe if -S tool specified'.
+
 ## Release 1.0.16 2023-06-19
 
 New `jprint` version "0.0.22 2023-06-19".

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.22 2023-06-19"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.23 2023-06-20"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern


### PR DESCRIPTION
Based on comments in the GitHub discussion I have implemented the processing of the write-only pipe. The comment suggested only if the JSON document is read from stdin but I presume that it can be if a file on disk too. If this is not correct it can be changed later. Here is an example command and output. I'm not entirely clear on the purpose of this but this is what it looks like with debug level 3 (debug level 3 as that shows the pipe exit status being okay if it is; if it's not it's an error with exit code 7):

    $ cat h2g2.json
    {"number":42,
    "number_str":"42",
    "panic":false,
    "false":true,
    "true":false,
    "killers":"Vogons"}

    $ jprint -v 3 -Y int -S /bin/cat h2g2.json 42 2>&1|grep -v 'debug\[0\]'
    debug[3]: valid JSON
    debug[3]: about to execute: /bin/cat h2g2.json >/dev/null 2>&1
    {"number":42,
    "number_str":"42",
    "panic":false,
    "false":true,
    "true":false,
    "killers":"Vogons"}
    {"number":42,
    "number_str":"42",
    "panic":false,
    "false":true,
    "true":false,
    "killers":"Vogons"}
    debug[3]: pipe child process exited OK
    42

As can be seen the opening of the pipe prints out the output too which might or might not be a problem but this can also be addressed later if necessary.