### PR TITLE
Debug log fix in jparse_test.sh

### DIFF
--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -317,14 +317,10 @@ run_location_err_test()
 	echo "$0: debug[9]: in run_location_err_test: test must fail"
 	echo "$0: debug[9]: in run_location_err_test: jparse: $JPARSE" 1>&2
 	echo "$0: debug[9]: in run_location_err_test: jparse_test_file: $jparse_test_file" 1>&2
-	if [[ $pass_fail = fail ]]; then
-	    echo "$0: debug[9]: in run_location_err_test: jparse_err_file: $jparse_err_file" 1>&2
-	fi
     fi
 
-    echo "$0: debug[3]: about to run test that must fail: $JPARSE -- $jparse_test_file >> ${LOGFILE} 2>$TMP_STDERR_FILE" 1>&2
     if [[ $V_FLAG -ge 3 ]]; then
-	echo "$0: debug[3]: in run_test: about to run: $JPARSE -- $jparse_test_file -- $jparse_test_file 2>$TMP_STDERR_FILE | tee -a -- ${LOGFILE}"
+	echo "$0: debug[3]: about to run test that must fail: $JPARSE -- $jparse_test_file >> ${LOGFILE} 2>$TMP_STDERR_FILE" 1>&2
     fi
 
     "$JPARSE" -- "$jparse_test_file" 2>"$TMP_STDERR_FILE" | tee -a -- "${LOGFILE}"


### PR DESCRIPTION
There was a debug message that was outside a check of the verbosity level and the script also erroneously referred to the non-existent variable pass_test in the same function which tests error locations (run_location_err_test()). The test must always fail which really means that jparse must return non-zero and have the exact same error message as the respective error file in jparse/test_jparse/test_JSON/bad_loc, one error file per JSON file in the same directory.