### PR TITLE
Fix potential NULL pointer dereference in jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.24 2023-06-27
+
+New `jprint` version "0.0.30 2023-06-27".
+
+Fix possible NULL pointer dereference. It should never have happened but it was
+theoretically possible. This fix involves a slight change in the way
+`is_jprint_match()` works in that it takes an additional `char *`: a name that
+is the name to match if `pattern` or `pattern->pattern` is NULL. If both are
+name and either `pattern` or `pattern->pattern` are NULL it is an error. This
+simplifies checking a bit and there is another use in mind that will have to
+come with another commit (if it proves useful; as the concept of `name_arg`s is
+currently not correct it might be that this won't be useful at all and that the
+struct is even removed).
+
+
 ## Release 1.0.23 2023-06-26
 
 New `jprint` version "0.0.29 2023-06-26".

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.29 2023-06-26"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.30 2023-06-27"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -260,7 +260,7 @@ struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_patte
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */
-bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct json *node, char *str);
+bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *name, struct json *node, char *str);
 void jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
 void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);


### PR DESCRIPTION
In the function is_jprint_match() it checked pattern != NULL but it happily passed pattern->pattern to strcmp(), strcasecmp(), strstr() and strcasestr(). The pointer should never be NULL but it is theoretically possible it is.

The function is_jprint_match() now takes another arg, a char *name, which if NULL is set to pattern->pattern. If both pattern and name are NULL or name is NULL and pattern->pattern is NULL it is an error. This simplifies the calls to the above mentioned functions and it also might prove useful for when no name_arg is specified as the idea of dumping the entire buffer read in from read_all() is not correct as it means we can't print the levels etc. Instead we have to traverse the tree and add the nodes to a single list of matches (not in a pattern) or otherwise have a function that goes through printing the nodes without worrying about matches. This is TBD but since the concept of patterns is not correct (due to an earlier misunderstanding) this might all be changed anyway.

New version of jprint 0.0.30 2023-06-27.