### PR TITLE
Check jprint -t / -Y more for matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ matches.
 
 Change debug level 0 messages to debug level 1.
 
+Implement case-insensitive option `-i`.
 
 ## Release 1.0.16 2023-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,14 @@ Change debug level 0 messages to debug level 1.
 
 Implement case-insensitive option `-i`.
 
+New `jparse` and JSON parser version both at "1.0.6 2023-06-20". Added boolean
+to `struct json_number` a boolean `is_integer` for integers to simplify checks
+in `jprint`. If integer the booleans for floating points are set to false but if
+number string is parsed as floating point only the integer boolean is set to
+false. This is because the function to parse floating points should take care of
+it (there are a lot of paths in the integer conversions) and that function only
+returns true or false without giving an indication if it's an exponent or not.
+
 ## Release 1.0.16 2023-06-19
 
 New `jprint` version "0.0.22 2023-06-19".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,9 @@ Process write only pipe if -S tool specified. To see details check git log and
 search for 'Process write only pipe if -S tool specified'.
 
 Implement `-c` option to show only count of matches. Use of `-o` (print entire
-file) and `-c` (show only count) cannot be used together. If empty patterns list
-then nothing will be done as there can't be any matches. It might be desirable
-to print the count of all json members but this is not currently supported.
+file) and `-c` (show only count) cannot be used together. Use of `-c` without
+specifying any patterns is also a command line error as there cannot be any
+matches.
 
 Change debug level 0 messages to debug level 1.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.17 2023-06-20
+
+New `jprint` version "0.0.23 2023-06-20".
+
+Process write only pipe if -S tool specified. To see details check git log and
+search for 'Process write only pipe if -S tool specified'.
+
 ## Release 1.0.16 2023-06-19
 
 New `jprint` version "0.0.22 2023-06-19".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,16 @@ false. This is because the function to parse floating points should take care of
 it (there are a lot of paths in the integer conversions) and that function only
 returns true or false without giving an indication if it's an exponent or not.
 
+Don't increment the count of matches if the type is not the same. By type this
+refers to the `JTYPE_*` enum found in `json_parse.h`.
+
+Add more strict checks for number types based on options.
+
+Disable explicit check for strings in match function as the check there is
+problematic anyway and this helps in another way until the function itself can
+be fixed. It's very much a work in progress.
+
+
 ## Release 1.0.16 2023-06-19
 
 New `jprint` version "0.0.22 2023-06-19".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@ New `jprint` version "0.0.23 2023-06-20".
 Process write only pipe if -S tool specified. To see details check git log and
 search for 'Process write only pipe if -S tool specified'.
 
+Implement `-c` option to show only count of matches. Use of `-o` (print entire
+file) and `-c` (show only count) cannot be used together. If empty patterns list
+then nothing will be done as there can't be any matches. It might be desirable
+to print the count of all json members but this is not currently supported.
+
+Change debug level 0 messages to debug level 1.
+
+
 ## Release 1.0.16 2023-06-19
 
 New `jprint` version "0.0.22 2023-06-19".

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.5 2023-06-14"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.6 2023-06-20"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.5 2023-06-14"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.0.6 2023-06-20"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -697,7 +697,7 @@ alloc_jprint(void)
 
     /* verify jprint != NULL */
     if (jprint == NULL) {
-	err(21, "jprint", "failed to allocate jprint struct");
+	err(20, "jprint", "failed to allocate jprint struct");
 	not_reached();
     }
 
