### PR TITLE
Fix bug with -S and make it more modular

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ the patterns list and go from there if `jprint_sanity_chks()` returns. As the
 `argc` and `argv` have to be shifted in main() they are a `int *` and `char ***`
 respectively rather than their usual `int` and `char **`.
 
+Add function `parse_jprint_name_args()` to iterate through command line, looking
+for `name_arg`s. This function is called by the `jprint_sanity_chks()` as some
+options have to be checked after looking on the command line for `name_arg`s.
+
 
 ## Release 1.0.20 2023-06-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.21 2023-06-24
+
+New `jprint` version at "0.0.27 2023-06-24". If `-j` is used don't make use of
+`-p b` or `-p both` an error. It's only an error if printing of just name or
+just value is specified (after the `-j` as `-j` will set both). Checking for
+this is just as simple as for `-p` being used at all and it seems slightly more
+user-friendly to do it this way.
+
+
 ## Release 1.0.20 2023-06-23
 
 New `jprint` version at "0.0.26 2023-06-23".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,11 @@ Add function `parse_jprint_name_args()` to iterate through command line, looking
 for `name_arg`s. This function is called by the `jprint_sanity_chks()` as some
 options have to be checked after looking on the command line for `name_arg`s.
 
+Make running JSON check tool more modular which fixes bug of printing output
+more than once. The `struct jprint` has the `FILE *json_file`, `char
+*file_contents` as well as a `FILE *` for the json check tool stream and `char
+*`s for the check tool path and args.
+
 
 ## Release 1.0.20 2023-06-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ just value is specified (after the `-j` as `-j` will set both). Checking for
 this is just as simple as for `-p` being used at all and it seems slightly more
 user-friendly to do it this way.
 
+Modularise option checking of `jprint` by moving it to the
+`jprint_sanity_chks()` function which now returns a `FILE *`, the file to read
+the JSON from. The function will never return a NULL `FILE *`. It will not
+return with a command line error. It will check all options and verify that the
+right number of args have been specified. `main()` will add the `name_arg`s to
+the patterns list and go from there if `jprint_sanity_chks()` returns. As the
+`argc` and `argv` have to be shifted in main() they are a `int *` and `char ***`
+respectively rather than their usual `int` and `char **`.
+
 
 ## Release 1.0.20 2023-06-23
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -422,7 +422,8 @@ int main(int argc, char **argv)
     /*
      * check for conflicting options prior to changing argc and argv so that the
      * user will know to correct the options before being told that they have
-     * the wrong number of arguments (if they do).
+     * the wrong number of arguments (if they do). Not everything can be checked
+     * prior to doing this though.
      */
 
     /* use of -g conflicts with -s and is an error. -G and -s do not conflict. */
@@ -447,15 +448,13 @@ int main(int argc, char **argv)
     }
 
     /*
-     * check that -j and -p are not used together.
-     *
-     * NOTE: this means check if -p was explicitly used: the default is -p v but
-     * -j conflicts with it and since -j enables a number of options it is
-     * easier to just make it an error.
+     * check that if -j was used that printing both name and value is used. -j
+     * does this but it's possible the user explicitly used -p after -j but if
+     * they did not specify 'b' or 'both' it is an error.
      */
