### PR TITLE
Modify behaviour of jprint -c to match grep -c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.19 2023-06-22
+
+New `jprint` version at "0.0.25 2023-06-22".
+
+Modify behaviour of `jprint -c` to completely match `grep -c` (which was my
+original idea in the first place). If more than one pattern (as in `name_arg`)
+is specified and found it is a total of the matches found.
+
+
 ## Release 1.0.18 2023-06-21
 
 New `jprint` version "0.0.24 2023-06-21".

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -66,7 +66,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.24 2023-06-21"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.25 2023-06-22"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern
@@ -149,6 +149,7 @@ struct jprint
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */
     uintmax_t number_of_patterns;		/* patterns specified */
+    uintmax_t total_matches;			/* total matches of all patterns (name_args) */
 };
 
 /* functions */


### PR DESCRIPTION
Instead of showing the prefix of each pattern (name_arg) matched show just a total count of the matches. This was my intended purpose in the first place when I suggested the option.