### PR TITLE
Fix -Y usage syntax in jprint usage string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,11 @@ More modularity in `jprint` printing matches. Several new functions have been
 added. These will be useful later for the printing of not just a JSON file if no
 pattern requested but also printing matches. More will be added.
 
+Fix typo in usage string with `-Y` based on the original concept. It takes just
+one `name_arg` but is not an option arg but rather an arg to the program itself.
+Only the type is an option arg to the option.
+
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-G regexp] [-c] [-m depth] [-K]\n"
-    "\t\t[-Y type:value] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\t\t[-Y type] [-S path] [-A args] file.json [name_arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"


### PR DESCRIPTION
It originally was thought to be -Y type:value but it was changed to be -Y type and then the other part was just a name_arg which is an arg to the program and not part of the option arg.