### PR TITLE
Partially fix jprint -Y str

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,17 @@ come with another commit (if it proves useful; as the concept of `name_arg`s is
 currently not correct it might be that this won't be useful at all and that the
 struct is even removed).
 
+`jprint -Y str` partially works now. It's not perfect in that in some cases it
+can end up matching other types but that depends on the JSON file and options.
+The function `add_jprint_match()` can now have a NULL pattern and also NULL
+`pattern->pattern`. If `pattern == NULL` then the new `jprint->matches` is
+iterated through and set up. This change is to facilitate adding matches without
+patterns for when printing the entire file but this part has not been
+implemented yet. More needs to be tested when calling this function but other
+things have to be done before that can be done and once again it might be that
+the pattern struct and patterns list is completely removed once certain pending
+functions are added to the jparse library.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.24 2023-06-27
+
+New `jprint` version "0.0.30 2023-06-27".
+
+Fix possible NULL pointer dereference. It should never have happened but it was
+theoretically possible. This fix involves a slight change in the way
+`is_jprint_match()` works in that it takes an additional `char *`: a name that
+is the name to match if `pattern` or `pattern->pattern` is NULL. If both are
+name and either `pattern` or `pattern->pattern` are NULL it is an error. This
+simplifies checking a bit and there is another use in mind that will have to
+come with another commit (if it proves useful; as the concept of `name_arg`s is
+currently not correct it might be that this won't be useful at all and that the
+struct is even removed).
+
+
 ## Release 1.0.23 2023-06-26
 
 New `jprint` version "0.0.29 2023-06-26".

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.29 2023-06-26"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.30 2023-06-27"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -197,6 +197,7 @@ struct jprint
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */
     uintmax_t number_of_patterns;		/* patterns specified */
+    struct jprint_match *matches;		/* for entire file i.e. no name_arg */
     uintmax_t total_matches;			/* total matches of all patterns (name_args) */
 };
 
@@ -256,7 +257,8 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
-	struct json *node_name, struct json *node_value, char *value, uintmax_t level, bool string, enum item_type type);
+	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level,
+	bool string, enum item_type type);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -260,7 +260,7 @@ struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_patte
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */
-bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct json *node, char *str);
+bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *name, struct json *node, char *str);
 void jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
 void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);

--- a/jparse/test_jparse/test_JSON/good/h2g2.json
+++ b/jparse/test_jparse/test_JSON/good/h2g2.json
@@ -1,5 +1,6 @@
 {
     "number":42,
+    "value":"value",
     "number_as_str":"42",
     "answer to life, the universe and everything" : 42,
     "panic":false,
@@ -36,5 +37,6 @@
 		]
 	    }
     ],
+    "value" : [ "value", "value", "value" ],
     "hitch-hikers":"hitchhikers"
 }


### PR DESCRIPTION

A bug in searching for already existing matches was also fixed.

The function add_jprint_match() now takes a char *name_str and char
*value_str and these are used instead of pattern->pattern. The pattern
can now be NULL. If it is then the new jprint->matches list will be
acted on and otherwise pattern->matches list.

Testing of the call to add_jprint_match() where calls are does still
need to be tested more thoroughly (in particular with the name_str and
value_str args) but with the caveat that the value is the same as the
name in the current matches list this cannot be tested as easily.

The purpose of the change to the function is to help with printing the
entire file as there are no patterns (or name_args) when this happens
but until now there was no way to have a match without a pattern (but
for patterns see below). Now a new function or functions can be added so
that goes through the tree but adds every node to the jprint->matches
list.

As the concept of patterns as it stands is not correct but currently is
all that it can be (until the new soon to be added functions are added
to the jparse library) this will do but the struct and list might very
well be removed. However matches are more likely to stay.

This fix to -Y str is not perfect in that in some cases it can end up
matching other types but that depends on the JSON file contents and the
options. It might be said that -Y int is also somewhat improved but
again depending on the json file (h2g2.json which has also been updated)
this cannot be tested entirely.