-    if (jprint->print_type_option && jprint->print_syntax) {
+    if (jprint->print_syntax && !jprint_print_name_value(jprint->print_type)) {
 	free_jprint(&jprint);
-	err(3, "jparse", "cannot use -j and explicit -p together"); /*ooo*/
+	err(3, "jparse", "cannot use -j without printing both name and value"); /*ooo*/
 	not_reached();
     }
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
 	jprint->pattern_specified = true;
 
 	if (add_jprint_pattern(jprint, jprint->use_regexps, jprint->substrings_okay, argv[i]) == NULL) {
-	    err(19, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
+	    err(18, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
 		    jprint->substrings_okay?"OK":"ignored", argv[i]);
 	    not_reached();
 	}
@@ -620,7 +620,7 @@ alloc_jprint(void)
 
     /* verify jprint != NULL */
     if (jprint == NULL) {
-	err(20, "jprint", "failed to allocate jprint struct");
+	err(19, "jprint", "failed to allocate jprint struct");
 	not_reached();
     }
 
@@ -739,20 +739,20 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
      * firewall
      */
     if (jprint == NULL) {
-	err(21, __func__, "passed NULL jprint struct");
+	err(20, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
     if (pattern == NULL) {
-	err(22, __func__, "passed NULL pattern");
+	err(21, __func__, "passed NULL pattern");
 	not_reached();
     } else if (pattern->pattern == NULL) {
-	err(23, __func__, "pattern->pattern is NULL");
+	err(22, __func__, "pattern->pattern is NULL");
 	not_reached();
     }
 
     if (str == NULL) {
-	err(24, __func__, "str is NULL");
+	err(23, __func__, "str is NULL");
 	not_reached();
     }
 
@@ -780,7 +780,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match = calloc(1, sizeof *match);
     if (match == NULL) {
-	errp(25, __func__, "unable to allocate struct jprint_match *");
+	errp(24, __func__, "unable to allocate struct jprint_match *");
 	not_reached();
     }
 
@@ -788,7 +788,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match->match = strdup(pattern->pattern);
     if (match->match == NULL) {
-	errp(26, __func__, "unable to strdup string '%s' for match list", pattern->pattern);
+	errp(25, __func__, "unable to strdup string '%s' for match list", pattern->pattern);
 	not_reached();
     }
 
@@ -796,7 +796,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match->value = strdup(str);
     if (match->match == NULL) {
-	errp(27, __func__, "unable to strdup value string '%s' for match list", str);
+	errp(26, __func__, "unable to strdup value string '%s' for match list", str);
 	not_reached();
     }
     /* set level of the match for -l / -L options */
@@ -858,7 +858,7 @@ free_jprint_matches_list(struct jprint_pattern *pattern)
     struct jprint_match *next_match = NULL; /* next in list */
 
     if (pattern == NULL) {
-	err(28, __func__, "passed NULL pattern struct");
+	err(27, __func__, "passed NULL pattern struct");
 	not_reached();
     }
 
@@ -916,11 +916,11 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
      * firewall
      */
     if (jprint == NULL) {
-	err(29, __func__, "passed NULL jprint struct");
+	err(28, __func__, "passed NULL jprint struct");
 	not_reached();
     }
     if (str == NULL) {
-	err(30, __func__, "passed NULL str");
+	err(29, __func__, "passed NULL str");
 	not_reached();
     }
 
@@ -950,14 +950,14 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     errno = 0; /* pre-clear errno for errp() */
     pattern = calloc(1, sizeof *pattern);
     if (pattern == NULL) {
-	errp(31, __func__, "unable to allocate struct jprint_pattern *");
+	errp(30, __func__, "unable to allocate struct jprint_pattern *");
 	not_reached();
     }
 
     errno = 0;
     pattern->pattern = strdup(str);
     if (pattern->pattern == NULL) {
-	errp(32, __func__, "unable to strdup string '%s' for patterns list", str);
+	errp(31, __func__, "unable to strdup string '%s' for patterns list", str);
 	not_reached();
     }
 
@@ -1004,7 +1004,7 @@ free_jprint_patterns_list(struct jprint *jprint)
     struct jprint_pattern *next_pattern = NULL; /* next in list */
 
     if (jprint == NULL) {
-	err(33, __func__, "passed NULL jprint struct");
+	err(32, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
@@ -1090,16 +1090,16 @@ jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char *
 
     /* firewall */
     if (jprint == NULL) {
-	err(34, __func__, "NULL jprint");
+	err(33, __func__, "NULL jprint");
 	not_reached();
     } else if (argc == NULL) {
-	err(35, __func__, "NULL argc");
+	err(34, __func__, "NULL argc");
 	not_reached();
     } else if (argv == NULL || *argv == NULL || **argv == NULL) {
-	err(36, __func__, "NULL argv");
+	err(35, __func__, "NULL argv");
 	not_reached();
     } else if (program == NULL) {
-	err(37, __func__, "NULL program");
+	err(36, __func__, "NULL program");
 	not_reached();
     }
 
@@ -1209,7 +1209,7 @@ jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char *
 
     if (jprint->search_value && *argc != 2 && jprint->number_of_patterns != 1) {
 	free_jprint(&jprint);
-	err(18, __func__, "-Y requires exactly one name_arg");
+	err(37, __func__, "-Y requires exactly one name_arg");
 	not_reached();
     } else if (!jprint->search_value && (*argv)[1] == NULL && !jprint->count_only) {
 	jprint->print_entire_file = true;   /* technically this boolean is redundant */
@@ -1443,7 +1443,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 					    if (add_jprint_match(jprint, pattern, jprint->search_value?
 						NULL:node, jprint->search_value?node:NULL, str, depth, false,
 						JTYPE_NUMBER) == NULL) {
-						    err(35, __func__, "adding match '%s' to pattern failed", str);
+						    err(38, __func__, "adding match '%s' to pattern failed", str);
 						    not_reached();
 					    }
 				    }
@@ -1453,7 +1453,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 					    if (add_jprint_match(jprint, pattern, jprint->search_value?
 						NULL:node, jprint->search_value?node:NULL, str, depth, false,
 						JTYPE_NUMBER) == NULL) {
-						    err(36, __func__, "adding match '%s' to pattern failed", str);
+						    err(39, __func__, "adding match '%s' to pattern failed", str);
 						    not_reached();
 					    }
 				    }
@@ -1474,7 +1474,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && strcasestr(str, pattern->pattern))) {
 					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					    jprint->search_value?node:NULL, str, depth, true, JTYPE_STRING) == NULL) {
-						err(37, __func__, "adding match '%s' to pattern failed", str);
+						err(40, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				}
@@ -1483,7 +1483,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && !strcasecmp(pattern->pattern, str))) {
 					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					    jprint->search_value?node:NULL, str, depth, true, JTYPE_STRING) == NULL) {
-						err(38, __func__, "adding match '%s' to pattern failed", str);
+						err(41, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				}
@@ -1503,7 +1503,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && strcasestr(str, pattern->pattern))) {
 					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					    jprint->search_value?node:NULL, str, depth, false, JTYPE_BOOL) == NULL) {
-						err(39, __func__, "adding match '%s' to pattern failed", str);
+						err(42, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				}
@@ -1513,7 +1513,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && !strcasecmp(pattern->pattern, str))) {
 					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					    jprint->search_value?node:NULL, str, depth, false, JTYPE_BOOL) == NULL) {
-						err(40, __func__, "adding match '%s' to pattern failed", str);
+						err(43, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				}
@@ -1533,7 +1533,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && strcasestr(str, pattern->pattern))) {
 				    if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					jprint->search_value?node:NULL, str, depth, false, JTYPE_NULL) == NULL) {
-					    err(41, __func__, "adding match '%s' to pattern failed", str);
+					    err(44, __func__, "adding match '%s' to pattern failed", str);
 					    not_reached();
 				    }
 				}
