### PR TITLE
Improve jprint_match wrt struct json node types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,12 @@ and printing syntax or quotes are requested but that the type of the match is a
 string (`JTYPE_STRING`) as well. Get rid of string bool in `jprint_match`
 struct as it's not needed with the `type`.
 
+Improvements in printing some types wrt quotes. Now the function
+`add_jprint_match()` takes two types, a name and value type and the `struct
+jprint_match` has a `enum item_type name_type` and `enum item_type value_type`.
+The determination of which type to use still only has one node at a time so it's
+not perfect but it does help somewhat and will be of value later on.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -118,7 +118,8 @@ struct jprint_match
     uintmax_t count;		    /* how many of this match are found */
     uintmax_t level;		    /* the level of the json member for -l */
     uintmax_t number;		    /* which match this is */
-    enum item_type type;	    /* match type */
+    enum item_type name_type;	    /* match type of name */
+    enum item_type value_type;	    /* match type of value */
 
     struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
     struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
@@ -258,7 +259,8 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
-	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level, enum item_type type);
+	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */


### PR DESCRIPTION
The struct now has a type for the name and a type for the value. Although in some cases we can only have one type in some we can determine because a number (for example) cannot be the name so not a string (if it's a string value that's a number that's another matter).

This is not perfect but it does help in some cases and it will be of value later on when both nodes can be passed into the function.