### PR TITLE
Make jparse/json parser version 1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Release 1.0.31 2023-07-15
 
-New JSON parser and jparse version "1.0.12 2023-07-15".
+New JSON parser and jparse version "1.1.0 2023-07-15".
+
+Completely resolve issue #752: 'Enhancement: add parsed boolean to the JSON
+parser'. This involved the below changes.
 
 Add more checks to JSON node `parsed` member so that if converted is false but
 parsed is true it's not an error (in the cases where parsed is allowed to be

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.0.12 2023-07-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.0 2023-07-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.0.12 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.0 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
As the enhancement issue 'add parsed boolean to the JSON parser' is in fact resolved as of commits I made earlier today I have updated the version to 1.1.0 as this is a significant change. This should allow issue #752 to be closed as complete.