### PR TITLE
Add initial (incomplete) man page for jprint tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ Fix typo in usage string with `-Y` based on the original concept. It takes just
 one `name_arg` but is not an option arg but rather an arg to the program itself.
 Only the type is an option arg to the option.
 
+Fix unmatched `.RE` in jsemtblgen.8 man page.
 
 ## Release 1.0.19 2023-06-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,16 @@ Only the type is an option arg to the option.
 
 Fix unmatched `.RE` in jsemtblgen.8 man page.
 
+Add initial man page for `jprint`. This is currently incomplete. The `BUGS`
+section just says that there are too many things to list at this time as the
+tool is in progress and there are a number of things that are incorrect even
+besides it. There are some examples but with the exception of one that prints
+out the file it is not correct output (and it's not correct for the file in full
+depending on options specified). The synopsis is complete and the description is
+a good start but the options list is incomplete. There are a lot more to be
+added but I want to have the file in and I'll continue working on it in the
+coming days.
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,11 @@ More modularity in `jprint` printing matches. Several new functions have been
 added. These will be useful later for the printing of not just a JSON file if no
 pattern requested but also printing matches. More will be added.
 
+Fix typo in usage string with `-Y` based on the original concept. It takes just
+one `name_arg` but is not an option arg but rather an arg to the program itself.
+Only the type is an option arg to the option.
+
+
 ## Release 1.0.19 2023-06-22
 
 New `jprint` version at "0.0.25 2023-06-22".

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -186,7 +186,7 @@ SH_FILES= jsemcgen.sh run_bison.sh run_flex.sh
 
 # all man pages that NOT built and NOT removed by make clobber
 #
-MAN1_PAGES= man/man1/jparse.1 man/man1/jstrdecode.1 man/man1/jstrencode.1
+MAN1_PAGES= man/man1/jparse.1 man/man1/jstrdecode.1 man/man1/jstrencode.1 man/man1/jprint.1
 MAN3_PAGES= man/man3/jparse.3 man/man3/json_dbg.3 man/man3/json_dbg_allowed.3 \
 	    man/man3/json_err_allowed.3 man/man3/json_warn_allowed.3 man/man3/parse_json.3 \
 	    man/man3/parse_json_file.3 man/man3/parse_json_stream.3

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-G regexp] [-c] [-m depth] [-K]\n"
-    "\t\t[-Y type:value] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\t\t[-Y type] [-S path] [-A args] file.json [name_arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"

