### PR TITLE
Fix match pointer check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ substring matching. The value is still the same as the name in the match struct
 but with substring matches the match is the pattern (`name_arg`) specified but
 the value (what to be printed) is the actual member found.
 
+Typo fix in debug message. The `jprint -o` option no longer exists but it was
+referenced.
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.20 2023-06-23
+
+New `jprint` version at "0.0.26 2023-06-23".
+
+Add booleans (including renaming one `uintmax_t` to be a boolean and adding a
+new `uintmax_t` in its place) in `struct jprint` to indicate that specific
+options were used rather than relying on the `uintmax_t`s being not 0.
+
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ for some of the int types. In particular it cast the booleans to an int rather
 than use the `as_type` members of the struct. This would mean that instead of
 printing the actual number it would print a boolean as an integer.
 
+More modularity in `jprint` printing matches. Several new functions have been
+added. These will be useful later for the printing of not just a JSON file if no
+pattern requested but also printing matches. More will be added.
 
 ## Release 1.0.19 2023-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Add booleans (including renaming one `uintmax_t` to be a boolean and adding a
 new `uintmax_t` in its place) in `struct jprint` to indicate that specific
 options were used rather than relying on the `uintmax_t`s being not 0.
 
+Add inclusion of `string.h` and feature test macro `_GNU_SOURCE` to `jprint.h`
+for `strcasestr()`.
+
 
 ## Release 1.0.19 2023-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ Fix sign comparison warning in `util.h`.
 
 Fix use after free error in `util.c` (function `vcmdprintf()`).
 
+Fix error in `jprint_run_tests()` causing invalid test result and warning about
+unused computed value.
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,12 @@ the value (what to be printed) is the actual member found.
 Typo fix in debug message. The `jprint -o` option no longer exists but it was
 referenced.
 
+New `jparse` version "1.0.8 2023-06-23". Fixed display bug in `vjson_fprint()`
+for some of the int types. In particular it cast the booleans to an int rather
+than use the `as_type` members of the struct. This would mean that instead of
+printing the actual number it would print a boolean as an integer.
+
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,18 @@ Fix use after free error in `util.c` (function `vcmdprintf()`).
 Fix error in `jprint_run_tests()` causing invalid test result and warning about
 unused computed value.
 
+The `jprint_match` struct (which is still a work in progress) now has two
+`struct json *`s: the node name and node value. The name is what was matched,
+whether or not value was searched or not and the value is what will be printed,
+either value or name depending on the options. As both might need to be printed
+this can also be a misnomer but I believe having the nodes will be useful at
+some point.
+
+Improve (but not yet fixed) the value / name added to matches particularly with
+substring matching. The value is still the same as the name in the match struct
+but with substring matches the match is the pattern (`name_arg`) specified but
+the value (what to be printed) is the actual member found.
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ for `strcasestr()`.
 
 Fix sign comparison warning in `util.h`.
 
+Fix use after free error in `util.c` (function `vcmdprintf()`).
 
 ## Release 1.0.19 2023-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ options were used rather than relying on the `uintmax_t`s being not 0.
 Add inclusion of `string.h` and feature test macro `_GNU_SOURCE` to `jprint.h`
 for `strcasestr()`.
 
+Fix sign comparison warning in `util.h`.
+
 
 ## Release 1.0.19 2023-06-22
 

--- a/README.md
+++ b/README.md
@@ -190,12 +190,12 @@ bug-report.YYYYMMDD.HHMMSS.txt
 
 This bug report file is intended to be uploaded to a [mkiocccentry repo related bug report](https://github.com/ioccc-src/mkiocccentry/issues).
 
-This tool was co-developed in 2022 by:
+This tool was written in 2022 by:
 
 *@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
 [https://ioccc.xexyl.net](https://ioccc.xexyl.net))
 
-and:
+with minor improvements by:
 
 *chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
 

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.7 2023-06-22"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.8 2023-06-23"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.7 2023-06-22"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.0.8 2023-06-23"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -1858,12 +1858,12 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 	return;
     }
 
-    if (match->match == NULL) {
-	err(48, __func__, "match '%s' has NULL match", match->match);
+    if (match->value == NULL) {
+	err(48, __func__, "match '%s' has NULL value", match->match);
 	not_reached();
-    } else if (*match->match == '\0') {
-	/* for now we only warn on empty match */
-	warn(__func__, "empty match for match '%s'", match->match);
+    } else if (*match->value == '\0') {
+	/* for now we only warn on empty value */
+	warn(__func__, "empty value for match '%s'", match->match);
 	return;
     }
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -690,7 +690,7 @@ int main(int argc, char **argv)
     if (!jprint->print_entire_file || jprint->count_only) {
 	jprint_print_matches(jprint);
     } else if (file_contents != NULL) {
-	dbg(DBG_MED, "no pattern requested or -o and no -c, will print entire file");
+	dbg(DBG_MED, "no pattern requested and no -c, will print entire file");
 	fpr(stdout, "jprint", "%s", file_contents);
     }
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -20,8 +20,10 @@
 #if !defined(INCLUDE_JPRINT_H)
 #    define  INCLUDE_JPRINT_H
 
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <regex.h> /* for -g, regular expression matching */
 #include <strings.h> /* for -i, strcasecmp */
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -78,14 +78,17 @@
  */
 struct jprint_match
 {
-    char *name;			    /* name of member */
-    char *value;		    /* value of member */
+    char *match;		    /* string that matched */
+    char *value;		    /* name or value string of that which matched */
 
     uintmax_t count;		    /* how many of this match are found */
     uintmax_t level;		    /* the level of the json member for -l */
     uintmax_t number;		    /* which match this is */
     enum item_type type;	    /* match type */
     bool string;		    /* match is a string */
+
+    struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
+    struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
 
     struct jprint_pattern *pattern; /* pointer to the pattern that matched. DO NOT FREE! */
     struct jprint_match *next; /* next match found */
@@ -166,8 +169,8 @@ struct jprint_pattern *add_jprint_pattern(struct jprint *jprint, bool use_regexp
 void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
-struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *value, uintmax_t level,
-	bool string, enum item_type type);
+struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
+	struct json *node_name, struct json *node_value, char *value, uintmax_t level, bool string, enum item_type type);
 void jprint_print_matches(struct jprint *jprint);
 void jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct jprint_match *match);
 void free_jprint_matches_list(struct jprint_pattern *pattern);

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -66,7 +66,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.25 2023-06-22"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.26 2023-06-23"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern
@@ -117,7 +117,8 @@ struct jprint
     bool pattern_specified;			/* true if a pattern was specified */
     bool encode_strings;			/* -e used */
     bool quote_strings;				/* -Q used */
-    uintmax_t type;				/* -t type used */
+    bool type_specified;			/* -t used */
+    uintmax_t type;				/* -t type */
     struct jprint_number jprint_max_matches;	/* -n count specified */
     bool max_matches_requested;			/* -n used */
     struct jprint_number jprint_min_matches;	/* -N count specified */
@@ -135,7 +136,8 @@ struct jprint
     bool print_colons;				/* -P specified */
     bool print_final_comma;			/* -C specified */
     bool print_braces;				/* -B specified */
-    uintmax_t indent_level;			/* -I specified */
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
     bool indent_tab;				/* -I <num>[{t|s}] specified */
     bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
     bool match_encoded;				/* -E used, match encoded name */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -161,6 +161,7 @@ struct jprint
 };
 
 /* functions */
