### PR TITLE
Add jprint -R option to disable sub-tree searching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@
 Add new good JSON test file 42.json under
 `jparse/test_jparse/test_JSON/good/42.json`.
 
+New `jprint` version "0.0.32 2023-06-28". Add option `-R` to disable recursive
+sub-tree searching. The temporary default is false which disables recursive
+searching but once recursive sub-tree searching is supported the default will be
+to search in a recursive sub-tree way. This means that the concept of patterns
+can work. It seems useful and it would be a shame to waste the code that was
+added due to a misunderstanding.
+
+Fixed potential memory leak in `jprint`: although currently none exist the
+matches list in the struct jprint (instead of the matches list in each pattern)
+was not freed.
+
 
 ## Release 1.0.24 2023-06-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.25 2023-06-28
+
+Add new good JSON test file 42.json under
+`jparse/test_jparse/test_JSON/good/42.json`.
+
+
 ## Release 1.0.24 2023-06-27
 
 New `jprint` version "0.0.30 2023-06-27".

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -430,7 +430,7 @@ main(int argc, char **argv)
 	case 'R':
 	    /* XXX - currently the default is false as recursive searching is
 	     * not done but the default will later be true - XXX */
-	    jprint->recurse_search = false;
+	    jprint->recursive_search = false;
 	    break;
 	case 'S':
 	    /* -S path to tool */

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type]\n"
-    "\t\t[-S path] [-A args] file.json [name_arg ...]\n"
+    "\t\t[-R] [-S path] [-A args] file.json [name_arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
@@ -143,7 +143,7 @@ static const char * const usage_msg2 =
     "\t-E\t\tMatch the JSON encoded name (def: match the JSON decoded name)\n"
     "\t-i\t\tIgnore case of name (def: case matters)\n"
     "\t-s\t\tSubstrings are used to match (def: the full name must match)\n"
-    "\t-g\t\tMatch using grep-like extended regular expressions (def: match strings)\n"
+    "\t-g\t\tMatch using grep-like extended regular expressions (def: match strings or substrings if -s)\n"
     "\n"
     "\t\t\tTo match from the beginning, start name_arg with '^'.\n"
     "\t\t\tTo match to the end, end name_arg with '$'.\n"
@@ -174,6 +174,7 @@ static const char * const usage_msg3 =
     "\t\t\tUse of -Y requires one and only one name_arg.\n"
     "\t\t\tUse of -Y changes the default from -p value to -p name.\n"
     "\n"
+    "\t-R\t\t\tDon't search in a recursive sub-tree manner (def: do search recursively)\n"
     "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
     "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
     "\n"
@@ -266,6 +267,7 @@ main(int argc, char **argv)
     struct jprint_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
     size_t len = 0;			/* length of file contents */
     bool is_valid = false;		/* if file is valid json */
+    int exit_code = 0;			/* for the end */
     int i;
 
     jprint = alloc_jprint();		/* allocate our struct jprint * */
@@ -282,7 +284,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:KY:sA:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEiS:m:cg:KY:sA:R")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jprint(&jprint);
@@ -425,6 +427,11 @@ main(int argc, char **argv)
 	    jprint->search_value = true;
 	    jprint->type = jprint_parse_value_type_option(optarg);
 	    break;
+	case 'R':
+	    /* XXX - currently the default is false as recursive searching is
+	     * not done but the default will later be true - XXX */
+	    jprint->recurse_search = false;
+	    break;
 	case 'S':
 	    /* -S path to tool */
 	    jprint->check_tool_path = optarg;
