### PR TITLE
Remove jprint -G option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.22 2023-06-25
+
+New `jprint` version "0.0.28 2023-06-25". Removed `-G regex` option.
+
+
 ## Release 1.0.21 2023-06-24
 
 New `jprint` version at "0.0.27 2023-06-24". If `-j` is used don't make use of

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.27 2023-06-24"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.28 2023-06-25"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jprint_match - a struct for a linked list of patterns matched in each pattern
@@ -150,7 +150,6 @@ struct jprint
     bool match_encoded;				/* -E used, match encoded name */
     bool substrings_okay;			/* -s used, matching substrings okay */
     bool use_regexps;				/* -g used, allow grep-like regexps */
-    bool explicit_regexp;			/* -G used, will not allow -Y */
     bool count_only;				/* -c used, only show count */
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */

--- a/jparse/man/man1/jprint.1
+++ b/jparse/man/man1/jprint.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jprint 1 "23 June 2023" "jprint" "IOCCC tools"
+.TH jprint 1 "25 June 2023" "jprint" "IOCCC tools"
 .SH NAME
 .B jprint
 \- IOCCC JSON printer
@@ -46,8 +46,6 @@
 .RB [\| \-i \|]
 .RB [\| \-s \|]
 .RB [\| \-g \|]
-.RB [\| \-G
-.IR regexp \|]
 .RB [\| \-c \|]
 .RB [\| \-m
 .IR depth \|]


### PR DESCRIPTION
Although I originally had some use cases it was brought up that it might be not that useful and with the example files that we have nothing is coming to mind that might make it useful so I have removed it.

It should be noted that the jprint_pattern struct (which is not completely correct in concept but it will still exist in some form or another, whether renamed or not, when this is corrected) still has the boolean use_regexp (just as it has use_substrings and use_value) to indicate what kind of search the pattern is (even though it's probably now okay to have them just in the struct jprint it doesn't hurt to have it in the other struct and they might have some use that is not yet shown).