### PR TITLE
More code for json struct parsed bool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.31 2023-07-15
+
+New JSON parser and jparse version "1.0.12 2023-07-15".
+
+Add more checks to JSON node `parsed` member so that if converted is false but
+parsed is true it's not an error (in the cases where parsed is allowed to be
+different it is not an error: if they're not allowed to be different we warn
+about it if they are different).
+
+Improve printing of string variables and numbers in `vjson_fprint()`.
+
+
 ## Release 1.0.30 2023-07-14
 
 New JSON parser and jparse version "1.0.11 2023-07-14".

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.11 2023-07-14"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.12 2023-07-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.11 2023-07-14"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.0.12 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -714,9 +714,9 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
  *		NULL ==> do not report a JSON semantic validation error
  *
  * returns:
- *	true ==> JSON node is converted and a valid JTYPE
+ *	true ==> JSON node is parsed and a valid JTYPE
  *	    The val_err arg is ignored
- *	NULL ==> JSON node is not converted, invalid node type, or internal error
+ *	NULL ==> JSON node is not parsed, invalid node type, or internal error
  *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
  */
 bool
@@ -732,7 +732,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
     }
 
     /*
-     * validate JSON parse node type and check for not converted
+     * validate JSON parse node type and check for not parsed
      */
     switch (node->type) {
     case JTYPE_UNSET:   /* JSON item has not been set - must be the value 0 */
@@ -827,7 +827,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
 	    /* parsed check */
 	    if (!item->parsed) {
 		if (val_err != NULL) {
-		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: converted is false");
+		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: parsed is false");
 		}
 		return false;
 	    }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -935,7 +935,7 @@ json_get_type_str(struct json *node, bool encoded)
 	case JTYPE_NUMBER:
 	    {
 		struct json_number *item = &(node->item.number);
-		if (item != NULL && (item->converted || item->parsed)) {
+		if (item != NULL && VALID_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -259,6 +259,19 @@ chk_test(int testnum, struct json_number *item, struct json_number *test, size_t
     }
 
     /*
+     * test parsed boolean
+     */
+    if (test_result[testnum].parsed != item->parsed) {
+	dbg(DBG_VHIGH, "ERROR: test_result[%d].parsed: %d != item.parsed: %d",
+		       testnum, test_result[testnum].parsed, item->parsed);
+	test_error = true;
+    } else {
+	dbg(DBG_VVHIGH, "test_result[%d].parsed: %d == item.parsed: %d",
+			testnum, test_result[testnum].parsed, item->parsed);
+    }
+
+
+    /*
      * test NULL strings
      */
     if (test_result[testnum].as_str == NULL) {


### PR DESCRIPTION
New JSON parser and jparse version 1.0.12 2023-07-15.

Add more checks for parsed bool in structs if converted is false. In the case of numbers this was already done but for others it was not. However the checks now check (except for numbers as they're allowed to be different) that both converted and parsed are true. If only one is true we print a warning.

Improve how numbers are printed and how strings are printed. For numbers it's messages improved and typo fixed. For strings there are new flags: 'c' for converted and 'p' for parsed. In the case of strings we do explicitly check for either or of converted or parsed but it might be more correct to be like the others: check for both true and warn if only one of them is true.