### PR TITLE
Add bools to struct jprint for some options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.20 2023-06-23
+
+New `jprint` version at "0.0.26 2023-06-23".
+
+Add booleans (including renaming one `uintmax_t` to be a boolean and adding a
+new `uintmax_t` in its place) in `struct jprint` to indicate that specific
+options were used rather than relying on the `uintmax_t`s being not 0.
+
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/README.md
+++ b/README.md
@@ -190,12 +190,12 @@ bug-report.YYYYMMDD.HHMMSS.txt
 
 This bug report file is intended to be uploaded to a [mkiocccentry repo related bug report](https://github.com/ioccc-src/mkiocccentry/issues).
 
-This tool was co-developed in 2022 by:
+This tool was written in 2022 by:
 
 *@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
 [https://ioccc.xexyl.net](https://ioccc.xexyl.net))
 
-and:
+with minor improvements by:
 
 *chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -66,7 +66,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.25 2023-06-22"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.26 2023-06-23"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern
@@ -117,7 +117,8 @@ struct jprint
     bool pattern_specified;			/* true if a pattern was specified */
     bool encode_strings;			/* -e used */
     bool quote_strings;				/* -Q used */
-    uintmax_t type;				/* -t type used */
+    bool type_specified;			/* -t used */
+    uintmax_t type;				/* -t type */
     struct jprint_number jprint_max_matches;	/* -n count specified */
     bool max_matches_requested;			/* -n used */
     struct jprint_number jprint_min_matches;	/* -N count specified */
@@ -135,7 +136,8 @@ struct jprint
     bool print_colons;				/* -P specified */
     bool print_final_comma;			/* -C specified */
     bool print_braces;				/* -B specified */
-    uintmax_t indent_level;			/* -I specified */
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
     bool indent_tab;				/* -I <num>[{t|s}] specified */
     bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
     bool match_encoded;				/* -E used, match encoded name */


### PR DESCRIPTION

New jprint version is 0.0.26 2023-06-23.

Added some booleans to struct jprint to make it more clear that specific
options are used rather than relying on a uintmax_t not being 0. This 
involved having to rename one uintmax_t to as it was more fitting as a 
boolean.