### PR TITLE
Modularise jprint strings and number matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,7 @@
 Add new good JSON test file 42.json under
 `jparse/test_jparse/test_JSON/good/42.json`.
 
-New `jprint` version "0.0.32 2023-06-28". Add option `-R` to disable recursive
-sub-tree searching. The temporary default is false which disables recursive
-searching but once recursive sub-tree searching is supported the default will be
-to search in a recursive sub-tree way. This means that the concept of patterns
-can work. It seems useful and it would be a shame to waste the code that was
-added due to a misunderstanding.
+New `jprint` version "0.0.32 2023-06-28".
 
 Fixed potential memory leak in `jprint`: although currently none exist the
 matches list in the struct jprint (instead of the matches list in each pattern)
@@ -19,10 +14,13 @@ was not freed.
 
 Use of `jprint -s` and `jprint -j` now possible.
 
-Add new function `extern char const *json_get_type_str(struct json *node, bool
-encoded);` to jparse library to get the matched (in the parser/lexer) name that
-triggered parsing. Updated man page.
+New jparse and json parser version "1.0.9 2023-06-28". Add new function `extern
+char const *json_get_type_str(struct json *node, bool encoded);` to jparse
+library to get the matched (in the parser/lexer) name that triggered parsing.
+Updated man page.
 
+Make use of `json_get_type_str()` in `jprint` for modularity. This only applies
+to strings and number types.
 
 ## Release 1.0.24 2023-06-27
 

--- a/jparse/jprint.c
+++ b/jparse/jprint.c
@@ -43,7 +43,7 @@ static const char * const usage_msg0 =
     "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
     "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
     "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type]\n"
-    "\t\t[-R] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\t\t[-S path] [-A args] file.json [name_arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
@@ -174,7 +174,6 @@ static const char * const usage_msg3 =
     "\t\t\tUse of -Y requires one and only one name_arg.\n"
     "\t\t\tUse of -Y changes the default from -p value to -p name.\n"
     "\n"
-    "\t-R\t\t\tDon't search in a recursive sub-tree manner (def: do search recursively)\n"
     "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
     "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
     "\n"
@@ -426,11 +425,6 @@ main(int argc, char **argv)
 	     */
 	    jprint->search_value = true;
 	    jprint->type = jprint_parse_value_type_option(optarg);
-	    break;
-	case 'R':
-	    /* XXX - currently the default is false as recursive searching is
-	     * not done but the default will later be true - XXX */
-	    jprint->recursive_search = false;
 	    break;
 	case 'S':
 	    /* -S path to tool */

--- a/jparse/jprint_util.h
+++ b/jparse/jprint_util.h
@@ -132,7 +132,7 @@ struct jprint_match
  * jprint_pattern - struct for a linked list of patterns requested, held in
  * struct jprint
  *
- * NOTE: the pattern concept is for the -R option
+ * XXX - the pattern concept is incorrect due to a misunderstanding - XXX
  */
 struct jprint_pattern
 {
@@ -190,12 +190,6 @@ struct jprint
     bool print_entire_file;			/* no name_arg specified */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     bool search_value;				/* -Y used, search for value, not name */
-    /*
-     * XXX - for recursive_search the default is supposed to be true but currently
-     * it is false until the searching of json in a recursive sub-tree way is
-     * implemented. -R will disable this for the old pattern concept.
-     */
-    bool recursive_search;			/* default true ==> search in a recursive way. XXX - temporarily def false */
     FILE *check_tool_stream;			/* FILE * stream for -S path */
     char *check_tool_path;			/* -S used */
     char *check_tool_args;			/* -A used */
@@ -265,12 +259,12 @@ void free_jprint_patterns_list(struct jprint *jprint);
 
 /* matches found of each pattern */
 struct jprint_match *add_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern,
-	struct json *node_name, struct json *node_value, char *name_str, char *value_str, uintmax_t level,
+	struct json *node_name, struct json *node_value, char const *name_str, char const *value_str, uintmax_t level,
 	enum item_type name_type, enum item_type value_type);
 void free_jprint_matches_list(struct jprint_pattern *pattern);
 
 /* functions to find matches in the JSON tree */
-bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char *name, struct json *node, char *str);
+bool is_jprint_match(struct jprint *jprint, struct jprint_pattern *pattern, char const *name, struct json *node, char const *str);
 void jprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value,
 	unsigned int depth, ...);
 void vjprint_json_search(struct jprint *jprint, struct json *name_node, struct json *value_node, bool is_value,


### PR DESCRIPTION
Make use of the function json_get_type_str() for strings and numbers. More will follow another time as more cases are added.

For now removed -R as it is thought that other things have to be considered.