### PR TITLE
Add macro VALID_JSON_NODE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,10 @@ invalid token but we do it for safety anyway.
 Add to function `vjson_fprint()` code that prints out the string of a number if
 converted is false but parsed is true.
 
+Add macro `VALID_JSON_NODE` that determines if a `struct json_foo` is valid
+which means that either `item->converted` or `item->parsed` is true. This macro
+is currently used prior to reporting an error in the conversion functions.
+
 
 ## Release 1.0.29 2023-07-13
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@ Check for more than one dot in floating point number strings for JSON and
 otherwise. For JSON this is not strictly necessary as the scanner will report an
 invalid token but we do it for safety anyway.
 
+Add to function `vjson_fprint()` code that prints out the string of a number if
+converted is false but parsed is true.
+
 
 ## Release 1.0.29 2023-07-13
 

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -1270,7 +1270,7 @@ parse_json_string(char const *string, size_t len)
         not_reached();
     }
     item = &(str->item.string);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	err(152, __func__, "couldn't decode string: <%s>", string);
 	not_reached();
     }
@@ -1314,7 +1314,7 @@ parse_json_bool(char const *string)
         not_reached();
     }
     item = &(boolean->item.boolean);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	/*
 	 * json_conv_bool_str() calls json_conv_bool() which will warn if the
 	 * boolean is neither true nor false. We know that this function should never
@@ -1402,7 +1402,7 @@ parse_json_null(char const *string)
         not_reached();
     }
     item = &(null->item.null);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	/* why is it an error if we can't convert nothing ? :-) */
 	err(166,__func__, "couldn't convert null: <%s>", string);
 	not_reached();
@@ -1451,7 +1451,7 @@ parse_json_number(char const *string)
         not_reached();
     }
     item = &(number->item.number);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	err(170, __func__, "couldn't convert number string: <%s>", string);
 	not_reached();
     }
@@ -1502,7 +1502,7 @@ parse_json_array(struct json *elements)
     elements->type = JTYPE_ARRAY;
     /* paranoia - these tests should never result in an error */
     item = &(elements->item.array);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	err(173, __func__, "couldn't convert array");
 	not_reached();
     }
@@ -1557,7 +1557,7 @@ parse_json_member(struct json *name, struct json *value)
         not_reached();
     }
     item = &(member->item.member);
