### PR TITLE
Add back call to json check tool to jprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,15 @@ things have to be done before that can be done and once again it might be that
 the pattern struct and patterns list is completely removed once certain pending
 functions are added to the jparse library.
 
+Add back call to run json check tool. Used after reading in the data block but
+prior to parsing json. Fix use after free in the function that does this. It
+dereferenced the jparse struct after calling `free_jparse()`. This was not
+detected because it happens only when the tool failed and the test case used was
+not invalid where I tested it but is in macOS.
+
+Add `struct json *json_tree` to `struct jprint` as a convenience. Some functions
+are directly passed this but this could be changed if desired.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,17 @@ come with another commit (if it proves useful; as the concept of `name_arg`s is
 currently not correct it might be that this won't be useful at all and that the
 struct is even removed).
 
+`jprint -Y str` partially works now. It's not perfect in that in some cases it
+can end up matching other types but that depends on the JSON file and options.
+The function `add_jprint_match()` can now have a NULL pattern and also NULL
+`pattern->pattern`. If `pattern == NULL` then the new `jprint->matches` is
+iterated through and set up. This change is to facilitate adding matches without
+patterns for when printing the entire file but this part has not been
+implemented yet. More needs to be tested when calling this function but other
+things have to be done before that can be done and once again it might be that
+the pattern struct and patterns list is completely removed once certain pending
+functions are added to the jparse library.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.24 2023-06-27
+
+New `jprint` version "0.0.30 2023-06-27".
+
+Fix possible NULL pointer dereference. It should never have happened but it was
+theoretically possible. This fix involves a slight change in the way
+`is_jprint_match()` works in that it takes an additional `char *`: a name that
+is the name to match if `pattern` or `pattern->pattern` is NULL. If both are
+name and either `pattern` or `pattern->pattern` are NULL it is an error. This
+simplifies checking a bit and there is another use in mind that will have to
+come with another commit (if it proves useful; as the concept of `name_arg`s is
+currently not correct it might be that this won't be useful at all and that the
+struct is even removed).
+
+
 ## Release 1.0.23 2023-06-26
 
 New `jprint` version "0.0.29 2023-06-26".

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -265,7 +265,6 @@ main(int argc, char **argv)
     struct jprint *jprint = NULL;	/* struct of all our options and other things */
     struct jprint_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
     size_t len = 0;			/* length of file contents */
-    struct json *json_tree;		/* json tree */
     bool is_valid = false;		/* if file is valid json */
     int i;
 
@@ -458,6 +457,7 @@ main(int argc, char **argv)
     /* run specific sanity checks on options etc. */
     jprint->json_file = jprint_sanity_chks(jprint, program, &argc, &argv);
 
+
     /*
      * jprint_sanity_chks() should never return a NULL FILE * but we check
      * anyway
@@ -491,8 +491,11 @@ main(int argc, char **argv)
     clearerr(jprint->json_file);
     rewind(jprint->json_file);
 
-    json_tree = parse_json_stream(jprint->json_file, argv[0], &is_valid);
-    if (!is_valid) {
+    /* run -S tool */
+    run_jprint_check_tool(jprint, argv);
+
+    jprint->json_tree = parse_json_stream(jprint->json_file, argv[0], &is_valid);
+    if (!is_valid || jprint->json_tree == NULL) {
 	if (jprint->json_file != stdin) {
 	    fclose(jprint->json_file);  /* close file prior to exiting */
 	    jprint->json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
@@ -508,7 +511,7 @@ main(int argc, char **argv)
 
 
    /* search for any patterns */
-    jprint_json_tree_search(jprint, json_tree, jprint->max_depth);
+    jprint_json_tree_search(jprint, jprint->json_tree, jprint->max_depth);
 
     /* report, if debug level high enough, what will be searched for. */
     if (jprint->patterns != NULL && !jprint->print_entire_file) {
@@ -538,7 +541,7 @@ main(int argc, char **argv)
     }
 
     /* free tree */
-    json_tree_free(json_tree, jprint->max_depth);
+    json_tree_free(jprint->json_tree, jprint->max_depth);
 
     /* All Done!!! -- Jessica Noll, Age 2 */
     if (jprint->match_found || !jprint->pattern_specified || jprint->print_entire_file) {

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.29 2023-06-26"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.30 2023-06-27"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -2563,7 +2563,6 @@ run_jprint_check_tool(struct jprint *jprint, char **argv)
 	    exit_code = shell_cmd(__func__, true, true, "% %", jprint->check_tool_path, argv[0]);
 	}
 	if(exit_code != 0) {
-	    free_jprint(&jprint);
 	    if (jprint->check_tool_args != NULL) {
 		err(7, __func__, "JSON check tool '%s' with args '%s' failed with exit code: %d",/*ooo*/
 			jprint->check_tool_path, jprint->check_tool_args, exit_code);
@@ -2581,7 +2580,6 @@ run_jprint_check_tool(struct jprint *jprint, char **argv)
 	    jprint->check_tool_stream = pipe_open(__func__, true, true, "% %", jprint->check_tool_path, argv[0]);
 	}
 	if (jprint->check_tool_stream == NULL) {
-	    free_jprint(&jprint);
 	    if (jprint->check_tool_args != NULL) {
 		err(7, __func__, "opening pipe to JSON check tool '%s' with args '%s' failed", /*ooo*/
 			jprint->check_tool_path, jprint->check_tool_args);

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -197,6 +197,7 @@ struct jprint
     /* any patterns specified */
     struct jprint_pattern *patterns;		/* linked list of patterns specified */
     uintmax_t number_of_patterns;		/* patterns specified */
+    struct jprint_match *matches;		/* for entire file i.e. no name_arg */
     uintmax_t total_matches;			/* total matches of all patterns (name_args) */
 };
 
@@ -256,7 +257,8 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
-	struct json *node_name, struct json *node_value, char *value, uintmax_t level, bool string, enum item_type type);
+	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level,
+	bool string, enum item_type type);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -199,6 +199,8 @@ struct jprint
     uintmax_t number_of_patterns;		/* patterns specified */
     struct jprint_match *matches;		/* for entire file i.e. no name_arg */
     uintmax_t total_matches;			/* total matches of all patterns (name_args) */
+
+    struct json *json_tree;			/* json tree if valid merely as a convenience */
 };
 
 

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -260,7 +260,7 @@ struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_patte
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */
-bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct json *node, char *str);
+bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *name, struct json *node, char *str);
 void jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
 void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
 void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);

--- a/jparse/test_jparse/test_JSON/good/h2g2.json
+++ b/jparse/test_jparse/test_JSON/good/h2g2.json
@@ -1,5 +1,6 @@
 {
     "number":42,
+    "value":"value",
     "number_as_str":"42",
     "answer to life, the universe and everything" : 42,
     "panic":false,
@@ -36,5 +37,6 @@
 		]
 	    }
     ],
+    "value" : [ "value", "value", "value" ],
     "hitch-hikers":"hitchhikers"
 }


### PR DESCRIPTION

In the process I discovered a use after free that was not detected 
before because of the test system it not being a problem but it is in 
macOS. As well it was not an actual problem until the tool path and tool
args were added to the struct jprint so it didn't even used to be a 
problem.

I also moved the FILE *json_file to the struct jprint as a convenience
though some functions are directly passed it. That could be changed if
so desired.