### PR TITLE
Updates to json_search.{h,c} header comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.25 2023-06-28
+
+Add new good JSON test file 42.json under
+`jparse/test_jparse/test_JSON/good/42.json`.
+
+
 ## Release 1.0.24 2023-06-27
 
 New `jprint` version "0.0.30 2023-06-27".

--- a/jparse/json_search.c
+++ b/jparse/json_search.c
@@ -14,8 +14,9 @@
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
-
- * This search function was implemented by:
+ *
+ * This JSON search functionality was designed and implemented in support of
+ * jprint by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *

--- a/jparse/json_search.c
+++ b/jparse/json_search.c
@@ -1,10 +1,20 @@
 /*
  * json_search - search JSON parse tree for matches
  *
- * Because sometimes is harder to see the JSON forest thru the JSON trees.
+ * Because sometimes is harder to see the JSON forest through the JSON trees.
  * By carefully searching the JSON parse tree, we avoid careless playing with matches.
  * Only you can prevent JSON tree fires! :-)
  *
+ * This JSON parser was co-developed in 2022 by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+
  * This search function was implemented by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/jparse/json_search.h
+++ b/jparse/json_search.h
@@ -1,17 +1,29 @@
 /*
  * json_search - search JSON parse tree for matches
  *
- * Because sometimes is harder to see the JSON forest thru the JSON trees.
+ * Because sometimes is harder to see the JSON forest through the JSON trees.
  * By carefully searching the JSON parse tree, we avoid careless playing with matches.
  * Only you can prevent JSON tree fires! :-)
  *
- * This search function was implemented by:
+ * This JSON parser was co-developed in 2022 by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * This JSON search functionality was designed and implemented in support of
+ * jprint by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
  */
+
 
 
 #if !defined(INCLUDE_JSON_SEARCH_H)


### PR DESCRIPTION

Part of this was done in the previous commit by accident but additional
fixes were made here and both files have the same comment now.