--- a/jparse/man/man1/jprint.1
+++ b/jparse/man/man1/jprint.1
@@ -1,0 +1,283 @@
+.\" section 1 man page for jprint
+.\"
+.\" This man page was first written by Cody Boone Ferguson for the IOCCC
+.\" in 2023.
+.\"
+.\" Humour impairment is not virtue nor is it a vice, it's just plain
+.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\"
+.\" "Share and Enjoy!"
+.\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+.\"
+.TH jprint 1 "23 June 2023" "jprint" "IOCCC tools"
+.SH NAME
+.B jprint
+\- IOCCC JSON printer
+.SH SYNOPSIS
+.B jprint
+.RB [\| \-h \|]
+.RB [\| \-V \|]
+.RB [\| \-v
+.IR level \|]
+.RB [\| \-J
+.IR level \|]
+.RB [\| \-e \|]
+.RB [\| \-q \|]
+.RB [\| -Q \|]
+.RB [\| -t
+.IR type \|]
+.RB [\| \-n
+.IR count \|]
+.RB [\| \-N
+.IR num \|]
+.RB [\| \-p
+.IR {n,v,b} \|]
+.RB [\| \-b
+.IR <num>{[t|s]} \|]
+.RB [\| \-L
+.IR <num>{[t|s]} \|]
+.RB [\| \-P \|]
+.RB [\| \-C \|]
+.RB [\| \-B \|]
+.RB [\| \-I
+.IR <num>{[t|s]}\|]
+.RB [\| \-j \|]
+.RB [\| \-E \|]
+.RB [\| \-i \|]
+.RB [\| \-s \|]
+.RB [\| \-g \|]
+.RB [\| \-G
+.IR regexp \|]
+.RB [\| \-c \|]
+.RB [\| \-m
+.IR depth \|]
+.RB [\| \-K \|]
+.RB [\| \-Y
+.IR type \|]
+.RB [\| \-S
+.IR path \|]
+.RB [\| \-A
+.IR args \|]
+.IR file.json
+.IR name_arg ...
+.SH DESCRIPTION
+.B jprint
+parses a JSON file and if it is valid it either prints out the file in full or prints specific members depending on either the name or value.
+If the
+.B \-g
+option is used it will allow one to use grep\-like regular expressions.
+The
+.B \-s
+option makes the tool search by substring rather than whole words or regular expression.
+The option
+.B \-t
+controls what types to search for, excluding matches if they are not any of the types in the comma-separated list.
+The
+.B \-Y
+option lets one search by value, printing the name instead of the value.
+.PP
+The
+.B \-p
+option lets you control what is printed: name, value or both.
+The option
+.B \-j
+pretty\-prints the JSON (for certain definitions of pretty printing JSON :-) ).
+The option
+.B \-C
+makes the program print a final comma after the JSON is printed.
+Despite the JSON spec not allowing this, this can be useful in case you want to use it to create a JSON document through this tool.
+There are many other options that control the program as described in the
+.B OPTIONS
+section.
+.PP
+The point of multiple
+.I name_args
+is to find a JSON member that is in the previous
+.I name_arg
+or
+.IR name_args .
+Matches are based on JSON names, printing values, unless
+.B \-Y
+is used in which case JSON values are matched and names are then printed.
+To make the program read from stdin use
+.B \-
+as the
+.I file.json
+arg.
+.PP
+.SH OPTIONS
+.TP
+.B \-h
+Show help and exit.
+.TP
+.B \-V
+Show version and exit.
+.TP
+.BI \-v\  level
+Set verbosity level to
+.IR level
+(def: 0).
+.TP
+.BI \-J\  level
+Set JSON verbosity level to
+.IR level
+(def: 0).
+.TP
+.B \-e
+Print JSON strings as encoded strings (default: decode JSON strings).
+.TP
+.B \-q
+Suppresses some of the output (def: not quiet).
+.TP
+.B \-Q
+Print JSON strings surrounded by double quotes (def: do not).
+.TP
+.BI \-t\  type
+Match only the comma separated types (def: simple).
+.RS
+.B int
+.RS
+integer values
+.RE
+.B float
+.RS
+floating point values
+.RE
+.B exp
+.RS
+exponential notation values
+.RE
+.B num
+.RS
+alias for int,float,exp
+.RE
+.B bool
+.RS
+boolean values
+.RE
+.B str
+.RS
+string values
+.RE
+.B null
+.RS
+null values
+.RE
+.B simple
+.RS
+alias for num,bool,str,null (the default)
+.RE
+.B member
+.RS
+JSON members
+.RE
+.B object
+.RS
+JSON objects
+.RE
+.B array
+.RS
+JSON arrays
+.RE
+.B compound
+.RS
+alias for object,null
+.RE
+.B any
+.RS
+any type of value
+.RE
+.RE
+.TP
+.BI \-l\  lvl
+
+.TP
+.B \-s
+Search by substring rather than a whole match.
+.TP
+.SH EXIT STATUS
+.TP
+0
+all is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK
+.TQ
+1
+file is valid JSON, name_arg given but no matches found
+.TQ
+2
+.B \-h
+or
+.B \-V
+used and help string or version string printed.
+.TQ
+3
+invalid command line, invalid option or option missing an argument
+.TQ
+4
+file does not exist, not a file, or unable to read the file
+.TQ
+5
+file contents is not valid JSON
+.TQ
+6
+test mode failed
+.TQ
+7
+JSON check tool failed
+.TQ
+>=10
+internal error
+.SH NOTES
+.PP
+The JSON parser was written as a collaboration between Cody Boone Ferguson and Landon Curt Noll, one of the IOCCC Judges, to support
+IOCCCMOCK, IOCCC28 and beyond.
+.PP
+.BR jprint (1)
+is being developed by Cody Boone Ferguson.
+.PP
+For more detailed history that goes beyond this humble man page we recommend you check
+.BR jprint (1),
+.IR CHANGES.md ,
+.IR README.md ,
+the GitHub git log as well as reading the source code (or not :\-) ).
+.PP
+We don't recommend you check the GitHub issue page! :\-)
+This is because it's incredibly long with a lot of OT things and would take even the fastest readers a very long time to read. :\-(
+.PP
+.SH BUGS
+.PP
+It is currently incomplete and listing the missing features and things that are not correct is not worth the time or effort.
+.SH EXAMPLES
+.PP
+Print a JSON file
+.I h2g2.json
+if it is valid JSON:
+.sp
+.RS
+.ft B
+ ./jprint h2g2.json
+.ft R
+.RE
+.PP
+Print the name of JSON members with the value 42 in the file
+.IR h2g2.json :
+.sp
+.RS
+.ft B
+ ./jprint -Y int 42 h2g2.json
+.ft R
+.RE
+.PP
+Print the value of the JSON member
+.IR panic
+in the file
+.IR h2g2.json :
+.sp
+.RS
+.ft B
+ ./jprint h2g2.json panic
+.ft R
+.RE
+.SH SEE ALSO
+.PP
+.BR jprint (1),
+.BR jparse (1)

--- a/jparse/man/man1/jprint.1
+++ b/jparse/man/man1/jprint.1
@@ -195,6 +195,53 @@ any type of value
 .B \-s
 Search by substring rather than a whole match.
 .TP
+.BI \-Y\  type
+Search for a value of of a specific type or types instead of a name, printing names instead of values.
+Types are specified in a comma separated list.
+Valid types are:
+.RS
+.B int
+.RS
+integer values
+.RE
+.B float
+.RS
+floating point values
+.RE
+.B exp
+.RS
+exponential notation values
+.RE
+.B num
+.RS
+alias for int,float,exp
+.RE
+.B bool
+.RS
+boolean values
+.RE
+.B str
+.RS
+string values
+.RE
+.B null
+.RS
+null values
+.RE
+.B simple
+.RS
+alias for num,bool,str,null
+.RE
+.PP
+Why is this option
+.BR \-Y ?
+Why not Y?
+Because Y, that's why Y!
+Why besides, all the other good options were already taken. :\-)
+Specifically the letter Y has a V in it and V would have been the
+obvious choice but both v and V are taken.
+This is why you'll have to believe us when we tell you that this is a good enough reason why Y! :\-)
+.RE
 .SH EXIT STATUS
 .TP
 0

--- a/jparse/man/man8/jsemtblgen.8
+++ b/jparse/man/man8/jsemtblgen.8
@@ -346,7 +346,6 @@ is a C language keyword, or does not start with a character that is valid for a 
 .BR x .
 .sp 1
 The default is to not use a prefix.
-.RE
 .TP
 .BI \-1\  func
 Validate


### PR DESCRIPTION

It is incomplete. In particular the options list is incomplete. The
synopsis is correct and the description is a good start (but needs some
work). Examples section is a good start but the commands don't show
correct output yet either except in one condition. Bugs section does not
list these problems as the tool is not finished yet.

I wanted the man page in the repo and it can be discussed and I can also
finish adding the options hopefully in the coming days.

jparse/Makefile updated so that make install will install jprint.1 along
with the other man pages.