@@ -532,6 +539,9 @@ main(int argc, char **argv)
     /*
      * we can't have this in the sanity checks function very easily as we don't
      * want to read in the entire contents from that function
+     *
+     * XXX - printing the entire file is incorrect here as it needs to print it
+     * according to the options - XXX
      */
     if (!jprint->print_entire_file || jprint->count_only) {
 	jprint_print_matches(jprint);
@@ -545,15 +555,15 @@ main(int argc, char **argv)
 
     /* All Done!!! -- Jessica Noll, Age 2 */
     if (jprint->match_found || !jprint->pattern_specified || jprint->print_entire_file) {
-	free_jprint(&jprint);	/* free jprint struct */
-	exit(0); /*ooo*/
+	exit_code = 0;
     } else {
-	free_jprint(&jprint);	/* free jprint struct */
-	/*
-	 * exit with 1 due to no pattern found
-	 */
-	exit(1); /*ooo*/
+	exit_code = 1;
     }
+    if (jprint != NULL) {
+	free_jprint(&jprint);	/* free jprint struct */
+    }
+
+    exit(exit_code); /*ooo*/
 }
 
 /* jprint_sanity_chks	- sanity checks on jprint tool options

--- a/jparse/jprint.h
+++ b/jparse/jprint.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jprint version string */
-#define JPRINT_VERSION "0.0.31 2023-06-27"		/* format: major.minor YYYY-MM-DD */
+#define JPRINT_VERSION "0.0.32 2023-06-28"		/* format: major.minor YYYY-MM-DD */
 
 /* jprint functions - see jprint_util.h for most */
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -112,6 +112,7 @@ alloc_jprint(void)
     jprint->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
 
     jprint->search_value = false;			/* -Y search by value, not name. Uses print type */
+    jprint->recurse_search = false;			/* XXX - change this to true when recursive searching is done - XXX */
 
     jprint->check_tool_stream = NULL;			/* FILE * stream for -S path */
     jprint->check_tool_path = NULL;			/* -S path */
