### PR TITLE
Resolve most or all of issue #752

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.31 2023-07-15
+
+New JSON parser and jparse version "1.0.12 2023-07-15".
+
+Add more checks to JSON node `parsed` member so that if converted is false but
+parsed is true it's not an error (in the cases where parsed is allowed to be
+different it is not an error: if they're not allowed to be different we warn
+about it if they are different).
+
+Improve printing of string variables and numbers in `vjson_fprint()`.
+
+
 ## Release 1.0.30 2023-07-14
 
 New JSON parser and jparse version "1.0.11 2023-07-14".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,13 @@ Add helper macros `CONVERTED_PARSED_JSON_NODE`, ` CONVERTED_JSON_NODE` and
 booleans are true. The `CONVERTED_JSON_NODE` checks that the boolean `converted`
 is true and that the `parsed` boolean is false and the `PARSED_JSON_NODE` checks
 that the `parsed` boolean is true and that the `converted` boolean is false.
-These macros have been used in `jparse/json_util.c` but other files need to be
-checked still.
+These macros have been used in in place of checks of `foo->converted` and
+`foo->parsed`.
+
+Rename function `sem_node_valid_converted()` to be just `sem_node_valid()` and
+make use of appropriate macro: for numbers it uses the `VALID_JSON_NODE` and or
+others it uses `CONVERTED_PARSED_JSON_NODE` as both `converted` and `parsed`
+must be true for non-number nodes.
 
 
 ## Release 1.0.30 2023-07-14

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,15 @@ about it if they are different).
 
 Improve printing of string variables and numbers in `vjson_fprint()`.
 
+Add helper macros `CONVERTED_PARSED_JSON_NODE`, ` CONVERTED_JSON_NODE` and
+`PARSED_JSON_NODE` and updated jparse.3 man page. The
+`CONVERTED_PARSED_JSON_NODE` checks that both the `converted` and `parsed`
+booleans are true. The `CONVERTED_JSON_NODE` checks that the boolean `converted`
+is true and that the `parsed` boolean is false and the `PARSED_JSON_NODE` checks
+that the `parsed` boolean is true and that the `converted` boolean is false.
+These macros have been used in `jparse/json_util.c` but other files need to be
+checked still.
+
 
 ## Release 1.0.30 2023-07-14
 

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.11 2023-07-14"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.0.12 2023-07-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.11 2023-07-14"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.0.12 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -32,6 +32,10 @@
 #define JSON_BYTE_VALUES (BYTE_VALUES) /* to make the purpose clearer we have the JSON_ prefix */
 
 #define VALID_JSON_NODE(item) ((item)->converted || (item)->parsed)
+#define CONVERTED_PARSED_JSON_NODE(item) ((item)->converted && (item)->parsed)
+#define CONVERTED_JSON_NODE(item) ((item)->converted && !(item)->parsed)
+#define PARSED_JSON_NODE(item) ((item)->parsed && !(item)->converted)
+
 
 /*
  * JSON encoding of an octet in a JSON string

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -714,9 +714,9 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
  *		NULL ==> do not report a JSON semantic validation error
  *
  * returns:
- *	true ==> JSON node is converted and a valid JTYPE
+ *	true ==> JSON node is parsed and a valid JTYPE
  *	    The val_err arg is ignored
- *	NULL ==> JSON node is not converted, invalid node type, or internal error
+ *	NULL ==> JSON node is not parsed, invalid node type, or internal error
  *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
  */
 bool
@@ -732,7 +732,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
     }
 
     /*
-     * validate JSON parse node type and check for not converted
+     * validate JSON parse node type and check for not parsed
      */
     switch (node->type) {
     case JTYPE_UNSET:   /* JSON item has not been set - must be the value 0 */
@@ -827,7 +827,7 @@ sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_s
 	    /* parsed check */
 	    if (!item->parsed) {
 		if (val_err != NULL) {
-		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: converted is false");
+		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: parsed is false");
 		}
 		return false;
 	    }

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -345,7 +345,7 @@ sem_chk_null_args(struct json const *node, unsigned int depth, struct json_sem *
 
 
 /*
- * sem_node_valid_converted - determine if a JSON node is a converted and valid type
+ * sem_node_valid - determine if a JSON node is a converted and valid type
  *
  * Given a JSON node, perform sanity checks on the JSON node.
  *
@@ -372,7 +372,7 @@ sem_chk_null_args(struct json const *node, unsigned int depth, struct json_sem *
  *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
  */
 bool
-sem_node_valid_converted(struct json const *node, unsigned int depth, struct json_sem *sem,
+sem_node_valid(struct json const *node, unsigned int depth, struct json_sem *sem,
 		         char const *name, struct json_sem_val_err **val_err)
 {
     /*
@@ -399,7 +399,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_number const *item = &(node->item.number);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!VALID_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(14, node, depth, sem, name, "JTYPE_NUMBER node: converted is false");
 		}
@@ -427,7 +427,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_string const *item = &(node->item.string);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(17, node, depth, sem, name, "JTYPE_STRING node: converted is false");
 		}
@@ -455,7 +455,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_boolean const *item = &(node->item.boolean);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(20, node, depth, sem, name, "JTYPE_BOOL node: converted is false");
 		}
@@ -477,7 +477,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_null const *item = &(node->item.null);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(22, node, depth, sem, name, "JTYPE_NULL node: converted is false");
 		}
@@ -507,7 +507,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_string *member_name_string;	/* name part of JTYPE_MEMBER as JTYPE_STRING */
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(25, node, depth, sem, name, "JTYPE_MEMBER node: converted is false");
 		}
@@ -551,7 +551,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 		return false;
 	    }
 	    member_name_string = &(member_name->item.string);
-	    if (member_name_string->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(member_name_string)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(31, node, depth, sem, name, "JTYPE_MEMBER name node: converted is false");
 		}
@@ -577,7 +577,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_object const *item = &(node->item.object);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(34, node, depth, sem, name, "JTYPE_OBJECT node: converted is false");
 		}
@@ -612,7 +612,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_array const *item = &(node->item.array);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(38, node, depth, sem, name, "JTYPE_ARRAY node: converted is false");
 		}
