### PR TITLE
Add new JSON node helper macros

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.31 2023-07-15
+
+New JSON parser and jparse version "1.0.12 2023-07-15".
+
+Add more checks to JSON node `parsed` member so that if converted is false but
+parsed is true it's not an error (in the cases where parsed is allowed to be
+different it is not an error: if they're not allowed to be different we warn
+about it if they are different).
+
+Improve printing of string variables and numbers in `vjson_fprint()`.
+
+
 ## Release 1.0.30 2023-07-14
 
 New JSON parser and jparse version "1.0.11 2023-07-14".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,15 @@ about it if they are different).
 
 Improve printing of string variables and numbers in `vjson_fprint()`.
 
+Add helper macros `CONVERTED_PARSED_JSON_NODE`, ` CONVERTED_JSON_NODE` and
+`PARSED_JSON_NODE` and updated jparse.3 man page. The
+`CONVERTED_PARSED_JSON_NODE` checks that both the `converted` and `parsed`
+booleans are true. The `CONVERTED_JSON_NODE` checks that the boolean `converted`
+is true and that the `parsed` boolean is false and the `PARSED_JSON_NODE` checks
+that the `parsed` boolean is true and that the `converted` boolean is false.
+These macros have been used in `jparse/json_util.c` but other files need to be
+checked still.
+
 
 ## Release 1.0.30 2023-07-14
 

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.11 2023-07-14"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.12 2023-07-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.11 2023-07-14"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.0.12 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -32,6 +32,10 @@
 #define JSON_BYTE_VALUES (BYTE_VALUES) /* to make the purpose clearer we have the JSON_ prefix */
 
 #define VALID_JSON_NODE(item) ((item)->converted || (item)->parsed)
+#define CONVERTED_PARSED_JSON_NODE(item) ((item)->converted && (item)->parsed)
+#define CONVERTED_JSON_NODE(item) ((item)->converted && !(item)->parsed)
+#define PARSED_JSON_NODE(item) ((item)->parsed && !(item)->converted)
+
 
 /*
  * JSON encoding of an octet in a JSON string

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -714,9 +714,9 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
  *		NULL ==> do not report a JSON semantic validation error
  *
  * returns:
- *	true ==> JSON node is converted and a valid JTYPE
+ *	true ==> JSON node is parsed and a valid JTYPE
  *	    The val_err arg is ignored
- *	NULL ==> JSON node is not converted, invalid node type, or internal error
+ *	NULL ==> JSON node is not parsed, invalid node type, or internal error
  *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
  */
 bool
@@ -732,7 +732,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
     }
 
     /*
-     * validate JSON parse node type and check for not converted
+     * validate JSON parse node type and check for not parsed
      */
     switch (node->type) {
     case JTYPE_UNSET:   /* JSON item has not been set - must be the value 0 */
@@ -827,7 +827,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
 	    /* parsed check */
 	    if (!item->parsed) {
 		if (val_err != NULL) {
-		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: converted is false");
+		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: parsed is false");
 		}
 		return false;
 	    }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -935,7 +935,7 @@ json_get_type_str(struct json *node, bool encoded)
 	case JTYPE_NUMBER:
 	    {
 		struct json_number *item = &(node->item.number);
-		if (item != NULL && (item->converted || item->parsed)) {
+		if (item != NULL && VALID_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -944,7 +944,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_string *item = &(node->item.string);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = encoded ? item->as_str : item->str;
 		}
 	    }
@@ -953,7 +953,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_boolean *item = &(node->item.boolean);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }
@@ -962,7 +962,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_null *item = &(node->item.null);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }
@@ -971,7 +971,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_member *item = &(node->item.member);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = encoded ? item->name_as_str : item->name_str;
 		}
 	    }
@@ -1474,7 +1474,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted number
 	     */
-	    if (item->converted) {
+	    if (CONVERTED_JSON_NODE(item)) {
 
 		/*
 		 * case: converted negative number
@@ -1625,7 +1625,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 
 	    }
 	    /* case: not converted but parsed */
-	    else if (item->parsed) {
+	    else if (PARSED_JSON_NODE(item)) {
 
 		/*
 		 * case: parsed negative number
@@ -1792,14 +1792,14 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: converted should always be equal to parsed
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		/*
 		 * print string preamble
 		 */
 		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
-				item->converted?"c":"",
-				item->parsed?"p":"",
+				CONVERTED_JSON_NODE(item)?"c":"",
+				PARSED_JSON_NODE(item)?"p":"",
 				item->quote ? "q" : "",
 				item->same ? "=" : "",
 				item->has_nul ? "0" : "",
@@ -1815,7 +1815,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: this should never happen
 	     */
-	    } else if (!item->converted && item->parsed) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "string item->converted == false but item->parsed == true");
 		fprstr(stream, "\tparsed true, converted false: will not print data");
 	    /*
@@ -1823,7 +1823,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: this should never happen
 	     */
-	    } else if (item->converted && !item->parsed) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "string item->converted == true but item->parsed == false");
 		fprstr(stream, "\tconverted true, parsed false: will not print data");
 	    /*
@@ -1842,7 +1842,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed boolean
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 
@@ -1852,7 +1852,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     * NOTE: this should never happen as if converted == false then
 	     * parsed should also == false. We check explicitly so we can warn.
 	     */