@@ -1121,12 +1122,33 @@ jprint_parse_value_type_option(char *optarg)
 void
 free_jprint(struct jprint **jprint)
 {
+    struct jprint_match *match = NULL; /* to iterate through matches list */
+    struct jprint_match *next_match = NULL; /* next in list */
+
     if (jprint == NULL || *jprint == NULL) {
 	warn(__func__, "passed NULL struct jprint ** or *jprint is NULL");
 	return;
     }
 
     free_jprint_patterns_list(*jprint); /* free patterns list first */
+
+    /* we have to free matches attached to jprint itself too */
+    for (match = (*jprint)->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
 
     free(*jprint);
     *jprint = NULL;
@@ -1157,6 +1179,10 @@ parse_jprint_name_args(struct jprint *jprint, char **argv)
 	not_reached();
     }
 
+    /*
+     * XXX - fix to search name_args, not patterns, if jprint->recurse_search is
+     * true (true will be the default but is currently false) - XXX
+     */
     for (i = 1; argv[i] != NULL; ++i) {
 	jprint->pattern_specified = true;
 
@@ -1190,6 +1216,10 @@ parse_jprint_name_args(struct jprint *jprint, char **argv)
  * added to the jprint patterns list.
  *
  * Duplicate patterns will not be added (case sensitive).
+ *
+ * XXX - this function will only be used for the -R option which disables the
+ * recursive sub-tree searching but until the other way, the searching in a
+ * recursive sub-tree way, is implemented, this is the way it's done.
  */
 struct jprint_pattern *
 add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, char *str)
@@ -1200,18 +1230,32 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     /*
      * firewall
      */
+
+    /* it is an error if calling this function if the jprint->recurse_search is true
+     * (will be the default)
+     */
+    if (jprint->recurse_search) {
+	err(26, __func__, "called pattern adding code without -R");
+	not_reached();
+    }
+
+    /* the usual checks on pointers */
     if (jprint == NULL) {
-	err(26, __func__, "passed NULL jprint struct");
+	err(27, __func__, "passed NULL jprint struct");
 	not_reached();
     }
     if (str == NULL) {
-	err(27, __func__, "passed NULL str");
+	err(28, __func__, "passed NULL str");
 	not_reached();
     }
 
     /*
      * first make sure the pattern is not already added to the list as the same
-     * type
+     * type and same case
+     *
+     * XXX - even if ignore case is true we have to check the case so that
+     * the count of the match is the same but the printing of the matches will,
+     * if case differs, be printed (when -c not specified) - XXX
      */
     for (pattern = jprint->patterns; pattern != NULL; pattern = pattern->next) {
 	if (pattern->pattern && pattern->use_regexp == use_regexp) {
@@ -1235,14 +1279,14 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
     errno = 0; /* pre-clear errno for errp() */
     pattern = calloc(1, sizeof *pattern);
     if (pattern == NULL) {
-	errp(28, __func__, "unable to allocate struct jprint_pattern *");
+	errp(29, __func__, "unable to allocate struct jprint_pattern *");
 	not_reached();
     }
 
     errno = 0;
     pattern->pattern = strdup(str);
     if (pattern->pattern == NULL) {
-	errp(29, __func__, "unable to strdup string '%s' for patterns list", str);
+	errp(30, __func__, "unable to strdup string '%s' for patterns list", str);
 	not_reached();
     }
 
@@ -1289,8 +1333,9 @@ free_jprint_patterns_list(struct jprint *jprint)
     struct jprint_pattern *pattern = NULL; /* to iterate through patterns list */
     struct jprint_pattern *next_pattern = NULL; /* next in list */
 
+    /* firewall */
     if (jprint == NULL) {
-	err(30, __func__, "passed NULL jprint struct");
+	err(31, __func__, "passed NULL jprint struct");
 	not_reached();
     }
 
@@ -1336,13 +1381,17 @@ free_jprint_patterns_list(struct jprint *jprint)
  * NOTE: this function will not return if any of the pointers are NULL (except
  * the name and value - for now) including the pointers in the pattern struct.
  *
- * Returns a pointer to the newly allocated struct jprint_match * that was
- * added to the jprint matched patterns list.
- *
  * NOTE: depending on jprint->search_value the name and value nodes will be in a
  * different order. Specifically the name is what matched, whether a value in
  * the json tree or name, and the value is what will be printed. At least once
  * this feature is done :-)
+ *
+ * XXX - the match concept is subject to change and the pattern concept will
+ * only be used with the -R option but for now the default is as if -R was
+ * specified - XXX
+ *
+ * Returns a pointer to the newly allocated struct jprint_match * that was
+ * added to the jprint matched patterns list.
  */
 struct jprint_match *
 add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct json *name,
@@ -1356,25 +1405,27 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
      * firewall
      */
     if (jprint == NULL) {
-	err(31, __func__, "passed NULL jprint struct");
+	err(32, __func__, "passed NULL jprint struct");
 	not_reached();
     }
-
     if (name_str == NULL) {
-	err(32, __func__, "passed NULL name_str");
+	err(33, __func__, "passed NULL name_str");
 	not_reached();
     }
     if (value_str == NULL) {
-	err(33, __func__, "value_str is NULL");
+	err(34, __func__, "value_str is NULL");
 	not_reached();
     }
+
+    /* NOTE: pattern can be NULL */
 
     /*
      * search for an exact match and only increment the count if found.
      *
      * NOTE: this means that when printing the output we have to go potentially
-     * print the match more than once; if -c is specified we print only the
-     * count.
+     * print the match more than once due to case (which means that case has to
+     * be considered in a different way than just ignore case or not); if -c is
+     * specified we print only the count.
      */
     for (tmp = pattern?pattern->matches:jprint->matches; tmp; tmp = tmp->next) {
 	if (name_type == tmp->name_type) {
@@ -1393,7 +1444,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match = calloc(1, sizeof *match);
     if (match == NULL) {
-	errp(34, __func__, "unable to allocate struct jprint_match *");
+	errp(35, __func__, "unable to allocate struct jprint_match *");
 	not_reached();
     }
 
@@ -1401,7 +1452,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match->match = strdup(name_str);
     if (match->match == NULL) {
-	errp(35, __func__, "unable to strdup string '%s' for match list", name_str);
+	errp(36, __func__, "unable to strdup string '%s' for match list", name_str);
 	not_reached();
     }
 
@@ -1409,7 +1460,7 @@ add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, struct j
     errno = 0; /* pre-clear errno for errp() */
     match->value = strdup(value_str);
     if (match->match == NULL) {
-	errp(36, __func__, "unable to strdup value string '%s' for match list", value_str);
+	errp(37, __func__, "unable to strdup value string '%s' for match list", value_str);
 	not_reached();
     }
     /* set level of the match for -l / -L options */
@@ -1476,7 +1527,7 @@ free_jprint_matches_list(struct jprint_pattern *pattern)
     struct jprint_match *next_match = NULL; /* next in list */
 
     if (pattern == NULL) {
-	err(37, __func__, "passed NULL pattern struct");
+	err(38, __func__, "passed NULL pattern struct");
 	not_reached();
     }
 
@@ -1520,16 +1571,16 @@ is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *nam
 {
     /* firewall */
     if (jprint == NULL) {
-	err(38, __func__, "jprint is NULL");
+	err(39, __func__, "jprint is NULL");
 	not_reached();
     } else if ((pattern == NULL || pattern->pattern == NULL) && name == NULL) {
-	err(39, __func__, "pattern and name are both NULL");
+	err(40, __func__, "pattern and name are both NULL");
 	not_reached();
     } else if (node == NULL) {
-	err(40, __func__, "node is NULL");
+	err(41, __func__, "node is NULL");
 	not_reached();
     } else if (str == NULL) {
-	err(41, __func__, "str is NULL");
+	err(42, __func__, "str is NULL");
 	not_reached();
     }
 
@@ -1540,7 +1591,7 @@ is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *nam
 
     /* check that name != NULL */
     if (name == NULL) {
-	err(42, __func__, "name is NULL");
+	err(43, __func__, "name is NULL");
 	not_reached();
     }
 
@@ -1884,7 +1935,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 							if (add_jprint_match(jprint, pattern, name, value,
 							    str, val, depth, jprint->search_value?JTYPE_STRING:JTYPE_NUMBER,
 							    jprint->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
-								err(43, __func__, "adding match '%s' to pattern failed", str);
+								err(44, __func__, "adding match '%s' to pattern failed", str);
 								not_reached();
 							}
 						    }
@@ -1919,7 +1970,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 							if (add_jprint_match(jprint, pattern, name, value,
 							    str, val, depth,
 							    name->type, value->type) == NULL) {
-								err(44, __func__, "adding match '%s' to pattern failed", str);
+								err(45, __func__, "adding match '%s' to pattern failed", str);
 								not_reached();
 							}
 						}
@@ -1935,7 +1986,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						if (is_jprint_match(jprint, pattern, pattern->pattern, name, str)) {
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
-							    err(45, __func__, "adding match '%s' to pattern failed", str);
+							    err(46, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1951,7 +2002,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, jprint->search_value?JTYPE_BOOL:JTYPE_STRING,
 							jprint->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
-							    err(46, __func__, "adding match '%s' to pattern failed", str);
+							    err(47, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1967,7 +2018,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 						    if (add_jprint_match(jprint, pattern, name, value, str, val,
 							depth, jprint->search_value?JTYPE_NULL:JTYPE_STRING,
 							jprint->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
-							    err(47, __func__, "adding match '%s' to pattern failed", str);
+							    err(48, __func__, "adding match '%s' to pattern failed", str);
 							    not_reached();
 						    }
 						}
@@ -1996,7 +2047,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
 					    jprint->search_value?JTYPE_STRING:JTYPE_BOOL,
 					    jprint->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
-						err(48, __func__, "adding match '%s' to pattern failed", str);
+						err(49, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				    }
@@ -2018,7 +2069,7 @@ vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *
 					    jprint->search_value?name:NULL, pattern->pattern, str, depth,
 					    jprint->search_value?JTYPE_STRING:JTYPE_NULL,
 					    jprint->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
-						err(49, __func__, "adding match '%s' to pattern failed", str);
+						err(50, __func__, "adding match '%s' to pattern failed", str);
 						not_reached();
 					}
 				    }
@@ -2326,7 +2377,7 @@ jprint_print_count(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(50, __func__, "jprint is NULL");
+	err(51, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2354,7 +2405,7 @@ jprint_print_final_comma(struct jprint *jprint)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(51, __func__, "jprint is NULL");
+	err(52, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2380,7 +2431,7 @@ jprint_print_brace(struct jprint *jprint, bool open)
 {
     /* firewall */
     if (jprint == NULL) {
-	err(52, __func__, "jprint is NULL");
+	err(53, __func__, "jprint is NULL");
 	not_reached();
     }
 
@@ -2415,19 +2466,19 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
 
     /* firewall */
     if (jprint == NULL) {
-	err(53, __func__, "jprint is NULL");
+	err(54, __func__, "jprint is NULL");
 	not_reached();
     } else if (match == NULL) {
-	err(54, __func__, "match is NULL");
+	err(55, __func__, "match is NULL");
 	not_reached();
     } else if (pattern == NULL) {
-	err(55, __func__, "pattern is NULL");
+	err(56, __func__, "pattern is NULL");
 	not_reached();
     }
 
     /* if the name of the match is NULL it is a fatal error */
     if (match->match == NULL) {
-	err(56, __func__, "match->match is NULL");
+	err(57, __func__, "match->match is NULL");
 	not_reached();
     } else if (*match->match == '\0') {
 	/* warn on empty name for now and then go to next match */
@@ -2436,7 +2487,7 @@ jprint_print_match(struct jprint *jprint, struct jprint_pattern *pattern, struct
     }
 
     if (match->value == NULL) {
-	err(57, __func__, "match '%s' has NULL value", match->match);
+	err(58, __func__, "match '%s' has NULL value", match->match);
 	not_reached();
     } else if (*match->value == '\0') {
 	/* for now we only warn on empty value */
@@ -2594,7 +2645,7 @@ jprint_print_matches(struct jprint *jprint)
 
     /* firewall */
     if (jprint == NULL) {
-	err(58, __func__, "jprint is NULL");
+	err(59, __func__, "jprint is NULL");
 	not_reached();
     } else if (jprint->patterns == NULL && jprint->matches == NULL) {
 	warn(__func__, "NULL patterns and matches list");
@@ -2671,10 +2722,10 @@ run_jprint_check_tool(struct jprint *jprint, char **argv)
 
     /* firewall */
     if (jprint == NULL) {
-	err(59, __func__, "NULL jprint");
+	err(60, __func__, "NULL jprint");
 	not_reached();
     } else if (jprint->file_contents == NULL) {
-	err(60, __func__, "NULL jprint->file_contents");
+	err(61, __func__, "NULL jprint->file_contents");
 	not_reached();
     }
 

--- a/jparse/jprint_util.c
+++ b/jparse/jprint_util.c
@@ -112,7 +112,7 @@ alloc_jprint(void)
     jprint->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
 
     jprint->search_value = false;			/* -Y search by value, not name. Uses print type */
-    jprint->recurse_search = false;			/* XXX - change this to true when recursive searching is done - XXX */
+    jprint->recursive_search = false;			/* XXX - change this to true when recursive searching is done - XXX */
 
     jprint->check_tool_stream = NULL;			/* FILE * stream for -S path */
     jprint->check_tool_path = NULL;			/* -S path */
@@ -1180,7 +1180,7 @@ parse_jprint_name_args(struct jprint *jprint, char **argv)
     }
 
     /*
-     * XXX - fix to search name_args, not patterns, if jprint->recurse_search is
+     * XXX - fix to search name_args, not patterns, if jprint->recursive_search is
      * true (true will be the default but is currently false) - XXX
      */
     for (i = 1; argv[i] != NULL; ++i) {
@@ -1231,10 +1231,10 @@ add_jprint_pattern(struct jprint *jprint, bool use_regexp, bool use_substrings, 
      * firewall
      */
 
-    /* it is an error if calling this function if the jprint->recurse_search is true
+    /* it is an error if calling this function if the jprint->recursive_search is true
      * (will be the default)
      */
-    if (jprint->recurse_search) {
+    if (jprint->recursive_search) {
 	err(26, __func__, "called pattern adding code without -R");
 	not_reached();
     }

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -191,11 +191,11 @@ struct jprint
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     bool search_value;				/* -Y used, search for value, not name */
     /*
-     * XXX - for recurse_search the default is supposed to be true but currently
+     * XXX - for recursive_search the default is supposed to be true but currently
      * it is false until the searching of json in a recursive sub-tree way is
      * implemented. -R will disable this for the old pattern concept.
      */
-    bool recurse_search;			/* default true ==> search in a recursive way. XXX - temporarily def false */
+    bool recursive_search;			/* default true ==> search in a recursive way. XXX - temporarily def false */
     FILE *check_tool_stream;			/* FILE * stream for -S path */
     char *check_tool_path;			/* -S used */
     char *check_tool_args;			/* -A used */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -132,7 +132,7 @@ struct jprint_match
  * jprint_pattern - struct for a linked list of patterns requested, held in
  * struct jprint
  *
- * XXX - the pattern concept is incorrect due to a misunderstanding - XXX
+ * NOTE: the pattern concept is for the -R option
  */
 struct jprint_pattern
 {
@@ -190,6 +190,12 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     bool search_value;				/* -Y used, search for value, not name */
+    /*
+     * XXX - for recurse_search the default is supposed to be true but currently
+     * it is false until the searching of json in a recursive sub-tree way is
+     * implemented. -R will disable this for the old pattern concept.
+     */
+    bool recurse_search;			/* default true ==> search in a recursive way. XXX - temporarily def false */
     FILE *check_tool_stream;			/* FILE * stream for -S path */
     char *check_tool_path;			/* -S used */
     char *check_tool_args;			/* -A used */

--- a/jparse/json_search.c
+++ b/jparse/json_search.c
@@ -14,8 +14,9 @@
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
-
- * This search function was implemented by:
+ *
+ * This JSON search functionality was designed and implemented in support of
+ * jprint by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *

--- a/jparse/json_search.c
+++ b/jparse/json_search.c
@@ -1,10 +1,20 @@
 /*
  * json_search - search JSON parse tree for matches
  *
- * Because sometimes is harder to see the JSON forest thru the JSON trees.
+ * Because sometimes is harder to see the JSON forest through the JSON trees.
  * By carefully searching the JSON parse tree, we avoid careless playing with matches.
  * Only you can prevent JSON tree fires! :-)
  *
+ * This JSON parser was co-developed in 2022 by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+
  * This search function was implemented by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\

--- a/jparse/json_search.h
+++ b/jparse/json_search.h
@@ -1,17 +1,29 @@
 /*
  * json_search - search JSON parse tree for matches
  *
- * Because sometimes is harder to see the JSON forest thru the JSON trees.
+ * Because sometimes is harder to see the JSON forest through the JSON trees.
  * By carefully searching the JSON parse tree, we avoid careless playing with matches.
  * Only you can prevent JSON tree fires! :-)
  *
- * This search function was implemented by:
+ * This JSON parser was co-developed in 2022 by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * This JSON search functionality was designed and implemented in support of
+ * jprint by:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
  */
+
 
 
 #if !defined(INCLUDE_JSON_SEARCH_H)


### PR DESCRIPTION
Add jprint -R option to disable sub-tree searching

New version of jprint - 0.0.32 2023-06-28.

The purpose of this option will be to allow one to find matches that are
not under a hierarchy of name_args. Although it was originally a 
misunderstanding it was a misunderstanding also in part because I feel 
that there is a great value in having it search in a non recursive way 
(in the sense of two name_args as described elsewhere) and it seems like
a waste of the code I already put in. Since there will be no ambiguity 
there should not be any problem.

The default will be to search in a recursive way but for now that is 
disabled as that feature is not yet implemented.

Fixed a potential memory leak that was discovered at the same time as 
well.