### PR TITLE
Fix handling of jprint -L and -I

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.23 2023-06-26
+
+New `jprint` version "0.0.29 2023-06-26".
+
+Fix handling of `-L` and `-I`. Indenting and printing of levels was messed up.
+Doing this I was able to remove a lot of duplicate code too.
+
+
 ## Release 1.0.22 2023-06-25
 
 New `jprint` version "0.0.28 2023-06-25". Removed `-G regex` option.

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -792,10 +792,3 @@ jprint_sanity_chks(struct jprint *jprint, char const *program, int *argc, char *
     /* all good: return the (presumably) json FILE * */
     return jprint->json_file;
 }
-
-
-
-
-
-
-

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.28 2023-06-25"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.29 2023-06-26"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -2352,25 +2352,32 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 	 *
 	 * XXX - This is buggy in some cases. This must be fixed.
 	 */
-	if (jprint_print_name_value(jprint->print_type) || jprint->print_syntax) {
-	    if (jprint->print_syntax) {
-		if (jprint->print_json_levels && jprint->indent_spaces) {
-			print("%ju", match->level);
+	if (jprint->print_json_levels) {
+	    print("%ju", match->level);
 
-			for (j = 0; j < jprint->num_level_spaces; ++j) {
-			    print("%s", jprint->print_level_tab?"\t":" ");
-			}
-		}
+	    for (j = 0; j < jprint->num_level_spaces; ++j) {
+		printf("%s", jprint->print_level_tab?"\t":" ");
+	    }
+	    if (jprint->indent_levels) {
 		if (jprint->indent_spaces) {
 		    for (j = 0; j < match->level * jprint->indent_spaces; ++j) {
 			print("%s", jprint->indent_tab?"\t":" ");
 		    }
 		}
+	    }
+
+	}
+	if (jprint_print_name_value(jprint->print_type) || jprint->print_syntax) {
+	    if (jprint->print_syntax) {
+
 		print("\"%s\"", match->match);
+
 		for (j = 0; j < jprint->num_token_spaces; ++j) {
 		    print("%s", jprint->print_token_tab?"\t":" ");
 		}
+
 		print("%s", ":");
+
 		for (j = 0; j < jprint->num_token_spaces; ++j) {
 		    print("%s", jprint->print_token_tab?"\t":" ");
 		}
@@ -2380,24 +2387,6 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 			match->value,
 			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
 			match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
-	    } else if (jprint->print_json_levels) {
-		print("%ju", match->level);
-		for (j = 0; j < jprint->num_level_spaces; ++j) {
-		    printf("%s", jprint->print_level_tab?"\t":" ");
-		}
-
-		print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->match,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
-
-		for (j = 0; j < jprint->num_level_spaces; ++j) {
-		    print("%s", jprint->print_level_tab?"\t":" ");
-		}
-		print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->value,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
 	    } else {
 		print("%s%s%s",
 			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
@@ -2418,37 +2407,15 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
 	    }
 	} else if (jprint_print_name(jprint->print_type)) {
-	    if (jprint->print_json_levels) {
-		print("%ju", match->level);
-		for (j = 0; j < jprint->num_level_spaces; ++j) {
-		    print("%s", jprint->print_level_tab?"\t":" ");
-		}
-		print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->match,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
-	    } else {
-	    	print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->match,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
-	    }
+	    print("%s%s%s\n",
+		  match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
+		  match->match,
+		  match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
 	} else if (jprint_print_value(jprint->print_type)) {
-	    if (jprint->print_json_levels) {
-		print("%ju", match->level);
-		for (j = 0; j < jprint->num_level_spaces; ++j) {
-		    printf("%s", jprint->print_level_tab?"\t":" ");
-		}
-		print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->value,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
-	    } else {
-		print("%s%s%s\n",
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
-			match->value,
-			match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
-	    }
+	    print("%s%s%s\n",
+		    match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"",
+		    match->value,
+		    match->string && (jprint->quote_strings||jprint->print_syntax||jprint->print_entire_file)?"\"":"");
 	}
 	/*
 	 * XXX: more functions will have to be added to print the matches


### PR DESCRIPTION
Doing this simplifies the printing of levels and tabs by removing duplicate code. Now the indenting and printing levels should work fine though this still does not work for no name_arg as currently that only dumps the entire buffer rather than traversing the tree and printing each node according to the options.

New version of jprint 0.0.29 2023-06-26.