### PR TITLE
Add back feature test macro for strcasestr

### DIFF
--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -20,6 +20,7 @@
 #if !defined(INCLUDE_JPRINT_UTIL_H)
 #    define  INCLUDE_JPRINT_UTIL_H
 
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
 #include <stdlib.h>
 #include <unistd.h>
 #include <regex.h> /* for -g and -G, regular expression matching */


### PR DESCRIPTION
It's still in jprint.h but it probably can be removed now as can probably some of the #includes - but this can be worried about later on. This should fix the warning on GitHub and linux.