-	    } else if (item->parsed && !item->converted) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "boolean item->converted == false but item->parsed == true");
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 	    /*
@@ -1861,7 +1861,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     * NOTE: this should never happen as if converted == false then
 	     * parsed should also == false. We check explicitly so we can warn.
 	     */
-	    } else if (!item->parsed && item->converted) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "boolean item->converted == true but item->parsed == false");
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 
@@ -1880,20 +1880,20 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed null
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprstr(stream, "\tvalue: null");
 
 	    /*
 	     * case: not converted but parsed null
 	     */
-	    } else if (!item->converted && item->parsed) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "null item->converted == false but item->parsed == false");
 
 	    /*
 	     * case: converted but not parsed null
 	     */
-	    } else if (item->converted && !item->parsed) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "null item->converted == false but item->parsed == false");
 	    /*
 	     * case: not converted not parsed null
@@ -1911,7 +1911,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed member
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		/*
 		 * print member name
@@ -1925,12 +1925,12 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 		    if (type == JTYPE_STRING) {
 			struct json_string *item2 = &(item->name->item.string);
 
-			if (item2->converted && item2->parsed) {
+			if (CONVERTED_PARSED_JSON_NODE(item2)) {
 			    fprstr(stream, "\tname: ");
 			    (void) fprint_line_buf(stream, item2->str, item2->str_len, '"', '"');
-			} else if (item2->converted && !item2->parsed) {
+			} else if (CONVERTED_JSON_NODE(item2)) {
 			    warn(__func__, "\tname: converted true but parsed false:");
-			} else if (!item2->converted && item2->parsed) {
+			} else if (PARSED_JSON_NODE(item2)) {
 			    warn(__func__, "\tname: converted false but parsed true:");
 			} else {
 			    fprstr(stream, "\tname {converted,parsed}: false");
@@ -1966,7 +1966,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {
@@ -1991,7 +1991,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {
@@ -2017,7 +2017,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "14 July 2023" "jparse"
+.TH jparse 3  "15 July 2023" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -27,6 +27,12 @@
 \fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item)->converted || (item)->parsed)\fP
+.br
+\fB#define CONVERTED_PARSED_JSON_NODE(item) ((item)->converted && (item)->parsed)\fP
+.br
+\fB#define CONVERTED_JSON_NODE(item) ((item)->converted && !(item)->parsed)\fP
+.br
+\fB#define PARSED_JSON_NODE(item) ((item)->parsed && !(item)->converted)\fP
 .sp
 .B "extern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */"
 .br
@@ -190,29 +196,58 @@ struct json
 .fi
 .in
 };
-.SS Checking for a valid JSON node
+.SS Checking for converted and/or parsed JSON nodes
 .PP
-To check if one of the JSON nodes is valid you can use the
-.B VALID_JSON_NODE
-macro, which checks that either the
+Each JSON node struct has two booleans:
 .B converted
-or the
+and
+.B parsed\c
+\&.
+The
+.B converted
+boolean indicates that the item could be converted whereas the
 .B parsed
-boolean is true.
+boolean indicates that the item could be parsed but it might or might not be converted.
+It might be that it could not be converted but is parsable if it is a number string but the number is too big for the C types.
+In this case the JSON can still be valid but the value is not converted.
 This macro is used in the conversion routines and it is an error if both conversion and parsing fails.
-The boolean
-.B parsed
-means it could be parsed as valid JSON and the boolean
-.B converted
-means that it could be converted.
 If
 .B converted
 is true then
 .B parsed
 should be true too.
-It might happen that only
+.PP
+The macro
+.B VALID_JSON_NODE
+checks that either of the JSON node booleans,
+.B converted
+and
+.B parsed\c
+\&, are true.
+.PP
+The macro
+.B CONVERTED_PARSED_JSON_NODE
+checks that the node's
+.B converted
+boolean is true and that the
 .B parsed
-is true if a number is too big for C types.
+boolean is true.
+.PP
+The macro
+.B CONVERTED_JSON_NODE
+checks that the node's
+.B converted
+boolean is true and its
+.B parsed
+boolean is false.
+.PP
+The macro
+.B PARSED_JSON_NODE
+checks that the node's
+.B parsed
+boolean is true and that its
+.B converted
+boolean is false.
 .SS Version strings
 The string
 .BR jparse_version ,

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -259,6 +259,19 @@ chk_test(int testnum, struct json_number *item, struct json_number *test, size_t
     }
 
     /*
+     * test parsed boolean
+     */
+    if (test_result[testnum].parsed != item->parsed) {
+	dbg(DBG_VHIGH, "ERROR: test_result[%d].parsed: %d != item.parsed: %d",
+		       testnum, test_result[testnum].parsed, item->parsed);
+	test_error = true;
+    } else {
+	dbg(DBG_VVHIGH, "test_result[%d].parsed: %d == item.parsed: %d",
+			testnum, test_result[testnum].parsed, item->parsed);
+    }
+
+
+    /*
      * test NULL strings
      */
     if (test_result[testnum].as_str == NULL) {


### PR DESCRIPTION

Three new macros have been added to check JSON nodes' converted and 
parsed booleans.

The CONVERTED_PARSED_JSON_NODE macro checks that both are true.
The CONVERTED_JSON_NODE macro checks that only converted is true.
The PARSED_JSON_NODE macro checks that only parsed is true.

These macros are now used in jparse/json_util.c but other files will be
checked and if necessary updated.