@@ -800,20 +800,20 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
      * firewall
      */
     if (jprint == NULL) {
-	err(22, __func__, "passed NULL jprint struct");
+	err(21, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
     if (pattern == NULL) {
-	err(23, __func__, "passed NULL pattern");
+	err(22, __func__, "passed NULL pattern");
 	not_reached();
     } else if (pattern->pattern == NULL) {
-	err(24, __func__, "pattern->pattern is NULL");
+	err(23, __func__, "pattern->pattern is NULL");
 	not_reached();
     }
 
     if (value == NULL) {
-	err(25, __func__, "value is NULL");
+	err(24, __func__, "value is NULL");
 	not_reached();
     }
 
@@ -836,7 +836,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     errno = 0; /* pre-clear errno for errp() */
     match = calloc(1, sizeof *match);
     if (match == NULL) {
-	errp(26, __func__, "unable to allocate struct jprint_match *");
+	errp(25, __func__, "unable to allocate struct jprint_match *");
 	not_reached();
     }
 
@@ -844,7 +844,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     errno = 0; /* pre-clear errno for errp() */
     match->name = strdup(pattern->pattern);
     if (match->name == NULL) {
-	errp(27, __func__, "unable to strdup string '%s' for match list", pattern->pattern);
+	errp(26, __func__, "unable to strdup string '%s' for match list", pattern->pattern);
 	not_reached();
     }
 
@@ -852,7 +852,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     errno = 0; /* pre-clear errno for errp() */
     match->value = strdup(value);
     if (match->value == NULL) {
-	errp(28, __func__, "unable to strdup value string '%s' for match list", value);
+	errp(27, __func__, "unable to strdup value string '%s' for match list", value);
 	not_reached();
     }
     /* set level of the match for -l / -L options */
@@ -905,7 +905,7 @@ free_jprint_matches_list(struct jprint_pattern *pattern)
     struct jprint_match *next_match = NULL; /* next in list */
 
     if (pattern == NULL) {
-	err(29, __func__, "passed NULL pattern struct");
+	err(28, __func__, "passed NULL pattern struct");
 	not_reached();
     }
 
@@ -963,11 +963,11 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
      * firewall
      */
     if (jprint == NULL) {
-	err(30, __func__, "passed NULL jprint struct");
+	err(29, __func__, "passed NULL jprint struct");
 	not_reached();
     }
     if (str == NULL) {
-	err(31, __func__, "passed NULL str");
+	err(30, __func__, "passed NULL str");
 	not_reached();
     }
 
@@ -994,14 +994,14 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     errno = 0; /* pre-clear errno for errp() */
     pattern = calloc(1, sizeof *pattern);
     if (pattern == NULL) {
-	errp(32, __func__, "unable to allocate struct jprint_pattern *");
+	errp(31, __func__, "unable to allocate struct jprint_pattern *");
 	not_reached();
     }
 
     errno = 0;
     pattern->pattern = strdup(str);
     if (pattern->pattern == NULL) {
-	errp(33, __func__, "unable to strdup string '%s' for patterns list", str);
+	errp(32, __func__, "unable to strdup string '%s' for patterns list", str);
 	not_reached();
     }
 
@@ -1048,7 +1048,7 @@ free_jprint_patterns_list(struct jprint *jprint)
     struct jprint_pattern *next_pattern = NULL; /* next in list */
 
     if (jprint == NULL) {
-	err(34, __func__, "passed NULL jprint struct");
+	err(33, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
@@ -1121,7 +1121,7 @@ jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *too
 {
     /* firewall */
     if (jprint == NULL) {
-	err(35, __func__, "NULL jprint");
+	err(34, __func__, "NULL jprint");
 	not_reached();
     }
 
@@ -1324,7 +1324,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 			    if (!strcmp(pattern->pattern, item->as_str) ||
 				(jprint->ignore_case&&!strcasecmp(pattern->pattern, item->as_str))) {
 				    if (add_jprint_match(jprint, pattern, item->as_str, depth, false) == NULL) {
-					err(36, __func__, "adding match '%s' to pattern failed", item->as_str);
+					err(35, __func__, "adding match '%s' to pattern failed", item->as_str);
 					not_reached();
 				    }
 			    }
@@ -1341,7 +1341,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 			    if (!strcmp(pattern->pattern, item->as_str) ||
 				(jprint->ignore_case && !strcasecmp(pattern->pattern, item->as_str))) {
 				    if (add_jprint_match(jprint, pattern, item->as_str, depth, true) == NULL) {
-					err(37, __func__, "adding match '%s' to pattern failed", item->as_str);
+					err(36, __func__, "adding match '%s' to pattern failed", item->as_str);
 					not_reached();
 				    }
 			    }
@@ -1357,7 +1357,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 			    if (!strcmp(pattern->pattern, item->as_str) ||
 				(jprint->ignore_case && !strcasecmp(pattern->pattern, item->as_str))) {
 				    if (add_jprint_match(jprint, pattern, item->as_str, depth, false) == NULL) {
-					err(38, __func__, "adding match '%s' to pattern failed", item->as_str);
+					err(37, __func__, "adding match '%s' to pattern failed", item->as_str);
 					not_reached();
 				    }
 			    }
@@ -1373,7 +1373,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 			    if (!strcmp(pattern->pattern, item->as_str) ||
 				(jprint->ignore_case && !strcasecmp(pattern->pattern, item->as_str))) {
 				if (add_jprint_match(jprint, pattern, item->as_str, depth, false) == NULL) {
-				    err(39, __func__, "adding match '%s' to pattern failed", item->as_str);
+				    err(38, __func__, "adding match '%s' to pattern failed", item->as_str);
 				    not_reached();
 				}
 			    }
@@ -1686,7 +1686,7 @@ jprint_print_matches(struct jprint *jprint)
 
     /* firewall */
     if (jprint == NULL) {
-	err(40, __func__, "jprint is NULL");
+	err(39, __func__, "jprint is NULL");
 	not_reached();
     } else if (jprint->patterns == NULL) {
 	warn(__func__, "empty patterns list");
@@ -1705,7 +1705,7 @@ jprint_print_matches(struct jprint *jprint)
 	for (match = pattern->matches; match != NULL; match = match->next) {
 	    /* if the name of the match is NULL it is a fatal error */
 		if (match->name == NULL) {
-		    err(41, __func__, "match->name is NULL");
+		    err(40, __func__, "match->name is NULL");
 		    not_reached();
 		} else if (*match->name == '\0') {
 		    /* warn on empty name for now and then go to next match */
@@ -1714,7 +1714,7 @@ jprint_print_matches(struct jprint *jprint)
 		}
 
 		if (match->value == NULL) {
-		    err(42, __func__, "match '%s' has NULL value", match->name);
+		    err(41, __func__, "match '%s' has NULL value", match->name);
 		    not_reached();
 		} else if (*match->value == '\0') {
 		    /* for now we only warn on empty value */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -110,7 +110,8 @@ static const char * const usage_msg2 =
     "\t-C\t\tWhen printing JSON syntax, always print a comma after final line (def: do not)\n"
     "\t\t\tUse of -C without -j has no effect\n\n"
     "\t-B\t\tWhen printing JSON syntax, start with a { line and end with a } line\n"
-    "\t\t\tUse of -B without -j has no effect\n\n"
+    "\t\t\tUse of -B without -j has no effect\n"
+    "\t\t\tUse of -B with -c is an error\n\n"
     "\t-I <num>{[t|s]}\tWhen printing JSON syntax, indent levels (i.e.: -I 4) (def: don't indent i.e.: -I 0)\n"
     "\t\t\tTrailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces\n"
     "\t\t\tNot specifying 's' or 't' implies spaces but any other character is an error\n"
@@ -132,7 +133,8 @@ static const char * const usage_msg2 =
     "\t\t\tNOTE: use of -g and -s is an error\n"
     "\t-G regex\tSpecify a pattern that is a regex irrespective of the name_args\n"
     "\t\t\tNOTE: use of -G does not conflict with -g or -s\n\n"
-    "\t-c\t\tOnly show count of matches found\n\n"
+    "\t-c\t\tOnly show count of matches found\n"
+    "\t\t\tNOTE: use of -c with any of -B, -L, -j and -I is an error\n\n"
     "\t-m max_depth\tSet the maximum JSON level depth to max_depth, 0 ==> infinite depth (def: 256)\n"
     "\t\t\tNOTE: 0 implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n\n"
     "\t-K\t\tRun tests on jprint constraints\n";
@@ -249,11 +251,11 @@ int main(int argc, char **argv)
 	    break;
 	case 'e':
 	    jprint->encode_strings = true;
-	    dbg(DBG_NONE, "-e specified, will encode strings");
+	    dbg(DBG_LOW, "-e specified, will encode strings");
 	    break;
 	case 'Q':
 	    jprint->quote_strings = true;
-	    dbg(DBG_NONE, "-Q specified, will quote strings");
+	    dbg(DBG_LOW, "-Q specified, will quote strings");
 	    break;
 	case 't':
 	    jprint->type = jprint_parse_types_option(optarg);
@@ -279,46 +281,46 @@ int main(int argc, char **argv)
 	    break;
 	case 'P':
 	    jprint->print_colons = true;
-	    dbg(DBG_NONE, "-P specified, will print colons");
+	    dbg(DBG_LOW, "-P specified, will print colons");
 	    break;
 	case 'C':
 	    jprint->print_final_comma = true;
-	    dbg(DBG_NONE, "-C specified, will print final comma");
+	    dbg(DBG_LOW, "-C specified, will print final comma");
 	    break;
 	case 'B':
 	    jprint->print_braces = true;
-	    dbg(DBG_NONE, "-B specified, will print braces");
+	    dbg(DBG_LOW, "-B specified, will print braces");
 	    break;
 	case 'I':
 	    jprint_parse_st_indent_option(optarg, &jprint->indent_level, &jprint->indent_tab);
 	    break;
 	case 'i':
 	    jprint->case_insensitive = true; /* make case cruel :-) */
-	    dbg(DBG_NONE, "-i specified, making matches case-insensitive");
+	    dbg(DBG_LOW, "-i specified, making matches case-insensitive");
 	    break;
 	case 'j':
 	    jprint->print_syntax = true;
-	    dbg(DBG_NONE, "-j, implying -p both");
+	    dbg(DBG_LOW, "-j, implying -p both");
 	    jprint->print_type = jprint_parse_print_option("both");
-	    dbg(DBG_NONE, "-j, implying -b 1");
+	    dbg(DBG_LOW, "-j, implying -b 1");
 	    jprint_parse_st_tokens_option("1", &jprint->num_token_spaces, &jprint->print_token_tab);
-	    dbg(DBG_NONE, "-j, implying -e -Q");
+	    dbg(DBG_LOW, "-j, implying -e -Q");
 	    jprint->encode_strings = true;
 	    jprint->quote_strings = true;
-	    dbg(DBG_NONE, "-j, implying -t any");
+	    dbg(DBG_LOW, "-j, implying -t any");
 	    jprint->type = jprint_parse_types_option("any");
 	    break;
 	case 'E':
 	    jprint->match_encoded = true;
-	    dbg(DBG_NONE, "-E specified, will match encoded strings, not decoded strings");
+	    dbg(DBG_LOW, "-E specified, will match encoded strings, not decoded strings");
 	    break;
 	case 's':
 	    jprint->substrings_okay = true;
-	    dbg(DBG_NONE, "-s specified, will match substrings");
+	    dbg(DBG_LOW, "-s specified, will match substrings");
 	    break;
 	case 'g':   /* allow grep-like ERE */
 	    jprint->use_regexps = true;
-	    dbg(DBG_NONE, "-g specified, name_args will be regexps");
+	    dbg(DBG_LOW, "-g specified, name_args will be regexps");
 	    break;
 	case 'G': /* this pattern is a regexp but the name_args will be a normal pattern unless -g specified */
 	    jprint->explicit_regexp = true;
@@ -330,7 +332,7 @@ int main(int argc, char **argv)
 	    break;
 	case 'c':
 	    jprint->count_only = true;
-	    dbg(DBG_NONE, "-c specified, will only show count of matches");
+	    dbg(DBG_LOW, "-c specified, will only show count of matches");
 	    break;
 	case 'q':
 	    quiet = true;
@@ -368,13 +370,13 @@ int main(int argc, char **argv)
 	case 'S':
 	    /* -S path to tool */
 	    tool_path = optarg;
-	    dbg(DBG_NONE, "set tool path to: '%s'", tool_path);
+	    dbg(DBG_LOW, "set tool path to: '%s'", tool_path);
 	    break;
 	case 'A':
 	    /*
 	     * -A args to tool. Requires use of -S. */
 	    tool_args = optarg;
-	    dbg(DBG_NONE, "set tool args to: '%s'", tool_args);
+	    dbg(DBG_LOW, "set tool args to: '%s'", tool_args);
 	    break;
 	case 'o': /* -o, print entire file if valid JSON. Incompatible with patterns to search for. */
 	    jprint->print_entire_file = true;
@@ -434,6 +436,25 @@ int main(int argc, char **argv)
     if (jprint->print_braces && !jprint->print_syntax) {
 	jprint->print_braces = false;
     }
+    /* use of -c with any of any of -B, -L, -j and -I is an error */
+    if (jprint->count_only) {
+	if (jprint->print_braces) {
+	    err(3, "jprint", "cannot use -B and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jprint->print_json_levels) {
+	    err(3, "jprint", "cannot use -L and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jprint->print_syntax) {
+	    err(3, "jprint", "cannot use -j and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jprint->indent_level) {
+	    err(3, "jprint", "cannot use -I and -c together"); /*ooo*/
+	    not_reached();
+	}
+    }
 
     /* without -j, -C has no effect */
     if (jprint->print_final_comma && !jprint->print_syntax) {
@@ -483,14 +504,14 @@ int main(int argc, char **argv)
     }
 
     /* the debug level will be increased at a later time */
-    dbg(DBG_NONE, "maximum depth to traverse: %ju%s", jprint->max_depth, (jprint->max_depth == 0?" (no limit)":
+    dbg(DBG_LOW, "maximum depth to traverse: %ju%s", jprint->max_depth, (jprint->max_depth == 0?" (no limit)":
 		jprint->max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
 
     if (jprint->search_value && argc != 2 && jprint->number_of_patterns != 1) {
 	free_jprint(&jprint);
 	err(18, "jprint", "-Y requires exactly one name_arg");
 	not_reached();
-    } else if (!jprint->search_value && argv[1] == NULL) {
+    } else if (!jprint->search_value && argv[1] == NULL && !jprint->count_only) {
 	jprint->print_entire_file = true;   /* technically this boolean is redundant */
     }
 
@@ -510,7 +531,7 @@ int main(int argc, char **argv)
 	 * foo or one arg is specified after the file
 	 */
 	free_jprint(&jprint);
-	err(20, "jprint", "-Y requires exactly one name_arg");
+	err(3, "jprint", "-Y requires exactly one name_arg"); /*ooo*/
 	not_reached();
     }
 
@@ -615,40 +636,31 @@ int main(int argc, char **argv)
 	err(3, "jprint", "printing the entire file not supported when searching for a pattern");/*ooo*/
 	not_reached();
     }
+
     if (jprint->patterns != NULL && !jprint->print_entire_file) {
-	/* TODO process name_args */
 	for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {
 	    if (pattern->pattern != NULL && *pattern->pattern) {
-		/*
-		 * XXX if matches found we set the boolean match_found to true to
-		 * indicate exit code of 0 but currently no matches are checked. In
-		 * other words in the future this setting of match_found will not always
-		 * happen.
-		 */
-		jprint->match_found = true;
 
 		if (pattern->use_regexp) {
-		    dbg(DBG_NONE, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
+		    dbg(DBG_LOW, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
 		} else {
-		    dbg(DBG_NONE, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+		    dbg(DBG_LOW, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
 			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
 			pattern->use_substrings?"OK":"ignored");
 		}
 	    }
 	}
-    } else {
-	/*
-	 * XXX remove this informative message or change debug level once processing
-	 * above is implemented.
-	 */
-	dbg(DBG_NONE,"no pattern requested or -o, will print entire file");
-	if (file_contents != NULL) {
-	    fpr(stdout, "jprint", "%s", file_contents);
-	}
-    }
 
+    }
+    /* search for any patterns */
     jprint_json_tree_search(jprint, json_tree, jprint->max_depth);
-    jprint_print_matches(jprint);
+
+    if (!jprint->print_entire_file || jprint->count_only) {
+	jprint_print_matches(jprint);
+    } else if (file_contents != NULL) {
+	dbg(DBG_MED, "no pattern requested or -o and no -c, will print entire file");
+	fpr(stdout, "jprint", "%s", file_contents);
+    }
 
     /* free tree */
     json_tree_free(json_tree, jprint->max_depth);
@@ -800,6 +812,21 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
 	not_reached();
     }
 
+    /*
+     * search for an exact match and only increment the count if found.
+     *
+     * NOTE: this means that when printing the output we have to go potentially
+     * print the match more than once; if -c is specified we print only the
+     * count.
+     */
+    for (tmp = pattern->matches; tmp; tmp = tmp->next) {
+	if (!strcmp(tmp->name, pattern->pattern) && !strcmp(tmp->value, value)) {
+	    tmp->count++;
+	    return tmp;
+	}
+    }
+
+    /* if we get here we have to add the match to the matches list */
     errno = 0; /* pre-clear errno for errp() */
     match = calloc(1, sizeof *match);
     if (match == NULL) {
@@ -825,8 +852,11 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     /* set level of the match for -l / -L options */
     match->level = level;
 
+    /* set count to 1 */
+    match->count = 1;
+
     /* record the pattern that was matched */
-    match->pattern = pattern; /* DO NOT FREE THIS */
+    match->pattern = pattern; /* DO NOT FREE THIS! */
 
     /* set which match number this is, incrementing the pattern's total matches */
     match->number = pattern->matches_found++;
@@ -834,7 +864,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     /* set if a string for -j */
     match->string = string;
 
-    dbg(DBG_NONE, "adding match '%s' to pattern '%s' to match list",
+    dbg(DBG_LOW, "adding match '%s' to pattern '%s' to match list",
 	    jprint->search_value?match->value:match->name, pattern->pattern);
 
     for (tmp = pattern->matches; tmp && tmp->next; tmp = tmp->next)
@@ -845,6 +875,9 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *va
     } else {
 	tmp->next = match;
     }
+
+    /* a match is found, set jprint->match_found to true */
+    jprint->match_found = true;
 
     return match;
 }
@@ -946,9 +979,9 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
      * processing is complete
      */
     if (use_regexp) {
-	dbg(DBG_NONE,"%s regex requested: '%s'", jprint->search_value?"value":"name", str);
+	dbg(DBG_LOW,"%s regex requested: '%s'", jprint->search_value?"value":"name", str);
     } else {
-	dbg(DBG_NONE,"%s pattern requested: '%s'", jprint->search_value?"value":"name", str);
+	dbg(DBG_LOW,"%s pattern requested: '%s'", jprint->search_value?"value":"name", str);
     }
 
     errno = 0; /* pre-clear errno for errp() */
@@ -974,7 +1007,7 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     jprint->pattern_specified = true;
     pattern->matches_found = 0; /* 0 matches found at first */
 
-    dbg(DBG_NONE, "adding %s pattern '%s' to patterns list", pattern->use_value?"value":"name", pattern->pattern);
+    dbg(DBG_LOW, "adding %s pattern '%s' to patterns list", pattern->use_value?"value":"name", pattern->pattern);
 
     for (tmp = jprint->patterns; tmp && tmp->next; tmp = tmp->next)
 	; /* on its own line to silence useless and bogus warning -Wempty-body */
@@ -1637,6 +1670,8 @@ jprint_print_matches(struct jprint *jprint)
 {
     struct jprint_pattern *pattern = NULL;  /* to iterate through patterns list */
     struct jprint_match *match = NULL;	    /* to iterate through matches of each pattern in the patterns list */
+    uintmax_t i = 0;			    /* to iterate through count of each match */
+    uintmax_t j = 0;			    /* temporary iterator */
 
     /* firewall */
     if (jprint == NULL) {
@@ -1650,110 +1685,119 @@ jprint_print_matches(struct jprint *jprint)
     /*
      * although printing syntax is not yet fully implemented, we will check for
      * -B and print the braces so that after the syntax printing is implemented
-     * nothing has to be done with -B.
+     * nothing has to be done with -B. Don't do this if -c used.
      */
-    if (jprint->print_braces) {
+    if (jprint->print_braces && !jprint->count_only) {
 	print("%c\n", '{');
     }
     for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {
 	for (match = pattern->matches; match != NULL; match = match->next) {
 	    /* if the name of the match is NULL it is a fatal error */
-	    if (match->name == NULL) {
-		err(41, __func__, "match->name is NULL");
-		not_reached();
-	    } else if (*match->name == '\0') {
-		/* warn on empty name for now and then go to next match */
-		warn(__func__, "empty match name");
-		continue;
-	    }
+		if (match->name == NULL) {
+		    err(41, __func__, "match->name is NULL");
+		    not_reached();
+		} else if (*match->name == '\0') {
+		    /* warn on empty name for now and then go to next match */
+		    warn(__func__, "empty match name");
+		    continue;
+		}
 
-	    if (match->value == NULL) {
-		err(42, __func__, "match '%s' has NULL value", match->name);
-		not_reached();
-	    } else if (*match->value == '\0') {
-		/* for now we only warn on empty value */
-		warn(__func__, "empty value for match '%s'", match->name);
-		continue;
-	    }
+		if (match->value == NULL) {
+		    err(42, __func__, "match '%s' has NULL value", match->name);
+		    not_reached();
+		} else if (*match->value == '\0') {
+		    /* for now we only warn on empty value */
+		    warn(__func__, "empty value for match '%s'", match->name);
+		    continue;
+		}
 
-	    /* print the match if constraints allow it
-	     *
-	     * XXX - add final constraint checks
-	     *
-	     * XXX - This is buggy in some cases. This must be fixed.
-	     */
-	    if (jprint_print_name_value(jprint->print_type) || jprint->print_syntax) {
-		if (jprint->print_syntax) {
-		    print("\"%s\" : %s%s%s%s\n", match->name,
-			    match->string?"\"":"", match->value, match->string?"\"":"",
-			    match->next||(pattern->next&&pattern->next->matches)?",":"");
-		} else if (jprint->print_json_levels) {
-		    uintmax_t i;
-		    print("%ju", match->level);
-		    for (i = 0; i < jprint->num_level_spaces; ++i) {
-			printf("%s", jprint->print_level_tab?"\t":" ");
-		    }
-		    print("%s\n", match->name);
-		    print("%ju", match->level);
-		    for (i = 0; i < jprint->num_level_spaces; ++i) {
-			printf("%s", jprint->print_level_tab?"\t":" ");
-		    }
-		    print("%s\n", match->value);
-		} else {
-		    print("%s\n", match->name);
-		    print("%s\n", match->value);
-		}
-	    } else if (jprint_print_name(jprint->print_type)) {
-		if (jprint->print_json_levels) {
-		    uintmax_t i;
-		    print("%ju", match->level);
-		    for (i = 0; i < jprint->num_level_spaces; ++i) {
-			printf("%s", jprint->print_level_tab?"\t":" ");
-		    }
-		    print("%s\n", match->name);
-		} else {
-		    print("%s\n", match->name);
-		}
-	    } else if (jprint_print_value(jprint->print_type)) {
-		if (jprint->print_json_levels) {
-		    uintmax_t i;
-		    print("%ju", match->level);
-		    for (i = 0; i < jprint->num_level_spaces; ++i) {
-			printf("%s", jprint->print_level_tab?"\t":" ");
-		    }
-		    print("%s\n", match->value);
-		} else {
-		    print("%s\n", match->value);
-		}
-	    }
 	    /*
-	     * XXX: more functions will have to be added to print the values
-	     * and currently the struct jprint_match struct is a work in
-	     * progress. More will have to be added like the JSON type that
-	     * matched (this includes not only the jprint type but the JSON
-	     * type).
+	     * if we get here we have to either print the count or we have to
+	     * print the name and/or value
 	     */
+	    if (jprint->count_only) {
+		/* -c used, print count only */
+		print("%s:%ju\n", jprint->search_value?match->name:match->value, match->count);
+	    } else {
+		for (i = 0; i < match->count; ++i) {
+				    /* print the match if constraints allow it
+		     *
+		     * XXX - add final constraint checks
+		     *
+		     * XXX - This is buggy in some cases. This must be fixed.
+		     */
+		    if (jprint_print_name_value(jprint->print_type) || jprint->print_syntax) {
+			if (jprint->print_syntax) {
+			    print("\"%s\" : %s%s%s%s", match->name,
+				    match->string?"\"":"", match->value, match->string?"\"":"",
+				    match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
+			} else if (jprint->print_json_levels) {
+			    print("%ju", match->level);
+			    for (j = 0; j < jprint->num_level_spaces; ++j) {
+				printf("%s", jprint->print_level_tab?"\t":" ");
+			    }
+			    print("%s\n", match->name);
+			    print("%ju", match->level);
+			    for (j = 0; j < jprint->num_level_spaces; ++j) {
+				printf("%s", jprint->print_level_tab?"\t":" ");
+			    }
+			    print("%s", match->value);
+			} else {
+			    print("%s\n", match->name);
+			    print("%s", match->value);
+			}
+		    } else if (jprint_print_name(jprint->print_type)) {
+			if (jprint->print_json_levels) {
+			    print("%ju", match->level);
+			    for (j = 0; j < jprint->num_level_spaces; ++j) {
+				printf("%s", jprint->print_level_tab?"\t":" ");
+			    }
+			    print("%s", match->name);
+			} else {
+			    print("%s", match->name);
+			}
+			puts("");
+		    } else if (jprint_print_value(jprint->print_type)) {
+			if (jprint->print_json_levels) {
+			    print("%ju", match->level);
+			    for (j = 0; j < jprint->num_level_spaces; ++j) {
+				printf("%s", jprint->print_level_tab?"\t":" ");
+			    }
+			    print("%s", match->value);
+			} else {
+			    print("%s", match->value);
+			}
+			puts("");
+		    }
+		    /*
+		     * XXX: more functions will have to be added to print the values
+		     * and currently the struct jprint_match struct is a work in
+		     * progress. More will have to be added like the JSON type that
+		     * matched (this includes not only the jprint type but the JSON
+		     * type).
+		     */
+		}
+	    }
 	}
     }
 
     /*
      * although printing syntax is not yet fully implemented, we will check for
      * -B and print the braces so that after the syntax printing is implemented
-     * nothing has to be done with -B.
+     * nothing has to be done with -B. Don't print braces if -c used.
      */
-    if (jprint->print_braces) {
+    if (jprint->print_braces && !jprint->count_only) {
 	print("%c", '}');
     }
     /*
      * as well, even though -j is not yet fully implemented, we will check for
      * -C and print the final comma if requested so that once -j fully
-     * implemented we shouldn't have to do anything else with this option.
+     * implemented we shouldn't have to do anything else with this option. Don't
+     * print final comma if -c used.
      */
-    if (jprint->print_final_comma) {
+    if (jprint->print_final_comma && !jprint->count_only) {
 	print("%c", ',');
     }
-    /* print final newline */
-    puts("");
 }
 
 /*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1739,10 +1739,9 @@ jprint_print_matches(struct jprint *jprint)
 		     */
 		    if (jprint_print_name_value(jprint->print_type) || jprint->print_syntax) {
 			if (jprint->print_syntax) {
-			    print("\"%s\" : %s%s%s%s", match->name,
+			    print("\"%s\" : %s%s%s%s\n", match->name,
 				    match->string?"\"":"", match->value, match->string?"\"":"",
 				    match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
-			    puts("");
 			} else if (jprint->print_json_levels) {
 			    print("%ju", match->level);
 			    for (j = 0; j < jprint->num_level_spaces; ++j) {
@@ -1751,36 +1750,33 @@ jprint_print_matches(struct jprint *jprint)
 			    print("%s\n", match->name);
 			    print("%ju", match->level);
 			    for (j = 0; j < jprint->num_level_spaces; ++j) {
-				printf("%s", jprint->print_level_tab?"\t":" ");
+				print("%s", jprint->print_level_tab?"\t":" ");
 			    }
-			    print("%s", match->value);
+			    print("%s\n", match->value);
 			} else {
 			    print("%s\n", match->name);
-			    print("%s", match->value);
+			    print("%s\n", match->value);
 			}
-			puts("");
 		    } else if (jprint_print_name(jprint->print_type)) {
 			if (jprint->print_json_levels) {
 			    print("%ju", match->level);
 			    for (j = 0; j < jprint->num_level_spaces; ++j) {
-				printf("%s", jprint->print_level_tab?"\t":" ");
+				print("%s", jprint->print_level_tab?"\t":" ");
 			    }
-			    print("%s", match->name);
+			    print("%s\n", match->name);
 			} else {
-			    print("%s", match->name);
+			    print("%s\n", match->name);
 			}
-			puts("");
 		    } else if (jprint_print_value(jprint->print_type)) {
 			if (jprint->print_json_levels) {
 			    print("%ju", match->level);
 			    for (j = 0; j < jprint->num_level_spaces; ++j) {
 				printf("%s", jprint->print_level_tab?"\t":" ");
 			    }
-			    print("%s", match->value);
+			    print("%s\n", match->value);
 			} else {
-			    print("%s", match->value);
+			    print("%s\n", match->value);
 			}
-			puts("");
 		    }
 		    /*
 		     * XXX: more functions will have to be added to print the values

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -535,6 +535,11 @@ int main(int argc, char **argv)
 	not_reached();
     }
 
+    if (jprint->count_only && jprint->patterns == NULL) {
+	err(3, "jprint", "use of -c without any patterns is an error"); /*ooo*/
+	not_reached();
+    }
+
     /* Before we can process the -S option, if it specified, we have to read in
      * the JSON file (either stdin or otherwise) and then verify that the JSON
      * is valid.

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1742,6 +1742,7 @@ jprint_print_matches(struct jprint *jprint)
 			    print("\"%s\" : %s%s%s%s", match->name,
 				    match->string?"\"":"", match->value, match->string?"\"":"",
 				    match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
+			    puts("");
 			} else if (jprint->print_json_levels) {
 			    print("%ju", match->level);
 			    for (j = 0; j < jprint->num_level_spaces; ++j) {
@@ -1757,6 +1758,7 @@ jprint_print_matches(struct jprint *jprint)
 			    print("%s\n", match->name);
 			    print("%s", match->value);
 			}
+			puts("");
 		    } else if (jprint_print_name(jprint->print_type)) {
 			if (jprint->print_json_levels) {
 			    print("%ju", match->level);

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -78,6 +78,7 @@ struct jprint_match
     char *name;			    /* name of member */
     char *value;		    /* value of member */
 
+    uintmax_t count;		    /* how many of this match are found */
     uintmax_t level;		    /* the level of the json member for -l */
     uintmax_t number;		    /* which match this is */
     bool string;		    /* match is a string */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <regex.h> /* for -g, regular expression matching */
+#include <strings.h> /* for -i, strcasecmp */
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
@@ -111,7 +112,7 @@ struct jprint
 {
     bool is_stdin;				/* reading from stdin */
     bool match_found;				/* true if a pattern is specified and there is a match */
-    bool case_insensitive;			/* true if -i, case-insensitive */
+    bool ignore_case;				/* true if -i, case-insensitive */
     bool pattern_specified;			/* true if a pattern was specified */
     bool encode_strings;			/* -e used */
     bool quote_strings;				/* -Q used */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -82,6 +82,7 @@ struct jprint_match
     uintmax_t count;		    /* how many of this match are found */
     uintmax_t level;		    /* the level of the json member for -l */
     uintmax_t number;		    /* which match this is */
+    enum item_type type;	    /* match type */
     bool string;		    /* match is a string */
 
     struct jprint_pattern *pattern; /* pointer to the pattern that matched. DO NOT FREE! */
@@ -160,7 +161,7 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *value, uintmax_t level,
-	bool string);
+	bool string, enum item_type type);
 void jprint_print_matches(struct jprint *jprint);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -65,7 +65,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.22 2023-06-19"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.23 2023-06-20"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -540,13 +540,13 @@ jprint_parse_print_option(char *optarg)
     }
 
     if (jprint_print_name_value(print_types)) {
-	dbg(DBG_NONE, "will print both name and value");
+	dbg(DBG_LOW, "will print both name and value");
     }
     else if (jprint_print_name(print_types)) {
-	dbg(DBG_NONE, "will only print name");
+	dbg(DBG_LOW, "will only print name");
     }
     else if (jprint_print_value(print_types)) {
-	dbg(DBG_NONE, "will only print value");
+	dbg(DBG_LOW, "will only print value");
     }
 
     if (dup != NULL) {
@@ -621,7 +621,7 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	    number->range.inclusive = false;
 	    number->range.less_than_equal = false;
 	    number->range.greater_than_equal = false;
-	    dbg(DBG_NONE, "exact number required for option %s: %jd", option, number->number);
+	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
 	} else {
 	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
 	    not_reached();
@@ -639,7 +639,7 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	/* XXX - this debug message is problematic wrt the negative number
 	 * option
 	 */
-	dbg(DBG_NONE, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
+	dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
 		number->range.max);
     } else if (sscanf(optarg, "%jd:", &min) == 1) {
 	number->number = 0;
@@ -649,7 +649,7 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	number->range.greater_than_equal = true;
 	number->range.less_than_equal = false;
 	number->range.inclusive = false;
-	dbg(DBG_NONE, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
     } else if (sscanf(optarg, ":%jd", &max) == 1) {
 	number->range.max = max;
 	number->range.min = number->range.max;
@@ -658,7 +658,7 @@ jprint_parse_number_range(const char *option, char *optarg, struct jprint_number
 	number->range.less_than_equal = true;
 	number->range.greater_than_equal = false;
 	number->range.inclusive = false;
-	dbg(DBG_NONE, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+	dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
     } else {
 	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
 	not_reached();
@@ -778,11 +778,11 @@ jprint_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *p
     if (sscanf(optarg, "%ju%c", num_token_spaces, &ch) == 2) {
 	if (ch == 't') {
 	    *print_token_tab = true;
-	    dbg(DBG_NONE, "will print %ju tab%s between name and value", *num_token_spaces,
+	    dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
 		*num_token_spaces==1?"":"s");
 	} else if (ch == 's') {
 	    *print_token_tab = false;
-	    dbg(DBG_NONE, "will print %ju space%s between name and value", *num_token_spaces,
+	    dbg(DBG_LOW, "will print %ju space%s between name and value", *num_token_spaces,
 		*num_token_spaces==1?"":"s");
 	} else {
 	    err(3, __func__, "syntax error for -b <num>[ts]"); /*ooo*/
@@ -791,14 +791,14 @@ jprint_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *p
     } else if (!strcmp(optarg, "tab")) {
 	*print_token_tab = true;
 	*num_token_spaces = 1;
-	dbg(DBG_NONE, "will print %ju tab%s between name and value", *num_token_spaces,
+	dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
 	    *num_token_spaces==1?"":"s");
     } else if (!string_to_uintmax(optarg, num_token_spaces)) {
 	err(3, "jprint", "couldn't parse -b <num>[ts]"); /*ooo*/
 	not_reached();
     } else {
 	*print_token_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_NONE, "will print %jd space%s between name and value", *num_token_spaces,
+	dbg(DBG_LOW, "will print %jd space%s between name and value", *num_token_spaces,
 		*num_token_spaces==1?"":"s");
     }
 }
@@ -849,10 +849,10 @@ jprint_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *inden
     if (sscanf(optarg, "%ju%c", indent_level, &ch) == 2) {
 	if (ch == 't') {
 	    *indent_tab = true;
-	    dbg(DBG_NONE, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
 	} else if (ch == 's') {
 	    *indent_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_NONE, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+	    dbg(DBG_LOW, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
 	} else {
 	    err(3, __func__, "syntax error for -I"); /*ooo*/
 	    not_reached();
@@ -860,13 +860,13 @@ jprint_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *inden
     } else if (!strcmp(optarg, "tab")) {
 	    *indent_tab = true;
 	    *indent_level = 1;
-	    dbg(DBG_NONE, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
     } else if (!string_to_uintmax(optarg, indent_level)) {
 	err(3, "jprint", "couldn't parse -I spaces"); /*ooo*/
 	not_reached();
     } else {
 	*indent_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_NONE, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+	dbg(DBG_LOW, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
     }
 }
 
@@ -915,10 +915,10 @@ jprint_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *pr
     if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
 	if (ch == 't') {
 	    *print_level_tab = true;
-	    dbg(DBG_NONE, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
 	} else if (ch == 's') {
 	    *print_level_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_NONE, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
 	} else {
 	    err(3, __func__, "syntax error for -L"); /*ooo*/
 	    not_reached();
@@ -926,13 +926,13 @@ jprint_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *pr
     } else if (!strcmp(optarg, "tab")) {
 	    *print_level_tab = true;
 	    *num_level_spaces = 1;
-	    dbg(DBG_NONE, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
     } else if (!string_to_uintmax(optarg, num_level_spaces)) {
 	err(3, "jprint", "couldn't parse -L spaces"); /*ooo*/
 	not_reached();
     } else {
 	*print_level_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_NONE, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
     }
 }
 

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -2434,6 +2434,7 @@ json_conv_number(char const *ptr, size_t len)
     item->is_floating = false;
     item->is_e_notation = false;
     /* integer values */
+    item->is_integer = false;
     item->int8_sized = false;
     item->uint8_sized = false;
     item->int16_sized = false;
@@ -2525,6 +2526,10 @@ json_conv_number(char const *ptr, size_t len)
 	if (success == false) {
 	    warn(__func__, "JSON number as base 10 integer in ASCII processing failed: <%*.*s>",
 			   (int)item->number_len, (int)item->number_len, item->first);
+	} else {
+	    item->is_integer = true;
+	    item->is_floating = false;
+	    item->is_e_notation = false;
 	}
 
     /*
@@ -2539,6 +2544,8 @@ json_conv_number(char const *ptr, size_t len)
 	if (success == false) {
 	    warn(__func__, "JSON number as floating point or e-notation number failed: <%*.*s>",
 			   (int)item->number_len, (int)item->number_len, item->first);
+	} else {
+	    item->is_integer = false;
 	}
     }
     json_dbg(JSON_DBG_VHIGH, __func__, "JSON return type: %s", json_item_type_name(ret));

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -113,6 +113,7 @@ struct json_number
 
     /* integer values */
 
+    bool is_integer;		/* true ==> converted to some integer type below */
     bool int8_sized;		/* true ==> converted JSON integer to C int8_t */
     int8_t as_int8;		/* JSON integer value in int8_t form, if int8_sized == true */
 


### PR DESCRIPTION

Don't increment the count of matches if the type is not the same. By type this
refers to the `JTYPE_*` enum found in `json_parse.h`. This means the
`jprint_match` struct now has a type.

Add more strict checks for number types based on options.
 
Disable explicit check for strings in match function as the check there is
problematic anyway and this helps in another way until the function itself can
be fixed. Strings are more problematic than others but matching also
currently matches on either name or value when it should only match on 
one or the other depending on the options specified.

Type checking is very much a work in progress.