@@ -647,7 +647,7 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 	    struct json_elements const *item = &(node->item.elements);
 
 	    /* converted check */
-	    if (item->converted == false) {
+	    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 		if (val_err != NULL) {
 		    *val_err = werr_sem_val(42, node, depth, sem, name, "JTYPE_ELEMENTS node: converted is false");
 		}
@@ -688,354 +688,6 @@ sem_node_valid_converted(struct json const *node, unsigned int depth, struct jso
 
     /*
      * node is converted and a valid JTYPE
-     */
-    return true;
-}
-
-/*
- * sem_node_valid_parsed - determine if a JSON node is a parsed and valid type
- *
- * Given a JSON node, perform sanity checks on the JSON node.
- *
- * Because this call is often made when a function is first given a JSON node,
- * we make a few other JTYPE specific checks such as looking for invalid
- * pointers to NULL.  Where there is an integer length, we check for < 0.
- *
- * For JTYPE_MEMBER, verify that the name is a valid JTYPE_STRING.
- * This valid JTYPE_STRING check is a manual check to avoid potential problems
- * with recursion and loops.
- *
- * given:
- *	node	JSON parse node being checked
- *	depth	depth of node in the JSON parse tree (0 ==> tree root)
- *	sem	JSON semantic node triggering the check
- *	name	name of caller function (NULL ==> "((NULL))")
- *	val_err	pointer to address where to place a JSON semantic validation error,
- *		NULL ==> do not report a JSON semantic validation error
- *
- * returns:
- *	true ==> JSON node is parsed and a valid JTYPE
- *	    The val_err arg is ignored
- *	NULL ==> JSON node is not parsed, invalid node type, or internal error
- *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_count_err)
- */
-bool
-sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_sem *sem,
-		         char const *name, struct json_sem_val_err **val_err)
-{
-    /*
-     * firewall - args
-     */
-    if (sem_chk_null_args(node, depth, sem, name, val_err) == true) {
-	/* sem_chk_null_args() will have set *val_err */
-	return false;
-    }
-
-    /*
-     * validate JSON parse node type and check for not parsed
-     */
-    switch (node->type) {
-    case JTYPE_UNSET:   /* JSON item has not been set - must be the value 0 */
-	if (val_err != NULL) {
-	    *val_err = werr_sem_val(47, node, depth, sem, name, "node is JTYPE_UNSET this type is invalid here");
-	}
-	return false;
-	break;
-
-    case JTYPE_NUMBER:  /* JSON item is number - see struct json_number */
-	{
-	    struct json_number const *item = &(node->item.number);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(48, node, depth, sem, name, "JTYPE_NUMBER node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_NUMBER specific sanity checks */
-	    if (item->as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(49, node, depth, sem, name, "JTYPE_NUMBER node: as_str is NULL");
-		}
-		return false;
-	    }
-	    if (item->first == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(50, node, depth, sem, name, "JTYPE_NUMBER node: first is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_STRING:  /* JSON item is a string - see struct json_string */
-	{
-	    struct json_string const *item = &(node->item.string);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(51, node, depth, sem, name, "JTYPE_STRING node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_STRING specific sanity checks */
-	    if (item->as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(52, node, depth, sem, name, "JTYPE_STRING node: as_str is NULL");
-		}
-		return false;
-	    }
-	    if (item->str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(53, node, depth, sem, name, "JTYPE_STRING node: str is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_BOOL:    /* JSON item is a boolean - see struct json_boolean */
-	{
-	    struct json_boolean const *item = &(node->item.boolean);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(54, node, depth, sem, name, "JTYPE_BOOL node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_BOOL specific sanity checks */
-	    if (item->as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(55, node, depth, sem, name, "JTYPE_BOOL node: as_str is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_NULL:    /* JSON item is a null - see struct json_null */
-	{
-	    struct json_null const *item = &(node->item.null);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(56, node, depth, sem, name, "JTYPE_NULL node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_NULL specific sanity checks */
-	    if (item->as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(57, node, depth, sem, name, "JTYPE_NULL node: as_str is NULL");
-		}
-		return false;
-	    }
-	    if (item->value != NULL) {	/* yes, value must be NULL for a parsed JTYPE_NULL */
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(58, node, depth, sem, name, "JTYPE_NULL node: ironically value is NOT NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_MEMBER:  /* JSON item is a member */
-	{
-	    struct json_member const *item = &(node->item.member);
-	    struct json *member_name = NULL;		/* name part of JTYPE_MEMBER */
-	    struct json_string *member_name_string;	/* name part of JTYPE_MEMBER as JTYPE_STRING */
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(59, node, depth, sem, name, "JTYPE_MEMBER node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_MEMBER specific sanity checks */
-	    if (item->name_as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(60, node, depth, sem, name, "JTYPE_MEMBER node: name_as_str is NULL");
-		}
-		return false;
-	    }
-	    if (item->name_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(61, node, depth, sem, name, "JTYPE_MEMBER node: name_str is NULL");
-		}
-		return false;
-	    }
-	    if (item->name == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(62, node, depth, sem, name, "JTYPE_MEMBER node: name is NULL");
-		}
-		return false;
-	    }
-	    if (item->value == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(63, node, depth, sem, name, "JTYPE_MEMBER node: value is NULL");
-		}
-		return false;
-	    }
-
-	    /* specific checks on name of JTYPE_MEMBER */
-	    member_name = item->name;
-	    if (member_name->type != JTYPE_STRING) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(64, node, depth, sem, name,
-					    "JTYPE_MEMBER name node type: %d <%s> != JTYPE_STRING",
-					    node->type, json_type_name(node->type));
-		}
-		return false;
-	    }
-	    member_name_string = &(member_name->item.string);
-	    if (!member_name_string->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(65, node, depth, sem, name, "JTYPE_MEMBER name node: parsed is false");
-		}
-		return false;
-	    }
-	    if (member_name_string->as_str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(66, node, depth, sem, name, "JTYPE_MEMBER name node as_str is NULL");
-		}
-		return false;
-	    }
-	    if (member_name_string->str == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(67, node, depth, sem, name, "JTYPE_MEMBER name node str is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_OBJECT:  /* JSON item is a { members } */
-	{
-	    struct json_object const *item = &(node->item.object);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(68, node, depth, sem, name, "JTYPE_OBJECT node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_OBJECT specific sanity checks */
-	    if (item->len < 0) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(69, node, depth, sem, name, "JTYPE_OBJECT node: len: %ju < 0",
-					    item->len);
-		}
-		return false;
-	    }
-	    if (item->set == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(70, node, depth, sem, name, "JTYPE_OBJECT node: set is NULL");
-		}
-		return false;
-	    }
-	    if (item->s == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(71, node, depth, sem, name, "JTYPE_OBJECT node: s is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_ARRAY:   /* JSON item is a [ elements ] */
-	{
-	    struct json_array const *item = &(node->item.array);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(72, node, depth, sem, name, "JTYPE_ARRAY node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_ARRAY specific sanity checks */
-	    if (item->len < 0) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(73, node, depth, sem, name, "JTYPE_ARRAY node: len: %ju < 0",
-					    item->len);
-		}
-		return false;
-	    }
-	    if (item->set == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(74, node, depth, sem, name, "JTYPE_ARRAY node: set is NULL");
-		}
-		return false;
-	    }
-	    if (item->s == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(75, node, depth, sem, name, "JTYPE_ARRAY node: s is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    case JTYPE_ELEMENTS:        /* JSON elements is zero or more JSON values */
-	{
-	    struct json_elements const *item = &(node->item.elements);
-
-	    /* parsed check */
-	    if (!item->parsed) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(76, node, depth, sem, name, "JTYPE_ELEMENTS node: parsed is false");
-		}
-		return false;
-	    }
-
-	    /* JTYPE_ELEMENTS specific sanity checks */
-	    if (item->len < 0) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(77, node, depth, sem, name, "JTYPE_ELEMENTS node: len: %ju < 0",
-					    item->len);
-		}
-		return false;
-	    }
-	    if (item->set == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(78, node, depth, sem, name, "JTYPE_ELEMENTS node: set is NULL");
-		}
-		return false;
-	    }
-	    if (item->s == NULL) {
-		if (val_err != NULL) {
-		    *val_err = werr_sem_val(79, node, depth, sem, name, "JTYPE_ARRAY node: s is NULL");
-		}
-		return false;
-	    }
-	}
-	break;
-
-    default:
-	if (val_err != NULL) {
-	    *val_err = werr_sem_val(80, node, depth, sem, name, "node type is unknown: %d <%s>",
-				    node->type, json_type_name(node->type));
-	}
-	return false;
-        break;
-    }
-
-    /*
-     * node is parsed and a valid JTYPE
      */
     return true;
 }
@@ -1081,22 +733,22 @@ sem_member_name(struct json const *node, unsigned int depth, struct json_sem *se
     /*
      * validate JSON parse node type
      */
-    valid = sem_node_valid_converted(node, depth, sem, name, val_err);
+    valid = sem_node_valid(node, depth, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
     if (node->type != JTYPE_MEMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(81, node, depth, sem, name, "node type %s != JTYPE_MEMBER",
+	    *val_err = werr_sem_val(47, node, depth, sem, name, "node type %s != JTYPE_MEMBER",
 				    json_type_name(node->type));
 	}
 	return NULL;
     }
     item = &(node->item.member);
-    if (item->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(82, node, depth, sem, name, "JTYPE_MEMBER node converted is false");
+	    *val_err = werr_sem_val(48, node, depth, sem, name, "JTYPE_MEMBER node converted is false");
 	}
 	return NULL;
     }
@@ -1107,7 +759,7 @@ sem_member_name(struct json const *node, unsigned int depth, struct json_sem *se
     n = item->name;
     if (n == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(83, node, depth, sem, name, "node name is NULL");
+	    *val_err = werr_sem_val(49, node, depth, sem, name, "node name is NULL");
 	}
 	return NULL;
     }
@@ -1115,14 +767,14 @@ sem_member_name(struct json const *node, unsigned int depth, struct json_sem *se
     /*
      * validate JSON parse node name type
      */
-    valid = sem_node_valid_converted(n, depth+1, sem, name, val_err);
+    valid = sem_node_valid(n, depth+1, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
     if (n->type != JTYPE_STRING) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(84, node, depth, sem, name, "node name type %s != JTYPE_STRING",
+	    *val_err = werr_sem_val(50, node, depth, sem, name, "node name type %s != JTYPE_STRING",
 				    json_type_name(n->type));
 	}
 	return NULL;
@@ -1170,22 +822,22 @@ sem_member_value(struct json const *node, unsigned int depth, struct json_sem *s
     /*
      * validate JSON parse node type
      */
-    valid = sem_node_valid_converted(node, depth, sem, name, val_err);
+    valid = sem_node_valid(node, depth, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
     if (node->type != JTYPE_MEMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(85, node, depth, sem, name, "node type %s != JTYPE_MEMBER",
+	    *val_err = werr_sem_val(51, node, depth, sem, name, "node type %s != JTYPE_MEMBER",
 				    json_type_name(node->type));
 	}
 	return NULL;
     }
     item = &(node->item.member);
-    if (item->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(86, node, depth, sem, name, "JTYPE_MEMBER node converted is false");
+	    *val_err = werr_sem_val(52, node, depth, sem, name, "JTYPE_MEMBER node converted is false");
 	}
 	return NULL;
     }
@@ -1196,13 +848,13 @@ sem_member_value(struct json const *node, unsigned int depth, struct json_sem *s
     n = item->value;
     if (n == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(87, node, depth, sem, name, "node name is NULL");
+	    *val_err = werr_sem_val(53, node, depth, sem, name, "node name is NULL");
 	}
 	return NULL;
     }
-    valid = sem_node_valid_converted(n, depth+1, sem, name, val_err);
+    valid = sem_node_valid(n, depth+1, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
     return n;
@@ -1255,15 +907,15 @@ sem_member_name_decoded_str(struct json const *node, unsigned int depth, struct 
      */
     if (n->type != JTYPE_STRING) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(88, node, depth, sem, name, "node name type %s != JTYPE_STRING",
+	    *val_err = werr_sem_val(54, node, depth, sem, name, "node name type %s != JTYPE_STRING",
 				    json_type_name(n->type));
 	}
 	return NULL;
     }
     istr = &(n->item.string);
-    if (istr->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(istr)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(89, node, depth, sem, name, "node name JTYPE_STRING converted is false");
+	    *val_err = werr_sem_val(55, node, depth, sem, name, "node name JTYPE_STRING converted is false");
 	}
 	return NULL;
     }
@@ -1274,7 +926,7 @@ sem_member_name_decoded_str(struct json const *node, unsigned int depth, struct 
     str = istr->str;
     if (str == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(90, node, depth, sem, name, "node name decoded JSON string is NULL");
+	    *val_err = werr_sem_val(56, node, depth, sem, name, "node name decoded JSON string is NULL");
 	}
 	return NULL;
     }
@@ -1332,15 +984,15 @@ sem_member_value_decoded_str(struct json const *node, unsigned int depth, struct
      */
     if (value->type != JTYPE_STRING) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(91, node, depth, sem, name, "node value type %s != JTYPE_STRING",
+	    *val_err = werr_sem_val(57, node, depth, sem, name, "node value type %s != JTYPE_STRING",
 				    json_type_name(value->type));
 	}
 	return NULL;
     }
     istr = &(value->item.string);
-    if (istr->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(istr)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(92, node, depth, sem, name, "node value JTYPE_STRING converted is false");
+	    *val_err = werr_sem_val(58, node, depth, sem, name, "node value JTYPE_STRING converted is false");
 	}
 	return NULL;
     }
@@ -1351,7 +1003,7 @@ sem_member_value_decoded_str(struct json const *node, unsigned int depth, struct
     str = istr->str;
     if (str == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(93, node, depth, sem, name, "node value decoded JSON string is NULL");
+	    *val_err = werr_sem_val(59, node, depth, sem, name, "node value decoded JSON string is NULL");
 	}
 	return NULL;
     }
@@ -1408,15 +1060,15 @@ sem_member_value_bool(struct json const *node, unsigned int depth, struct json_s
      */
     if (value->type != JTYPE_BOOL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(94, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(60, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
 				    json_type_name(value->type));
 	}
 	return NULL;
     }
     ibool = &(value->item.boolean);
-    if (ibool->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(ibool)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(95, node, depth, sem, name, "node value JTYPE_BOOL converted is false");
+	    *val_err = werr_sem_val(61, node, depth, sem, name, "node value JTYPE_BOOL converted is false");
 	}
 	return NULL;
     }
@@ -1503,9 +1155,9 @@ sem_member_value_str_or_null(struct json const *node, unsigned int depth, struct
 	 * firewall - value
 	 */
 	istr = &(value->item.string);
-	if (istr->converted == false) {
+	if (!CONVERTED_PARSED_JSON_NODE(istr)) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(96, node, depth, sem, name, "node value JTYPE_STRING converted is false");
+		*val_err = werr_sem_val(62, node, depth, sem, name, "node value JTYPE_STRING converted is false");
 	    }
 	    return ret;
 	}
@@ -1516,7 +1168,7 @@ sem_member_value_str_or_null(struct json const *node, unsigned int depth, struct
 	ret.str = istr->str;
 	if (ret.str == NULL) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(97, node, depth, sem, name, "node value decoded JSON string is NULL");
+		*val_err = werr_sem_val(63, node, depth, sem, name, "node value decoded JSON string is NULL");
 	    }
 	    return ret;
 	}
@@ -1532,9 +1184,9 @@ sem_member_value_str_or_null(struct json const *node, unsigned int depth, struct
 	 * firewall - value
 	 */
 	inull = &(value->item.null);
-	if (inull->converted == false) {
+	if (!CONVERTED_PARSED_JSON_NODE(inull)) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(98, node, depth, sem, name, "node value JTYPE_NULL converted is false");
+		*val_err = werr_sem_val(64, node, depth, sem, name, "node value JTYPE_NULL converted is false");
 	    }
 	    return ret;
 	}
@@ -1547,7 +1199,7 @@ sem_member_value_str_or_null(struct json const *node, unsigned int depth, struct
      */
     default:
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(99, node, depth, sem, name, "node value type %s != JTYPE_STRING and != JTYPE_NULL",
+	    *val_err = werr_sem_val(65, node, depth, sem, name, "node value type %s != JTYPE_STRING and != JTYPE_NULL",
 				    json_type_name(value->type));
 	}
 	break;
@@ -1607,15 +1259,15 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(100, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(66, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
 				    json_type_name(value->type));
 	}
 	return NULL;
     }
     inum = &(value->item.number);
-    if (inum->converted == false) {
+    if (!VALID_JSON_NODE(inum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(101, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(67, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1625,7 +1277,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
      */
     if (inum->int_sized == false) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(102, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to an int");
+	    *val_err = werr_sem_val(68, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to an int");
 	}
 	return NULL;
     }
@@ -1684,15 +1336,15 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(103, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(69, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
 				    json_type_name(value->type));
 	}
 	return NULL;
     }
     snum = &(value->item.number);
-    if (snum->converted == false) {
+    if (!VALID_JSON_NODE(snum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(104, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(70, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1702,7 +1354,7 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
      */
     if (snum->size_sized == false) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(105, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to a size_t");
+	    *val_err = werr_sem_val(71, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to a size_t");
 	}
 	return NULL;
     }
@@ -1762,15 +1414,15 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(106, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(72, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
 				    json_type_name(value->type));
 	}
 	return NULL;
     }
     inum = &(value->item.number);
-    if (inum->converted == false) {
+    if (!VALID_JSON_NODE(inum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(107, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(73, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1785,13 +1437,13 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
 	 */
 	if (inum->is_negative == true) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(108, node, depth, sem, name, "node negative JTYPE_NUMBER with unsigned time_t");
+		*val_err = werr_sem_val(74, node, depth, sem, name, "node negative JTYPE_NUMBER with unsigned time_t");
 	    }
 	    return NULL;
 	}
 	if (inum->umaxint_sized == false) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(109, node, depth, sem, name, "JTYPE_NUMBER umaxint_sized false with unsigned time_t");
+		*val_err = werr_sem_val(75, node, depth, sem, name, "JTYPE_NUMBER umaxint_sized false with unsigned time_t");
 	    }
 	    return NULL;
 	}
@@ -1804,7 +1456,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
 	 */
 	if (inum->maxint_sized == false) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(110, node, depth, sem, name, "JTYPE_NUMBER maxint_sized false with signed time_t");
+		*val_err = werr_sem_val(76, node, depth, sem, name, "JTYPE_NUMBER maxint_sized false with signed time_t");
 	    }
 	    return NULL;
 	}
@@ -1858,9 +1510,9 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
     /*
      * validate this JSON parse node type
      */
-    valid = sem_node_valid_converted(node, depth, sem, name, val_err);
+    valid = sem_node_valid(node, depth, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
 
@@ -1871,7 +1523,7 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
     if (depth <= 0) {
 	if (parent != NULL) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(111, node, depth, sem, name,
+		*val_err = werr_sem_val(77, node, depth, sem, name,
 					"depth: %d <= 0 with non-NULL parent node pointer", depth);
 	    }
 	}
@@ -1883,7 +1535,7 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
      */
     if (parent == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(112, node, depth, sem, name, "node parent node NULL");
+	    *val_err = werr_sem_val(78, node, depth, sem, name, "node parent node NULL");
 	}
 	return NULL;
     }
@@ -1891,9 +1543,9 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
     /*
      * validate parent JSON parse node type
      */
-    valid = sem_node_valid_converted(parent, depth-1, sem, name, val_err);
+    valid = sem_node_valid(parent, depth-1, sem, name, val_err);
     if (valid == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return NULL;
     }
 
@@ -1944,7 +1596,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
     }
     if (memname == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(113, node, depth, sem, name, "memname is NULL");
+	    *val_err = werr_sem_val(79, node, depth, sem, name, "memname is NULL");
 	}
 	return NULL;
     }
@@ -1954,15 +1606,15 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      */
     if (node->type != JTYPE_OBJECT) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(114, node, depth, sem, name, "node type %s != JTYPE_OBJECT",
+	    *val_err = werr_sem_val(80, node, depth, sem, name, "node type %s != JTYPE_OBJECT",
 				    json_type_name(node->type));
 	}
 	return NULL;
     }
     item = &(node->item.object);
-    if (item->converted == false) {
+    if (!CONVERTED_PARSED_JSON_NODE(item)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(115, node, depth, sem, name, "JTYPE_OBJECT node converted is false");
+	    *val_err = werr_sem_val(81, node, depth, sem, name, "JTYPE_OBJECT node converted is false");
 	}
 	return NULL;
     }
@@ -1972,7 +1624,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      */
     if (item->len < 0) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(116, node, depth, sem, name, "JTYPE_OBJECT set length: %ju < 0", item->len);
+	    *val_err = werr_sem_val(82, node, depth, sem, name, "JTYPE_OBJECT set length: %ju < 0", item->len);
 	}
 	return NULL;
     } else if (item->len == 0) {
@@ -1981,7 +1633,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
     }
     if (item->set == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(117, node, depth, sem, name, "JTYPE_OBJECT len: %ju > 0 and set is NULL", item->len);
+	    *val_err = werr_sem_val(83, node, depth, sem, name, "JTYPE_OBJECT len: %ju > 0 and set is NULL", item->len);
 	}
 	return NULL;
     }
@@ -1998,18 +1650,18 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
 	 */
 	if (s == NULL) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(118, node, depth, sem, name, "JTYPE_OBJECT set[%d] is NULL", i);
+		*val_err = werr_sem_val(84, node, depth, sem, name, "JTYPE_OBJECT set[%d] is NULL", i);
 	    }
 	    return NULL;
 	}
-	valid = sem_node_valid_converted(s, depth+1, sem, name, val_err);
+	valid = sem_node_valid(s, depth+1, sem, name, val_err);
 	if (valid == false) {
-	    /* sem_node_valid_converted() will have set *val_err */
+	    /* sem_node_valid() will have set *val_err */
 	    return NULL;
 	}
 	if (s->type != JTYPE_MEMBER) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(119, node, depth+1, sem, name, "JTYPE_OBJECT set[%d] type: %s != JTYPE_MEMBER",
+		*val_err = werr_sem_val(85, node, depth+1, sem, name, "JTYPE_OBJECT set[%d] type: %s != JTYPE_MEMBER",
 					i, json_type_name(s->type));
 	    }
 	    return NULL;
@@ -2033,7 +1685,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      * no such member
      */
     if (val_err != NULL) {
-	*val_err = werr_sem_val(120, node, depth, sem, name, "JTYPE_OBJECT has no member named: <%s>", memname);
+	*val_err = werr_sem_val(86, node, depth, sem, name, "JTYPE_OBJECT has no member named: <%s>", memname);
     }
     return NULL;
 }
@@ -2056,7 +1708,7 @@ json_sem_zero_count(struct json_sem *sem)
      * firewall - args
      */
     if (sem == NULL) {
-	err(121, __func__, "sem is NULL");
+	err(87, __func__, "sem is NULL");
 	not_reached();
     }
 
@@ -2222,11 +1874,11 @@ json_sem_find(struct json *node, unsigned int depth, struct json_sem *sem)
     type = node->type;
     if (type == JTYPE_MEMBER) {
         /* sem_member_name_decoded_str() call checks args via sem_chk_null_args() */
-	/* sem_member_name_decoded_str() also calls sem_node_valid_converted() */
+	/* sem_member_name_decoded_str() also calls sem_node_valid() */
 	/* determine name of JTYPE_MEMBER or return NULL */
 	name = sem_member_name_decoded_str(node, depth, sem, __func__, NULL);
     } else {
-	test = sem_node_valid_converted(node, depth, sem, __func__, NULL);
+	test = sem_node_valid(node, depth, sem, __func__, NULL);
 	if (test == false) {
 	    warn(__func__, "JSON node is invalid");
 	    return -4;

--- a/jparse/json_sem.h
+++ b/jparse/json_sem.h
@@ -131,9 +131,7 @@ extern struct json_sem_val_err *werrp_sem_val(int val_err, struct json const *no
 	__attribute__((format(printf, 6, 7)));		/* 6=format 7=params */
 extern bool sem_chk_null_args(struct json const *node, unsigned int depth, struct json_sem *sem,
 			      char const *name, struct json_sem_val_err **val_err);
-extern bool sem_node_valid_converted(struct json const *node, unsigned int depth, struct json_sem *sem,
-				     char const *name, struct json_sem_val_err **val_err);
-extern bool sem_node_valid_parsed(struct json const *node, unsigned int depth, struct json_sem *sem,
+extern bool sem_node_valid(struct json const *node, unsigned int depth, struct json_sem *sem,
 				     char const *name, struct json_sem_val_err **val_err);
 extern struct json *sem_member_name(struct json const *node, unsigned int depth, struct json_sem *sem,
 				    char const *name, struct json_sem_val_err **val_err);

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -935,7 +935,7 @@ json_get_type_str(struct json *node, bool encoded)
 	case JTYPE_NUMBER:
 	    {
 		struct json_number *item = &(node->item.number);
-		if (item != NULL && (item->converted || item->parsed)) {
+		if (item != NULL && VALID_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -944,7 +944,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_string *item = &(node->item.string);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = encoded ? item->as_str : item->str;
 		}
 	    }
@@ -953,7 +953,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_boolean *item = &(node->item.boolean);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }
@@ -962,7 +962,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_null *item = &(node->item.null);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = item->as_str;
 		}
 	    }
@@ -971,7 +971,7 @@ json_get_type_str(struct json *node, bool encoded)
 	    {
 		struct json_member *item = &(node->item.member);
 
-		if (item != NULL && (item->converted && item->parsed)) {
+		if (item != NULL && CONVERTED_PARSED_JSON_NODE(item)) {
 		    str = encoded ? item->name_as_str : item->name_str;
 		}
 	    }
@@ -1474,7 +1474,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted number
 	     */
-	    if (item->converted) {
+	    if (CONVERTED_JSON_NODE(item)) {
 
 		/*
 		 * case: converted negative number
@@ -1625,7 +1625,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 
 	    }
 	    /* case: not converted but parsed */
-	    else if (item->parsed) {
+	    else if (PARSED_JSON_NODE(item)) {
 
 		/*
 		 * case: parsed negative number
@@ -1792,14 +1792,14 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: converted should always be equal to parsed
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		/*
 		 * print string preamble
 		 */
 		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
-				item->converted?"c":"",
-				item->parsed?"p":"",
+				CONVERTED_JSON_NODE(item)?"c":"",
+				PARSED_JSON_NODE(item)?"p":"",
 				item->quote ? "q" : "",
 				item->same ? "=" : "",
 				item->has_nul ? "0" : "",
@@ -1815,7 +1815,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: this should never happen
 	     */
-	    } else if (!item->converted && item->parsed) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "string item->converted == false but item->parsed == true");
 		fprstr(stream, "\tparsed true, converted false: will not print data");
 	    /*
@@ -1823,7 +1823,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     *
 	     * NOTE: this should never happen
 	     */
-	    } else if (item->converted && !item->parsed) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "string item->converted == true but item->parsed == false");
 		fprstr(stream, "\tconverted true, parsed false: will not print data");
 	    /*
@@ -1842,7 +1842,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed boolean
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 
@@ -1852,7 +1852,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     * NOTE: this should never happen as if converted == false then
 	     * parsed should also == false. We check explicitly so we can warn.
 	     */
-	    } else if (item->parsed && !item->converted) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "boolean item->converted == false but item->parsed == true");
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 	    /*
@@ -1861,7 +1861,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	     * NOTE: this should never happen as if converted == false then
 	     * parsed should also == false. We check explicitly so we can warn.
 	     */
-	    } else if (!item->parsed && item->converted) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "boolean item->converted == true but item->parsed == false");
 		fprint(stream, "\tvalue: %s", booltostr(item->value));
 
@@ -1880,20 +1880,20 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed null
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprstr(stream, "\tvalue: null");
 
 	    /*
 	     * case: not converted but parsed null
 	     */
-	    } else if (!item->converted && item->parsed) {
+	    } else if (PARSED_JSON_NODE(item)) {
 		warn(__func__, "null item->converted == false but item->parsed == false");
 
 	    /*
 	     * case: converted but not parsed null
 	     */
-	    } else if (item->converted && !item->parsed) {
+	    } else if (CONVERTED_JSON_NODE(item)) {
 		warn(__func__, "null item->converted == false but item->parsed == false");
 	    /*
 	     * case: not converted not parsed null
@@ -1911,7 +1911,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed member
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		/*
 		 * print member name
@@ -1925,12 +1925,12 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 		    if (type == JTYPE_STRING) {
 			struct json_string *item2 = &(item->name->item.string);
 
-			if (item2->converted && item2->parsed) {
+			if (CONVERTED_PARSED_JSON_NODE(item2)) {
 			    fprstr(stream, "\tname: ");
 			    (void) fprint_line_buf(stream, item2->str, item2->str_len, '"', '"');
-			} else if (item2->converted && !item2->parsed) {
+			} else if (CONVERTED_JSON_NODE(item2)) {
 			    warn(__func__, "\tname: converted true but parsed false:");
-			} else if (!item2->converted && item2->parsed) {
+			} else if (PARSED_JSON_NODE(item2)) {
 			    warn(__func__, "\tname: converted false but parsed true:");
 			} else {
 			    fprstr(stream, "\tname {converted,parsed}: false");
@@ -1966,7 +1966,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {
@@ -1991,7 +1991,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {
@@ -2017,7 +2017,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted and parsed object
 	     */
-	    if (item->converted && item->parsed) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		fprint(stream, "\tlen: %ju", item->len);
 		if (item->set == NULL) {

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "14 July 2023" "jparse"
+.TH jparse 3  "15 July 2023" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -27,6 +27,12 @@
 \fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item)->converted || (item)->parsed)\fP
+.br
+\fB#define CONVERTED_PARSED_JSON_NODE(item) ((item)->converted && (item)->parsed)\fP
+.br
+\fB#define CONVERTED_JSON_NODE(item) ((item)->converted && !(item)->parsed)\fP
+.br
+\fB#define PARSED_JSON_NODE(item) ((item)->parsed && !(item)->converted)\fP
 .sp
 .B "extern const char *const json_parser_version;	/* library version format: major.minor YYYY-MM-DD */"
 .br
@@ -190,29 +196,58 @@ struct json
 .fi
 .in
 };
-.SS Checking for a valid JSON node
+.SS Checking for converted and/or parsed JSON nodes
 .PP
-To check if one of the JSON nodes is valid you can use the
-.B VALID_JSON_NODE
-macro, which checks that either the
+Each JSON node struct has two booleans:
 .B converted
-or the
+and
+.B parsed\c
+\&.
+The
+.B converted
+boolean indicates that the item could be converted whereas the
 .B parsed
-boolean is true.
+boolean indicates that the item could be parsed but it might or might not be converted.
+It might be that it could not be converted but is parsable if it is a number string but the number is too big for the C types.
+In this case the JSON can still be valid but the value is not converted.
 This macro is used in the conversion routines and it is an error if both conversion and parsing fails.
-The boolean
-.B parsed
-means it could be parsed as valid JSON and the boolean
-.B converted
-means that it could be converted.
 If
 .B converted
 is true then
 .B parsed
 should be true too.
-It might happen that only
+.PP
+The macro
+.B VALID_JSON_NODE
+checks that either of the JSON node booleans,
+.B converted
+and
+.B parsed\c
+\&, are true.
+.PP
+The macro
+.B CONVERTED_PARSED_JSON_NODE
+checks that the node's
+.B converted
+boolean is true and that the
 .B parsed
-is true if a number is too big for C types.
+boolean is true.
+.PP
+The macro
+.B CONVERTED_JSON_NODE
+checks that the node's
+.B converted
+boolean is true and its
+.B parsed
+boolean is false.
+.PP
+The macro
+.B PARSED_JSON_NODE
+checks that the node's
+.B parsed
+boolean is true and that its
+.B converted
+boolean is false.
 .SS Version strings
 The string
 .BR jparse_version ,

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -259,6 +259,19 @@ chk_test(int testnum, struct json_number *item, struct json_number *test, size_t
     }
 
     /*
+     * test parsed boolean
+     */
+    if (test_result[testnum].parsed != item->parsed) {
+	dbg(DBG_VHIGH, "ERROR: test_result[%d].parsed: %d != item.parsed: %d",
+		       testnum, test_result[testnum].parsed, item->parsed);
+	test_error = true;
+    } else {
+	dbg(DBG_VVHIGH, "test_result[%d].parsed: %d == item.parsed: %d",
+			testnum, test_result[testnum].parsed, item->parsed);
+    }
+
+
+    /*
      * test NULL strings
      */
     if (test_result[testnum].as_str == NULL) {

--- a/soup/chk_validate.c
+++ b/soup/chk_validate.c
@@ -662,9 +662,9 @@ chk_authors(struct json const *node,
     /*
      * firewall - node type
      */
-    test = sem_node_valid_converted(node, depth, sem, __func__, val_err);
+    test = sem_node_valid(node, depth, sem, __func__, val_err);
     if (test == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return false;
     }
     if (node->type != JTYPE_MEMBER) {
@@ -2183,9 +2183,9 @@ chk_manifest(struct json const *node,
     /*
      * firewall - node type
      */
-    test = sem_node_valid_converted(node, depth, sem, __func__, val_err);
+    test = sem_node_valid(node, depth, sem, __func__, val_err);
     if (test == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return false;
     }
     if (node->type != JTYPE_MEMBER) {
@@ -2908,9 +2908,9 @@ chk_tarball(struct json const *node,
     /*
      * firewall - node type
      */
-    test = sem_node_valid_converted(node, depth, sem, __func__, val_err);
+    test = sem_node_valid(node, depth, sem, __func__, val_err);
     if (test == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return false;
     }
     if (node->type != JTYPE_MEMBER) {

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -518,9 +518,9 @@ object2author(struct json *node, unsigned int depth, struct json_sem *sem,
     /*
      * firewall - validate JTYPE_MEMBER item in the JTYPE_ARRAY
      */
-    test = sem_node_valid_converted(node, depth, sem, __func__, val_err);
+    test = sem_node_valid(node, depth, sem, __func__, val_err);
     if (test == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return false;
     }
     if (node->type != JTYPE_OBJECT) {
@@ -559,9 +559,9 @@ object2author(struct json *node, unsigned int depth, struct json_sem *sem,
 	/*
 	 * firewall - validate JTYPE_MEMBER item in the JTYPE_OBJECT
 	 */
-	test = sem_node_valid_converted(e, depth+1, sem, __func__, val_err);
+	test = sem_node_valid(e, depth+1, sem, __func__, val_err);
 	if (test == false) {
-	    /* sem_node_valid_converted() will have set *val_err */
+	    /* sem_node_valid() will have set *val_err */
 	    return false;
 	}
 	if (e->type != JTYPE_MEMBER) {
@@ -1382,9 +1382,9 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
     /*
      * firewall - validate JTYPE_MEMBER item in the JTYPE_ARRAY
      */
-    test = sem_node_valid_converted(node, depth, sem, __func__, val_err);
+    test = sem_node_valid(node, depth, sem, __func__, val_err);
     if (test == false) {
-	/* sem_node_valid_converted() will have set *val_err */
+	/* sem_node_valid() will have set *val_err */
 	return false;
     }
     if (node->type != JTYPE_ARRAY) {
@@ -1438,9 +1438,9 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	/*
 	 * firewall - validate JTYPE_OBJECT item in the JTYPE_ARRAY
 	 */
-	test = sem_node_valid_converted(e, depth+1, sem, __func__, val_err);
+	test = sem_node_valid(e, depth+1, sem, __func__, val_err);
 	if (test == false) {
-	    /* sem_node_valid_converted() will have set *val_err */
+	    /* sem_node_valid() will have set *val_err */
 	    dyn_array_free(man.extra);
 	    return false;
 	}
@@ -1475,9 +1475,9 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 	 * firewall - validate JTYPE_MEMBER item in the JTYPE_OBJECT of the manifest JTYPE_ARRAY
 	 */
 	jo = o->set[0];
-	test = sem_node_valid_converted(jo, depth+2, sem, __func__, val_err);
+	test = sem_node_valid(jo, depth+2, sem, __func__, val_err);
 	if (test == false) {
-	    /* sem_node_valid_converted() will have set *val_err */
+	    /* sem_node_valid() will have set *val_err */
 	    dyn_array_free(man.extra);
 	    return false;
 	}


### PR DESCRIPTION

More use of macros added in commit
1e4240bf00fd3abe7e695c0eb302bd682dae12ea.
 
Renamed sem_node_valid_converted() to sem_node_valid() and update it to
use the macro CONVERTED_PARSED_JSON_NODE (for non-numbers) and 
VALID_JSON_NODE for numbers. For numbers either converted or parsed can
be true: if neither are true it is an error. For other types both 
converted and parsed have to be true.

Unless I am mistaken this commit fully resolves the issue #752. If this
is so I will then update the jparse and json parser version to 1.1.0 but
in case this is not done yet I haven't yet.