+
 /* to free the entire struct jprint */
 void free_jprint(struct jprint **jprint);
 
@@ -171,8 +172,6 @@ void free_jprint_patterns_list(struct jprint *jprint);
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
 	struct json *node_name, struct json *node_value, char *value, uintmax_t level, bool string, enum item_type type);
-void jprint_print_matches(struct jprint *jprint);
-void jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct jprint_match *match);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* for finding matches and printing them */
@@ -181,7 +180,11 @@ void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value
 void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
 void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
 		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
-
+void jprint_print_matches(struct jprint *jprint);
+bool jprint_print_count(struct jprint *jprint);
+void jprint_print_final_comma(struct jprint *jprint);
+void jprint_print_brace(struct jprint *jprint, bool open);
+void jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct jprint_match *match);
 
 /* sanity checks on environment for specific options */
 void jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *tool_args);

--- a/jparse/jprint_test.c
+++ b/jparse/jprint_test.c
@@ -295,7 +295,7 @@ jprint_run_tests(void)
      * each match function
      */
     bits = JPRINT_TYPE_NONE;
-	   jprint_test_bits(false, bits, __LINE__, jprint_match_int, "JPRINT_TYPE_INT") &&
+    test = jprint_test_bits(false, bits, __LINE__, jprint_match_int, "JPRINT_TYPE_INT") &&
 	   jprint_test_bits(false, bits, __LINE__, jprint_match_float, "JPRINT_TYPE_FLOAT") &&
 	   jprint_test_bits(false, bits, __LINE__, jprint_match_exp, "JPRINT_TYPE_EXP") &&
 	   jprint_test_bits(false, bits, __LINE__, jprint_match_num, "JPRINT_TYPE_NUM") &&

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1442,11 +1442,11 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 			} else if (item->int16_sized == true) {
 			    fprint(stream, "\tval-16: %jd", (intmax_t)item->as_int16);
 			} else if (item->int32_sized == true) {
-			    fprint(stream, "\tval-32: %jd", (intmax_t)item->int32_sized);
+			    fprint(stream, "\tval-32: %jd", (intmax_t)item->as_int32);
 			} else if (item->int64_sized == true) {
-			    fprint(stream, "\tval-64: %jd", (intmax_t)item->int64_sized);
+			    fprint(stream, "\tval-64: %jd", (intmax_t)item->as_int64);
 			} else if (item->maxint_sized == true) {
-			    fprint(stream, "\tval-max: %jd", (intmax_t)item->maxint_sized);
+			    fprint(stream, "\tval-max: %jd", (intmax_t)item->as_maxint);
 			} else {
 			    fprstr(stream, "\tWarning: -integer: no common size:\t");
 			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -2376,7 +2376,7 @@ string_to_uintmax(char const *str, uintmax_t *ret)
 	errno = saved_errno;
 	warnp(__func__, "error converting string <%s> to uintmax_t", str);
 	return false;
-    } else if (num < 0 || num >= UINTMAX_MAX) {
+    } else if (num <= 0 || num >= UINTMAX_MAX) {
 	warn(__func__, "number %s out of range for uintmax_t (must be >= %jd && < %jd)", str, (uintmax_t)0, UINTMAX_MAX);
 	return false;
     }

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1097,12 +1097,13 @@ vcmdprintf(char const *fmt, va_list ap)
      * verify amount of data written
      */
     if ((size_t)(d + 1 - cmd) != size) {
+	warn(__func__, "stored characters: %jd != size: %ju",
+	     (intmax_t)((size_t)(d + 1 - cmd)), (uintmax_t)size);
+
 	if (cmd != NULL) {
 	    free(cmd);
 	    cmd = NULL;
 	}
-	warn(__func__, "stored characters: %jd != size: %ju",
-	     (intmax_t)((size_t)(d + 1 - cmd)), (uintmax_t)size);
 	return NULL;
     }
 


### PR DESCRIPTION

When renaming variables in the jprint_match struct checks for two NULL 
pointers were changed to the same pointer checked twice.