-    if (!item->converted && !item->parsed) {
+    if (!VALID_JSON_NODE(item)) {
 	err(179, __func__, "couldn't convert member");
 	not_reached();
     }

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -31,6 +31,7 @@
  */
 #define JSON_BYTE_VALUES (BYTE_VALUES) /* to make the purpose clearer we have the JSON_ prefix */
 
+#define VALID_JSON_NODE(item) ((item)->converted || (item)->parsed)
 
 /*
  * JSON encoding of an octet in a JSON string

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1466,7 +1466,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted number
 	     */
-	    if (item->converted == true) {
+	    if (item->converted) {
 
 		/*
 		 * case: converted negative number
@@ -1615,11 +1615,162 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 		    }
 		}
 
+	    }
+	    /* case: not converted but parsed */
+	    else if (item->parsed) {
+
+		/*
+		 * case: parsed negative number
+		 */
+		if (item->is_negative == true) {
+
+		    /*
+		     * case: parsed e-notation negative number
+		     */
+		    if (item->is_e_notation == true) {
+
+			/*
+			 * try to print the smallest parsed floating point
+			 */
+			if (item->float_sized == true) {
+			    fprint(stream, "\tf-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_float_int));
+			} else if (item->double_sized == true) {
+			    fprint(stream, "\td-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_double_int));
+			} else if (item->longdouble_sized == true) {
+			    fprint(stream, "\tL-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_longdouble_int));
+			} else {
+			    fprstr(stream, "\tWarning: -e-notation: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+
+		    /*
+		     * case: parsed floating negative number
+		     */
+		    } else if (item->is_floating == true) {
+
+			/*
+			 * try to print the smallest parsed floating point
+			 */
+			if (item->float_sized == true) {
+			    fprint(stream, "\tf-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_float_int));
+			} else if (item->double_sized == true) {
+			    fprint(stream, "\td-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_double_int));
+			} else if (item->longdouble_sized == true) {
+			    fprint(stream, "\tL-val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_longdouble_int));
+			} else {
+			    fprstr(stream, "\tWarning: -floating: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+
+		    /*
+		     * case: parsed integer negative number
+		     */
+		    } else {
+
+			/*
+			 * try to print the smallest parsed integer
+			 */
+			if (item->int8_sized == true) {
+			    fprint(stream, "\tval-8: %s", item->as_str);
+			} else if (item->int16_sized == true) {
+			    fprint(stream, "\tval-16: %s", item->as_str);
+			} else if (item->int32_sized == true) {
+			    fprint(stream, "\tval-32: %s", item->as_str);
+			} else if (item->int64_sized == true) {
+			    fprint(stream, "\tval-64: %s", item->as_str);
+			} else if (item->maxint_sized == true) {
+			    fprint(stream, "\tval-max: %s", item->as_str);
+			} else {
+			    fprstr(stream, "\tWarning: -integer: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+		    }
+
+		/*
+		 * case: parsed positive number
+		 */
+		} else {
+
+		    /*
+		     * case: parsed e-notation positive number
+		     */
+		    if (item->is_e_notation == true) {
+
+			/*
+			 * try to print the smallest parsed floating point
+			 */
+			if (item->float_sized == true) {
+			    fprint(stream, "\tf+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_float_int));
+			} else if (item->double_sized == true) {
+			    fprint(stream, "\td+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_double_int));
+			} else if (item->longdouble_sized == true) {
+			    fprint(stream, "\tL+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_longdouble_int));
+			} else {
+			    fprstr(stream, "\tWarning: +e-notation: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+
+		    /*
+		     * case: parsed floating positive number
+		     */
+		    } else if (item->is_floating == true) {
+
+			/*
+			 * try to print the smallest parsed floating point
+			 */
+			if (item->float_sized == true) {
+			    fprint(stream, "\tf+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_float_int));
+			} else if (item->double_sized == true) {
+			    fprint(stream, "\td+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_double_int));
+			} else if (item->longdouble_sized == true) {
+			    fprint(stream, "\tL+val: %s\tinteger: %s",
+					   item->as_str, booltostr(item->as_longdouble_int));
+			} else {
+			    fprstr(stream, "\tWarning: +floating: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+
+		    /*
+		     * case: parsed integer positive number
+		     */
+		    } else {
+
+			/*
+			 * try to print the smallest parsed integer
+			 */
+			if (item->int8_sized == true) {
+			    fprint(stream, "\tval+8: %s", item->as_str);
+			} else if (item->int16_sized == true) {
+			    fprint(stream, "\tval+16: %s", item->as_str);
+			} else if (item->int32_sized == true) {
+			    fprint(stream, "\tval+32: %s", item->as_str);
+			} else if (item->int64_sized == true) {
+			    fprint(stream, "\tval+64: %s", item->as_str);
+			} else if (item->maxint_sized == true) {
+			    fprint(stream, "\tval+max: %s", item->as_str);
+			} else {
+			    fprstr(stream, "\tWarning: +integer: no common size:\t");
+			    (void) fprint_line_buf(stream, item->first, item->number_len, '<', '>');
+			}
+		    }
+		}
+
 	    /*
 	     * case: not converted number
 	     */
 	    } else {
-		fprstr(stream, "\tconverted: false");
+		fprstr(stream, "\tconverted and parsed: false");
 	    }
 	}
 	break;


### PR DESCRIPTION

This is used to simplify checking if the node is valid after conversion
(or attempting to convert). If either item->converted or item->parsed is
true it is valid JSON. It does not mean that it could be converted.