### PR TITLE
Fix adding of value/name matches for num/str

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,12 @@ and printing syntax or quotes are requested but that the type of the match is a
 string (`JTYPE_STRING`) as well. Get rid of string bool in `jprint_match`
 struct as it's not needed with the `type`.
 
+Improvements in printing some types wrt quotes. Now the function
+`add_jprint_match()` takes two types, a name and value type and the `struct
+jprint_match` has a `enum item_type name_type` and `enum item_type value_type`.
+The determination of which type to use still only has one node at a time so it's
+not perfect but it does help somewhat and will be of value later on.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@ jprint_match` has a `enum item_type name_type` and `enum item_type value_type`.
 The determination of which type to use still only has one node at a time so it's
 not perfect but it does help somewhat and will be of value later on.
 
+Further update version of `jprint` to "0.0.31 2023-06-27". The handling of
+adding matches of strings and numbers with values and names being different (if
+they are in the file) has been implemented. This required a lot of extra code
+and more modularity needs to be added but that can come later.
+
 
 ## Release 1.0.23 2023-06-26
 

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.30 2023-06-27"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.31 2023-06-27"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -1711,7 +1711,8 @@ is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *nam
  *
  * given:
  *	jprint	    pointer to our struct jprint
- *	node	    pointer to a JSON parser tree node to try and match
+ *	name_node   pointer to a JSON parser tree name node to try and match or add
+ *	value_node  pointer to a JSON parser tree value node to try and match or add
  *	is_value    whether node is a value or name
  *	depth	    current tree depth (0 ==> top of tree)
  *	...	    extra args are ignored, required extra args if <=
@@ -1736,12 +1737,12 @@ is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *nam
  * NOTE: This function does nothing if jprint == NULL or node == NULL.
  */
 void
-jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...)
+jprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value, unsigned int depth, ...)
 {
     va_list ap;		/* variable argument list */
 
     /* firewall */
-    if (jprint == NULL || node == NULL) {
+    if (jprint == NULL || (name_node == NULL&&value_node == NULL)) {
 	return;
     }
 
@@ -1753,7 +1754,7 @@ jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsi
     /*
      * call va_list argument list function
      */
-    vjprint_json_search(jprint, node, is_value, depth, ap);
+    vjprint_json_search(jprint, name_node, value_node, is_value, depth, ap);
 
     /*
      * stdarg variable argument list clean up
@@ -1776,7 +1777,8 @@ jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsi
  *
  * given:
  *	jprint	    pointer to our struct json
- *	node	    pointer to a JSON parser tree node to free
+ *	name_node   pointer to a JSON parser tree name node to search
+ *	value_node  pointer to a JSON parser tree value node to search
  *	is_value    boolean to indicate if this is a value or name
  *	depth	    current tree depth (0 ==> top of tree)
  *	ap	    variable argument list, required ap args:
@@ -1794,7 +1796,8 @@ jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsi
  * problems will be fixed in a future commit.
  */
 void
-vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap)
+vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap)
 {
     FILE *stream = NULL;	/* stream to print on */
     int json_dbg_lvl = JSON_DBG_DEFAULT;	/* JSON debug level if json_dbg_used */
@@ -1802,9 +1805,10 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
     va_list ap2;		/* copy of va_list ap */
 
     /*
-     * firewall - nothing to do for NULL jprint or NULL patterns list or NULL node
+     * firewall - nothing to do for NULL jprint or NULL patterns list or NULL
+     * nodes
      */
-    if (jprint == NULL || jprint->patterns == NULL || node == NULL) {
+    if (jprint == NULL || jprint->patterns == NULL || name_node == NULL || value_node == NULL) {
 	return;
     }
 
@@ -1854,141 +1858,218 @@ vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, uns
 	    /*
 	     * if there is a match found add it to the matches list
 	     */
-	    switch (node->type) {
+	    struct json *name = jprint->search_value?value_node:name_node;
+	    struct json *value = jprint->search_value?name_node:value_node;
+	    if (name != NULL) {
+		switch (name->type) {
 
-		case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
-		    break;
+		    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+			break;
 
-		case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
-		    {
-			struct json_number *item = &(node->item.number);
-			if (item != NULL && item->converted) {
-			    char *str = item->as_str;
+		    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+			{
+			    struct json_number *item = &(name->item.number);
+			    if (item != NULL && item->converted) {
+				char *str = item->as_str;
 
-			    if (str != NULL) {
-				if (is_jprint_match(jprint, pattern, pattern->pattern, node, str)) {
-				    if (add_jprint_match(jprint, pattern, jprint->search_value?
-					NULL:node, jprint->search_value?node:NULL, pattern->pattern, str, depth,
-					jprint->search_value?JTYPE_STRING:JTYPE_NUMBER,
-					jprint->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
-					    err(43, __func__, "adding match '%s' to pattern failed", str);
-					    not_reached();
+				if (str != NULL) {
+				    switch (value->type) {
+					case JTYPE_STRING:
+					    {
+					    struct json_string *string = &(value->item.string);
+					    if (string != NULL && string->converted) {
+						char *val = string->as_str;
+						if (val != NULL) {
+						    if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+							if (add_jprint_match(jprint, pattern, name, value,
+							    str, val, depth, jprint->search_value?JTYPE_STRING:JTYPE_NUMBER,
+							    jprint->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
+								err(43, __func__, "adding match '%s' to pattern failed", str);
+								not_reached();
+							}
+						    }
+						}
+					    }
+					}
+					break;
+					default:
+					    /* XXX - determine if other types need to be handled */
+					break;
 				    }
 				}
 			    }
 			}
-		    }
-		    break;
+			break;
 
-		case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
-		    {
-			struct json_string *item = &(node->item.string);
-			if (item != NULL && item->converted) {
-			    char *str = jprint->match_encoded ? item->as_str : item->str;
+		    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+			{
+			    struct json_string *item = &(name->item.string);
+			    if (item != NULL && item->converted) {
+				char *str = jprint->match_encoded ? item->as_str : item->str;
 
-			    if (str != NULL) {
-				/* XXX - as noted above, the -Y for strings is buggy - XXX */
-				if (is_jprint_match(jprint, pattern, pattern->pattern, node, str)) {
-				    if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
-					jprint->search_value?node:NULL, jprint->search_value?pattern->pattern:str,
-					jprint->search_value?str:pattern->pattern, depth,
-					jprint->search_value?JTYPE_STRING:JTYPE_STRING,
-					jprint->search_value?JTYPE_STRING:JTYPE_STRING) == NULL) {
-					    err(44, __func__, "adding match '%s' to pattern failed", str);
-					    not_reached();
+				if (str != NULL) {
+				    switch (value->type) {
+					case JTYPE_NUMBER:
+					{
+					    struct json_number *json_num = &(value->item.number);
+					    if (json_num != NULL && json_num->converted) {
+						char *val = json_num->as_str;
+						if (is_jprint_match(jprint, pattern, pattern->pattern, name,
+						    jprint->search_value?val:str)) {
+							if (add_jprint_match(jprint, pattern, name, value,
+							    str, val, depth,
+							    name->type, value->type) == NULL) {
+								err(44, __func__, "adding match '%s' to pattern failed", str);
+								not_reached();
+							}
+						}
+					    }
+					}
+					break;
+					case JTYPE_STRING:
+					{
+					    struct json_string *string = &(value->item.string);
+					    if (string != NULL && string->converted) {
+						char *val = string->as_str;
+
+						if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+						    if (add_jprint_match(jprint, pattern, name, value, str, val,
+							depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
+							    err(44, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					    }
+					}
+					break;
+					case JTYPE_BOOL:
+					{
+					    struct json_boolean *boolean = &(value->item.boolean);
+					    if (boolean != NULL && boolean->converted) {
+						char *val = boolean->as_str;
+						if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+						    if (add_jprint_match(jprint, pattern, name, value, str, val,
+							depth, jprint->search_value?JTYPE_BOOL:JTYPE_STRING,
+							jprint->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
+							    err(45, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					    }
+					}
+					break;
+					case JTYPE_NULL:
+					{
+					    struct json_null *null = &(value->item.null);
+					    if (null != NULL && null->converted) {
+						char *val = null->as_str;
+						if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+						    if (add_jprint_match(jprint, pattern, name, value, str, val,
+							depth, jprint->search_value?JTYPE_NULL:JTYPE_STRING,
+							jprint->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
+							    err(45, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					    }
+
+					}
+					break;
+					default:
+					    break;
 				    }
 				}
 			    }
 			}
-		    }
-		    break;
+			break;
 
-		case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
-		    {
-			struct json_boolean *item = &(node->item.boolean);
+		    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+			{
+			    struct json_boolean *item = &(name->item.boolean);
 
-			if (item != NULL && item->converted) {
-			    char *str = item->as_str;
+			    if (item != NULL && item->converted) {
+				char *str = item->as_str;
 
-			    if (str != NULL) {
-				if (is_jprint_match(jprint, pattern, pattern->pattern, node, str)) {
-				    if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
-					jprint->search_value?node:NULL, pattern->pattern, str, depth,
-					jprint->search_value?JTYPE_STRING:JTYPE_BOOL,
-					jprint->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
-					    err(45, __func__, "adding match '%s' to pattern failed", str);
-					    not_reached();
+				if (str != NULL) {
+				    if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:name,
+					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
+					    jprint->search_value?JTYPE_STRING:JTYPE_BOOL,
+					    jprint->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
+						err(45, __func__, "adding match '%s' to pattern failed", str);
+						not_reached();
+					}
 				    }
 				}
 			    }
 			}
-		    }
-		    break;
+			break;
 
-		case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
-		    {
-			struct json_null *item = &(node->item.null);
+		    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+			{
+			    struct json_null *item = &(name->item.null);
 
-			if (item != NULL && item->converted) {
-			    char *str = item->as_str;
+			    if (item != NULL && item->converted) {
+				char *str = item->as_str;
 
-			    if (str != NULL) {
-				if (is_jprint_match(jprint, pattern, pattern->pattern, node, str)) {
-				    if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:node,
-					jprint->search_value?node:NULL, pattern->pattern, str, depth,
-					jprint->search_value?JTYPE_STRING:JTYPE_NULL,
-					jprint->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
-					    err(46, __func__, "adding match '%s' to pattern failed", str);
-					    not_reached();
+				if (str != NULL) {
+				    if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
+					if (add_jprint_match(jprint, pattern, jprint->search_value?NULL:name,
+					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
+					    jprint->search_value?JTYPE_STRING:JTYPE_NULL,
+					    jprint->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
+						err(46, __func__, "adding match '%s' to pattern failed", str);
+						not_reached();
+					}
 				    }
 				}
 			    }
 			}
-		    }
-		    break;
+			break;
 
-		case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
-		    {
-			struct json_member *item = &(node->item.member);
+		    case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+			{
+			    struct json_member *item = &(name->item.member);
 
-			/* XXX - fix to check for match of the member and add to
-			 * the matches list if it fits within constraints - XXX */
-			UNUSED_ARG(item);
-		    }
-		    break;
+			    /* XXX - fix to check for match of the member and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
 
-		case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
-		    {
-			struct json_object *item = &(node->item.object);
+		    case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+			{
+			    struct json_object *item = &(name->item.object);
 
-			/* XXX - fix to check for match of the object and add to
-			 * the matches list if it fits within constraints - XXX */
-			UNUSED_ARG(item);
-		    }
-		    break;
+			    /* XXX - fix to check for match of the object and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
 
-		case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
-		    {
-			struct json_array *item = &(node->item.array);
+		    case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+			{
+			    struct json_array *item = &(name->item.array);
 
-			/* XXX - fix to check for match of the array and add it
-			 * to the matches list if it fits within the constraints - XXX */
-			UNUSED_ARG(item);
-		    }
-		    break;
+			    /* XXX - fix to check for match of the array and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
 
-		case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
-		    {
-			struct json_elements *item = &(node->item.elements);
+		    case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+			{
+			    struct json_elements *item = &(name->item.elements);
 
-			/* XXX - fix to check for match of the element and add it
-			 * to the matches list if it fits within the constraints - XXX */
-			UNUSED_ARG(item);
-		    }
-		    break;
+			    /* XXX - fix to check for match of the element and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
 
-		default:
-		    break;
+		    default:
+			break;
+		}
 	    }
 	}
     }
@@ -2054,7 +2135,7 @@ jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int m
     /*
      * walk the JSON parse tree
      */
-    jprint_json_tree_walk(jprint, node, max_depth, false, 0, vjprint_json_search, ap);
+    jprint_json_tree_walk(jprint, node, node, max_depth, false, 0, vjprint_json_search, ap);
 
     /*
      * stdarg variable argument list clean up
@@ -2107,15 +2188,16 @@ jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int m
  * If this is the case it will be fixed in a future update.
  */
 void
-jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
-		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap)
+jprint_json_tree_walk(struct jprint *jprint, struct json *lnode, struct json *rnode, bool is_value,
+	unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jprint *, struct json *, struct json *, bool,
+	unsigned int, va_list), va_list ap)
 {
     int i;
 
     /*
      * firewall
      */
-    if (node == NULL) {
+    if (lnode == NULL || rnode == NULL) {
 	warn(__func__, "node is NULL");
 	return ;
     }
@@ -2140,7 +2222,7 @@ jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, u
     /*
      * walk based on type of node
      */
-    switch (node->type) {
+    switch (lnode->type) {
 
     case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
     case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
@@ -2148,80 +2230,80 @@ jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, u
     case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
 	/* perform function operation on this terminal parse tree node, all of
 	 * which have to be a value */
-	(*vcallback)(jprint, node, true, depth, ap);
+	(*vcallback)(jprint, lnode, rnode, true, depth, ap);
 	break;
 
     case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
 
 	/* perform function operation on this terminal parse tree node */
-	(*vcallback)(jprint, node, is_value, depth, ap);
+	(*vcallback)(jprint, lnode, rnode, is_value, depth, ap);
 	break;
 
     case JTYPE_MEMBER:	/* JSON item is a member */
 	{
-	    struct json_member *item = &(node->item.member);
+	    struct json_member *item = &(lnode->item.member);
 
 	    /* perform function operation on JSON member name (left branch) node */
-	    jprint_json_tree_walk(jprint, item->name, false, max_depth, depth+1, vcallback, ap);
+	    jprint_json_tree_walk(jprint, item->name, item->value, false, max_depth, depth+1, vcallback, ap);
 
 	    /* perform function operation on JSON member value (right branch) node */
-	    jprint_json_tree_walk(jprint, item->value, true, max_depth, depth+1, vcallback, ap);
+	    jprint_json_tree_walk(jprint, item->name, item->value, true, max_depth, depth+1, vcallback, ap);
 	}
 
 	/* finally perform function operation on the parent node */
-	(*vcallback)(jprint, node, is_value, depth+1, ap);
+	(*vcallback)(jprint, lnode, rnode, is_value, depth+1, ap);
 	break;
 
     case JTYPE_OBJECT:	/* JSON item is a { members } */
 	{
-	    struct json_object *item = &(node->item.object);
+	    struct json_object *item = &(lnode->item.object);
 
 	    /* perform function operation on each object member in order */
 	    if (item->set != NULL) {
 		for (i=0; i < item->len; ++i) {
-		    jprint_json_tree_walk(jprint, item->set[i], is_value, max_depth, depth, vcallback, ap);
+		    jprint_json_tree_walk(jprint, item->set[i], item->set[i], is_value, max_depth, depth, vcallback, ap);
 		}
 	    }
 	}
 
 	/* finally perform function operation on the parent node */
-	(*vcallback)(jprint, node, is_value, depth+1, ap);
+	(*vcallback)(jprint, lnode, rnode, is_value, depth+1, ap);
 	break;
 
     case JTYPE_ARRAY:	/* JSON item is a [ elements ] */
 	{
-	    struct json_array *item = &(node->item.array);
+	    struct json_array *item = &(lnode->item.array);
 
 	    /* perform function operation on each object member in order */
 	    if (item->set != NULL) {
 		for (i=0; i < item->len; ++i) {
-		    jprint_json_tree_walk(jprint, item->set[i], true, max_depth, depth, vcallback, ap);
+		    jprint_json_tree_walk(jprint, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
 		}
 	    }
 	}
 
 	/* finally perform function operation on the parent node */
-	(*vcallback)(jprint, node, is_value, depth+1, ap);
+	(*vcallback)(jprint, lnode, rnode, is_value, depth+1, ap);
 	break;
 
     case JTYPE_ELEMENTS:	/* JSON items is zero or more JSON values */
 	{
-	    struct json_elements *item = &(node->item.elements);
+	    struct json_elements *item = &(lnode->item.elements);
 
 	    /* perform function operation on each object member in order */
 	    if (item->set != NULL) {
 		for (i=0; i < item->len; ++i) {
-		    jprint_json_tree_walk(jprint, item->set[i], true, max_depth, depth, vcallback, ap);
+		    jprint_json_tree_walk(jprint, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
 		}
 	    }
 	}
 
 	/* finally perform function operation on the parent node */
-	(*vcallback)(jprint, node, is_value, depth+1, ap);
+	(*vcallback)(jprint, lnode, rnode, is_value, depth+1, ap);
 	break;
 
     default:
-	warn(__func__, "node type is unknown: %d", node->type);
+	warn(__func__, "node type is unknown: %d", lnode->type);
 	/* nothing we can traverse */
 	break;
     }

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -1935,7 +1935,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
-							    err(44, __func__, "adding match '%s' to pattern failed", str);
+							    err(45, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1951,7 +1951,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, jprint->search_value?JTYPE_BOOL:JTYPE_STRING,
 							jprint->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
-							    err(45, __func__, "adding match '%s' to pattern failed", str);
+							    err(46, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1967,7 +1967,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, jprint->search_value?JTYPE_NULL:JTYPE_STRING,
 							jprint->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
-							    err(45, __func__, "adding match '%s' to pattern failed", str);
+							    err(47, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1996,7 +1996,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
 					    jprint->search_value?JTYPE_STRING:JTYPE_BOOL,
 					    jprint->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
-						err(45, __func__, "adding match '%s' to pattern failed", str);
+						err(48, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				    }
@@ -2018,7 +2018,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
 					    jprint->search_value?JTYPE_STRING:JTYPE_NULL,
 					    jprint->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
-						err(46, __func__, "adding match '%s' to pattern failed", str);
+						err(49, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				    }
@@ -2326,7 +2326,7 @@ jprint_print_count(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(47, __func__, "jprint is NULL");
+	err(50, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2354,7 +2354,7 @@ jprint_print_final_comma(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(48, __func__, "jprint is NULL");
+	err(51, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2380,7 +2380,7 @@ jprint_print_brace(struct jprint *jprint, bool open)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(49, __func__, "jprint is NULL");
+	err(52, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2415,19 +2415,19 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 
     /* firewall */
     if (jprint == NULL) {
-	err(50, __func__, "jprint is NULL");
+	err(53, __func__, "jprint is NULL");
 	not_reached();
     } else if (match == NULL) {
-	err(51, __func__, "match is NULL");
+	err(54, __func__, "match is NULL");
 	not_reached();
     } else if (pattern == NULL) {
-	err(52, __func__, "pattern is NULL");
+	err(55, __func__, "pattern is NULL");
 	not_reached();
     }
 
     /* if the name of the match is NULL it is a fatal error */
     if (match->match == NULL) {
-	err(53, __func__, "match->match is NULL");
+	err(56, __func__, "match->match is NULL");
 	not_reached();
     } else if (*match->match == '\0') {
 	/* warn on empty name for now and then go to next match */
@@ -2436,7 +2436,7 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
     }
 
     if (match->value == NULL) {
-	err(54, __func__, "match '%s' has NULL value", match->match);
+	err(57, __func__, "match '%s' has NULL value", match->match);
 	not_reached();
     } else if (*match->value == '\0') {
 	/* for now we only warn on empty value */
@@ -2594,7 +2594,7 @@ jprint_print_matches(struct jprint *jprint)
 
     /* firewall */
     if (jprint == NULL) {
-	err(55, __func__, "jprint is NULL");
+	err(58, __func__, "jprint is NULL");
 	not_reached();
     } else if (jprint->patterns == NULL && jprint->matches == NULL) {
 	warn(__func__, "NULL patterns and matches list");
@@ -2671,10 +2671,10 @@ run_jprint_check_tool(struct jprint *jprint, char **argv)
 
     /* firewall */
     if (jprint == NULL) {
-	err(56, __func__, "NULL jprint");
+	err(59, __func__, "NULL jprint");
 	not_reached();
     } else if (jprint->file_contents == NULL) {
-	err(57, __func__, "NULL jprint->file_contents");
+	err(60, __func__, "NULL jprint->file_contents");
 	not_reached();
     }
 

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -118,7 +118,8 @@ struct jprint_match
     uintmax_t count;		    /* how many of this match are found */
     uintmax_t level;		    /* the level of the json member for -l */
     uintmax_t number;		    /* which match this is */
-    enum item_type type;	    /* match type */
+    enum item_type name_type;	    /* match type of name */
+    enum item_type value_type;	    /* match type of value */
 
     struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
     struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
@@ -258,7 +259,8 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
-	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level, enum item_type type);
+	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -265,11 +265,14 @@ void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */
 bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *name, struct json *node, char *str);
-void jprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, ...);
-void vjprint_json_search(struct jprint *jprint, struct json *node, bool is_value, unsigned int depth, va_list ap);
+void jprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, ...);
+void vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap);
 void jprint_json_tree_search(struct jprint *jprint, struct json *node, unsigned int max_depth, ...);
-void jprint_json_tree_walk(struct jprint *jprint, struct json *node, bool is_value, unsigned int max_depth, unsigned int depth,
-		void (*vcallback)(struct jprint *, struct json *, bool, unsigned int, va_list), va_list ap);
+void jprint_json_tree_walk(struct jprint *jprint, struct json *lnode, struct json *rnode, bool is_value,
+		unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jprint *, struct json *, struct json *, bool,
+		unsigned int, va_list), va_list ap);
 
 /* functions to print matches */
 bool jprint_print_count(struct jprint *jprint);


### PR DESCRIPTION

For strings and numbers (but see below) the adding of names versus 
values has been corrected. This required a lot of new code and more
modularity is called for but this can be done later. However now one can
get the name or value or both of these types and this goes for the -Y 
type option too.

The caveat is that there might be cases that have not been handled as 
for each type of name there has to be a check for types of values too
and there might be some I missed for numbers (and there might be the
same problem for strings but I am not sure yet). 

Others were not done yet but I wanted this in as it's a
significant accomplishment that will help move forward in the tool. For
that reason I have updated the jprint version again to 0.0.31 2023-06-27.