@@ -1542,7 +1542,7 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 				    (jprint->ignore_case && !strcasecmp(pattern->pattern, str))) {
 				    if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
 					jprint->search_value?node:NULL, str, depth, false, JTYPE_NULL) == NULL) {
-					    err(42, __func__, "adding match '%s' to pattern failed", str);
+					    err(45, __func__, "adding match '%s' to pattern failed", str);
 					    not_reached();
 				    }
 				}
@@ -1848,7 +1848,7 @@ jprint_print_brace(struct jprint *jprint, bool open)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(43, __func__, "jprint is NULL");
+	err(46, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -1882,19 +1882,19 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 
     /* firewall */
     if (jprint == NULL) {
-	err(44, __func__, "jprint is NULL");
+	err(47, __func__, "jprint is NULL");
 	not_reached();
     } else if (match == NULL) {
-	err(45, __func__, "match is NULL");
+	err(48, __func__, "match is NULL");
 	not_reached();
     } else if (pattern == NULL) {
-	err(46, __func__, "pattern is NULL");
+	err(49, __func__, "pattern is NULL");
 	not_reached();
     }
 
     /* if the name of the match is NULL it is a fatal error */
     if (match->match == NULL) {
-	err(47, __func__, "match->match is NULL");
+	err(50, __func__, "match->match is NULL");
 	not_reached();
     } else if (*match->match == '\0') {
 	/* warn on empty name for now and then go to next match */
@@ -1903,7 +1903,7 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
     }
 
     if (match->value == NULL) {
-	err(48, __func__, "match '%s' has NULL value", match->match);
+	err(51, __func__, "match '%s' has NULL value", match->match);
 	not_reached();
     } else if (*match->value == '\0') {
 	/* for now we only warn on empty value */
@@ -2019,7 +2019,7 @@ jprint_print_count(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(49, __func__, "jprint is NULL");
+	err(52, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2046,7 +2046,7 @@ jprint_print_final_comma(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(50, __func__, "jprint is NULL");
+	err(53, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2083,7 +2083,7 @@ jprint_print_matches(struct jprint *jprint)
 
     /* firewall */
     if (jprint == NULL) {
-	err(51, __func__, "jprint is NULL");
+	err(54, __func__, "jprint is NULL");
 	not_reached();
     } else if (jprint->patterns == NULL) {
 	warn(__func__, "empty patterns list");

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -187,6 +187,7 @@ void jprint_print_brace(struct jprint *jprint, bool open);
 void jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct jprint_match *match);
 
 /* sanity checks on environment for specific options */
-void jprint_sanity_chks(struct jprint *jprint, char const *tool_path, char const *tool_args);
+FILE *jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char ***argv,
+	char const *tool_path, char const *tool_args);
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.26 2023-06-23"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.27 2023-06-24"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -117,6 +117,8 @@ struct jprint_pattern
 struct jprint
 {
     bool is_stdin;				/* reading from stdin */
+    FILE *json_file;				/* FILE * to json file */
+    char *file_contents;			/* file contents */
     bool match_found;				/* true if a pattern is specified and there is a match */
     bool ignore_case;				/* true if -i, case-insensitive */
     bool pattern_specified;			/* true if a pattern was specified */
@@ -153,6 +155,9 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     bool search_value;				/* -Y used, search for value, not name */
+    FILE *check_tool_stream;			/* FILE * stream for -S path */
+    char *check_tool_path;			/* -S used */
+    char *check_tool_args;			/* -A used */
 
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */
@@ -188,7 +193,10 @@ void jprint_print_brace(struct jprint *jprint, bool open);
 void jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct jprint_match *match);
 
 /* sanity checks on environment for specific options */
-FILE *jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char ***argv,
-	char const *tool_path, char const *tool_args);
+FILE *jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char ***argv);
+
+/* for the -S check tool and -A check tool args */
+void run_jprint_check_tool(struct jprint *jprint, char **argv);
+
 
 #endif /* !defined INCLUDE_JPRINT_H */

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -166,6 +166,7 @@ struct jprint
 void free_jprint(struct jprint **jprint);
 
 /* patterns list in struct jprint */
+void parse_jprint_name_args(struct jprint *jprint, char **argv);
 struct jprint_pattern *add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, char *str);
 void free_jprint_patterns_list(struct jprint *jprint);
 


### PR DESCRIPTION
     
The code that was in main() that runs the JSON check tool if -S path
used is now in a new function, run_jprint_check_tool(). The stream for
the pipe is now in the struct jprint. The file contents, the json.file
FILE *, the tool path and tool args are also all in the struct jprint.

This fixes a bug too where the file.json could be printed more than once
if -S was used. For instance doing:

    jprint -S /bin/cat h2g2.json

used to print the file three times but now it prints it just once which
I believe is the correct behaviour.
