### PR TITLE
Add placeholder JSON tools source and header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,14 @@ jparse.tab.c
 jparse.tab.h
 jparse.xml
 jparse/jparse
-jparse/jprint
+jparse/jfmt
+jparse/jnamval
+jparse/jval
 jparse/lex.yy.c
 jparse_test.log
-jprint_test.log
+jfmt_test.log
+jnamval.log
+jval.log
 jsemtblgen
 jstr_test.out
 jstr_test2.out

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,36 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.32 2023-07-16
+
+Add **TEMPORARY PLACEHOLDER** source and header files for `jfmt`, `jval` and
+`jnamval` tools. The key term that is important is _TEMPORARY PLACEHOLDER_. The
+files are actually copies of what were once jprint related but for each tool
+jprint / JPRINT were changed to their new tool counterparts. This is done this
+way because some of the code is common and this way they are in the repo. A lot
+of code will be removed but some will be kept. Much will also be changed. Option
+parsing in particular is useful but this will also have some changes. As it will
+take more work to get them in order I have kept the other things in too for now
+but this **GREATLY** simplifies starting the tools which seems like a worthy
+thing to do.  A very nice way that this simplifies starting the tools is that
+the parsing of the JSON file is already done. Along with this some of the
+options being the same and some of the structs being the same (though they will
+have to be modified and some will be removed) it will help get started.
+
+Respective test scripts for each tool have also been added which are also
+updated copies of the old script for jprint. These are not run yet because there
+is no point in running them yet and it would only slow down make test.
+
+With the exception of the scripts the required changes will be done soon -
+hopefully sometime in the coming week (real weeks start on Monday) - but what
+this means is that **TEMPORARILY** the tools function as the incomplete no
+longer useful jprint. By required changes I mean that the unnecessary code will
+be removed and option parsing / usage strings will be updated (whether the
+option parsing is completed in the next week is indeterminate).
+
+Updated `jparse/Makefile` and run make depend.
+
+Update .gitignore: fixed references of `jprint` and add the other tools.
+
 ## Release 1.0.31 2023-07-15
 
 New JSON parser and jparse version "1.1.0 2023-07-15".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ make use of appropriate macro: for numbers it uses the `VALID_JSON_NODE` and or
 others it uses `CONVERTED_PARSED_JSON_NODE` as both `converted` and `parsed`
 must be true for non-number nodes.
 
+Fixes in `json_util_README.md` up through the beginning of `jnamval`. The rest
+of the document and a more thorough check of that which has been checked will
+come later.
 
 ## Release 1.0.30 2023-07-14
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -164,9 +164,11 @@ CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${LDFLAGS}
 # source files that are permanent (not made, nor removed)
 #
 C_SRC= jparse_main.c json_parse.c json_sem.c json_util.c \
-       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c
+       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c jfmt.c jfmt_util.c \
+       jfmt_test.c jval.c jval_util.c jval_test.c jnamval.c jnamval_util.c jnamval_test.c
 H_SRC= jparse.h jparse_main.h jsemtblgen.h json_parse.h json_sem.h json_util.h \
-       jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h \
+       jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h jfmt.h jfmt_util.h \
+       jfmt_test.h jval.h jval_util.h jval_test.h jnamval.h jnamval_util.h jnamval_test.h \
        jparse.tab.ref.h
 
 # source files that do not conform to strict picky standards
@@ -351,7 +353,7 @@ SH_TARGETS=
 
 # program targets to make by all, installed by install, and removed by clobber
 #
-PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode
+PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode jfmt jval jnamval
 
 # include files NOT to removed by clobber
 #
@@ -441,6 +443,44 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 
 jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
+
+jfmt_test.o: jfmt_test.c jfmt_test.h jfmt_test.h json_util.h json_util.c
+	${CC} ${CFLAGS} jfmt_test.c -c
+
+jfmt_util.o: jfmt.c jfmt_util.h jfmt.h json_util.h json_util.c
+	${CC} ${CFLAGS} jfmt_util.c -c
+
+jfmt.o: jfmt.c jfmt.h jfmt_util.h jfmt_test.h json_util.h json_util.c
+	${CC} ${CFLAGS} jfmt.c -c
+
+jfmt: jfmt.o jfmt_util.o jfmt_test.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+	${CC} ${CFLAGS} $^ -lm -o $@
+
+jval_test.o: jval_test.c jval_test.h jval_test.h json_util.h json_util.c
+	${CC} ${CFLAGS} jval_test.c -c
+
+jval_util.o: jval_util.c jval_util.h jval_util.h json_util.h json_util.c
+	${CC} ${CFLAGS} jval_util.c -c
+
+jval.o: jval.c jval.h json_util.h jval_test.h json_util.c
+	${CC} ${CFLAGS} jval.c -c
+
+jval: jval.o jval_util.o jval_test.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+	${CC} ${CFLAGS} $^ -lm -o $@
+
+jnamval_test.o: jnamval_test.c jnamval_test.h jnamval_test.h json_util.h json_util.c
+	${CC} ${CFLAGS} jnamval_test.c -c
+
+jnamval_util.o: jnamval_util.c jnamval_util.h jnamval_util.h json_util.h json_util.c
+	${CC} ${CFLAGS} jnamval_util.c -c
+
+jnamval.o: jnamval.c jnamval.h json_util.h jnamval_test.h json_util.c
+	${CC} ${CFLAGS} jnamval.c -c
+
+jnamval: jnamval.o jnamval_util.o jnamval_test.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+	${CC} ${CFLAGS} $^ -lm -o $@
+
+
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -927,6 +967,23 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
+jfmt.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jfmt.c jfmt.h jfmt_test.h \
+    jfmt_util.h jparse.h jparse.tab.h json_parse.h json_sem.h json_util.h \
+    util.h
+jfmt_test.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jfmt_test.c jfmt_test.h \
+    jfmt_util.h jparse.h jparse.tab.h json_parse.h json_sem.h json_util.h \
+    util.h
+jfmt_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jfmt_util.c jfmt_util.h \
+    jparse.h jparse.tab.h json_parse.h json_sem.h json_util.h util.h
+jnamval.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jnamval.c jnamval.h \
+    jnamval_test.h jnamval_util.h jparse.h jparse.tab.h json_parse.h \
+    json_sem.h json_util.h util.h
+jnamval_test.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jnamval_test.c \
+    jnamval_test.h jnamval_util.h jparse.h jparse.tab.h json_parse.h \
+    json_sem.h json_util.h util.h
+jnamval_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jnamval_util.c \
+    jnamval_util.h jparse.h jparse.tab.h json_parse.h json_sem.h \
+    json_util.h util.h
 jparse.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.c jparse.h \
     jparse.tab.h json_parse.h json_sem.h json_util.h util.h
 jparse.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.ref.c \
@@ -951,5 +1008,13 @@ jstrdecode.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h \
     jstrdecode.c jstrdecode.h util.h
 jstrencode.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h \
     jstrencode.c jstrencode.h util.h
+jval.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
+    json_parse.h json_sem.h json_util.h jval.c jval.h jval_test.h \
+    jval_util.h util.h
+jval_test.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
+    json_parse.h json_sem.h json_util.h jval_test.c jval_test.h jval_util.h \
+    util.h
+jval_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
+    json_parse.h json_sem.h json_util.h jval_util.c jval_util.h util.h
 util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h util.c util.h
 verge.o: ../dbg/dbg.h ../dyn_array/dyn_array.h util.h verge.c verge.h

--- a/jparse/jfmt.c
+++ b/jparse/jfmt.c
@@ -1,0 +1,804 @@
+/*
+ * jfmt - JSON printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jfmt.h"
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+/*
+ * static globals
+ */
+static bool quiet = false;				/* true ==> quiet mode */
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the usage_msg([0-9]?)+ strings.
+ */
+static const char * const usage_msg0 =
+    "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
+    "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
+    "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type]\n"
+    "\t\t[-o] [-r] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\n"
+    "\t-h\t\tPrint help and exit\n"
+    "\t-V\t\tPrint version and exit\n"
+    "\t-v level\tVerbosity level (def: %d)\n"
+    "\t-J level\tJSON verbosity level (def: %d)\n"
+    "\n"
+    "\t-e\t\tPrint JSON strings as encoded strings (def: decode JSON strings)\n"
+    "\t-q\t\tQuiet mode (def: print stuff to stdout)\n"
+    "\t-Q\t\tPrint JSON strings surrounded by double quotes (def: do not)\n"
+    "\t-t type\t\tMatch only one of the these comma-separated types (def: simple):\n"
+    "\n"
+    "\t\t\t\tint\t\tinteger values\n"
+    "\t\t\t\tfloat\t\tfloating point values\n"
+    "\t\t\t\texp\t\texponential notation values\n"
+    "\t\t\t\tnum\t\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\t\tboolean values\n"
+    "\t\t\t\tstr\t\tstring values\n"
+    "\t\t\t\tnull\t\tnull values\n"
+    "\t\t\t\tsimple\t\talias for 'int,float,exp,bool,str,null' (the default)\n"
+    "\t\t\t\tmember\t\tJSON members\n"
+    "\t\t\t\tobject\t\tJSON objects\n"
+    "\t\t\t\tarray\t\tJSON arrays\n"
+    "\t\t\t\tcompound\talias for 'object,array'\n"
+    "\t\t\t\tany\t\tany type of value\n"
+    "\n"
+    "\t\t\tMatches are based on JSON names unless -Y is used in which case JSON values are matched.\n";
+
+static const char * const usage_msg1 =
+    "\t-l lvl\t\tPrint values at specific JSON levels (def: print any level)\n"
+    "\n"
+    "\t\t\tIf lvl is a number (e.g.: -l 3), level must == number.\n"
+    "\t\t\tIf lvl is a number followed by : (e.g. '-l 3:'), level must be >= number.\n"
+    "\t\t\tIf lvl is a : followed by a number (e.g. '-l :3'), level must be <= number.\n"
+    "\t\t\tIf lvl is num:num (e.g. '-l 3:5'), level must be inclusively in the range.\n"
+    "\n"
+    "\t-n count\tPrint up to count matches (def: print all matches)\n"
+    "\n"
+    "\t\t\tIf count is a number (e.g. '-n 3'), the matches must == number\n"
+    "\t\t\tIf count is a number followed by : (e.g. '-n 3:'), matches must be >= number.\n"
+    "\t\t\tIf count is a : followed by a number (e.g. '-n :3'), matches must be <= number.\n"
+    "\t\t\tIf count is num:num (e.g. '-n 3:5'), matches must be inclusively in the range.\n"
+    "\t\t\tA number < 0 refers printing from last match (e.g. '-n -1' will print last match).\n"
+    "\n"
+    "\t-N num\t\tPrint only if there are only a given number of matches (def: do not limit)\n"
+    "\n"
+    "\t\t\tIf num is only a number (e.g. '-l 1'), there must be only that many matches.\n"
+    "\t\t\tIf num is a number followed by : (e.g. '-l 3:'), there must >= num matches.\n"
+    "\t\t\tIf num is a : followed by a number (e.g. '-n :3'), there must <= num matches.\n"
+    "\t\t\tIf num is num:num (e.g. '-n 3:5'), the number of matches must be inclusively in the range.\n"
+    "\n"
+    "\t-p {n,v,b}\tPrint JSON key, value or both (def: print JSON values or JSON names if -Y is used)\n"
+    "\t-p name\t\tAlias for '-p n'\n"
+    "\t-p value\tAlias for '-p v'\n"
+    "\t-p both\t\tAlias for '-p n,v'\n"
+    "\n"
+    "\t\t\tIt is an error to use -p n or -p v with -j.\n"
+    "\n"
+    "\t-b <num>[{t|s}]\tPrint specified number of tabs or spaces between JSON tokens printed via -j (def: 1 space)\n"
+    "\t-b tab\t\tAlias for '-b 1t'\n"
+    "\n"
+    "\t\t\tNot specifying a character after the number implies spaces.\n"
+    "\t\t\tThis option is only useful with -j or -p b or -p both.\n"
+    "\t\t\tIt is an error to use -b without -p b or -p both.\n"
+    "\n"
+    "\t-L <num>[{t|s}]\tPrint JSON level (root is 0) followed by a number of tabs or spaces (def: don't print levels)\n"
+    "\t-L tab\t\tAlias for: '-L 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n";
+
+static const char * const usage_msg2 =
+    "\t-P\t\tWhen printing both i.e. '-p both', separate name/value by a : (colon) (def: do not)\n"
+    "\n"
+    "\t\t\tWhen -P is used with -b, the same whitespace is used round the : (colon).\n"
+    "\n"
+    "\t-C\t\tWhen printing JSON syntax, always print a comma after final line (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -C without -j has no effect.\n"
+    "\n"
+    "\t-B\t\tWhen printing JSON syntax, start with a '{' line and end with a '}' line.\n"
+    "\n"
+    "\t\t\tUse of -B without -j has no effect.\n"
+    "\t\t\tUse of both -B and -c is an error.\n"
+    "\n"
+    "\t-I <num>{[t|s]}\tWhen printing JSON syntax, indent levels (def: do not indent)\n"
+    "\t-I tab\t\tAlias for '-I 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies indent with number of tabs whereas trailing 's' implies spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n"
+    "\n"
+    "\t-j\t\tPrint using JSON syntax (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -j implies '-p both -b 1s -e -Q -I 4 -t any'.\n"
+    "\t\t\tSubsequent use of options after -j will change the effect of -j.\n"
+    "\t\t\tUse of both -p and -j is an error.\n"
+    "\n"
+    "\t-E\t\tMatch the JSON encoded name (def: match the JSON decoded name)\n"
+    "\t-i\t\tIgnore case of name (def: case matters)\n"
+    "\t-s\t\tSubstrings are used to match (def: the full name must match)\n"
+    "\t-g\t\tMatch using grep-like extended regular expressions (def: match strings or substrings if -s)\n"
+    "\n"
+    "\t\t\tTo match from the beginning, start name_arg with '^'.\n"
+    "\t\t\tTo match to the end, end name_arg with '$'.\n"
+    "\t\t\tUse of -g and -s is an error.\n"
+    "\n"
+    "\t-c\t\tOnly show count of matches found\n"
+    "\n"
+    "\t\t\tUse of -c with -B, -L, -j, or -I is an error.\n"
+    "\n"
+    "\t-m max_depth\tSet the maximum JSON level depth to max_depth (0 == infinite depth, def: %d)\n"
+    "\n"
+    "\t\t\tA 0 max_depth implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n"
+    "\n"
+    "\t-K\t\tRun tests on jfmt constraints\n";
+
+static const char * const usage_msg3 =
+    "\t-Y type\t\tSearch for a JSON value of a given comma-separated type (def: search for JSON names)\n"
+    "\n"
+    "\t\t\t\tint\tinteger values\n"
+    "\t\t\t\tfloat\tfloating point values\n"
+    "\t\t\t\texp\texponential notation values\n"
+    "\t\t\t\tnum\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\tboolean values\n"
+    "\t\t\t\tstr\tstring values\n"
+    "\t\t\t\tnull\tnull values\n"
+    "\t\t\t\tsimple\talias for 'int,float,exp,bool,str,null'\n"
+    "\n"
+    "\t\t\tUse of -Y requires one and only one name_arg.\n"
+    "\t\t\tUse of -Y changes the default from -p value to -p name.\n"
+    "\n"
+    "\t-o\t\tSearch by OR mode like grep -E 'foo|bar' (def: don't)\n"
+    "\t-r\t\tSearch under anywhere (def: don't)\n"
+    "\n"
+    "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
+    "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
+    "\n"
+    "\t\t\tUse of -A requires use of -S.\n";
+
+/*
+ * NOTE: this next one should be the last number; if any additional usage message strings
+ * have to be added the first additional one should be the number this is and this one
+ * should be changed to be the final string before this one + 1. Similarly if a
+ * string can be removed this one should have its number changed to be + 1 from
+ * the last one before it.
+ */
+static const char * const usage_msg4 =
+    "\tfile.json\tJSON file to parse (- ==> read from stdin)\n"
+    "\tname_arg\tsearch file.json for JSON name(s) (or one value if -Y) (def: match all)\n"
+    "\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n"
+    "    7\tJSON check tool failed\n"
+    " >=10\tinternal error\n"
+    "\n"
+    "JSON parser version: %s\n"
+    "jfmt version: %s";
+
+/*
+ * functions
+ */
+static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
+
+/*
+ * usage - print usage to stderr
+ *
+ * Example:
+ *      usage(3, program, "wrong number of arguments");;
+ *
+ * given:
+ *	exitcode        value to exit with
+ *	str		top level usage message
+ *	prog		our program name
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *       Normally one should NOT include newlines in warn messages.
+ *
+ * This function does not return.
+ */
+static void
+usage(int exitcode, char const *prog, char const *str)
+{
+    /*
+     * firewall
+     */
+    if (prog == NULL) {
+	prog = "((NULL prog))";
+	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
+    }
+    if (str == NULL) {
+	str = "((NULL str))";
+	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
+    }
+
+    /*
+     * print the formatted usage stream
+     */
+    if (*str != '\0') {
+	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
+    }
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg0, prog, DBG_DEFAULT, JSON_DBG_DEFAULT);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg1);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg2, JSON_DEFAULT_MAX_DEPTH);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg3);
+    fprintf_usage(exitcode, stderr, usage_msg4, json_parser_version, JFMT_VERSION);
+    exit(exitcode); /*ooo*/
+    not_reached();
+}
+
+
+int
+main(int argc, char **argv)
+{
+    char const *program = NULL;		/* our name */
+    extern char *optarg;
+    extern int optind;
+    struct jfmt *jfmt = NULL;	/* struct of all our options and other things */
+    struct jfmt_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
+    size_t len = 0;			/* length of file contents */
+    bool is_valid = false;		/* if file is valid json */
+    int exit_code = 0;			/* for the end */
+    int i;
+
+    jfmt = alloc_jfmt();		/* allocate our struct jfmt * */
+    /*
+     * the alloc_jfmt() will never return a NULL pointer but check just in
+     * case
+     */
+    if (jfmt == NULL) {
+	err(23, "jfmt", "failed to allocate jfmt struct");
+	not_reached();
+    }
+
+    /*
+     * parse args
+     */
+    program = argv[0];
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEim:cg:KY:sorS:A:")) != -1) {
+	switch (i) {
+	case 'h':		/* -h - print help to stderr and exit 0 */
+	    free_jfmt(&jfmt);
+	    usage(2, program, "");	/*ooo*/
+	    not_reached();
+	    break;
+	case 'V':		/* -V - print version and exit */
+	    free_jfmt(&jfmt);
+	    print("%s\n", JFMT_VERSION);
+	    exit(2);		/*ooo*/
+	    not_reached();
+	    break;
+	case 'v':		/* -v verbosity */
+	    /*
+	     * parse verbosity
+	     */
+	    verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'J':		/* -J json_verbosity */
+	    /*
+	     * parse JSON verbosity level
+	     */
+	    json_verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'l':
+	    jfmt->levels_constrained = true;
+	    jfmt_parse_number_range("-l", optarg, false, &jfmt->jfmt_levels);
+	    break;
+	case 'e':
+	    jfmt->encode_strings = true;
+	    dbg(DBG_LOW, "-e specified, will encode strings");
+	    break;
+	case 'Q':
+	    jfmt->quote_strings = true;
+	    dbg(DBG_LOW, "-Q specified, will quote strings");
+	    break;
+	case 't':
+	    jfmt->json_types_specified = true;
+	    jfmt->json_types = jfmt_parse_types_option(optarg);
+	    break;
+	case 'n':
+	    jfmt_parse_number_range("-n", optarg, true, &jfmt->jfmt_max_matches);
+	    jfmt->max_matches_requested = true;
+	    break;
+	case 'N':
+	    jfmt_parse_number_range("-N", optarg, false, &jfmt->jfmt_min_matches);
+	    jfmt->min_matches_requested = true;
+	    break;
+	case 'p':
+	    jfmt->print_json_types_option = true;
+	    jfmt->print_json_types = jfmt_parse_print_option(optarg);
+	    break;
+	case 'b':
+	    jfmt->print_token_spaces = true;
+	    jfmt_parse_st_tokens_option(optarg, &jfmt->num_token_spaces, &jfmt->print_token_tab);
+	    break;
+	case 'L':
+	    jfmt->print_json_levels = true; /* print JSON levels */
+	    jfmt_parse_st_level_option(optarg, &jfmt->num_level_spaces, &jfmt->print_level_tab);
+	    break;
+	case 'P':
+	    jfmt->print_colons = true;
+	    dbg(DBG_LOW, "-P specified, will print colons");
+	    break;
+	case 'C':
+	    jfmt->print_final_comma = true;
+	    dbg(DBG_LOW, "-C specified, will print final comma");
+	    break;
+	case 'B':
+	    jfmt->print_braces = true;
+	    dbg(DBG_LOW, "-B specified, will print braces");
+	    break;
+	case 'I':
+	    jfmt->indent_levels = true;
+	    jfmt_parse_st_indent_option(optarg, &jfmt->indent_spaces, &jfmt->indent_tab);
+	    break;
+	case 'i':
+	    jfmt->ignore_case = true; /* make case cruel :-) */
+	    dbg(DBG_LOW, "-i specified, making matches case-insensitive");
+	    break;
+	case 'j':
+	    jfmt->print_syntax = true;
+	    dbg(DBG_LOW, "-j, implying -p both");
+	    jfmt->print_json_types = jfmt_parse_print_option("both");
+	    dbg(DBG_LOW, "-j, implying -b 1");
+	    jfmt_parse_st_tokens_option("1", &jfmt->num_token_spaces, &jfmt->print_token_tab);
+	    dbg(DBG_LOW, "-j, implying -e -Q");
+	    jfmt->encode_strings = true;
+	    jfmt->quote_strings = true;
+	    dbg(DBG_LOW, "-j, implying -t any");
+	    /* don't set jfmt->json_types_specified as that's for explicit use of -t */
+	    jfmt->json_types = jfmt_parse_types_option("any");
+	    break;
+	case 'E':
+	    jfmt->match_encoded = true;
+	    dbg(DBG_LOW, "-E specified, will match encoded strings, not decoded strings");
+	    break;
+	case 's':
+	    jfmt->use_substrings = true;
+	    dbg(DBG_LOW, "-s specified, will match substrings");
+	    break;
+	case 'g':   /* allow grep-like ERE */
+	    jfmt->use_regexps = true;
+	    dbg(DBG_LOW, "-g specified, name_args will be regexps");
+	    break;
+	case 'c':
+	    jfmt->count_only = true;
+	    dbg(DBG_LOW, "-c specified, will only show count of matches");
+	    break;
+	case 'q':
+	    quiet = true;
+	    msg_warn_silent = true;
+	    break;
+	case 'm': /* set maximum depth to traverse json tree */
+	    if (!string_to_uintmax(optarg, &jfmt->max_depth)) {
+		free_jfmt(&jfmt);
+		err(3, "jfmt", "couldn't parse -m depth"); /*ooo*/
+		not_reached();
+	    }
+	    break;
+	case 'K': /* run test code */
+	    if (!jfmt_run_tests()) {
+		free_jfmt(&jfmt);
+		exit(6); /*ooo*/
+	    }
+	    else {
+		free_jfmt(&jfmt);
+		exit(0); /*ooo*/
+	    }
+	    break;
+	case 'Y':
+	    /*
+	     * Why is this option -Y? Why not Y? Because Y, that's why Y! Why
+	     * besides, all the other good options were already taken. :-)
+	     * Specifically the letter Y has a V in it and V would have been the
+	     * obvious choice but both v and V are taken. This is why you'll
+	     * have to believe us when we tell you that this is a good enough
+	     * reason why Y! :-)
+	     */
+	    jfmt->search_value = true;
+	    jfmt->json_types = jfmt_parse_value_type_option(optarg);
+	    break;
+	case 'o': /* search with OR mode */
+	    jfmt->search_or_mode = true;
+	    break;
+	case 'r': /* search under anywhere */
+	    jfmt->search_anywhere = true;  /* Why is -o before -r? To spell out OR when -o itself is OR! :-) */
+	    break;
+	case 'S':
+	    /* -S path to tool */
+	    jfmt->check_tool_specified = true;
+	    jfmt->check_tool_path = optarg;
+	    dbg(DBG_LOW, "set tool path to: '%s'", jfmt->check_tool_path);
+	    break;
+	case 'A':
+	    /*
+	     * -A args to tool. Requires use of -S. */
+	    jfmt->check_tool_args = optarg;
+	    dbg(DBG_LOW, "set tool args to: '%s'", jfmt->check_tool_args);
+	    break;
+	case ':':   /* option requires an argument */
+	case '?':   /* illegal option */
+	default:    /* anything else but should not actually happen */
+	    check_invalid_option(program, i, optopt);
+	    usage(3, program, ""); /*ooo*/
+	    not_reached();
+	    break;
+	}
+    }
+
+
+    /*
+     * check for conflicting options prior to changing argc and argv so that the
+     * user will know to correct the options before being told that they have
+     * the wrong number of arguments (if they do). Not everything can be checked
+     * prior to doing this though.
+     */
+
+    /* run specific sanity checks on options etc. */
+    jfmt->json_file = jfmt_sanity_chks(jfmt, program, &argc, &argv);
+
+
+    /*
+     * jfmt_sanity_chks() should never return a NULL FILE * but we check
+     * anyway
+     */
+    if (jfmt->json_file == NULL) {
+	/*
+	 * NOTE: don't make this exit code 3 as it's an internal error if the
+	 * jfmt_sanity_chks() returns a NULL pointer.
+	 */
+	err(24, "jfmt", "could not open regular readable file");
+	not_reached();
+    }
+
+    /* Before we can process the -S option, if it specified (which we know is
+     * sane), we have to read in the JSON file (either stdin or otherwise) and
+     * then verify that the JSON is valid.
+     *
+     * Read in entire file BEFORE trying to parse it as json as the parser
+     * function will close the file if not stdin.
+     *
+     * NOTE: why doesn't the jfmt_sanity_chks() function do this? Because this
+     * is not so much about a sane environment as much as being unable to
+     * continue after verify the command line is correct.
+     */
+    jfmt->file_contents = read_all(jfmt->json_file, &len);
+    if (jfmt->file_contents == NULL) {
+	err(4, "jfmt", "could not read in file: %s", argv[0]); /*ooo*/
+	not_reached();
+    }
+    /* clear EOF status and rewind for parse_json_stream() */
+    clearerr(jfmt->json_file);
+    rewind(jfmt->json_file);
+
+    /* run -S tool */
+    run_jfmt_check_tool(jfmt, argv);
+
+    jfmt->json_tree = parse_json_stream(jfmt->json_file, argv[0], &is_valid);
+    if (!is_valid || jfmt->json_tree == NULL) {
+	if (jfmt->json_file != stdin) {
+	    fclose(jfmt->json_file);  /* close file prior to exiting */
+	    jfmt->json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
+	}
+
+	/* free our jfmt struct */
+	free_jfmt(&jfmt);
+	err(5, "jfmt", "%s invalid JSON", argv[0]); /*ooo*/
+	not_reached();
+    }
+
+    dbg(DBG_MED, "valid JSON");
+
+
+    /* search for any patterns */
+    jfmt_json_tree_search(jfmt, jfmt->json_tree, jfmt->max_depth);
+
+    /* report, if debug level high enough, what will be searched for. */
+    if (jfmt->patterns != NULL && !jfmt->print_entire_file) {
+	for (pattern = jfmt->patterns; pattern != NULL; pattern = pattern->next) {
+	    if (pattern->pattern != NULL && *pattern->pattern) {
+
+		if (pattern->use_regexp) {
+		    dbg(DBG_LOW, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
+		} else {
+		    dbg(DBG_LOW, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
+			pattern->use_substrings?"OK":"ignored");
+		}
+	    }
+	}
+    }
+
+    /*
+     * we can't have this in the sanity checks function very easily as we don't
+     * want to read in the entire contents from that function
+     *
+     * XXX - printing the entire file is incorrect here as it needs to print it
+     * according to the options - XXX
+     */
+    if (!jfmt->print_entire_file || jfmt->count_only) {
+	jfmt_print_matches(jfmt);
+    } else if (jfmt->file_contents != NULL) {
+	dbg(DBG_MED, "no pattern requested and no -c, will print entire file");
+	fpr(stdout, "jfmt", "%s", jfmt->file_contents);
+    }
+
+    /* free tree */
+    json_tree_free(jfmt->json_tree, jfmt->max_depth);
+
+    /* All Done!!! -- Jessica Noll, Age 2 */
+    if (jfmt->match_found || !jfmt->pattern_specified || jfmt->print_entire_file) {
+	exit_code = 0;
+    } else {
+	exit_code = 1;
+    }
+    if (jfmt != NULL) {
+	free_jfmt(&jfmt);	/* free jfmt struct */
+    }
+
+    exit(exit_code); /*ooo*/
+}
+
+/* jfmt_sanity_chks	- sanity checks on jfmt tool options
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our jfmt struct
+ *	program	    - program name
+ *	argc	    - pointer to argc from main()
+ *	argv	    - pointer to argv from main()
+ *
+ * This function runs any important checks on the jfmt internal state. It also
+ * runs checks that a file arg is specified and that the right number of options
+ * are specified done after options are parsed.
+ *
+ * If passed a NULL pointer or anything is not sane this function will not
+ * return.
+ *
+ * This function returns a FILE *, the file to read the json from. It will not
+ * return if this cannot be done (i.e. it will never return a NULL pointer
+ * though main() still checks to be defensive).
+ *
+ * NOTE: this function does NOT check for valid JSON.
+ *
+ * NOTE: jfmt->check_tool_path and jfmt->check_tool_args can be NULL.
+ *
+ * NOTE: this function must be in jfmt.c, not jfmt_util.h, because it uses
+ * the usage() function which needs to be in this file.
+ */
+FILE *
+jfmt_sanity_chks(struct jfmt *jfmt, char const *program, int *argc, char ***argv)
+{
+    /* firewall */
+    if (jfmt == NULL) {
+	err(25, __func__, "NULL jfmt");
+	not_reached();
+    } else if (argc == NULL) {
+	err(26, __func__, "NULL argc");
+	not_reached();
+    } else if (argv == NULL || *argv == NULL || **argv == NULL) {
+	err(27, __func__, "NULL argv");
+	not_reached();
+    } else if (program == NULL) {
+	err(28, __func__, "NULL program");
+	not_reached();
+    }
+
+    /*
+     * first check for invalid option combinations which if any found it is a
+     * command line error.
+     */
+
+    /* use of -g conflicts with -s and is an error. */
+    if (jfmt->use_regexps && jfmt->use_substrings) {
+	free_jfmt(&jfmt);
+	err(3, __func__, "cannot use both -g and -s"); /*ooo*/
+	not_reached();
+    }
+
+    /* check that if -b [num]t is used then -p both is true */
+    if (jfmt->print_token_tab && !jfmt_print_name_value(jfmt->print_json_types)) {
+	free_jfmt(&jfmt);
+	err(3, "jparse", "use of -b [num]t cannot be used without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * check that if -j was used that printing both name and value is used. -j
+     * does this but it's possible the user explicitly used -p after -j but if
+     * they did not specify 'b' or 'both' it is an error.
+     */
+    if (jfmt->print_syntax && !jfmt_print_name_value(jfmt->print_json_types)) {
+	free_jfmt(&jfmt);
+	err(3, "jparse", "cannot use -j without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+
+    /* use of -c with any of any of -B, -L, -j and -I is an error */
+    if (jfmt->count_only) {
+	if (jfmt->print_braces) {
+	    err(3, __func__, "cannot use -B and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jfmt->print_json_levels) {
+	    err(3, __func__, "cannot use -L and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jfmt->print_syntax) {
+	    err(3, __func__, "cannot use -j and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jfmt->indent_levels) {
+	    err(3, __func__, "cannot use -I and -c together"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * shift argc and argv for further processing. They're a pointer to those in
+     * main() so we have to dereference them here because main() also requires
+     * that they are shifted.
+     */
+    (*argc) -= optind;
+    (*argv) += optind;
+
+    /* must have at least one arg */
+    if ((*argv)[0] == NULL) {
+	usage(3, program, "wrong number of arguments"); /*ooo*/
+	not_reached();
+    }
+
+    /* if argv[0] != "-" we will attempt to open a regular readable file */
+    if (strcmp((*argv)[0], "-") != 0) {
+        /* check that the path exists and is a regular readable file */
+	if (!exists((*argv)[0])) {
+	    free_jfmt(&jfmt);
+	    err(4, __func__, "%s: file does not exist", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_file((*argv)[0])) {
+	    free_jfmt(&jfmt);
+	    err(4, __func__, "%s: not a regular file", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_read((*argv)[0])) {
+	    free_jfmt(&jfmt);
+	    err(4, __func__, "%s: unreadable file", (*argv[0])); /*ooo*/
+	    not_reached();
+	}
+
+	errno = 0; /* pre-clear errno for errp() */
+	jfmt->json_file = fopen((*argv)[0], "r");
+	if (jfmt->json_file == NULL) {
+	    free_jfmt(&jfmt);
+	    errp(4, __func__, "%s: could not open for reading", (*argv)[0]); /*ooo*/
+	    not_reached();
+	}
+    } else { /* argv[0] is "-": will read from stdin */
+	jfmt->is_stdin = true;
+	jfmt->json_file = stdin;
+    }
+
+    dbg(DBG_LOW, "maximum depth to traverse: %ju%s", jfmt->max_depth, (jfmt->max_depth == 0?" (no limit)":
+		jfmt->max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
+
+    if (jfmt->search_value && *argc != 2 && jfmt->number_of_patterns != 1) {
+	free_jfmt(&jfmt);
+	err(29, __func__, "-Y requires exactly one name_arg");
+	not_reached();
+    } else if (!jfmt->search_value && (*argv)[1] == NULL && !jfmt->count_only) {
+	jfmt->print_entire_file = true;   /* technically this boolean is redundant */
+    }
+
+
+    /*
+     * if -S specified then we need to verify that the tool is a regular
+     * executable file
+     */
+    if (jfmt->check_tool_path != NULL) {
+	if (!exists(jfmt->check_tool_path)) {
+	    err(3, __func__, "jfmt tool path does not exist: %s", jfmt->check_tool_path);/*ooo*/
+	    not_reached();
+	} else if (!is_file(jfmt->check_tool_path)) {
+	    err(3, __func__, "jfmt tool not a regular file: %s", jfmt->check_tool_path); /*ooo*/
+	    not_reached();
+	} else if (!is_exec(jfmt->check_tool_path)) {
+	    err(3, __func__, "jfmt tool not an executable file: %s", jfmt->check_tool_path); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * if -A args is specified then we must have an -S tool as well */
+    if (jfmt->check_tool_args != NULL) {
+	if (jfmt->check_tool_path == NULL) {
+	    /* it is an error if -A args specified without -S path */
+	    free_jfmt(&jfmt);
+	    err(3, __func__, "-A used without -S"); /*ooo*/
+	    not_reached();
+	} else if (jfmt->check_tool_args == NULL) {
+	    free_jfmt(&jfmt);
+	    err(3, __func__, "-A args NULL"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * final processing: some options require the use of others but they are not
+     * an error if they not used together; the one simply has no effect. Also
+     * once options are parsed we have to check name_args and verify some things
+     * after that.
+     */
+
+    /* without -j, -B has no effect */
+    if (jfmt->print_braces && !jfmt->print_syntax) {
+	jfmt->print_braces = false;
+    }
+
+    /* without -j, -C has no effect */
+    if (jfmt->print_final_comma && !jfmt->print_syntax) {
+	jfmt->print_final_comma = false;
+    }
+
+    /* parse name_args first */
+    parse_jfmt_name_args(jfmt, *argv);
+
+    /* now verify final options that require looking at name_args first */
+    if (jfmt->search_value && jfmt->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only one
+	 * arg is specified after the file
+	 */
+	free_jfmt(&jfmt);
+	err(3, __func__, "-Y requires exactly one name_arg"); /*ooo*/
+	not_reached();
+    }
+
+    if (jfmt->count_only && jfmt->patterns == NULL) {
+	err(3, __func__, "use of -c without any patterns is an error"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * verify that if patterns list is not NULL that we're not printing the
+     * entire file
+     */
+    if (jfmt->patterns != NULL && jfmt->print_entire_file) {
+	free_jfmt(&jfmt);
+	err(3, __func__, "printing the entire file not supported when searching for a pattern");/*ooo*/
+	not_reached();
+    }
+
+    /* all good: return the (presumably) json FILE * */
+    return jfmt->json_file;
+}

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -1,0 +1,78 @@
+/* jfmt - JSON printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JFMT_H)
+#    define  INCLUDE_JFMT_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <strings.h> /* for -i, strcasecmp */
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jfmt_util - our utility functions, macros, jfmt structs and variables
+ */
+#include "jfmt_util.h"
+
+/*
+ * jfmt_test - test functions
+ */
+#include "jfmt_test.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* jfmt version string */
+#define JFMT_VERSION "0.0.0 2023-07-16"		/* format: major.minor YYYY-MM-DD */
+
+/* jfmt functions - see jfmt_util.h for most */
+
+/* sanity checks on environment for specific options and the tool arguments */
+FILE *jfmt_sanity_chks(struct jfmt *jfmt, char const *program, int *argc, char ***argv);
+
+#endif /* !defined INCLUDE_JFMT_H */

--- a/jparse/jfmt_test.c
+++ b/jparse/jfmt_test.c
@@ -1,0 +1,426 @@
+/*
+ * jfmt_test - test functions for the jfmt tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#include "jfmt_test.h"
+
+/* jfmt_run_tests	- run test functions
+ *
+ * given:
+ *
+ *	void	    - no args: this function is selfish :-)
+ *
+ * Returns false if any test failed. Will only return after all tests are run.
+ */
+bool
+jfmt_run_tests(void)
+{
+    struct jfmt_number number;    /* number range */
+    bool test = false;		    /* whether current test passes or fails */
+    bool okay = true;	    /* if any test fails set to true, is return value */
+    uintmax_t bits = 0;	    /* for bits tests */
+
+    /* set up exact match of 5 */
+    jfmt_parse_number_range("-l", "5", false, &number);
+
+    /* make sure number matches exactly */
+    test = jfmt_test_number_range_opts(true, 5, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure number does NOT match */
+    test = jfmt_test_number_range_opts(false, 6, 7, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up inclusive range of >= 5 && <= 10 */
+    jfmt_parse_number_range("-l", "5:10", false, &number);
+    /* make sure that number is in the range >= 5 && <= 10 */
+    test = jfmt_test_number_range_opts(true, 6, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to >= max */
+    test = jfmt_test_number_range_opts(false, 11, 12, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jfmt_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
+     * last match)
+     */
+    jfmt_parse_number_range("-n", "5:-3", true, &number);
+    /* make sure that number is in the range >= 5 && <= 10 - 3 */
+    test = jfmt_test_number_range_opts(true, 7, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to >=
+     * total_matches
+     */
+    test = jfmt_test_number_range_opts(false, 11, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to being
+     * > total_matches - -max
+     */
+    test = jfmt_test_number_range_opts(false, 8, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jfmt_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+
+    /* set up minimum number */
+    jfmt_parse_number_range("-l", "10:", false, &number);
+    /* make sure that number 10 is in the range >= 10 */
+    test = jfmt_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 11 is in the range >= 10 */
+    test = jfmt_test_number_range_opts(true, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 9 is NOT >= 10 */
+    test = jfmt_test_number_range_opts(false, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up maximum number */
+    jfmt_parse_number_range("-l", ":10", false, &number);
+    /* make sure that number 10 is in the range <= 10 */
+    test = jfmt_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 9 is in the range <= 10 */
+    test = jfmt_test_number_range_opts(true, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 11 is NOT <= 10 */
+    test = jfmt_test_number_range_opts(false, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* now check bits */
+
+    /* set bits to JFMT_PRINT_BOTH */
+    bits = jfmt_parse_print_option("both");
+
+    /* check that JFMT_PRINT_BOTH is equal to bits */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_print_name_value, "JFMT_PRINT_BOTH");
+    if (!test) {
+	okay = false;
+    }
+
+    /* set bits to JFMT_PRINT_NAME */
+    bits = jfmt_parse_print_option("name");
+    /* check that only JFMT_PRINT_NAME is set: both and value are not set */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_print_name, "JFMT_PRINT_NAME") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_print_value, "JFMT_PRINT_VALUE") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_print_name_value, "JFMT_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+    /* set bits to JFMT_PRINT_VALUE */
+    bits = jfmt_parse_print_option("v");
+    /* check that only JFMT_PRINT_VALUE is set: both and name are not set */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_print_value, "JFMT_PRINT_VALUE") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_print_name, "JFMT_PRINT_NAME") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_print_name_value, "JFMT_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+
+    /* test -t option bits */
+
+    /* first int,float,exp */
+    bits = jfmt_parse_types_option("int,float,exp");
+    /* check that any number will match */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_float, "JFMT_TYPE_FLOAT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_exp, "JFMT_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* just exponents */
+    bits = jfmt_parse_types_option("exp");
+    /* check that int and float will fail but exp will succeed */
+    test = jfmt_test_bits(false, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_float, "JFMT_TYPE_FLOAT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_exp, "JFMT_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test all types */
+    bits = jfmt_parse_types_option("any");
+    /* verify that it is the any bit */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_any, "JFMT_TYPE_ANY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test compound */
+    bits = jfmt_parse_types_option("compound");
+    /* verify that the compound type is set by compound match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_compound, "JFMT_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the compound type is set by matching all types */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_object, "JFMT_TYPE_OBJECT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_array, "JFMT_TYPE_ARRAY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test simple */
+    bits = jfmt_parse_types_option("simple");
+    /* verify that the simple type is set by simple match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_simple, "JFMT_TYPE_SIMPLE");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the simple type is set by matching each type */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_num, "JFMT_TYPE_NUM") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_bool, "JFMT_TYPE_BOOL") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_string, "JFMT_TYPE_STR") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_null, "JFMT_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int */
+    bits = jfmt_parse_types_option("int");
+    /* verify that the int type is set by int match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test float */
+    bits = jfmt_parse_types_option("float");
+    /* verify that the float type is set by float match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_float, "JFMT_TYPE_FLOAT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test exp */
+    bits = jfmt_parse_types_option("exp");
+    /* verify that the exp type is set by exp match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_exp, "JFMT_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test bool */
+    bits = jfmt_parse_types_option("bool");
+    /* verify that the bool type is set by bool match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_bool, "JFMT_TYPE_BOOL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test string */
+    bits = jfmt_parse_types_option("str");
+    /* verify that the string type is set by string match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_string, "JFMT_TYPE_STR");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test null */
+    bits = jfmt_parse_types_option("null");
+    /* verify that the null type is set by null match function */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_null, "JFMT_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int,str,null */
+    bits = jfmt_parse_types_option("int,str,null");
+    /* verify that the int,str,null types are set by match functions */
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_string, "JFMT_TYPE_STR") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_null, "JFMT_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * test that none of the bits are set not via the match none function but by
+     * each match function
+     */
+    bits = JFMT_TYPE_NONE;
+    test = jfmt_test_bits(false, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_float, "JFMT_TYPE_FLOAT") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_exp, "JFMT_TYPE_EXP") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_num, "JFMT_TYPE_NUM") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_bool, "JFMT_TYPE_BOOL") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_string, "JFMT_TYPE_STR") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_null, "JFMT_TYPE_NULL") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_object, "JFMT_TYPE_OBJECT") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_array, "JFMT_TYPE_ARRAY") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_any, "JFMT_TYPE_ANY") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_simple, "JFMT_TYPE_SIMPLE") &&
+	   jfmt_test_bits(false, bits, __LINE__, jfmt_match_compound, "JFMT_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+    /* check all types */
+    bits = jfmt_parse_types_option("int,float,exp,num,bool,str,null,object,array,any,simple,compound");
+    test = jfmt_test_bits(true, bits, __LINE__, jfmt_match_int, "JFMT_TYPE_INT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_float, "JFMT_TYPE_FLOAT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_exp, "JFMT_TYPE_EXP") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_num, "JFMT_TYPE_NUM") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_bool, "JFMT_TYPE_BOOL") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_string, "JFMT_TYPE_STR") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_null, "JFMT_TYPE_NULL") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_object, "JFMT_TYPE_OBJECT") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_array, "JFMT_TYPE_ARRAY") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_any, "JFMT_TYPE_ANY") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_simple, "JFMT_TYPE_SIMPLE") &&
+	   jfmt_test_bits(true, bits, __LINE__, jfmt_match_compound, "JFMT_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+
+
+    return okay;
+}
+
+/* jfmt_test_number_range_opts
+ *
+ * Test that the number range functionality works okay.
+ *
+ * given:
+ *
+ *	option	     	option that this is testing
+ *	expected     	whether test should return true or false
+ *	number		number to test
+ *	total_matches	number of total matches
+ *	line		line number of code which called this function
+ *	range		range to verify number against
+ *
+ * Returns true if test is okay.
+ *
+ * NOTE: this will not return on NULL pointers.
+ */
+bool
+jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jfmt_number *range)
+{
+    bool test = false;	    /* result of test */
+
+    if (range == NULL) {
+	err(15, __func__, "NULL range, cannot test");
+	not_reached();
+    }
+
+    test = jfmt_number_in_range(number, total_matches, range);
+    print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
+    if (range->exact) {
+	print("expect exact match for number %jd: ", number);
+    } else if (range->range.inclusive) {
+	if (range->range.max < 0) {
+	    /* if max is < 0 then it's up through the total_matches - max item */
+	    print("expect number %jd to be >= %jd && <= (%jd - %jd): ", number, range->range.min, total_matches,
+		    -range->range.max);
+	} else {
+	    print("expect number %jd to be >= %jd && <= %jd: ", number, range->range.min, range->range.max);
+	}
+    } else if (range->range.greater_than_equal) {
+	print("expect number %jd to be >= %ju: ", number, range->range.min);
+    } else if (range->range.less_than_equal) {
+	print("expect number %jd to be <= %jd: ", number, range->range.max);
+    }
+
+    print("test %s\n", expected == test?"OK":"failed");
+
+    return expected == test;
+}
+
+/* jfmt_test_bits    -	test bits code
+ *
+ * given:
+ *
+ *	expected	- whether test should fail or not
+ *	set_bits	- the bits actually set
+ *	line		- line number of code that called this function
+ *	check_func	- pointer to function of appropriate check
+ *	name		- name of bits to check
+ *
+ * Returns true if the test succeeds otherwise false.
+ *
+ * NOTE: this function will not return on NULL function pointer or NULL name.
+ */
+bool
+jfmt_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name)
+{
+    bool okay = true;	/* assume test will pass */
+    bool test = false;	/* return value of function call */
+
+    /* firewall */
+    if (check_func == NULL) {
+	err(16, __func__, "NULL check_func");
+	not_reached();
+    } else if (name == NULL) {
+	err(17, __func__, "NULL name");
+	not_reached();
+    }
+
+    print("in function %s from line %jd (bits %ju): expects %s %s set: ", __func__, line, set_bits,
+	    name, expected?"to be":"to NOT be");
+    test = check_func(set_bits);
+
+    if (test != expected) {
+	okay = false;
+    }
+    print("test %s\n", okay?"OK":"failed");
+
+    return okay;
+}

--- a/jparse/jfmt_test.h
+++ b/jparse/jfmt_test.h
@@ -1,0 +1,68 @@
+/* jfmt_test - test functions for the jfmt tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JFMT_TEST_H)
+#    define  INCLUDE_JFMT_TEST_H
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/*
+ * jfmt_util - jfmt utility functions
+ */
+#include "jfmt_util.h"
+
+bool jfmt_run_tests(void);
+bool jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
+	intmax_t line, struct jfmt_number *range);
+bool jfmt_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
+
+#endif /* !defined INCLUDE_JFMT_TEST_H */

--- a/jparse/jfmt_util.c
+++ b/jparse/jfmt_util.c
@@ -1,0 +1,2780 @@
+/*
+ * jfmt_util - utility functions for JSON printer jfmt
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jfmt_util.h"
+
+/* alloc_jfmt	    - allocate a struct jfmt *, clear it out and set defaults
+ *
+ * This function returns a newly allocated and cleared struct jfmt *.
+ *
+ * This function will never return a NULL pointer.
+ */
+struct jfmt *
+alloc_jfmt(void)
+{
+    /* allocate our struct jfmt */
+    struct jfmt *jfmt = calloc(1, sizeof *jfmt);
+
+    /* verify jfmt != NULL */
+    if (jfmt == NULL) {
+	err(22, __func__, "failed to allocate jfmt struct");
+	not_reached();
+    }
+
+    /* explicitly clear everything out and set defaults */
+
+    /* JSON file member variables */
+    jfmt->is_stdin = false;			/* true if it's stdin */
+    jfmt->file_contents = NULL;		/* file.json contents */
+    jfmt->json_file = NULL;			/* JSON file * */
+
+    /* string related options */
+    jfmt->encode_strings = false;		/* -e used */
+    jfmt->quote_strings = false;		/* -Q used */
+
+
+    /* number range options, see struct jfmt_number_range in jfmt_util.h for details */
+
+    /* max matches number range */
+    jfmt->jfmt_max_matches.number = 0;
+    jfmt->jfmt_max_matches.exact = false;
+    jfmt->jfmt_max_matches.range.min = 0;
+    jfmt->jfmt_max_matches.range.max = 0;
+    jfmt->jfmt_max_matches.range.less_than_equal = false;
+    jfmt->jfmt_max_matches.range.greater_than_equal = false;
+    jfmt->jfmt_max_matches.range.inclusive = false;
+    jfmt->max_matches_requested = false;
+
+    /* min matches number range */
+    jfmt->jfmt_min_matches.number = 0;
+    jfmt->jfmt_min_matches.exact = false;
+    jfmt->jfmt_min_matches.range.min = 0;
+    jfmt->jfmt_min_matches.range.max = 0;
+    jfmt->jfmt_min_matches.range.less_than_equal = false;
+    jfmt->jfmt_min_matches.range.greater_than_equal = false;
+    jfmt->jfmt_min_matches.range.inclusive = false;
+    jfmt->min_matches_requested = false;
+
+    /* levels number range */
+    jfmt->jfmt_levels.number = 0;
+    jfmt->jfmt_levels.exact = false;
+    jfmt->jfmt_levels.range.min = 0;
+    jfmt->jfmt_levels.range.max = 0;
+    jfmt->jfmt_levels.range.less_than_equal = false;
+    jfmt->jfmt_levels.range.greater_than_equal = false;
+    jfmt->jfmt_levels.range.inclusive = false;
+    jfmt->levels_constrained = false;
+
+    /* print related options */
+    jfmt->print_json_types_option = false;		/* -p explicitly used */
+    jfmt->print_json_types = JFMT_PRINT_VALUE;	/* -p type specified */
+    jfmt->print_token_spaces = false;			/* -b specified */
+    jfmt->num_token_spaces = 1;			/* -b specified number of spaces or tabs */
+    jfmt->print_token_tab = false;			/* -b tab (or -b <num>[t]) specified */
+    jfmt->print_json_levels = false;			/* -L specified */
+    jfmt->num_level_spaces = 0;			/* number of spaces or tab for -L */
+    jfmt->print_level_tab = false;			/* -L tab option */
+    jfmt->print_colons = false;			/* -P specified */
+    jfmt->print_final_comma = false;			/* -C specified */
+    jfmt->print_braces = false;			/* -B specified */
+    jfmt->indent_levels = false;			/* -I used */
+    jfmt->indent_spaces = 0;				/* -I number of tabs or spaces */
+    jfmt->indent_tab = false;				/* -I <num>[{t|s}] specified */
+    jfmt->print_syntax = false;			/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* misc options */
+    jfmt->count_only = false;				/* -c used, only show count */
+
+
+    /* search related bools */
+    /* json types to look for */
+    jfmt->json_types_specified = false;		/* -t used */
+    jfmt->json_types = JFMT_TYPE_SIMPLE;		/* -t type specified, default simple */
+    jfmt->print_entire_file = false;			/* no name_arg specified */
+    jfmt->match_found = false;			/* true if a pattern is specified and there is a match */
+    jfmt->ignore_case = false;			/* true if -i, case-insensitive */
+    jfmt->pattern_specified = false;			/* true if a pattern was specified */
+    jfmt->search_value = false;			/* -Y search by value, not name. Uses print type */
+    /*
+     * Why is -o specified before -r? This is so that it spells out 'or' which
+     * is what -o means. Obviously! :-)
+     */
+    jfmt->search_or_mode = false;			/* -o used: search with OR mode */
+    jfmt->search_anywhere = false;			/* -r used: search under anywhere */
+
+    jfmt->match_encoded = false;			/* -E used, match encoded name */
+    jfmt->use_substrings = false;			/* -s used, matching substrings okay */
+    jfmt->use_regexps = false;			/* -g used, allow grep-like regexps */
+    jfmt->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+
+
+    /* check tool related */
+    jfmt->check_tool_specified = false;		/* bool indicating -S was used */
+    jfmt->check_tool_stream = NULL;			/* FILE * stream for -S tool */
+    jfmt->check_tool_path = NULL;			/* -S tool_path */
+    jfmt->check_tool_args = NULL;			/* -A tool_args */
+
+    /* finally the linked list of patterns for matches */
+    /* XXX - the pattern concept is incorrect */
+    jfmt->patterns = NULL;
+    jfmt->number_of_patterns = 0;
+    /* matches - subject to change */
+    jfmt->matches = NULL;
+    jfmt->total_matches = 0;
+
+    return jfmt;
+}
+
+
+/*
+ * jfmt_match_none	- if no types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types == 0.
+ */
+bool
+jfmt_match_none(uintmax_t types)
+{
+    return types == JFMT_TYPE_NONE;
+}
+
+/*
+ * jfmt_match_int	- if ints should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_INT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_int(uintmax_t types)
+{
+    return (types & JFMT_TYPE_INT) != 0;
+}
+/*
+ * jfmt_match_float	- if floats should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_FLOAT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_float(uintmax_t types)
+{
+    return (types & JFMT_TYPE_FLOAT) != 0;
+}
+/*
+ * jfmt_match_exp	- if exponents should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_EXP set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_exp(uintmax_t types)
+{
+    return (types & JFMT_TYPE_EXP) != 0;
+}
+/*
+ * jfmt_match_num	- if numbers of any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_NUM (or any of the number types) set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_num(uintmax_t types)
+{
+    return ((types & JFMT_TYPE_NUM)||(types & JFMT_TYPE_INT) || (types & JFMT_TYPE_FLOAT) ||
+	    (types & JFMT_TYPE_EXP))!= 0;
+}
+/*
+ * jfmt_match_bool	- if booleans should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_BOOL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_bool(uintmax_t types)
+{
+    return (types & JFMT_TYPE_BOOL) != 0;
+}
+/*
+ * jfmt_match_string	    - if strings should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_STR set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_string(uintmax_t types)
+{
+    return (types & JFMT_TYPE_STR) != 0;
+}
+/*
+ * jfmt_match_null	- if null should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_NULL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_null(uintmax_t types)
+{
+    return (types & JFMT_TYPE_NULL) != 0;
+}
+/*
+ * jfmt_match_object	    - if objects should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_OBJECT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_object(uintmax_t types)
+{
+    return (types & JFMT_TYPE_OBJECT) != 0;
+}
+/*
+ * jfmt_match_array	    - if arrays should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JFMT_TYPE_ARRAY set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_array(uintmax_t types)
+{
+    return (types & JFMT_TYPE_ARRAY) != 0;
+}
+/*
+ * jfmt_match_any	- if any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types is equal to JFMT_TYPE_ANY.
+ *
+ * Why does it have to equal JFMT_TYPE_ANY if it checks for any type? Because
+ * the point is that if JFMT_TYPE_ANY is set it can be any type but not
+ * specific types. For the specific types those bits have to be set instead. If
+ * JFMT_TYPE_ANY is set then any type can be set but if types is say
+ * JFMT_TYPE_INT then checking for JFMT_TYPE_INT & JFMT_TYPE_ANY would be
+ * != 0 (as it's a bitwise OR of all the types) which would suggest that any
+ * type is okay even if JFMT_TYPE_INT was the only type.
+ */
+bool
+jfmt_match_any(uintmax_t types)
+{
+    return types == JFMT_TYPE_ANY;
+}
+/*
+ * jfmt_match_simple	- if simple types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Simple is defined as a number, a bool, a string or a null.
+ *
+ * Returns true if types has JFMT_TYPE_SIMPLE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_simple(uintmax_t types)
+{
+    return (types & JFMT_TYPE_SIMPLE) != 0;
+}
+/*
+ * jfmt_match_compound   - if compounds should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * A compound is defined as an object or array.
+ *
+ * Returns true if types has JFMT_TYPE_COMPOUND set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_match_compound(uintmax_t types)
+{
+    return (types & JFMT_TYPE_COMPOUND) != 0;
+}
+
+/*
+ * jfmt_parse_types_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JFMT_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jfmt_parse_types_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t type = JFMT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    } else {
+	/* pre-clear errno for errp() */
+	errno = 0;
+	dup = strdup(optarg);
+	if (dup == NULL) {
+	    errp(23, __func__, "strdup(%s) failed", optarg);
+	    not_reached();
+	}
+    }
+
+    /*
+     * Go through comma-separated list of types, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might be - I've thought of a number of ways already).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "int")) {
+	    type |= JFMT_TYPE_INT;
+	} else if (!strcmp(p, "float")) {
+	    type |= JFMT_TYPE_FLOAT;
+	} else if (!strcmp(p, "exp")) {
+	    type |= JFMT_TYPE_EXP;
+	} else if (!strcmp(p, "num")) {
+	    type |= JFMT_TYPE_NUM;
+	} else if (!strcmp(p, "bool")) {
+	    type |= JFMT_TYPE_BOOL;
+	} else if (!strcmp(p, "str")) {
+	    type |= JFMT_TYPE_STR;
+	} else if (!strcmp(p, "null")) {
+	    type |= JFMT_TYPE_NULL;
+	} else if (!strcmp(p, "object")) {
+	    type |= JFMT_TYPE_OBJECT;
+	} else if (!strcmp(p, "array")) {
+	    type |= JFMT_TYPE_ARRAY;
+	} else if (!strcmp(p, "simple")) {
+	    type |= JFMT_TYPE_SIMPLE;
+	} else if (!strcmp(p, "compound")) {
+	    type |= JFMT_TYPE_COMPOUND;
+	} else if (!strcmp(p, "any")) {
+	    type |= JFMT_TYPE_ANY;
+	} else {
+	    /* unknown type */
+	    err(3, __func__, "unknown type '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+    return type;
+}
+
+/*
+ * jfmt_print_name	- if only names should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JFMT_PRINT_NAME set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_print_name(uintmax_t types)
+{
+    return ((types & JFMT_PRINT_NAME) && !(types & JFMT_PRINT_VALUE)) != 0;
+}
+/*
+ * jfmt_print_value	- if only values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JFMT_PRINT_VALUE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jfmt_print_value(uintmax_t types)
+{
+    return ((types & JFMT_PRINT_VALUE) && !(types & JFMT_PRINT_NAME)) != 0;
+}
+/*
+ * jfmt_print_both	- if names AND values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types has JFMT_PRINT_BOTH set.
+ */
+bool
+jfmt_print_name_value(uintmax_t types)
+{
+    return types == JFMT_PRINT_BOTH;
+}
+
+
+/*
+ * jfmt_parse_print_option	- parse -p option list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -p option
+ *
+ * Returns: bitvector of types to print.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JFMT_PRINT_VALUE (as if '-p v').
+ */
+uintmax_t
+jfmt_parse_print_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t print_json_types = 0; /* default is to print values */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return JFMT_PRINT_VALUE;
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    dup = strdup(optarg);
+    if (dup == NULL) {
+	errp(24, __func__, "strdup(%s) failed", optarg);
+	not_reached();
+    }
+
+    /*
+     * Go through comma-separated list of what to print, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might very well be).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "v") || !strcmp(p, "value")) {
+	    print_json_types |= JFMT_PRINT_VALUE;
+	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
+	    print_json_types |= JFMT_PRINT_NAME;
+	} else if (!strcmp(p, "b") || !strcmp(p, "both")) {
+	    print_json_types |= JFMT_PRINT_BOTH;
+	} else {
+	    /* unknown keyword */
+	    err(3, __func__, "unknown keyword '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (jfmt_print_name_value(print_json_types)) {
+	dbg(DBG_LOW, "will print both name and value");
+    }
+    else if (jfmt_print_name(print_json_types)) {
+	dbg(DBG_LOW, "will only print name");
+    }
+    else if (jfmt_print_value(print_json_types)) {
+	dbg(DBG_LOW, "will only print value");
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+
+    return print_json_types;
+}
+
+/* jfmt_parse_number_range	- parse a number range for options -l, -N, -n
+ *
+ * given:
+ *
+ *	option		- option string (e.g. "-l"). Used for error and debug messages.
+ *	optarg		- the option argument
+ *	allow_negative	- true if max can be < 0
+ *	number		- pointer to struct number
+ *
+ * Returns true if successfully parsed.
+ *
+ * The following rules apply:
+ *
+ * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
+ * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
+ *     (1a) the last number can be negative in which case it's up through the
+ *	    count - max.
+ * (2) a minimum number, that is num >= minimum, is <num>:
+ * (3) a maximum number, that is num <= maximum, is :<num>
+ * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
+ * (5) anything else is an error
+ *
+ * See also the structs jfmt_number_range and jfmt_number in jfmt_util.h
+ * for more details.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
+ */
+bool
+jfmt_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jfmt_number *number)
+{
+    intmax_t max = 0;
+    intmax_t min = 0;
+
+    /* firewall */
+    if (option == NULL || *option == '\0') {
+	err(3, __func__, "NULL or empty option given"); /*ooo*/
+	not_reached();
+    }
+    if (number == NULL) {
+	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
+	not_reached();
+    } else {
+	memset(number, 0, sizeof(struct jfmt_number));
+
+	/* don't assume everything is 0 */
+	number->exact = false;
+	number->range.min = 0;
+	number->range.max = 0;
+	number->range.inclusive = false;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
+    }
+
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
+	return false;
+    }
+
+    if (!strchr(optarg, ':')) {
+	if (string_to_intmax(optarg, &number->number)) {
+	    number->exact = true;
+	    number->range.min = 0;
+	    number->range.max = 0;
+	    number->range.inclusive = false;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
+	} else {
+	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
+	    not_reached();
+	}
+    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    /*
+	     * NOTE: we can't check that min >= max because a negative number in the
+	     * maximum means that the range is up through the count - max matches
+	     */
+	    number->range.min = min;
+	    number->range.max = max;
+	    number->range.inclusive = true;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    /* XXX - this debug message is problematic wrt the negative number
+	     * option
+	     */
+	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
+		    number->range.max);
+	}
+    } else if (sscanf(optarg, "%jd:", &min) == 1) {
+	number->number = 0;
+	number->exact = false;
+	number->range.min = min;
+	number->range.max = number->range.min;
+	number->range.greater_than_equal = true;
+	number->range.less_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+    } else if (sscanf(optarg, ":%jd", &max) == 1) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    number->range.max = max;
+	    number->range.min = number->range.max;
+	    number->number = 0;
+	    number->exact = false;
+	    number->range.less_than_equal = true;
+	    number->range.greater_than_equal = false;
+	    number->range.inclusive = false;
+	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+	}
+    } else {
+	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
+	not_reached();
+    }
+
+    return true;
+}
+
+/* jfmt_number_in_range   - check if number is in required range
+ *
+ * given:
+ *
+ *	number		- number to check
+ *	total_matches	- total number of matches found
+ *	range		- pointer to struct jfmt_number with range
+ *
+ * Returns true if the number is in range.
+ *
+ * NOTE: if range is NULL it will return false.
+ */
+bool
+jfmt_number_in_range(intmax_t number, intmax_t total_matches, struct jfmt_number *range)
+{
+    /* firewall check */
+    if (range == NULL) {
+	return false;
+    }
+
+    /* if exact is set and range->number == number then return true. */
+    if (range->exact && range->number == number) {
+	return true;
+    } else if (range->range.inclusive) {
+	/* if the number must be inclusive in range then we have to make sure
+	 * that number >= min and <= max.
+	 *
+	 * NOTE: we have to make a special check for negative numbers because a
+	 * negative number is up through the count of matches - the negative max
+	 * number (rather if there are 10 matches and the string -l 5:-3 is
+	 * specified then the items 5, 6, 7, 8 are to be printed).
+	 */
+	if (number >= range->range.min) {
+	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
+		return true;
+	    } else if (number <= range->range.max) {
+		return true;
+	    } else {
+		return false;
+	    }
+	} else {
+	    return false;
+	}
+    } else if (range->range.less_than_equal) {
+	/* if number has to be less than equal we check number <= the maximum
+	 * number (range->range.max).
+	 */
+	if (number <= range->range.max) {
+	    return true;
+	} else {
+	    return false;
+	}
+    } else if (range->range.greater_than_equal) {
+	/* if number has to be greater than or equal to the number then we check
+	 * that number >= minimum number (range->range.min).
+	 */
+	if (number >= range->range.min) {
+	    return true;
+	} else {
+	    return false;
+	}
+    }
+
+    return false; /* no match */
+}
+
+/* jfmt_parse_st_tokens_option    - parse -b [num]{s,t}/-b tab option
+ *
+ * This function parses the -b option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_token_spaces    - pointer to number of token spaces or tabs
+ *	print_token_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jfmt_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_token_spaces == NULL) {
+	err(3, __func__, "NULL num_token_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_token_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_token_spaces == 0 */
+	*num_token_spaces = 0;
+	/* make *print_token_tab == false */
+	*print_token_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_token_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_token_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_token_tab = false;
+	    dbg(DBG_LOW, "will print %ju space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -b <num>[ts]"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	*print_token_tab = true;
+	*num_token_spaces = 1;
+	dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+	    *num_token_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_token_spaces)) {
+	err(3, __func__, "couldn't parse -b <num>[ts]"); /*ooo*/
+	not_reached();
+    } else {
+	*print_token_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+    }
+}
+
+/* jfmt_parse_st_indent_option    - parse -I [num]{s,t}/-b indent option
+ *
+ * This function parses the -I option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	indent_level	    - pointer to number of indent spaces or tabs
+ *	indent_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jfmt_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (indent_level == NULL) {
+	err(3, __func__, "NULL indent_level"); /*ooo*/
+	not_reached();
+    } else if (indent_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *indent_level == 0 */
+	*indent_level = 0;
+	/* make *ident_tab == false */
+	*indent_tab = false;
+    }
+
+
+    if (sscanf(optarg, "%ju%c", indent_level, &ch) == 2) {
+	if (ch == 't') {
+	    *indent_tab = true;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else if (ch == 's') {
+	    *indent_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -I"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *indent_tab = true;
+	    *indent_level = 1;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+    } else if (!string_to_uintmax(optarg, indent_level)) {
+	err(3, __func__, "couldn't parse -I spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*indent_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+    }
+}
+
+/* jfmt_parse_st_level_option    - parse -L [num]{s,t}/-b level option
+ *
+ * This function parses the -L option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
+ *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jfmt_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_level_spaces == NULL) {
+	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_level_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_level_spaces == 0 */
+	*num_level_spaces = 0;
+	/* make *print_level_tab == false */
+	*print_level_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_level_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_level_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -L"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *print_level_tab = true;
+	    *num_level_spaces = 1;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
+	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*print_level_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    }
+}
+
+/*
+ * jfmt_parse_value_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JFMT_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jfmt_parse_value_type_option(char *optarg)
+{
+    uintmax_t type = JFMT_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+    char *p = NULL;
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    }
+    p = optarg;
+
+    /* Determine if the arg is a valid type.  */
+    if (!strcmp(p, "int")) {
+	type = JFMT_TYPE_INT;
+    } else if (!strcmp(p, "float")) {
+	type = JFMT_TYPE_FLOAT;
+    } else if (!strcmp(p, "exp")) {
+	type = JFMT_TYPE_EXP;
+    } else if (!strcmp(p, "num")) {
+	type = JFMT_TYPE_NUM;
+    } else if (!strcmp(p, "bool")) {
+	type = JFMT_TYPE_BOOL;
+    } else if (!strcmp(p, "str")) {
+	type = JFMT_TYPE_STR;
+    } else if (!strcmp(p, "null")) {
+	type = JFMT_TYPE_NULL;
+    } else if (!strcmp(p, "simple")) {
+	type = JFMT_TYPE_SIMPLE;
+    } else {
+	/* unknown or unsupported type */
+	err(3, __func__, "unknown or unsupported type '%s'", p); /*ooo*/
+	not_reached();
+    }
+
+    return type;
+}
+
+/*
+ * free_jfmt	    - free jfmt struct
+ *
+ * given:
+ *
+ *	jfmt	    - a struct jfmt **
+ *
+ * This function will do nothing other than warn on NULL pointer (even though
+ * it's safe to free a NULL pointer though if jfmt itself was NULL it would be
+ * an error to dereference it).
+ *
+ * We pass a struct jfmt ** so that in the caller jfmt can be set to NULL to
+ * remove the need to repeatedly set it to NULL each time this function is
+ * called. This way we remove the need to do more than just call this function.
+ */
+void
+free_jfmt(struct jfmt **jfmt)
+{
+    struct jfmt_match *match = NULL; /* to iterate through matches list */
+    struct jfmt_match *next_match = NULL; /* next in list */
+
+    /* firewall */
+    if (jfmt == NULL || *jfmt == NULL) {
+	warn(__func__, "passed NULL struct jfmt ** or *jfmt is NULL");
+	return;
+    }
+
+    free_jfmt_patterns_list(*jfmt); /* free patterns list first */
+
+    /* we have to free matches attached to jfmt itself too */
+    for (match = (*jfmt)->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+
+    free(*jfmt);
+    *jfmt = NULL;
+}
+
+
+/* parse_jfmt_name_args - add name_args to patterns list
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our struct jfmt
+ *	argv	    - argv from main()
+ *
+ * This function will not return on NULL pointers.
+ *
+ * NOTE: by patterns we refer to name_args.
+ *
+ * XXX - the pattern concept is currently incorrect and needs to be fixed - XXX
+ */
+void
+parse_jfmt_name_args(struct jfmt *jfmt, char **argv)
+{
+    int i;  /* to iterate through argv */
+
+    /* firewall */
+    if (argv == NULL) {
+	err(15, __func__, "argv is NULL"); /*ooo*/
+	not_reached();
+    }
+
+    for (i = 1; argv[i] != NULL; ++i) {
+	jfmt->pattern_specified = true;
+
+	if (add_jfmt_pattern(jfmt, jfmt->use_regexps, jfmt->use_substrings, argv[i]) == NULL) {
+	    err(25, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
+		    jfmt->use_substrings?"OK":"ignored", argv[i]);
+	    not_reached();
+	}
+    }
+}
+
+
+/*
+ * add_jfmt_pattern
+ *
+ * Add jfmt pattern to the jfmt struct pattern list.
+ *
+ * given:
+ *
+ *	jfmt		- pointer to the jfmt struct
+ *	use_regexp	- whether to use regexp or not
+ *	use_substrings	- if -s was specified, make this a substring match
+ *	str		- the pattern to be added to the list
+ *
+ * NOTE: this function will not return if jfmt is NULL. If str is NULL
+ * this function will not return but if str is empty it will add an empty
+ * string to the list. However the caller will usually check that it's not empty
+ * prior to calling this function.
+ *
+ * Returns a pointer to the newly allocated struct jfmt_pattern * that was
+ * added to the jfmt patterns list.
+ *
+ * Duplicate patterns will not be added (case sensitive).
+ */
+struct jfmt_pattern *
+add_jfmt_pattern(struct jfmt *jfmt, bool use_regexp, bool use_substrings, char *str)
+{
+    struct jfmt_pattern *pattern = NULL;
+    struct jfmt_pattern *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jfmt == NULL) {
+	err(26, __func__, "passed NULL jfmt struct");
+	not_reached();
+    }
+    if (str == NULL) {
+	err(27, __func__, "passed NULL str");
+	not_reached();
+    }
+
+    /*
+     * first make sure the pattern is not already added to the list as the same
+     * type
+     */
+    for (pattern = jfmt->patterns; pattern != NULL; pattern = pattern->next) {
+	if (pattern->pattern && pattern->use_regexp == use_regexp) {
+	    /* XXX - add support for regexps - XXX */
+	    if ((!jfmt->ignore_case && !strcmp(pattern->pattern, str))||
+		(jfmt->ignore_case && strcasecmp(pattern->pattern, str))) {
+		return pattern;
+	    }
+	}
+    }
+    /*
+     * XXX either change the debug level or remove this message once
+     * processing is complete
+     */
+    if (use_regexp) {
+	dbg(DBG_LOW,"%s regex requested: '%s'", jfmt->search_value?"value":"name", str);
+    } else {
+	dbg(DBG_LOW,"%s pattern requested: '%s'", jfmt->search_value?"value":"name", str);
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    pattern = calloc(1, sizeof *pattern);
+    if (pattern == NULL) {
+	errp(28, __func__, "unable to allocate struct jfmt_pattern *");
+	not_reached();
+    }
+
+    errno = 0;
+    pattern->pattern = strdup(str);
+    if (pattern->pattern == NULL) {
+	errp(29, __func__, "unable to strdup string '%s' for patterns list", str);
+	not_reached();
+    }
+
+    pattern->use_regexp = use_regexp;
+    pattern->use_value = jfmt->search_value;
+    pattern->use_substrings = use_substrings;
+    /* increment how many patterns have been specified */
+    ++jfmt->number_of_patterns;
+    /* let jfmt know that a pattern was indeed specified */
+    jfmt->pattern_specified = true;
+    pattern->matches_found = 0; /* 0 matches found at first */
+
+    dbg(DBG_LOW, "adding %s pattern '%s' to patterns list", pattern->use_value?"value":"name", pattern->pattern);
+
+    for (tmp = jfmt->patterns; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	jfmt->patterns = pattern;
+    } else {
+	tmp->next = pattern;
+    }
+
+    return pattern;
+}
+
+
+/* free_jfmt_patterns_list	- free patterns list in a struct jfmt *
+ *
+ * given:
+ *
+ *	jfmt	    - the jfmt struct
+ *
+ * If the jfmt patterns list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL jfmt.
+ *
+ * NOTE: this function calls free_jfmt_matches_list() on all the patterns
+ * prior to freeing the pattern itself.
+ */
+void
+free_jfmt_patterns_list(struct jfmt *jfmt)
+{
+    struct jfmt_pattern *pattern = NULL; /* to iterate through patterns list */
+    struct jfmt_pattern *next_pattern = NULL; /* next in list */
+
+    if (jfmt == NULL) {
+	err(30, __func__, "passed NULL jfmt struct");
+	not_reached();
+    }
+
+    for (pattern = jfmt->patterns; pattern != NULL; pattern = next_pattern) {
+	next_pattern = pattern->next;
+
+	/* first free any matches */
+	free_jfmt_matches_list(pattern);
+
+	/* now free the pattern string itself */
+	if (pattern->pattern) {
+	    free(pattern->pattern);
+	    pattern->pattern = NULL;
+	}
+
+	/* finally free the pattern and set to NULL for the next pass */
+	free(pattern);
+	pattern = NULL;
+    }
+
+    jfmt->patterns = NULL;
+}
+
+
+/*
+ * add_jfmt_match
+ *
+ * Add jfmt pattern match to the jfmt struct pattern match list.
+ *
+ * given:
+ *
+ *	jfmt		- pointer to the jfmt struct
+ *	pattern		- the pattern that matched
+ *	name		- struct json * name that matched
+ *	value		- struct json * value that matched
+ *	name_str	- the matching value, either a value or name
+ *	value_str	- the matching value, the opposite of name_str
+ *	level		- the depth or level for the -l / -L options (level 0 is top of tree)
+ *	string		- boolean to indicate if the match is a string
+ *	name_type	- enum item_type indicating the type of name node (JTYPE_* in json_parse.h)
+ *	value_type	- enum item_type indicating the type of value node (JTYPE_* in json_parse.h)
+ *
+ * NOTE: this function will not return if any of the pointers are NULL (except
+ * the name and value - for now) including the pointers in the pattern struct.
+ *
+ * Returns a pointer to the newly allocated struct jfmt_match * that was
+ * added to the jfmt matched patterns list.
+ *
+ * NOTE: depending on jfmt->search_value the name and value nodes will be in a
+ * different order. Specifically the name is what matched, whether a value in
+ * the json tree or name, and the value is what will be printed. At least once
+ * this feature is done :-)
+ */
+struct jfmt_match *
+add_jfmt_match(struct jfmt *jfmt, struct jfmt_pattern *pattern, struct json *name,
+	struct json *value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type)
+{
+    struct jfmt_match *match = NULL;
+    struct jfmt_match *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jfmt == NULL) {
+	err(31, __func__, "passed NULL jfmt struct");
+	not_reached();
+    }
+
+    if (name_str == NULL) {
+	err(32, __func__, "passed NULL name_str");
+	not_reached();
+    }
+    if (value_str == NULL) {
+	err(33, __func__, "value_str is NULL");
+	not_reached();
+    }
+
+    /*
+     * search for an exact match and only increment the count if found.
+     *
+     * NOTE: this means that when printing the output we have to go potentially
+     * print the match more than once; if -c is specified we print only the
+     * count.
+     */
+    for (tmp = pattern?pattern->matches:jfmt->matches; tmp; tmp = tmp->next) {
+	if (name_type == tmp->name_type) {
+	    /* XXX - add support for regexps - XXX */
+	    if (((!jfmt->ignore_case && !strcmp(tmp->match, value_str) && !strcmp(tmp->match, value_str)))||
+		(jfmt->ignore_case && !strcasecmp(tmp->match, value_str) && !strcasecmp(tmp->match, value_str))) {
+		    dbg(DBG_LOW, "incrementing count of match '%s' to %ju", tmp->match, tmp->count + 1);
+		    jfmt->total_matches++;
+		    tmp->count++;
+		    return tmp;
+	    }
+	}
+    }
+
+    /* if we get here we have to add the match to the matches list */
+    errno = 0; /* pre-clear errno for errp() */
+    match = calloc(1, sizeof *match);
+    if (match == NULL) {
+	errp(34, __func__, "unable to allocate struct jfmt_match *");
+	not_reached();
+    }
+
+    /* duplicate the match (name_str) */
+    errno = 0; /* pre-clear errno for errp() */
+    match->match = strdup(name_str);
+    if (match->match == NULL) {
+	errp(35, __func__, "unable to strdup string '%s' for match list", name_str);
+	not_reached();
+    }
+
+    /* duplicate the value of the match, either name or value */
+    errno = 0; /* pre-clear errno for errp() */
+    match->value = strdup(value_str);
+    if (match->match == NULL) {
+	errp(36, __func__, "unable to strdup value string '%s' for match list", value_str);
+	not_reached();
+    }
+    /* set level of the match for -l / -L options */
+    match->level = level;
+
+    /* set count to 1 */
+    match->count = 1;
+
+    /* record the pattern that was matched. It's okay if it is NULL. */
+    match->pattern = pattern; /* DO NOT FREE THIS! */
+
+    /* set struct json * nodes */
+    match->node_name = name;
+    match->node_value = value;
+
+    /* set which match number this is, incrementing the pattern's total matches */
+    if (pattern) {
+	match->number = pattern->matches_found++;
+    }
+
+    /* increment total matches of ALL patterns (name_args) in jfmt struct */
+    jfmt->total_matches++;
+
+    /* record types */
+    match->name_type = name_type;
+    match->value_type = value_type;
+
+    dbg(DBG_LOW, "adding match '%s' to pattern '%s' to match list",
+	    jfmt->search_value?match->value:match->match, name_str);
+
+    for (tmp = pattern?pattern->matches:jfmt->matches; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	if (pattern != NULL) {
+	    pattern->matches = match;
+	} else {
+	    jfmt->matches = match;
+	}
+    } else {
+	tmp->next = match;
+    }
+
+    /* a match is found, set jfmt->match_found to true */
+    jfmt->match_found = true;
+
+    return match;
+}
+
+/* free_jfmt_matches_list   - free matches list in a struct jfmt_pattern *
+ *
+ * given:
+ *
+ *	pattern	    - the jfmt pattern
+ *
+ * If the jfmt patterns match list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL pattern.
+ */
+void
+free_jfmt_matches_list(struct jfmt_pattern *pattern)
+{
+    struct jfmt_match *match = NULL; /* to iterate through matches list */
+    struct jfmt_match *next_match = NULL; /* next in list */
+
+    if (pattern == NULL) {
+	err(37, __func__, "passed NULL pattern struct");
+	not_reached();
+    }
+
+    for (match = pattern->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+    pattern->matches = NULL;
+}
+
+/* is_jfmt_match	- if the name or value is a match based on type
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our struct jfmt
+ *	pattern	    - pointer to the pattern
+ *	name	    - char const * that is the matching name (if pattern == NULL)
+ *	node	    - struct json node
+ *	str	    - the string to compare
+ *
+ * Returns true if a match; else false.
+ *
+ * This function will not return if jfmt or node or str is NULL. The pattern
+ * and name pointers can be NULL unless both are NULL.
+ */
+bool
+is_jfmt_match(struct jfmt *jfmt, struct jfmt_pattern *pattern, char const *name, struct json *node, char const *str)
+{
+    /* firewall */
+    if (jfmt == NULL) {
+	err(38, __func__, "jfmt is NULL");
+	not_reached();
+    } else if ((pattern == NULL || pattern->pattern == NULL) && name == NULL) {
+	err(39, __func__, "pattern and name are both NULL");
+	not_reached();
+    } else if (node == NULL) {
+	err(40, __func__, "node is NULL");
+	not_reached();
+    } else if (str == NULL) {
+	err(41, __func__, "str is NULL");
+	not_reached();
+    }
+
+    /* set up name if NULL to be pattern->pattern */
+    if (name == NULL) {
+	name = pattern->pattern;
+    }
+
+    /* check that name != NULL */
+    if (name == NULL) {
+	err(42, __func__, "name is NULL");
+	not_reached();
+    }
+
+    /*
+     * if there is a match found add it to the matches list
+     *
+     * XXX - an issue that must be worked out is that if one does something
+     * like:
+     *
+     *	    jfmt -Y int -j h2g2.json 42
+     *
+     * they will get not just the integer values but the string "42". The
+     * problem is that in that file there is a string "42" and due to the bug in
+     * string matching and possibly the traversing of the tree (how it's done)
+     * this matches as all this function does is check the type of node and
+     * compare that it's equal. The string node should not actually be examined
+     * if the type does not match but this has to be fixed at a later time.
+     */
+    switch (node->type) {
+
+	case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+	    break;
+
+	case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	    {
+		struct json_number *item = &(node->item.number);
+
+		if (item != NULL && item->converted) {
+		    if (!jfmt->search_value || jfmt_match_num(jfmt->json_types) ||
+			(item->is_integer&&jfmt_match_int(jfmt->json_types))||
+			(item->is_floating && jfmt_match_float(jfmt->json_types)) ||
+			(item->is_e_notation && jfmt_match_exp(jfmt->json_types))) {
+			    if (jfmt->use_substrings) {
+				if (strstr(str, name) ||
+				    (jfmt->ignore_case&&strcasestr(str, name))) {
+					return true;
+				}
+			    } else {
+				if (!strcmp(name, str) ||
+				    (jfmt->ignore_case&&!strcasecmp(name, str))) {
+					return true;
+				}
+			    }
+			}
+		}
+	    }
+	    break;
+
+	case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+	    {
+		struct json_string *item = &(node->item.string);
+
+		if (item != NULL && item->converted) {
+		    if (!jfmt->search_value || jfmt_match_string(jfmt->json_types)) {
+			if (jfmt->use_substrings) {
+			    if (strstr(str, name) ||
+				(jfmt->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jfmt->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+	    {
+		struct json_boolean *item = &(node->item.boolean);
+
+		if (item != NULL && item->converted) {
+		    if (!jfmt->search_value || jfmt_match_bool(jfmt->json_types)) {
+			if (jfmt->use_substrings) {
+			    if (strstr(str, name) ||
+				(jfmt->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+
+			} else {
+			    if (!strcmp(name, str) ||
+				(jfmt->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+	    {
+		struct json_null *item = &(node->item.null);
+
+		if (item != NULL && item->converted) {
+		    if (!jfmt->search_value || jfmt_match_null(jfmt->json_types)) {
+			if (jfmt->use_substrings) {
+			    if (strstr(str, name) ||
+				(jfmt->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jfmt->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+	    }
+	    break;
+
+	case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+	    {
+		struct json_member *item = &(node->item.member);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+	    {
+		struct json_object *item = &(node->item.object);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+	    {
+		struct json_array *item = &(node->item.array);
+
+		/* XXX - check if anything has to be done here as a quick test
+		 * suggests nothing has to be done - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+	    {
+		struct json_elements *item = &(node->item.elements);
+
+		/* XXX - check if anything has to be done here - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	default:
+	    break;
+	}
+    }
+    /* nothing found, return false */
+    return false;
+}
+
+
+/*
+ * jfmt_json_search
+ *
+ * Print information about a JSON node, depending on the booleans in struct
+ * jfmt if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * given:
+ *	jfmt	    pointer to our struct jfmt
+ *	name_node   pointer to a JSON parser tree name node to try and match or add
+ *	value_node  pointer to a JSON parser tree value node to try and match or add
+ *	is_value    whether node is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	...	    extra args are ignored, required extra args if <=
+ *		    json_verbosity_level:
+ *
+ *			stream		stream to print on
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * Example use - print a JSON parse tree
+ *
+ *	jfmt_json_search(node, true, depth, JSON_DBG_MED);
+ *	jfmt_json_search(node, false, depth, JSON_DBG_FORCED;
+ *	jfmt_json_search(node, false, depth, JSON_DBG_MED);
+ *
+ * While the ... variable arg are ignored, we need to declare
+ * then in order to be in vcallback form for use by json_tree_walk().
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jfmt == NULL or node == NULL.
+ */
+void
+jfmt_json_search(struct jfmt *jfmt, struct json *name_node, struct json *value_node, bool is_value, unsigned int depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /* firewall */
+    if (jfmt == NULL || (name_node == NULL&&value_node == NULL)) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, depth);
+
+    /*
+     * call va_list argument list function
+     */
+    vjfmt_json_search(jfmt, name_node, value_node, is_value, depth, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+
+/*
+ * vjfmt_json_search
+ *
+ * Search for matches in a JSON node, depending on the booleans in struct
+ * jfmt if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * This is a variable argument list interface to jfmt_json_search().
+ *
+ * See jfmt_json_tree_search() to go through the entire tree.
+ *
+ * given:
+ *	jfmt	    pointer to our struct json
+ *	name_node   pointer to a JSON parser tree name node to search
+ *	value_node  pointer to a JSON parser tree value node to search
+ *	is_value    boolean to indicate if this is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	ap	    variable argument list, required ap args:
+ *
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * NOTE: This function does nothing if jfmt == NULL or jfmt->patterns ==
+ * NULL or if none of the names/values match any of the patterns or node ==
+ * NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is incomplete and does not do everything correctly. Any
+ * problems will be fixed in a future commit.
+ */
+void
+vjfmt_json_search(struct jfmt *jfmt, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap)
+{
+    FILE *stream = NULL;	/* stream to print on */
+    int json_dbg_lvl = JSON_DBG_DEFAULT;	/* JSON debug level if json_dbg_used */
+    struct jfmt_pattern *pattern = NULL; /* to iterate through patterns list */
+    va_list ap2;		/* copy of va_list ap */
+
+    /*
+     * firewall - nothing to do for NULL jfmt or NULL patterns list or NULL
+     * nodes
+     */
+    if (jfmt == NULL || jfmt->patterns == NULL || name_node == NULL || value_node == NULL) {
+	return;
+    }
+
+    /*
+     * duplicate va_list ap
+     */
+    va_copy(ap2, ap);
+
+    /*
+     * obtain the stream, json_dbg_used, and json_dbg args
+     */
+    stream = stdout;
+    if (stream == NULL) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+    json_dbg_lvl = va_arg(ap2, int);
+
+    /*
+     * XXX: This is buggy in a number of ways and the is_value will possibly
+     * have to change. Strings in particular are problematic here and it does
+     * not work right. Also -t can end up searching by value without -Y even
+     * though it's not supposed to. What does work is that specifying a type in
+     * general can prevent one or the other from showing up. Nevertheless to
+     * develop the type checks this has to be done until it can be fixed. This
+     * is very much a work in progress.
+     */
+    if (((!jfmt->search_value && is_value) || (!is_value && jfmt->search_value))) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+
+    /* only search for matches if level constraints allow it */
+    if (!jfmt->levels_constrained || jfmt_number_in_range(depth, jfmt->number_of_patterns, &jfmt->jfmt_levels))
+    {
+	for (pattern = jfmt->patterns; pattern != NULL; pattern = pattern->next) {
+	    /* XXX: for each pattern we have to find a match and then add it to
+	     * the matches list of that pattern. After that we can go through
+	     * the matches found and print out the matches as desired by the
+	     * user. We will not add matches if the constraints do not allow it.
+	     *
+	     * However note that we currently do not have a working way to check
+	     * if the node is a value or name so what ends up happening is that
+	     * a value can match as a name and vice versa. See above comment.
+	     */
+
+	    /* get the name and value */
+	    struct json *name = jfmt->search_value?value_node:name_node;
+	    struct json *value = jfmt->search_value?name_node:value_node;
+
+	    /*
+	     * Get strings of name and value. NULL is checked prior to use,
+	     * below
+	     */
+	    char const *str = name  != NULL ? json_get_type_str(name, jfmt->match_encoded) : NULL;
+	    char const *val = value != NULL ? json_get_type_str(value, jfmt->match_encoded) : NULL;
+
+	    if (name != NULL) {
+		switch (name->type) {
+
+		    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+			break;
+
+		    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+					{
+					    if (val != NULL) {
+						if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						    if (add_jfmt_match(jfmt, pattern, name, value,
+							str, val, depth, jfmt->search_value?JTYPE_STRING:JTYPE_NUMBER,
+							jfmt->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
+							    err(43, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					}
+				    }
+				    break;
+				    default:
+					/* XXX - determine if other types need to be handled */
+				    break;
+				    }
+			    }
+			}
+			break;
+
+		    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_NUMBER:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name,
+						jfmt->search_value?val:str)) {
+						    if (add_jfmt_match(jfmt, pattern, name, value,
+							str, val, depth,
+							name->type, value->type) == NULL) {
+							    err(44, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						if (add_jfmt_match(jfmt, pattern, name, value, str, val,
+						    depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
+							err(45, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_BOOL:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						if (add_jfmt_match(jfmt, pattern, name, value, str, val,
+						    depth, jfmt->search_value?JTYPE_BOOL:JTYPE_STRING,
+						    jfmt->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
+							err(46, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_NULL:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						if (add_jfmt_match(jfmt, pattern, name, value, str, val,
+						    depth, jfmt->search_value?JTYPE_NULL:JTYPE_STRING,
+						    jfmt->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
+							err(47, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+
+				    }
+				    break;
+				    default:
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						if (add_jfmt_match(jfmt, pattern, name, value, str, val,
+						    depth, jfmt->search_value?JTYPE_STRING:JTYPE_BOOL,
+						    jfmt->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
+							err(48, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jfmt_match(jfmt, pattern, pattern->pattern, name, str)) {
+						if (add_jfmt_match(jfmt, pattern, name, value, str, val,
+						    depth, jfmt->search_value?JTYPE_STRING:JTYPE_NULL,
+						    jfmt->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
+							err(49, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+			{
+			    struct json_member *item = &(name->item.member);
+
+			    /* XXX - fix to check for match of the member and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+			{
+			    struct json_object *item = &(name->item.object);
+
+			    /* XXX - fix to check for match of the object and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+			{
+			    struct json_array *item = &(name->item.array);
+
+			    /* XXX - fix to check for match of the array and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+			{
+			    struct json_elements *item = &(name->item.elements);
+
+			    /* XXX - fix to check for match of the element and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    default:
+			break;
+		}
+	    }
+	}
+    }
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap2);
+    return;
+}
+
+
+/*
+ * jfmt_json_tree_search - search nodes of an entire JSON parse tree
+ *
+ * This function uses the jfmt_json_tree_walk() interface to walk
+ * the JSON parse tree and print requested information about matching nodes.
+ *
+ * given:
+ *	jfmt	    pointer to our struct jfmt
+ *	node	    pointer to a JSON parser tree node to free
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	...	extra args are ignored, required extra args:
+ *
+ *		json_dbg_lvl   print message if JSON_DBG_FORCED
+ *			       OR if <= json_verbosity_level
+ *
+ * Example uses - print an entire JSON parse tree
+ *
+ *	jfmt_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jfmt_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jfmt_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_MED);
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jfmt == NULL, jfmt->patterns == NULL
+ * or node == NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is a wrapper to jfmt_json_tree_walk() with the callback
+ * vjfmt_json_search().
+ */
+void
+jfmt_json_tree_search(struct jfmt *jfmt, struct json *node, unsigned int max_depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /*
+     * firewall - nothing to do for a NULL node
+     */
+    if (jfmt == NULL || jfmt->patterns == NULL || node == NULL) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, max_depth);
+
+    /*
+     * walk the JSON parse tree
+     */
+    jfmt_json_tree_walk(jfmt, node, node, max_depth, false, 0, vjfmt_json_search, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+/*
+ * jfmt_json_tree_walk - walk a JSON parse tree calling a function on each node in va_list form
+ *
+ * This is the va_list form of json_tree_walk().
+ *
+ * Walk a JSON parse tree, Depth-first Post-order (LRN) order.  See:
+ *
+ *	https://en.wikipedia.org/wiki/Tree_traversal#Post-order,_LRN
+ *
+ * Example use - walk an entire JSON parse tree, looking for matches and
+ * printing requested information on those matches.
+ *
+ *	jfmt_json_tree_walk(jfmt, tree, JSON_DEFAULT_MAX_DEPTH, 0, json_free);
+ *
+ * given:
+ *	node	    pointer to a JSON parse tree
+ *	is_value    if it's a value or name
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	vcallback   function to operate JSON parse tree node in va_list form
+ *	ap	    variable argument list
+ *
+ * The vcallback() function must NOT call va_arg() nor call va_end() on the
+ * va_list argument directly.  Instead they must call va_copy() and then use
+ * va_arg() and va_end() on the va_list copy.
+ *
+ * Although in C ALL functions are pointers which means one can call foo()
+ * as foo() or (*foo)() we use the latter format for the callback function
+ * to make it clearer that it is in fact a function that's passed in so
+ * that we can use this function to do more than one thing. This is also
+ * why we call it vcallback and not something else.
+ *
+ * If max_depth is >= 0 and the tree depth > max_depth, then this function return.
+ * In this case it will NOT operate on the node, or will be descend and further
+ * into the tree.
+ *
+ * NOTE: This function warns but does not do anything if an arg is NULL.
+ *
+ * NOTE: this function might be incomplete or does something that is incorrect.
+ * If this is the case it will be fixed in a future update.
+ */
+void
+jfmt_json_tree_walk(struct jfmt *jfmt, struct json *lnode, struct json *rnode, bool is_value,
+	unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jfmt *, struct json *, struct json *, bool,
+	unsigned int, va_list), va_list ap)
+{
+    int i;
+
+    /*
+     * firewall
+     */
+    if (lnode == NULL || rnode == NULL) {
+	warn(__func__, "node is NULL");
+	return ;
+    }
+    if (vcallback == NULL) {
+	warn(__func__, "vcallback is NULL");
+	return ;
+    }
+
+    /*
+     * do nothing if we are too deep
+     */
+    if (max_depth != JSON_INFINITE_DEPTH && depth > max_depth) {
+	warn(__func__, "tree walk descent stopped, tree depth: %u > max_depth: %u", depth, max_depth);
+	return;
+    }
+
+    /* if depth is 0 it can't be a value */
+    if (depth == 0) {
+	is_value = false;
+    }
+
+    /*
+     * walk based on type of node
+     */
+    switch (lnode->type) {
+
+    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	/* perform function operation on this terminal parse tree node, all of
+	 * which have to be a value */
+	(*vcallback)(jfmt, lnode, rnode, true, depth, ap);
+	break;
+
+    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+
+	/* perform function operation on this terminal parse tree node */
+	(*vcallback)(jfmt, lnode, rnode, is_value, depth, ap);
+	break;
+
+    case JTYPE_MEMBER:	/* JSON item is a member */
+	{
+	    struct json_member *item = &(lnode->item.member);
+
+	    /* perform function operation on JSON member name (left branch) node */
+	    jfmt_json_tree_walk(jfmt, item->name, item->value, false, max_depth, depth+1, vcallback, ap);
+
+	    /* perform function operation on JSON member value (right branch) node */
+	    jfmt_json_tree_walk(jfmt, item->name, item->value, true, max_depth, depth+1, vcallback, ap);
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jfmt, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_OBJECT:	/* JSON item is a { members } */
+	{
+	    struct json_object *item = &(lnode->item.object);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jfmt_json_tree_walk(jfmt, item->set[i], item->set[i], is_value, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jfmt, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ARRAY:	/* JSON item is a [ elements ] */
+	{
+	    struct json_array *item = &(lnode->item.array);
+
+	    /* perform function operation on each object member in order */
+
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jfmt_json_tree_walk(jfmt, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* just call callback on the array node */
+	(*vcallback)(jfmt, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ELEMENTS:	/* JSON items is zero or more JSON values */
+	{
+	    struct json_elements *item = &(lnode->item.elements);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jfmt_json_tree_walk(jfmt, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jfmt, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    default:
+	warn(__func__, "node type is unknown: %d", lnode->type);
+	/* nothing we can traverse */
+	break;
+    }
+    return;
+}
+
+
+/* jfmt_print_count	- print total matches if -c used
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our struct jfmt
+ *
+ * This function will not return on NULL jfmt.
+ *
+ * This function returns false if -c was not used and true if it was.
+ */
+bool
+jfmt_print_count(struct jfmt *jfmt)
+{
+    /* firewall */
+    if (jfmt == NULL) {
+	err(50, __func__, "jfmt is NULL");
+	not_reached();
+    }
+
+    if (jfmt->count_only) {
+	print("%ju\n", jfmt->total_matches);
+	return true;
+    }
+
+    return false;
+}
+
+
+/* jfmt_print_final_comma	- print final comma if -C used
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our struct jfmt
+ *
+ * This function will not return on NULL jfmt.
+ *
+ * This function does nothing if -C was not used or if -c was used.
+ */
+void
+jfmt_print_final_comma(struct jfmt *jfmt)
+{
+    /* firewall */
+    if (jfmt == NULL) {
+	err(51, __func__, "jfmt is NULL");
+	not_reached();
+    }
+
+    if (jfmt->print_final_comma && !jfmt->count_only) {
+	print("%c", ',');
+    }
+}
+
+
+/* jfmt_print_brace - print a brace if -B used
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our jfmt struct
+ *	open	    - boolean indicating if we need an open or close brace
+ *
+ * This function returns void.
+ *
+ * This function will not return on NULL jfmt.
+ */
+void
+jfmt_print_brace(struct jfmt *jfmt, bool open)
+{
+    /* firewall */
+    if (jfmt == NULL) {
+	err(52, __func__, "jfmt is NULL");
+	not_reached();
+    }
+
+    if (jfmt->print_braces && !jfmt->count_only) {
+	print("%c\n", open?'{':'}');
+    }
+}
+
+
+/* jfmt_print_match	    - print a single match
+ *
+ * given:
+ *
+ *	jfmt	    - our struct jfmt with patterns list
+ *	pattern	    - the pattern with the match
+ *	match	    - the match to print
+ *
+ * NOTE: this function will not return if NULL pointers.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jfmt_print_match(struct jfmt *jfmt, struct jfmt_pattern *pattern, struct jfmt_match *match)
+{
+    uintmax_t i = 0;			    /* to iterate through count of each match */
+    uintmax_t j = 0;			    /* temporary iterator */
+
+    /* firewall */
+    if (jfmt == NULL) {
+	err(53, __func__, "jfmt is NULL");
+	not_reached();
+    } else if (match == NULL) {
+	err(54, __func__, "match is NULL");
+	not_reached();
+    } else if (pattern == NULL) {
+	err(55, __func__, "pattern is NULL");
+	not_reached();
+    }
+
+    /* if the name of the match is NULL it is a fatal error */
+    if (match->match == NULL) {
+	err(56, __func__, "match->match is NULL");
+	not_reached();
+    } else if (*match->match == '\0') {
+	/* warn on empty name for now and then go to next match */
+	warn(__func__, "empty match name");
+	return;
+    }
+
+    if (match->value == NULL) {
+	err(57, __func__, "match '%s' has NULL value", match->match);
+	not_reached();
+    } else if (*match->value == '\0') {
+	/* for now we only warn on empty value */
+	warn(__func__, "empty value for match '%s'", match->match);
+	return;
+    }
+
+    /*
+     * if we get here we have to print the name and/or match
+     */
+    for (i = 0; i < match->count; ++i) {
+	/* print the match in the way requested
+	 *
+	 * XXX - the count is probably incorrect as it means the printing could
+	 * be out of order
+	 *
+	 * XXX - add final constraint checks
+	 *
+	 * XXX - part of the below is buggy in some cases. This must be fixed.
+	 *
+	 * XXX - more functions will have to be added to print the matches.
+	 * Currently the jfmt_match struct is a work in progress. More will
+	 * have to be done depending on the type that matched (this includes not
+	 * only the jfmt type but the JSON type too).
+	 */
+
+	/* first print JSON levels if requested */
+	if (jfmt->print_json_levels) {
+	    print("%ju", match->level);
+
+	    for (j = 0; j < jfmt->num_level_spaces; ++j) {
+		printf("%s", jfmt->print_level_tab?"\t":" ");
+	    }
+	    if (jfmt->indent_levels) {
+		if (jfmt->indent_spaces) {
+		    for (j = 0; j < match->level * jfmt->indent_spaces; ++j) {
+			print("%s", jfmt->indent_tab?"\t":" ");
+		    }
+		}
+	    }
+
+	}
+
+	/*
+	 * if we're printing name and value or the syntax we have extra things
+	 * to do
+	 */
+	if (jfmt_print_name_value(jfmt->print_json_types) || jfmt->print_syntax) {
+	    /* if we print syntax there are some extra things we have to do */
+	    if (jfmt->print_syntax) {
+
+		/* XXX - this doesn't print arrays and other more complicated types - XXX */
+		print("\"%s\"", match->match);
+
+		for (j = 0; j < jfmt->num_token_spaces; ++j) {
+		    print("%s", jfmt->print_token_tab?"\t":" ");
+		}
+
+		print("%s", ":");
+
+		for (j = 0; j < jfmt->num_token_spaces; ++j) {
+		    print("%s", jfmt->print_token_tab?"\t":" ");
+		}
+
+		print("%s%s%s%s\n",
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
+	    } else { /* if we're not printing syntax */
+		/* print the name, quoting it if necessary */
+		print("%s%s%s",
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"",
+			match->match,
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"");
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jfmt->num_token_spaces; ++j) {
+		    print("%s", jfmt->print_token_tab?"\t":" ");
+		}
+
+		/*
+		 * we're not printing the syntax but if colons are requested we
+		 * have to print them
+		 */
+		if (jfmt->print_colons) {
+		    print("%s", ":");
+		}
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jfmt->num_token_spaces; ++j) {
+		    print("%s", jfmt->print_token_tab?"\t":" ");
+		}
+
+		/* finally print the value.
+		 *
+		 * NOTE the check for printing syntax or entire file is not
+		 * necessary as such.
+		 */
+		print("%s%s%s\n",
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"");
+	    }
+	} else if (jfmt_print_name(jfmt->print_json_types) || jfmt_print_value(jfmt->print_json_types)) {
+	    /*
+	     * here we will print just the name or value, quoting and doing
+	     * other things as necessary.
+	     *
+	     * NOTE the check for printing syntax or entire file is not
+	     * necessary as such.
+	     */
+	    print("%s%s%s\n",
+		  (jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jfmt_print_name(jfmt->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jfmt_print_value(jfmt->print_json_types)))?"\"":"",
+		  jfmt_print_name(jfmt->print_json_types)?match->match:match->value,
+		  (jfmt->quote_strings||jfmt->print_syntax||jfmt->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jfmt_print_name(jfmt->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jfmt_print_value(jfmt->print_json_types)))?"\"":"");
+	}
+    }
+}
+
+/* jfmt_print_matches	    - print all matches found
+ *
+ * given:
+ *
+ *	jfmt	    - our struct jfmt with patterns list
+ *
+ * NOTE: this function will not return if jfmt is NULL.
+ *
+ * NOTE: this function will only warn if patterns and matches are both NULL.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * NOTE: this function uses jfmt_print_match() to print each match.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jfmt_print_matches(struct jfmt *jfmt)
+{
+    struct jfmt_pattern *pattern = NULL;  /* to iterate through patterns list */
+    struct jfmt_match *match = NULL;	    /* to iterate through matches of each pattern in the patterns list */
+
+    /* firewall */
+    if (jfmt == NULL) {
+	err(58, __func__, "jfmt is NULL");
+	not_reached();
+    } else if (jfmt->patterns == NULL && jfmt->matches == NULL) {
+	warn(__func__, "NULL patterns and matches list");
+	return;
+    }
+
+    /* if -c used just print total number of matches */
+    if (jfmt_print_count(jfmt)) {
+	return;
+    }
+
+    /* if -c was not used we have more to do */
+
+    /*
+     * although printing syntax is not yet fully implemented (though a
+     * reasonable amount of it is), we will check for -B and print the braces so
+     * that after the syntax printing is implemented nothing has to be done with
+     * -B. The function jfmt_print_braces() will not do anything if -B was not
+     * used.
+     */
+    jfmt_print_brace(jfmt, true);
+
+    for (pattern = jfmt->patterns; pattern != NULL; pattern = pattern->next) {
+	for (match = pattern->matches; match != NULL; match = match->next) {
+	    jfmt_print_match(jfmt, pattern, match);
+	}
+    }
+
+    /*
+     * although printing syntax is not yet fully implemented, we will check for
+     * -B and print the braces so that after the syntax printing is implemented
+     * nothing has to be done with -B. The function jfmt_print_braces() will
+     * not do anything if -B was not used.
+     */
+    if (jfmt->print_braces && !jfmt->count_only) {
+	jfmt_print_brace(jfmt, false);
+    }
+    /*
+     * as well, even though -j is not yet fully implemented, we will check for
+     * -C and print the final comma if requested so that once -j fully
+     * implemented we shouldn't have to do anything else with this option. Don't
+     * print final comma if -c used.
+     */
+    jfmt_print_final_comma(jfmt);
+
+    /* if we need a newline print it */
+    if ((jfmt->print_braces || jfmt->print_final_comma) && !jfmt->count_only) {
+	puts("");
+    }
+}
+
+/* run_jfmt_check_tool    - run the JSON check tool from -S path
+ *
+ * given:
+ *
+ *	jfmt	    - pointer to our struct jfmt (has everything needed)
+ *	argv	    - main()'s argv
+ *
+ * This function does not return on NULL jfmt. It does check for NULL
+ * jfmt->check_tool_path and jfmt->check_tool_args as it's not required to
+ * be set: the jfmt_sanity_chks() function only verifies that IF it is set it
+ * exists and is executable and if the args are specified that the -S is also
+ * specified (and the path is an executable file).
+ *
+ * This function does not return on NULL jfmt->file_contents.
+ *
+ * It does NOT check for the path existing as an executable file as the
+ * jfmt_sanity_chks() does that and if it somehow failed it's an error anyway.
+ */
+void
+run_jfmt_check_tool(struct jfmt *jfmt, char **argv)
+{
+    int exit_code = 0;			/* exit code for -S path execution */
+
+    /* firewall */
+    if (jfmt == NULL) {
+	err(59, __func__, "NULL jfmt");
+	not_reached();
+    } else if (jfmt->file_contents == NULL) {
+	err(60, __func__, "NULL jfmt->file_contents");
+	not_reached();
+    }
+
+    /* run tool if -S used */
+    if (jfmt->check_tool_path != NULL) {
+	/* try running via shell_cmd() first */
+	if (jfmt->check_tool_args != NULL) {
+	    dbg(DBG_MED, "about to execute: %s %s -- %s >/dev/null 2>&1",
+		    jfmt->check_tool_path, jfmt->check_tool_args, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% % -- %", jfmt->check_tool_path, jfmt->check_tool_args, argv[0]);
+	} else {
+	    dbg(DBG_MED, "about to execute: %s %s >/dev/null 2>&1", jfmt->check_tool_path, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% %", jfmt->check_tool_path, argv[0]);
+	}
+	if(exit_code != 0) {
+	    if (jfmt->check_tool_args != NULL) {
+		err(7, __func__, "JSON check tool '%s' with args '%s' failed with exit code: %d",/*ooo*/
+			jfmt->check_tool_path, jfmt->check_tool_args, exit_code);
+	    } else {
+		err(7, __func__, "JSON check tool '%s' without args failed with exit code: %d",/*ooo*/
+			jfmt->check_tool_path, exit_code);
+	    }
+	    not_reached();
+	}
+	/* now open a write-only pipe */
+	if (jfmt->check_tool_args != NULL) {
+	    jfmt->check_tool_stream = pipe_open(__func__, true, true, "% % %", jfmt->check_tool_path,
+		    jfmt->check_tool_args, argv[0]);
+	} else {
+	    jfmt->check_tool_stream = pipe_open(__func__, true, true, "% %", jfmt->check_tool_path, argv[0]);
+	}
+	if (jfmt->check_tool_stream == NULL) {
+	    if (jfmt->check_tool_args != NULL) {
+		err(7, __func__, "opening pipe to JSON check tool '%s' with args '%s' failed", /*ooo*/
+			jfmt->check_tool_path, jfmt->check_tool_args);
+	    } else {
+		err(7, __func__, "opening pipe to JSON check tool '%s' without args failed", jfmt->check_tool_path); /*ooo*/
+	    }
+	    not_reached();
+	} else {
+	    /* process the pipe */
+	    int exit_status = 0;
+
+	    /*
+	     * write the file contents, which we know to be a valid JSON
+	     * document that is NUL terminated, to the pipe.
+	     */
+	    fpr(jfmt->check_tool_stream, __func__, "%s", jfmt->file_contents);
+
+	    /*
+	     * close down the pipe to the child process and obtain the status of the pipe child process
+	     */
+	    exit_status = pclose(jfmt->check_tool_stream);
+
+	    /*
+	     * examine the exit status of the child process and error if the child had a non-zero exit
+	     */
+	    if (WEXITSTATUS(exit_status) != 0) {
+		free_jfmt(&jfmt);
+		err(7, __func__, "pipe child process exited non-zero"); /*ooo*/
+		not_reached();
+	    } else {
+		dbg(DBG_MED, "pipe child process exited OK");
+	    }
+	}
+	jfmt->check_tool_stream = NULL;
+    }
+}
+
+

--- a/jparse/jfmt_util.h
+++ b/jparse/jfmt_util.h
@@ -1,0 +1,324 @@
+/* jfmt_util - utility functions for JSON printer jfmt
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JFMT_UTIL_H)
+#    define  INCLUDE_JFMT_UTIL_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g and -G, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* defines */
+
+/* -t types */
+#define JFMT_TYPE_NONE    (0)
+#define JFMT_TYPE_INT	    (1)
+#define JFMT_TYPE_FLOAT   (2)
+#define JFMT_TYPE_EXP	    (4)
+#define JFMT_TYPE_NUM	    (8)
+#define JFMT_TYPE_BOOL    (16)
+#define JFMT_TYPE_STR	    (32)
+#define JFMT_TYPE_NULL    (64)
+#define JFMT_TYPE_OBJECT  (128)
+#define JFMT_TYPE_ARRAY   (256)
+#define JFMT_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JFMT_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JFMT_TYPE_SIMPLE  (JFMT_TYPE_NUM|JFMT_TYPE_BOOL|JFMT_TYPE_STR|JFMT_TYPE_NULL)
+/* JFMT_TYPE_COMPOUND is bitwise OR of object and array */
+#define JFMT_TYPE_COMPOUND (JFMT_TYPE_OBJECT|JFMT_TYPE_ARRAY)
+
+/* print types for -p option */
+#define JFMT_PRINT_NAME   (1)
+#define JFMT_PRINT_VALUE  (2)
+#define JFMT_PRINT_BOTH   (JFMT_PRINT_NAME | JFMT_PRINT_VALUE)
+
+
+/* structs */
+
+/* structs for various options */
+/* number ranges for the options -l, -n and -n */
+struct jfmt_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
+};
+struct jfmt_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
+
+    /* for number ranges */
+    struct jfmt_number_range range;	/* for ranges */
+};
+
+/* jfmt_array - a struct for when an array matches, used in jfmt_match below
+ *
+ * XXX - this struct might or might not have to change - XXX
+ */
+struct jfmt_array
+{
+    struct json_array *array;
+
+    struct jfmt_match *match;	    /* what matched this array */
+};
+/*
+ * jfmt_match - a struct for a linked list of patterns matched in each pattern
+ * requested.
+ *
+ * XXX - this struct is a work in progress - XXX
+ */
+struct jfmt_match
+{
+    char *match;		    /* string that matched */
+    char *value;		    /* name or value string of that which matched */
+
+    uintmax_t count;		    /* how many of this match are found */
+    uintmax_t level;		    /* the level of the json member for -l */
+    uintmax_t number;		    /* which match this is */
+    enum item_type name_type;	    /* match type of name */
+    enum item_type value_type;	    /* match type of value */
+
+    struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
+    struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
+
+    struct jfmt_array *array;	    /* will not be NULL if match is an array. */
+
+    struct jfmt_pattern *pattern; /* pointer to the pattern that matched. DO NOT FREE! */
+    struct jfmt_match *next; /* next match found */
+};
+
+/*
+ * jfmt_pattern - struct for a linked list of patterns requested, held in
+ * struct jfmt
+ *
+ * XXX - the pattern concept is incorrect due to a misunderstanding - XXX
+ */
+struct jfmt_pattern
+{
+    char *pattern;		    /* the actual pattern or regexp string */
+    bool use_regexp;		    /* whether -g was used */
+    bool use_value;		    /* whether -Y was used, implying to search values */
+    bool use_substrings;	    /* if -s was used */
+    uintmax_t matches_found;	    /* number of matches found so far with this pattern */
+
+    struct jfmt_pattern *next;    /* the next in the list */
+
+    struct jfmt_match *matches;   /* matches found */
+};
+
+/*
+ * jfmt - struct that holds most of the options, other settings and other data
+ */
+struct jfmt
+{
+    /* JSON file related */
+    bool is_stdin;				/* reading from stdin */
+    FILE *json_file;				/* FILE * to json file */
+    char *file_contents;			/* file contents */
+
+    /* string related options */
+    bool encode_strings;			/* -e used */
+    bool quote_strings;				/* -Q used */
+
+
+    /* number ranges */
+    /* max number of matches */
+    bool max_matches_requested;			/* -n used */
+    struct jfmt_number jfmt_max_matches;	/* -n count specified */
+    /* min number of matches */
+    bool min_matches_requested;			/* -N used */
+    struct jfmt_number jfmt_min_matches;	/* -N count specified */
+    /* level constraints */
+    bool levels_constrained;			/* -l specified */
+    struct jfmt_number jfmt_levels;		/* -l level specified */
+
+    /* printing related options */
+    bool print_json_types_option;		/* -p explicitly used */
+    uintmax_t print_json_types;			/* -p type specified */
+    bool print_token_spaces;			/* -b specified */
+    uintmax_t num_token_spaces;			/* -b specified number of spaces or tabs */
+    bool print_token_tab;			/* -b tab (or -b <num>[t]) specified */
+    bool print_json_levels;			/* -L specified */
+    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
+    bool print_level_tab;			/* -L tab option */
+    bool print_colons;				/* -P specified */
+    bool print_final_comma;			/* -C specified */
+    bool print_braces;				/* -B specified */
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
+    bool indent_tab;				/* -I <num>[{t|s}] specified */
+    bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* search related bools */
+    bool json_types_specified;			/* -t used */
+    uintmax_t json_types;			/* -t type */
+    bool print_entire_file;			/* no name_arg specified */
+    bool match_found;				/* true if a pattern is specified and there is a match */
+    bool ignore_case;				/* true if -i, case-insensitive */
+    bool pattern_specified;			/* true if a pattern was specified */
+    bool search_value;				/* -Y used, search for value, not name */
+    bool search_or_mode;			/* -o used: search with OR mode */
+    bool search_anywhere;			/* -r used: search under anywhere */
+    bool match_encoded;				/* -E used, match encoded name */
+    bool use_substrings;			/* -s used, matching substrings okay */
+    bool use_regexps;				/* -g used, allow grep-like regexps */
+    bool count_only;				/* -c used, only show count */
+    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
+
+    /* check tool related things */
+    bool check_tool_specified;			/* bool indicating -S was used */
+    FILE *check_tool_stream;			/* FILE * stream for -S path */
+    char *check_tool_path;			/* -S tool path used */
+    char *check_tool_args;			/* -A tool args used */
+
+    /* any patterns specified */
+    /* XXX - the pattern concept is incorrect - XXX */
+    struct jfmt_pattern *patterns;		/* linked list of patterns specified */
+    uintmax_t number_of_patterns;		/* patterns specified */
+    /* matches found - subject to change */
+    struct jfmt_match *matches;		/* for entire file i.e. no name_arg */
+    uintmax_t total_matches;			/* total matches of all patterns (name_args) */
+
+    struct json *json_tree;			/* json tree if valid merely as a convenience */
+};
+
+
+/* function prototypes */
+struct jfmt *alloc_jfmt(void);
+
+/* JSON types - -t option*/
+uintmax_t jfmt_parse_types_option(char *optarg);
+bool jfmt_match_none(uintmax_t types);
+bool jfmt_match_int(uintmax_t types);
+bool jfmt_match_float(uintmax_t types);
+bool jfmt_match_exp(uintmax_t types);
+bool jfmt_match_exp(uintmax_t types);
+bool jfmt_match_bool(uintmax_t types);
+bool jfmt_match_num(uintmax_t types);
+bool jfmt_match_string(uintmax_t types);
+bool jfmt_match_null(uintmax_t types);
+bool jfmt_match_object(uintmax_t types);
+bool jfmt_match_array(uintmax_t types);
+bool jfmt_match_any(uintmax_t types);
+bool jfmt_match_simple(uintmax_t types);
+bool jfmt_match_compound(uintmax_t types);
+
+/* -Y type option */
+uintmax_t jfmt_parse_value_type_option(char *optarg);
+
+/* what to print - -p option */
+uintmax_t jfmt_parse_print_option(char *optarg);
+bool jfmt_print_name(uintmax_t types);
+bool jfmt_print_value(uintmax_t types);
+bool jfmt_print_name_value(uintmax_t types);
+
+/* for number range options: -l, -n, -n */
+bool jfmt_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jfmt_number *number);
+bool jfmt_number_in_range(intmax_t number, intmax_t total_matches, struct jfmt_number *range);
+
+/* for -b option */
+void jfmt_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab);
+
+/* for -I option */
+void jfmt_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
+
+/* for -L option */
+void jfmt_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
+
+/*
+ * patterns (name_args) specified
+ *
+ * XXX - the concept of the patterns is incorrect in that it's not individual
+ * patterns but rather the second, third and Nth patterns are under the previous
+ * patterns in the file.
+ */
+void parse_jfmt_name_args(struct jfmt *jfmt, char **argv);
+struct jfmt_pattern *add_jfmt_pattern(struct jfmt *jfmt, bool use_regexp, bool use_substrings, char *str);
+void free_jfmt_patterns_list(struct jfmt *jfmt);
+
+/* matches found of each pattern */
+struct jfmt_match *add_jfmt_match(struct jfmt *jfmt, struct jfmt_pattern *pattern,
+	struct json *node_name, struct json *node_value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type);
+void free_jfmt_matches_list(struct jfmt_pattern *pattern);
+
+/* functions to find matches in the JSON tree */
+bool is_jfmt_match(struct jfmt *jfmt, struct jfmt_pattern *pattern, char const *name, struct json *node, char const *str);
+void jfmt_json_search(struct jfmt *jfmt, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, ...);
+void vjfmt_json_search(struct jfmt *jfmt, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap);
+void jfmt_json_tree_search(struct jfmt *jfmt, struct json *node, unsigned int max_depth, ...);
+void jfmt_json_tree_walk(struct jfmt *jfmt, struct json *lnode, struct json *rnode, bool is_value,
+		unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jfmt *, struct json *, struct json *, bool,
+		unsigned int, va_list), va_list ap);
+
+/* functions to print matches */
+bool jfmt_print_count(struct jfmt *jfmt);
+void jfmt_print_final_comma(struct jfmt *jfmt);
+void jfmt_print_brace(struct jfmt *jfmt, bool open);
+void jfmt_print_match(struct jfmt *jfmt, struct jfmt_pattern *pattern, struct jfmt_match *match);
+void jfmt_print_matches(struct jfmt *jfmt);
+
+
+/* for the -S check tool and -A check tool args */
+void run_jfmt_check_tool(struct jfmt *jfmt, char **argv);
+
+/* to free the entire struct jfmt */
+void free_jfmt(struct jfmt **jfmt);
+
+
+#endif /* !defined INCLUDE_JFMT_UTIL_H */

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -1,0 +1,804 @@
+/*
+ * jnamval - JSON member printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jnamval.h"
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+/*
+ * static globals
+ */
+static bool quiet = false;				/* true ==> quiet mode */
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the usage_msg([0-9]?)+ strings.
+ */
+static const char * const usage_msg0 =
+    "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
+    "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
+    "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type]\n"
+    "\t\t[-o] [-r] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\n"
+    "\t-h\t\tPrint help and exit\n"
+    "\t-V\t\tPrint version and exit\n"
+    "\t-v level\tVerbosity level (def: %d)\n"
+    "\t-J level\tJSON verbosity level (def: %d)\n"
+    "\n"
+    "\t-e\t\tPrint JSON strings as encoded strings (def: decode JSON strings)\n"
+    "\t-q\t\tQuiet mode (def: print stuff to stdout)\n"
+    "\t-Q\t\tPrint JSON strings surrounded by double quotes (def: do not)\n"
+    "\t-t type\t\tMatch only one of the these comma-separated types (def: simple):\n"
+    "\n"
+    "\t\t\t\tint\t\tinteger values\n"
+    "\t\t\t\tfloat\t\tfloating point values\n"
+    "\t\t\t\texp\t\texponential notation values\n"
+    "\t\t\t\tnum\t\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\t\tboolean values\n"
+    "\t\t\t\tstr\t\tstring values\n"
+    "\t\t\t\tnull\t\tnull values\n"
+    "\t\t\t\tsimple\t\talias for 'int,float,exp,bool,str,null' (the default)\n"
+    "\t\t\t\tmember\t\tJSON members\n"
+    "\t\t\t\tobject\t\tJSON objects\n"
+    "\t\t\t\tarray\t\tJSON arrays\n"
+    "\t\t\t\tcompound\talias for 'object,array'\n"
+    "\t\t\t\tany\t\tany type of value\n"
+    "\n"
+    "\t\t\tMatches are based on JSON names unless -Y is used in which case JSON values are matched.\n";
+
+static const char * const usage_msg1 =
+    "\t-l lvl\t\tPrint values at specific JSON levels (def: print any level)\n"
+    "\n"
+    "\t\t\tIf lvl is a number (e.g.: -l 3), level must == number.\n"
+    "\t\t\tIf lvl is a number followed by : (e.g. '-l 3:'), level must be >= number.\n"
+    "\t\t\tIf lvl is a : followed by a number (e.g. '-l :3'), level must be <= number.\n"
+    "\t\t\tIf lvl is num:num (e.g. '-l 3:5'), level must be inclusively in the range.\n"
+    "\n"
+    "\t-n count\tPrint up to count matches (def: print all matches)\n"
+    "\n"
+    "\t\t\tIf count is a number (e.g. '-n 3'), the matches must == number\n"
+    "\t\t\tIf count is a number followed by : (e.g. '-n 3:'), matches must be >= number.\n"
+    "\t\t\tIf count is a : followed by a number (e.g. '-n :3'), matches must be <= number.\n"
+    "\t\t\tIf count is num:num (e.g. '-n 3:5'), matches must be inclusively in the range.\n"
+    "\t\t\tA number < 0 refers printing from last match (e.g. '-n -1' will print last match).\n"
+    "\n"
+    "\t-N num\t\tPrint only if there are only a given number of matches (def: do not limit)\n"
+    "\n"
+    "\t\t\tIf num is only a number (e.g. '-l 1'), there must be only that many matches.\n"
+    "\t\t\tIf num is a number followed by : (e.g. '-l 3:'), there must >= num matches.\n"
+    "\t\t\tIf num is a : followed by a number (e.g. '-n :3'), there must <= num matches.\n"
+    "\t\t\tIf num is num:num (e.g. '-n 3:5'), the number of matches must be inclusively in the range.\n"
+    "\n"
+    "\t-p {n,v,b}\tPrint JSON key, value or both (def: print JSON values or JSON names if -Y is used)\n"
+    "\t-p name\t\tAlias for '-p n'\n"
+    "\t-p value\tAlias for '-p v'\n"
+    "\t-p both\t\tAlias for '-p n,v'\n"
+    "\n"
+    "\t\t\tIt is an error to use -p n or -p v with -j.\n"
+    "\n"
+    "\t-b <num>[{t|s}]\tPrint specified number of tabs or spaces between JSON tokens printed via -j (def: 1 space)\n"
+    "\t-b tab\t\tAlias for '-b 1t'\n"
+    "\n"
+    "\t\t\tNot specifying a character after the number implies spaces.\n"
+    "\t\t\tThis option is only useful with -j or -p b or -p both.\n"
+    "\t\t\tIt is an error to use -b without -p b or -p both.\n"
+    "\n"
+    "\t-L <num>[{t|s}]\tPrint JSON level (root is 0) followed by a number of tabs or spaces (def: don't print levels)\n"
+    "\t-L tab\t\tAlias for: '-L 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n";
+
+static const char * const usage_msg2 =
+    "\t-P\t\tWhen printing both i.e. '-p both', separate name/value by a : (colon) (def: do not)\n"
+    "\n"
+    "\t\t\tWhen -P is used with -b, the same whitespace is used round the : (colon).\n"
+    "\n"
+    "\t-C\t\tWhen printing JSON syntax, always print a comma after final line (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -C without -j has no effect.\n"
+    "\n"
+    "\t-B\t\tWhen printing JSON syntax, start with a '{' line and end with a '}' line.\n"
+    "\n"
+    "\t\t\tUse of -B without -j has no effect.\n"
+    "\t\t\tUse of both -B and -c is an error.\n"
+    "\n"
+    "\t-I <num>{[t|s]}\tWhen printing JSON syntax, indent levels (def: do not indent)\n"
+    "\t-I tab\t\tAlias for '-I 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies indent with number of tabs whereas trailing 's' implies spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n"
+    "\n"
+    "\t-j\t\tPrint using JSON syntax (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -j implies '-p both -b 1s -e -Q -I 4 -t any'.\n"
+    "\t\t\tSubsequent use of options after -j will change the effect of -j.\n"
+    "\t\t\tUse of both -p and -j is an error.\n"
+    "\n"
+    "\t-E\t\tMatch the JSON encoded name (def: match the JSON decoded name)\n"
+    "\t-i\t\tIgnore case of name (def: case matters)\n"
+    "\t-s\t\tSubstrings are used to match (def: the full name must match)\n"
+    "\t-g\t\tMatch using grep-like extended regular expressions (def: match strings or substrings if -s)\n"
+    "\n"
+    "\t\t\tTo match from the beginning, start name_arg with '^'.\n"
+    "\t\t\tTo match to the end, end name_arg with '$'.\n"
+    "\t\t\tUse of -g and -s is an error.\n"
+    "\n"
+    "\t-c\t\tOnly show count of matches found\n"
+    "\n"
+    "\t\t\tUse of -c with -B, -L, -j, or -I is an error.\n"
+    "\n"
+    "\t-m max_depth\tSet the maximum JSON level depth to max_depth (0 == infinite depth, def: %d)\n"
+    "\n"
+    "\t\t\tA 0 max_depth implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n"
+    "\n"
+    "\t-K\t\tRun tests on jnamval constraints\n";
+
+static const char * const usage_msg3 =
+    "\t-Y type\t\tSearch for a JSON value of a given comma-separated type (def: search for JSON names)\n"
+    "\n"
+    "\t\t\t\tint\tinteger values\n"
+    "\t\t\t\tfloat\tfloating point values\n"
+    "\t\t\t\texp\texponential notation values\n"
+    "\t\t\t\tnum\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\tboolean values\n"
+    "\t\t\t\tstr\tstring values\n"
+    "\t\t\t\tnull\tnull values\n"
+    "\t\t\t\tsimple\talias for 'int,float,exp,bool,str,null'\n"
+    "\n"
+    "\t\t\tUse of -Y requires one and only one name_arg.\n"
+    "\t\t\tUse of -Y changes the default from -p value to -p name.\n"
+    "\n"
+    "\t-o\t\tSearch by OR mode like grep -E 'foo|bar' (def: don't)\n"
+    "\t-r\t\tSearch under anywhere (def: don't)\n"
+    "\n"
+    "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
+    "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
+    "\n"
+    "\t\t\tUse of -A requires use of -S.\n";
+
+/*
+ * NOTE: this next one should be the last number; if any additional usage message strings
+ * have to be added the first additional one should be the number this is and this one
+ * should be changed to be the final string before this one + 1. Similarly if a
+ * string can be removed this one should have its number changed to be + 1 from
+ * the last one before it.
+ */
+static const char * const usage_msg4 =
+    "\tfile.json\tJSON file to parse (- ==> read from stdin)\n"
+    "\tname_arg\tsearch file.json for JSON name(s) (or one value if -Y) (def: match all)\n"
+    "\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n"
+    "    7\tJSON check tool failed\n"
+    " >=10\tinternal error\n"
+    "\n"
+    "JSON parser version: %s\n"
+    "jnamval version: %s";
+
+/*
+ * functions
+ */
+static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
+
+/*
+ * usage - print usage to stderr
+ *
+ * Example:
+ *      usage(3, program, "wrong number of arguments");;
+ *
+ * given:
+ *	exitcode        value to exit with
+ *	str		top level usage message
+ *	prog		our program name
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *       Normally one should NOT include newlines in warn messages.
+ *
+ * This function does not return.
+ */
+static void
+usage(int exitcode, char const *prog, char const *str)
+{
+    /*
+     * firewall
+     */
+    if (prog == NULL) {
+	prog = "((NULL prog))";
+	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
+    }
+    if (str == NULL) {
+	str = "((NULL str))";
+	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
+    }
+
+    /*
+     * print the formatted usage stream
+     */
+    if (*str != '\0') {
+	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
+    }
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg0, prog, DBG_DEFAULT, JSON_DBG_DEFAULT);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg1);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg2, JSON_DEFAULT_MAX_DEPTH);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg3);
+    fprintf_usage(exitcode, stderr, usage_msg4, json_parser_version, JNAMVAL_VERSION);
+    exit(exitcode); /*ooo*/
+    not_reached();
+}
+
+
+int
+main(int argc, char **argv)
+{
+    char const *program = NULL;		/* our name */
+    extern char *optarg;
+    extern int optind;
+    struct jnamval *jnamval = NULL;	/* struct of all our options and other things */
+    struct jnamval_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
+    size_t len = 0;			/* length of file contents */
+    bool is_valid = false;		/* if file is valid json */
+    int exit_code = 0;			/* for the end */
+    int i;
+
+    jnamval = alloc_jnamval();		/* allocate our struct jnamval * */
+    /*
+     * the alloc_jnamval() will never return a NULL pointer but check just in
+     * case
+     */
+    if (jnamval == NULL) {
+	err(23, "jnamval", "failed to allocate jnamval struct");
+	not_reached();
+    }
+
+    /*
+     * parse args
+     */
+    program = argv[0];
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEim:cg:KY:sorS:A:")) != -1) {
+	switch (i) {
+	case 'h':		/* -h - print help to stderr and exit 0 */
+	    free_jnamval(&jnamval);
+	    usage(2, program, "");	/*ooo*/
+	    not_reached();
+	    break;
+	case 'V':		/* -V - print version and exit */
+	    free_jnamval(&jnamval);
+	    print("%s\n", JNAMVAL_VERSION);
+	    exit(2);		/*ooo*/
+	    not_reached();
+	    break;
+	case 'v':		/* -v verbosity */
+	    /*
+	     * parse verbosity
+	     */
+	    verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'J':		/* -J json_verbosity */
+	    /*
+	     * parse JSON verbosity level
+	     */
+	    json_verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'l':
+	    jnamval->levels_constrained = true;
+	    jnamval_parse_number_range("-l", optarg, false, &jnamval->jnamval_levels);
+	    break;
+	case 'e':
+	    jnamval->encode_strings = true;
+	    dbg(DBG_LOW, "-e specified, will encode strings");
+	    break;
+	case 'Q':
+	    jnamval->quote_strings = true;
+	    dbg(DBG_LOW, "-Q specified, will quote strings");
+	    break;
+	case 't':
+	    jnamval->json_types_specified = true;
+	    jnamval->json_types = jnamval_parse_types_option(optarg);
+	    break;
+	case 'n':
+	    jnamval_parse_number_range("-n", optarg, true, &jnamval->jnamval_max_matches);
+	    jnamval->max_matches_requested = true;
+	    break;
+	case 'N':
+	    jnamval_parse_number_range("-N", optarg, false, &jnamval->jnamval_min_matches);
+	    jnamval->min_matches_requested = true;
+	    break;
+	case 'p':
+	    jnamval->print_json_types_option = true;
+	    jnamval->print_json_types = jnamval_parse_print_option(optarg);
+	    break;
+	case 'b':
+	    jnamval->print_token_spaces = true;
+	    jnamval_parse_st_tokens_option(optarg, &jnamval->num_token_spaces, &jnamval->print_token_tab);
+	    break;
+	case 'L':
+	    jnamval->print_json_levels = true; /* print JSON levels */
+	    jnamval_parse_st_level_option(optarg, &jnamval->num_level_spaces, &jnamval->print_level_tab);
+	    break;
+	case 'P':
+	    jnamval->print_colons = true;
+	    dbg(DBG_LOW, "-P specified, will print colons");
+	    break;
+	case 'C':
+	    jnamval->print_final_comma = true;
+	    dbg(DBG_LOW, "-C specified, will print final comma");
+	    break;
+	case 'B':
+	    jnamval->print_braces = true;
+	    dbg(DBG_LOW, "-B specified, will print braces");
+	    break;
+	case 'I':
+	    jnamval->indent_levels = true;
+	    jnamval_parse_st_indent_option(optarg, &jnamval->indent_spaces, &jnamval->indent_tab);
+	    break;
+	case 'i':
+	    jnamval->ignore_case = true; /* make case cruel :-) */
+	    dbg(DBG_LOW, "-i specified, making matches case-insensitive");
+	    break;
+	case 'j':
+	    jnamval->print_syntax = true;
+	    dbg(DBG_LOW, "-j, implying -p both");
+	    jnamval->print_json_types = jnamval_parse_print_option("both");
+	    dbg(DBG_LOW, "-j, implying -b 1");
+	    jnamval_parse_st_tokens_option("1", &jnamval->num_token_spaces, &jnamval->print_token_tab);
+	    dbg(DBG_LOW, "-j, implying -e -Q");
+	    jnamval->encode_strings = true;
+	    jnamval->quote_strings = true;
+	    dbg(DBG_LOW, "-j, implying -t any");
+	    /* don't set jnamval->json_types_specified as that's for explicit use of -t */
+	    jnamval->json_types = jnamval_parse_types_option("any");
+	    break;
+	case 'E':
+	    jnamval->match_encoded = true;
+	    dbg(DBG_LOW, "-E specified, will match encoded strings, not decoded strings");
+	    break;
+	case 's':
+	    jnamval->use_substrings = true;
+	    dbg(DBG_LOW, "-s specified, will match substrings");
+	    break;
+	case 'g':   /* allow grep-like ERE */
+	    jnamval->use_regexps = true;
+	    dbg(DBG_LOW, "-g specified, name_args will be regexps");
+	    break;
+	case 'c':
+	    jnamval->count_only = true;
+	    dbg(DBG_LOW, "-c specified, will only show count of matches");
+	    break;
+	case 'q':
+	    quiet = true;
+	    msg_warn_silent = true;
+	    break;
+	case 'm': /* set maximum depth to traverse json tree */
+	    if (!string_to_uintmax(optarg, &jnamval->max_depth)) {
+		free_jnamval(&jnamval);
+		err(3, "jnamval", "couldn't parse -m depth"); /*ooo*/
+		not_reached();
+	    }
+	    break;
+	case 'K': /* run test code */
+	    if (!jnamval_run_tests()) {
+		free_jnamval(&jnamval);
+		exit(6); /*ooo*/
+	    }
+	    else {
+		free_jnamval(&jnamval);
+		exit(0); /*ooo*/
+	    }
+	    break;
+	case 'Y':
+	    /*
+	     * Why is this option -Y? Why not Y? Because Y, that's why Y! Why
+	     * besides, all the other good options were already taken. :-)
+	     * Specifically the letter Y has a V in it and V would have been the
+	     * obvious choice but both v and V are taken. This is why you'll
+	     * have to believe us when we tell you that this is a good enough
+	     * reason why Y! :-)
+	     */
+	    jnamval->search_value = true;
+	    jnamval->json_types = jnamval_parse_value_type_option(optarg);
+	    break;
+	case 'o': /* search with OR mode */
+	    jnamval->search_or_mode = true;
+	    break;
+	case 'r': /* search under anywhere */
+	    jnamval->search_anywhere = true;  /* Why is -o before -r? To spell out OR when -o itself is OR! :-) */
+	    break;
+	case 'S':
+	    /* -S path to tool */
+	    jnamval->check_tool_specified = true;
+	    jnamval->check_tool_path = optarg;
+	    dbg(DBG_LOW, "set tool path to: '%s'", jnamval->check_tool_path);
+	    break;
+	case 'A':
+	    /*
+	     * -A args to tool. Requires use of -S. */
+	    jnamval->check_tool_args = optarg;
+	    dbg(DBG_LOW, "set tool args to: '%s'", jnamval->check_tool_args);
+	    break;
+	case ':':   /* option requires an argument */
+	case '?':   /* illegal option */
+	default:    /* anything else but should not actually happen */
+	    check_invalid_option(program, i, optopt);
+	    usage(3, program, ""); /*ooo*/
+	    not_reached();
+	    break;
+	}
+    }
+
+
+    /*
+     * check for conflicting options prior to changing argc and argv so that the
+     * user will know to correct the options before being told that they have
+     * the wrong number of arguments (if they do). Not everything can be checked
+     * prior to doing this though.
+     */
+
+    /* run specific sanity checks on options etc. */
+    jnamval->json_file = jnamval_sanity_chks(jnamval, program, &argc, &argv);
+
+
+    /*
+     * jnamval_sanity_chks() should never return a NULL FILE * but we check
+     * anyway
+     */
+    if (jnamval->json_file == NULL) {
+	/*
+	 * NOTE: don't make this exit code 3 as it's an internal error if the
+	 * jnamval_sanity_chks() returns a NULL pointer.
+	 */
+	err(24, "jnamval", "could not open regular readable file");
+	not_reached();
+    }
+
+    /* Before we can process the -S option, if it specified (which we know is
+     * sane), we have to read in the JSON file (either stdin or otherwise) and
+     * then verify that the JSON is valid.
+     *
+     * Read in entire file BEFORE trying to parse it as json as the parser
+     * function will close the file if not stdin.
+     *
+     * NOTE: why doesn't the jnamval_sanity_chks() function do this? Because this
+     * is not so much about a sane environment as much as being unable to
+     * continue after verify the command line is correct.
+     */
+    jnamval->file_contents = read_all(jnamval->json_file, &len);
+    if (jnamval->file_contents == NULL) {
+	err(4, "jnamval", "could not read in file: %s", argv[0]); /*ooo*/
+	not_reached();
+    }
+    /* clear EOF status and rewind for parse_json_stream() */
+    clearerr(jnamval->json_file);
+    rewind(jnamval->json_file);
+
+    /* run -S tool */
+    run_jnamval_check_tool(jnamval, argv);
+
+    jnamval->json_tree = parse_json_stream(jnamval->json_file, argv[0], &is_valid);
+    if (!is_valid || jnamval->json_tree == NULL) {
+	if (jnamval->json_file != stdin) {
+	    fclose(jnamval->json_file);  /* close file prior to exiting */
+	    jnamval->json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
+	}
+
+	/* free our jnamval struct */
+	free_jnamval(&jnamval);
+	err(5, "jnamval", "%s invalid JSON", argv[0]); /*ooo*/
+	not_reached();
+    }
+
+    dbg(DBG_MED, "valid JSON");
+
+
+    /* search for any patterns */
+    jnamval_json_tree_search(jnamval, jnamval->json_tree, jnamval->max_depth);
+
+    /* report, if debug level high enough, what will be searched for. */
+    if (jnamval->patterns != NULL && !jnamval->print_entire_file) {
+	for (pattern = jnamval->patterns; pattern != NULL; pattern = pattern->next) {
+	    if (pattern->pattern != NULL && *pattern->pattern) {
+
+		if (pattern->use_regexp) {
+		    dbg(DBG_LOW, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
+		} else {
+		    dbg(DBG_LOW, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
+			pattern->use_substrings?"OK":"ignored");
+		}
+	    }
+	}
+    }
+
+    /*
+     * we can't have this in the sanity checks function very easily as we don't
+     * want to read in the entire contents from that function
+     *
+     * XXX - printing the entire file is incorrect here as it needs to print it
+     * according to the options - XXX
+     */
+    if (!jnamval->print_entire_file || jnamval->count_only) {
+	jnamval_print_matches(jnamval);
+    } else if (jnamval->file_contents != NULL) {
+	dbg(DBG_MED, "no pattern requested and no -c, will print entire file");
+	fpr(stdout, "jnamval", "%s", jnamval->file_contents);
+    }
+
+    /* free tree */
+    json_tree_free(jnamval->json_tree, jnamval->max_depth);
+
+    /* All Done!!! -- Jessica Noll, Age 2 */
+    if (jnamval->match_found || !jnamval->pattern_specified || jnamval->print_entire_file) {
+	exit_code = 0;
+    } else {
+	exit_code = 1;
+    }
+    if (jnamval != NULL) {
+	free_jnamval(&jnamval);	/* free jnamval struct */
+    }
+
+    exit(exit_code); /*ooo*/
+}
+
+/* jnamval_sanity_chks	- sanity checks on jnamval tool options
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our jnamval struct
+ *	program	    - program name
+ *	argc	    - pointer to argc from main()
+ *	argv	    - pointer to argv from main()
+ *
+ * This function runs any important checks on the jnamval internal state. It also
+ * runs checks that a file arg is specified and that the right number of options
+ * are specified done after options are parsed.
+ *
+ * If passed a NULL pointer or anything is not sane this function will not
+ * return.
+ *
+ * This function returns a FILE *, the file to read the json from. It will not
+ * return if this cannot be done (i.e. it will never return a NULL pointer
+ * though main() still checks to be defensive).
+ *
+ * NOTE: this function does NOT check for valid JSON.
+ *
+ * NOTE: jnamval->check_tool_path and jnamval->check_tool_args can be NULL.
+ *
+ * NOTE: this function must be in jnamval.c, not jnamval_util.h, because it uses
+ * the usage() function which needs to be in this file.
+ */
+FILE *
+jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, char ***argv)
+{
+    /* firewall */
+    if (jnamval == NULL) {
+	err(25, __func__, "NULL jnamval");
+	not_reached();
+    } else if (argc == NULL) {
+	err(26, __func__, "NULL argc");
+	not_reached();
+    } else if (argv == NULL || *argv == NULL || **argv == NULL) {
+	err(27, __func__, "NULL argv");
+	not_reached();
+    } else if (program == NULL) {
+	err(28, __func__, "NULL program");
+	not_reached();
+    }
+
+    /*
+     * first check for invalid option combinations which if any found it is a
+     * command line error.
+     */
+
+    /* use of -g conflicts with -s and is an error. */
+    if (jnamval->use_regexps && jnamval->use_substrings) {
+	free_jnamval(&jnamval);
+	err(3, __func__, "cannot use both -g and -s"); /*ooo*/
+	not_reached();
+    }
+
+    /* check that if -b [num]t is used then -p both is true */
+    if (jnamval->print_token_tab && !jnamval_print_name_value(jnamval->print_json_types)) {
+	free_jnamval(&jnamval);
+	err(3, "jparse", "use of -b [num]t cannot be used without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * check that if -j was used that printing both name and value is used. -j
+     * does this but it's possible the user explicitly used -p after -j but if
+     * they did not specify 'b' or 'both' it is an error.
+     */
+    if (jnamval->print_syntax && !jnamval_print_name_value(jnamval->print_json_types)) {
+	free_jnamval(&jnamval);
+	err(3, "jparse", "cannot use -j without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+
+    /* use of -c with any of any of -B, -L, -j and -I is an error */
+    if (jnamval->count_only) {
+	if (jnamval->print_braces) {
+	    err(3, __func__, "cannot use -B and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jnamval->print_json_levels) {
+	    err(3, __func__, "cannot use -L and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jnamval->print_syntax) {
+	    err(3, __func__, "cannot use -j and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jnamval->indent_levels) {
+	    err(3, __func__, "cannot use -I and -c together"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * shift argc and argv for further processing. They're a pointer to those in
+     * main() so we have to dereference them here because main() also requires
+     * that they are shifted.
+     */
+    (*argc) -= optind;
+    (*argv) += optind;
+
+    /* must have at least one arg */
+    if ((*argv)[0] == NULL) {
+	usage(3, program, "wrong number of arguments"); /*ooo*/
+	not_reached();
+    }
+
+    /* if argv[0] != "-" we will attempt to open a regular readable file */
+    if (strcmp((*argv)[0], "-") != 0) {
+        /* check that the path exists and is a regular readable file */
+	if (!exists((*argv)[0])) {
+	    free_jnamval(&jnamval);
+	    err(4, __func__, "%s: file does not exist", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_file((*argv)[0])) {
+	    free_jnamval(&jnamval);
+	    err(4, __func__, "%s: not a regular file", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_read((*argv)[0])) {
+	    free_jnamval(&jnamval);
+	    err(4, __func__, "%s: unreadable file", (*argv[0])); /*ooo*/
+	    not_reached();
+	}
+
+	errno = 0; /* pre-clear errno for errp() */
+	jnamval->json_file = fopen((*argv)[0], "r");
+	if (jnamval->json_file == NULL) {
+	    free_jnamval(&jnamval);
+	    errp(4, __func__, "%s: could not open for reading", (*argv)[0]); /*ooo*/
+	    not_reached();
+	}
+    } else { /* argv[0] is "-": will read from stdin */
+	jnamval->is_stdin = true;
+	jnamval->json_file = stdin;
+    }
+
+    dbg(DBG_LOW, "maximum depth to traverse: %ju%s", jnamval->max_depth, (jnamval->max_depth == 0?" (no limit)":
+		jnamval->max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
+
+    if (jnamval->search_value && *argc != 2 && jnamval->number_of_patterns != 1) {
+	free_jnamval(&jnamval);
+	err(29, __func__, "-Y requires exactly one name_arg");
+	not_reached();
+    } else if (!jnamval->search_value && (*argv)[1] == NULL && !jnamval->count_only) {
+	jnamval->print_entire_file = true;   /* technically this boolean is redundant */
+    }
+
+
+    /*
+     * if -S specified then we need to verify that the tool is a regular
+     * executable file
+     */
+    if (jnamval->check_tool_path != NULL) {
+	if (!exists(jnamval->check_tool_path)) {
+	    err(3, __func__, "jnamval tool path does not exist: %s", jnamval->check_tool_path);/*ooo*/
+	    not_reached();
+	} else if (!is_file(jnamval->check_tool_path)) {
+	    err(3, __func__, "jnamval tool not a regular file: %s", jnamval->check_tool_path); /*ooo*/
+	    not_reached();
+	} else if (!is_exec(jnamval->check_tool_path)) {
+	    err(3, __func__, "jnamval tool not an executable file: %s", jnamval->check_tool_path); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * if -A args is specified then we must have an -S tool as well */
+    if (jnamval->check_tool_args != NULL) {
+	if (jnamval->check_tool_path == NULL) {
+	    /* it is an error if -A args specified without -S path */
+	    free_jnamval(&jnamval);
+	    err(3, __func__, "-A used without -S"); /*ooo*/
+	    not_reached();
+	} else if (jnamval->check_tool_args == NULL) {
+	    free_jnamval(&jnamval);
+	    err(3, __func__, "-A args NULL"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * final processing: some options require the use of others but they are not
+     * an error if they not used together; the one simply has no effect. Also
+     * once options are parsed we have to check name_args and verify some things
+     * after that.
+     */
+
+    /* without -j, -B has no effect */
+    if (jnamval->print_braces && !jnamval->print_syntax) {
+	jnamval->print_braces = false;
+    }
+
+    /* without -j, -C has no effect */
+    if (jnamval->print_final_comma && !jnamval->print_syntax) {
+	jnamval->print_final_comma = false;
+    }
+
+    /* parse name_args first */
+    parse_jnamval_name_args(jnamval, *argv);
+
+    /* now verify final options that require looking at name_args first */
+    if (jnamval->search_value && jnamval->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only one
+	 * arg is specified after the file
+	 */
+	free_jnamval(&jnamval);
+	err(3, __func__, "-Y requires exactly one name_arg"); /*ooo*/
+	not_reached();
+    }
+
+    if (jnamval->count_only && jnamval->patterns == NULL) {
+	err(3, __func__, "use of -c without any patterns is an error"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * verify that if patterns list is not NULL that we're not printing the
+     * entire file
+     */
+    if (jnamval->patterns != NULL && jnamval->print_entire_file) {
+	free_jnamval(&jnamval);
+	err(3, __func__, "printing the entire file not supported when searching for a pattern");/*ooo*/
+	not_reached();
+    }
+
+    /* all good: return the (presumably) json FILE * */
+    return jnamval->json_file;
+}

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -1,0 +1,78 @@
+/* jnamval - JSON member printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JNAMVAL_H)
+#    define  INCLUDE_JNAMVAL_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <strings.h> /* for -i, strcasecmp */
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jnamval_util - our utility functions, macros, jnamval structs and variables
+ */
+#include "jnamval_util.h"
+
+/*
+ * jnamval_test - test functions
+ */
+#include "jnamval_test.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* jnamval version string */
+#define JNAMVAL_VERSION "0.0.0 2023-07-16"		/* format: major.minor YYYY-MM-DD */
+
+/* jnamval functions - see jnamval_util.h for most */
+
+/* sanity checks on environment for specific options and the tool arguments */
+FILE *jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, char ***argv);
+
+#endif /* !defined INCLUDE_JNAMVAL_H */

--- a/jparse/jnamval_test.c
+++ b/jparse/jnamval_test.c
@@ -1,0 +1,426 @@
+/*
+ * jnamval_test - test functions for the jnamval tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#include "jnamval_test.h"
+
+/* jnamval_run_tests	- run test functions
+ *
+ * given:
+ *
+ *	void	    - no args: this function is selfish :-)
+ *
+ * Returns false if any test failed. Will only return after all tests are run.
+ */
+bool
+jnamval_run_tests(void)
+{
+    struct jnamval_number number;    /* number range */
+    bool test = false;		    /* whether current test passes or fails */
+    bool okay = true;	    /* if any test fails set to true, is return value */
+    uintmax_t bits = 0;	    /* for bits tests */
+
+    /* set up exact match of 5 */
+    jnamval_parse_number_range("-l", "5", false, &number);
+
+    /* make sure number matches exactly */
+    test = jnamval_test_number_range_opts(true, 5, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure number does NOT match */
+    test = jnamval_test_number_range_opts(false, 6, 7, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up inclusive range of >= 5 && <= 10 */
+    jnamval_parse_number_range("-l", "5:10", false, &number);
+    /* make sure that number is in the range >= 5 && <= 10 */
+    test = jnamval_test_number_range_opts(true, 6, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to >= max */
+    test = jnamval_test_number_range_opts(false, 11, 12, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jnamval_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
+     * last match)
+     */
+    jnamval_parse_number_range("-n", "5:-3", true, &number);
+    /* make sure that number is in the range >= 5 && <= 10 - 3 */
+    test = jnamval_test_number_range_opts(true, 7, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to >=
+     * total_matches
+     */
+    test = jnamval_test_number_range_opts(false, 11, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to being
+     * > total_matches - -max
+     */
+    test = jnamval_test_number_range_opts(false, 8, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jnamval_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+
+    /* set up minimum number */
+    jnamval_parse_number_range("-l", "10:", false, &number);
+    /* make sure that number 10 is in the range >= 10 */
+    test = jnamval_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 11 is in the range >= 10 */
+    test = jnamval_test_number_range_opts(true, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 9 is NOT >= 10 */
+    test = jnamval_test_number_range_opts(false, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up maximum number */
+    jnamval_parse_number_range("-l", ":10", false, &number);
+    /* make sure that number 10 is in the range <= 10 */
+    test = jnamval_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 9 is in the range <= 10 */
+    test = jnamval_test_number_range_opts(true, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 11 is NOT <= 10 */
+    test = jnamval_test_number_range_opts(false, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* now check bits */
+
+    /* set bits to JNAMVAL_PRINT_BOTH */
+    bits = jnamval_parse_print_option("both");
+
+    /* check that JNAMVAL_PRINT_BOTH is equal to bits */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_print_name_value, "JNAMVAL_PRINT_BOTH");
+    if (!test) {
+	okay = false;
+    }
+
+    /* set bits to JNAMVAL_PRINT_NAME */
+    bits = jnamval_parse_print_option("name");
+    /* check that only JNAMVAL_PRINT_NAME is set: both and value are not set */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_print_name, "JNAMVAL_PRINT_NAME") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_print_value, "JNAMVAL_PRINT_VALUE") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_print_name_value, "JNAMVAL_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+    /* set bits to JNAMVAL_PRINT_VALUE */
+    bits = jnamval_parse_print_option("v");
+    /* check that only JNAMVAL_PRINT_VALUE is set: both and name are not set */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_print_value, "JNAMVAL_PRINT_VALUE") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_print_name, "JNAMVAL_PRINT_NAME") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_print_name_value, "JNAMVAL_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+
+    /* test -t option bits */
+
+    /* first int,float,exp */
+    bits = jnamval_parse_types_option("int,float,exp");
+    /* check that any number will match */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_float, "JNAMVAL_TYPE_FLOAT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_exp, "JNAMVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* just exponents */
+    bits = jnamval_parse_types_option("exp");
+    /* check that int and float will fail but exp will succeed */
+    test = jnamval_test_bits(false, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_float, "JNAMVAL_TYPE_FLOAT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_exp, "JNAMVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test all types */
+    bits = jnamval_parse_types_option("any");
+    /* verify that it is the any bit */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_any, "JNAMVAL_TYPE_ANY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test compound */
+    bits = jnamval_parse_types_option("compound");
+    /* verify that the compound type is set by compound match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_compound, "JNAMVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the compound type is set by matching all types */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_object, "JNAMVAL_TYPE_OBJECT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_array, "JNAMVAL_TYPE_ARRAY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test simple */
+    bits = jnamval_parse_types_option("simple");
+    /* verify that the simple type is set by simple match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_simple, "JNAMVAL_TYPE_SIMPLE");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the simple type is set by matching each type */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_num, "JNAMVAL_TYPE_NUM") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_bool, "JNAMVAL_TYPE_BOOL") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_string, "JNAMVAL_TYPE_STR") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_null, "JNAMVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int */
+    bits = jnamval_parse_types_option("int");
+    /* verify that the int type is set by int match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test float */
+    bits = jnamval_parse_types_option("float");
+    /* verify that the float type is set by float match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_float, "JNAMVAL_TYPE_FLOAT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test exp */
+    bits = jnamval_parse_types_option("exp");
+    /* verify that the exp type is set by exp match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_exp, "JNAMVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test bool */
+    bits = jnamval_parse_types_option("bool");
+    /* verify that the bool type is set by bool match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_bool, "JNAMVAL_TYPE_BOOL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test string */
+    bits = jnamval_parse_types_option("str");
+    /* verify that the string type is set by string match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_string, "JNAMVAL_TYPE_STR");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test null */
+    bits = jnamval_parse_types_option("null");
+    /* verify that the null type is set by null match function */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_null, "JNAMVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int,str,null */
+    bits = jnamval_parse_types_option("int,str,null");
+    /* verify that the int,str,null types are set by match functions */
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_string, "JNAMVAL_TYPE_STR") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_null, "JNAMVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * test that none of the bits are set not via the match none function but by
+     * each match function
+     */
+    bits = JNAMVAL_TYPE_NONE;
+    test = jnamval_test_bits(false, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_float, "JNAMVAL_TYPE_FLOAT") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_exp, "JNAMVAL_TYPE_EXP") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_num, "JNAMVAL_TYPE_NUM") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_bool, "JNAMVAL_TYPE_BOOL") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_string, "JNAMVAL_TYPE_STR") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_null, "JNAMVAL_TYPE_NULL") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_object, "JNAMVAL_TYPE_OBJECT") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_array, "JNAMVAL_TYPE_ARRAY") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_any, "JNAMVAL_TYPE_ANY") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_simple, "JNAMVAL_TYPE_SIMPLE") &&
+	   jnamval_test_bits(false, bits, __LINE__, jnamval_match_compound, "JNAMVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+    /* check all types */
+    bits = jnamval_parse_types_option("int,float,exp,num,bool,str,null,object,array,any,simple,compound");
+    test = jnamval_test_bits(true, bits, __LINE__, jnamval_match_int, "JNAMVAL_TYPE_INT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_float, "JNAMVAL_TYPE_FLOAT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_exp, "JNAMVAL_TYPE_EXP") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_num, "JNAMVAL_TYPE_NUM") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_bool, "JNAMVAL_TYPE_BOOL") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_string, "JNAMVAL_TYPE_STR") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_null, "JNAMVAL_TYPE_NULL") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_object, "JNAMVAL_TYPE_OBJECT") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_array, "JNAMVAL_TYPE_ARRAY") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_any, "JNAMVAL_TYPE_ANY") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_simple, "JNAMVAL_TYPE_SIMPLE") &&
+	   jnamval_test_bits(true, bits, __LINE__, jnamval_match_compound, "JNAMVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+
+
+    return okay;
+}
+
+/* jnamval_test_number_range_opts
+ *
+ * Test that the number range functionality works okay.
+ *
+ * given:
+ *
+ *	option	     	option that this is testing
+ *	expected     	whether test should return true or false
+ *	number		number to test
+ *	total_matches	number of total matches
+ *	line		line number of code which called this function
+ *	range		range to verify number against
+ *
+ * Returns true if test is okay.
+ *
+ * NOTE: this will not return on NULL pointers.
+ */
+bool
+jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jnamval_number *range)
+{
+    bool test = false;	    /* result of test */
+
+    if (range == NULL) {
+	err(15, __func__, "NULL range, cannot test");
+	not_reached();
+    }
+
+    test = jnamval_number_in_range(number, total_matches, range);
+    print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
+    if (range->exact) {
+	print("expect exact match for number %jd: ", number);
+    } else if (range->range.inclusive) {
+	if (range->range.max < 0) {
+	    /* if max is < 0 then it's up through the total_matches - max item */
+	    print("expect number %jd to be >= %jd && <= (%jd - %jd): ", number, range->range.min, total_matches,
+		    -range->range.max);
+	} else {
+	    print("expect number %jd to be >= %jd && <= %jd: ", number, range->range.min, range->range.max);
+	}
+    } else if (range->range.greater_than_equal) {
+	print("expect number %jd to be >= %ju: ", number, range->range.min);
+    } else if (range->range.less_than_equal) {
+	print("expect number %jd to be <= %jd: ", number, range->range.max);
+    }
+
+    print("test %s\n", expected == test?"OK":"failed");
+
+    return expected == test;
+}
+
+/* jnamval_test_bits    -	test bits code
+ *
+ * given:
+ *
+ *	expected	- whether test should fail or not
+ *	set_bits	- the bits actually set
+ *	line		- line number of code that called this function
+ *	check_func	- pointer to function of appropriate check
+ *	name		- name of bits to check
+ *
+ * Returns true if the test succeeds otherwise false.
+ *
+ * NOTE: this function will not return on NULL function pointer or NULL name.
+ */
+bool
+jnamval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name)
+{
+    bool okay = true;	/* assume test will pass */
+    bool test = false;	/* return value of function call */
+
+    /* firewall */
+    if (check_func == NULL) {
+	err(16, __func__, "NULL check_func");
+	not_reached();
+    } else if (name == NULL) {
+	err(17, __func__, "NULL name");
+	not_reached();
+    }
+
+    print("in function %s from line %jd (bits %ju): expects %s %s set: ", __func__, line, set_bits,
+	    name, expected?"to be":"to NOT be");
+    test = check_func(set_bits);
+
+    if (test != expected) {
+	okay = false;
+    }
+    print("test %s\n", okay?"OK":"failed");
+
+    return okay;
+}

--- a/jparse/jnamval_test.h
+++ b/jparse/jnamval_test.h
@@ -1,0 +1,68 @@
+/* jnamval_test - test functions for the jnamval tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JNAMVAL_TEST_H)
+#    define  INCLUDE_JNAMVAL_TEST_H
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/*
+ * jnamval_util - jnamval utility functions
+ */
+#include "jnamval_util.h"
+
+bool jnamval_run_tests(void);
+bool jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
+	intmax_t line, struct jnamval_number *range);
+bool jnamval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
+
+#endif /* !defined INCLUDE_JNAMVAL_TEST_H */

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -1,0 +1,2780 @@
+/*
+ * jnamval_util - utility functions for JSON printer jnamval
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jnamval_util.h"
+
+/* alloc_jnamval	    - allocate a struct jnamval *, clear it out and set defaults
+ *
+ * This function returns a newly allocated and cleared struct jnamval *.
+ *
+ * This function will never return a NULL pointer.
+ */
+struct jnamval *
+alloc_jnamval(void)
+{
+    /* allocate our struct jnamval */
+    struct jnamval *jnamval = calloc(1, sizeof *jnamval);
+
+    /* verify jnamval != NULL */
+    if (jnamval == NULL) {
+	err(22, __func__, "failed to allocate jnamval struct");
+	not_reached();
+    }
+
+    /* explicitly clear everything out and set defaults */
+
+    /* JSON file member variables */
+    jnamval->is_stdin = false;			/* true if it's stdin */
+    jnamval->file_contents = NULL;		/* file.json contents */
+    jnamval->json_file = NULL;			/* JSON file * */
+
+    /* string related options */
+    jnamval->encode_strings = false;		/* -e used */
+    jnamval->quote_strings = false;		/* -Q used */
+
+
+    /* number range options, see struct jnamval_number_range in jnamval_util.h for details */
+
+    /* max matches number range */
+    jnamval->jnamval_max_matches.number = 0;
+    jnamval->jnamval_max_matches.exact = false;
+    jnamval->jnamval_max_matches.range.min = 0;
+    jnamval->jnamval_max_matches.range.max = 0;
+    jnamval->jnamval_max_matches.range.less_than_equal = false;
+    jnamval->jnamval_max_matches.range.greater_than_equal = false;
+    jnamval->jnamval_max_matches.range.inclusive = false;
+    jnamval->max_matches_requested = false;
+
+    /* min matches number range */
+    jnamval->jnamval_min_matches.number = 0;
+    jnamval->jnamval_min_matches.exact = false;
+    jnamval->jnamval_min_matches.range.min = 0;
+    jnamval->jnamval_min_matches.range.max = 0;
+    jnamval->jnamval_min_matches.range.less_than_equal = false;
+    jnamval->jnamval_min_matches.range.greater_than_equal = false;
+    jnamval->jnamval_min_matches.range.inclusive = false;
+    jnamval->min_matches_requested = false;
+
+    /* levels number range */
+    jnamval->jnamval_levels.number = 0;
+    jnamval->jnamval_levels.exact = false;
+    jnamval->jnamval_levels.range.min = 0;
+    jnamval->jnamval_levels.range.max = 0;
+    jnamval->jnamval_levels.range.less_than_equal = false;
+    jnamval->jnamval_levels.range.greater_than_equal = false;
+    jnamval->jnamval_levels.range.inclusive = false;
+    jnamval->levels_constrained = false;
+
+    /* print related options */
+    jnamval->print_json_types_option = false;		/* -p explicitly used */
+    jnamval->print_json_types = JNAMVAL_PRINT_VALUE;	/* -p type specified */
+    jnamval->print_token_spaces = false;			/* -b specified */
+    jnamval->num_token_spaces = 1;			/* -b specified number of spaces or tabs */
+    jnamval->print_token_tab = false;			/* -b tab (or -b <num>[t]) specified */
+    jnamval->print_json_levels = false;			/* -L specified */
+    jnamval->num_level_spaces = 0;			/* number of spaces or tab for -L */
+    jnamval->print_level_tab = false;			/* -L tab option */
+    jnamval->print_colons = false;			/* -P specified */
+    jnamval->print_final_comma = false;			/* -C specified */
+    jnamval->print_braces = false;			/* -B specified */
+    jnamval->indent_levels = false;			/* -I used */
+    jnamval->indent_spaces = 0;				/* -I number of tabs or spaces */
+    jnamval->indent_tab = false;				/* -I <num>[{t|s}] specified */
+    jnamval->print_syntax = false;			/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* misc options */
+    jnamval->count_only = false;				/* -c used, only show count */
+
+
+    /* search related bools */
+    /* json types to look for */
+    jnamval->json_types_specified = false;		/* -t used */
+    jnamval->json_types = JNAMVAL_TYPE_SIMPLE;		/* -t type specified, default simple */
+    jnamval->print_entire_file = false;			/* no name_arg specified */
+    jnamval->match_found = false;			/* true if a pattern is specified and there is a match */
+    jnamval->ignore_case = false;			/* true if -i, case-insensitive */
+    jnamval->pattern_specified = false;			/* true if a pattern was specified */
+    jnamval->search_value = false;			/* -Y search by value, not name. Uses print type */
+    /*
+     * Why is -o specified before -r? This is so that it spells out 'or' which
+     * is what -o means. Obviously! :-)
+     */
+    jnamval->search_or_mode = false;			/* -o used: search with OR mode */
+    jnamval->search_anywhere = false;			/* -r used: search under anywhere */
+
+    jnamval->match_encoded = false;			/* -E used, match encoded name */
+    jnamval->use_substrings = false;			/* -s used, matching substrings okay */
+    jnamval->use_regexps = false;			/* -g used, allow grep-like regexps */
+    jnamval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+
+
+    /* check tool related */
+    jnamval->check_tool_specified = false;		/* bool indicating -S was used */
+    jnamval->check_tool_stream = NULL;			/* FILE * stream for -S tool */
+    jnamval->check_tool_path = NULL;			/* -S tool_path */
+    jnamval->check_tool_args = NULL;			/* -A tool_args */
+
+    /* finally the linked list of patterns for matches */
+    /* XXX - the pattern concept is incorrect */
+    jnamval->patterns = NULL;
+    jnamval->number_of_patterns = 0;
+    /* matches - subject to change */
+    jnamval->matches = NULL;
+    jnamval->total_matches = 0;
+
+    return jnamval;
+}
+
+
+/*
+ * jnamval_match_none	- if no types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types == 0.
+ */
+bool
+jnamval_match_none(uintmax_t types)
+{
+    return types == JNAMVAL_TYPE_NONE;
+}
+
+/*
+ * jnamval_match_int	- if ints should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_INT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_int(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_INT) != 0;
+}
+/*
+ * jnamval_match_float	- if floats should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_FLOAT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_float(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_FLOAT) != 0;
+}
+/*
+ * jnamval_match_exp	- if exponents should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_EXP set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_exp(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_EXP) != 0;
+}
+/*
+ * jnamval_match_num	- if numbers of any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_NUM (or any of the number types) set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_num(uintmax_t types)
+{
+    return ((types & JNAMVAL_TYPE_NUM)||(types & JNAMVAL_TYPE_INT) || (types & JNAMVAL_TYPE_FLOAT) ||
+	    (types & JNAMVAL_TYPE_EXP))!= 0;
+}
+/*
+ * jnamval_match_bool	- if booleans should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_BOOL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_bool(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_BOOL) != 0;
+}
+/*
+ * jnamval_match_string	    - if strings should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_STR set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_string(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_STR) != 0;
+}
+/*
+ * jnamval_match_null	- if null should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_NULL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_null(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_NULL) != 0;
+}
+/*
+ * jnamval_match_object	    - if objects should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_OBJECT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_object(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_OBJECT) != 0;
+}
+/*
+ * jnamval_match_array	    - if arrays should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JNAMVAL_TYPE_ARRAY set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_array(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_ARRAY) != 0;
+}
+/*
+ * jnamval_match_any	- if any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types is equal to JNAMVAL_TYPE_ANY.
+ *
+ * Why does it have to equal JNAMVAL_TYPE_ANY if it checks for any type? Because
+ * the point is that if JNAMVAL_TYPE_ANY is set it can be any type but not
+ * specific types. For the specific types those bits have to be set instead. If
+ * JNAMVAL_TYPE_ANY is set then any type can be set but if types is say
+ * JNAMVAL_TYPE_INT then checking for JNAMVAL_TYPE_INT & JNAMVAL_TYPE_ANY would be
+ * != 0 (as it's a bitwise OR of all the types) which would suggest that any
+ * type is okay even if JNAMVAL_TYPE_INT was the only type.
+ */
+bool
+jnamval_match_any(uintmax_t types)
+{
+    return types == JNAMVAL_TYPE_ANY;
+}
+/*
+ * jnamval_match_simple	- if simple types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Simple is defined as a number, a bool, a string or a null.
+ *
+ * Returns true if types has JNAMVAL_TYPE_SIMPLE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_simple(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_SIMPLE) != 0;
+}
+/*
+ * jnamval_match_compound   - if compounds should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * A compound is defined as an object or array.
+ *
+ * Returns true if types has JNAMVAL_TYPE_COMPOUND set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_match_compound(uintmax_t types)
+{
+    return (types & JNAMVAL_TYPE_COMPOUND) != 0;
+}
+
+/*
+ * jnamval_parse_types_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JNAMVAL_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jnamval_parse_types_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t type = JNAMVAL_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    } else {
+	/* pre-clear errno for errp() */
+	errno = 0;
+	dup = strdup(optarg);
+	if (dup == NULL) {
+	    errp(23, __func__, "strdup(%s) failed", optarg);
+	    not_reached();
+	}
+    }
+
+    /*
+     * Go through comma-separated list of types, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might be - I've thought of a number of ways already).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "int")) {
+	    type |= JNAMVAL_TYPE_INT;
+	} else if (!strcmp(p, "float")) {
+	    type |= JNAMVAL_TYPE_FLOAT;
+	} else if (!strcmp(p, "exp")) {
+	    type |= JNAMVAL_TYPE_EXP;
+	} else if (!strcmp(p, "num")) {
+	    type |= JNAMVAL_TYPE_NUM;
+	} else if (!strcmp(p, "bool")) {
+	    type |= JNAMVAL_TYPE_BOOL;
+	} else if (!strcmp(p, "str")) {
+	    type |= JNAMVAL_TYPE_STR;
+	} else if (!strcmp(p, "null")) {
+	    type |= JNAMVAL_TYPE_NULL;
+	} else if (!strcmp(p, "object")) {
+	    type |= JNAMVAL_TYPE_OBJECT;
+	} else if (!strcmp(p, "array")) {
+	    type |= JNAMVAL_TYPE_ARRAY;
+	} else if (!strcmp(p, "simple")) {
+	    type |= JNAMVAL_TYPE_SIMPLE;
+	} else if (!strcmp(p, "compound")) {
+	    type |= JNAMVAL_TYPE_COMPOUND;
+	} else if (!strcmp(p, "any")) {
+	    type |= JNAMVAL_TYPE_ANY;
+	} else {
+	    /* unknown type */
+	    err(3, __func__, "unknown type '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+    return type;
+}
+
+/*
+ * jnamval_print_name	- if only names should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JNAMVAL_PRINT_NAME set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_print_name(uintmax_t types)
+{
+    return ((types & JNAMVAL_PRINT_NAME) && !(types & JNAMVAL_PRINT_VALUE)) != 0;
+}
+/*
+ * jnamval_print_value	- if only values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JNAMVAL_PRINT_VALUE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jnamval_print_value(uintmax_t types)
+{
+    return ((types & JNAMVAL_PRINT_VALUE) && !(types & JNAMVAL_PRINT_NAME)) != 0;
+}
+/*
+ * jnamval_print_both	- if names AND values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types has JNAMVAL_PRINT_BOTH set.
+ */
+bool
+jnamval_print_name_value(uintmax_t types)
+{
+    return types == JNAMVAL_PRINT_BOTH;
+}
+
+
+/*
+ * jnamval_parse_print_option	- parse -p option list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -p option
+ *
+ * Returns: bitvector of types to print.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JNAMVAL_PRINT_VALUE (as if '-p v').
+ */
+uintmax_t
+jnamval_parse_print_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t print_json_types = 0; /* default is to print values */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return JNAMVAL_PRINT_VALUE;
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    dup = strdup(optarg);
+    if (dup == NULL) {
+	errp(24, __func__, "strdup(%s) failed", optarg);
+	not_reached();
+    }
+
+    /*
+     * Go through comma-separated list of what to print, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might very well be).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "v") || !strcmp(p, "value")) {
+	    print_json_types |= JNAMVAL_PRINT_VALUE;
+	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
+	    print_json_types |= JNAMVAL_PRINT_NAME;
+	} else if (!strcmp(p, "b") || !strcmp(p, "both")) {
+	    print_json_types |= JNAMVAL_PRINT_BOTH;
+	} else {
+	    /* unknown keyword */
+	    err(3, __func__, "unknown keyword '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (jnamval_print_name_value(print_json_types)) {
+	dbg(DBG_LOW, "will print both name and value");
+    }
+    else if (jnamval_print_name(print_json_types)) {
+	dbg(DBG_LOW, "will only print name");
+    }
+    else if (jnamval_print_value(print_json_types)) {
+	dbg(DBG_LOW, "will only print value");
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+
+    return print_json_types;
+}
+
+/* jnamval_parse_number_range	- parse a number range for options -l, -N, -n
+ *
+ * given:
+ *
+ *	option		- option string (e.g. "-l"). Used for error and debug messages.
+ *	optarg		- the option argument
+ *	allow_negative	- true if max can be < 0
+ *	number		- pointer to struct number
+ *
+ * Returns true if successfully parsed.
+ *
+ * The following rules apply:
+ *
+ * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
+ * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
+ *     (1a) the last number can be negative in which case it's up through the
+ *	    count - max.
+ * (2) a minimum number, that is num >= minimum, is <num>:
+ * (3) a maximum number, that is num <= maximum, is :<num>
+ * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
+ * (5) anything else is an error
+ *
+ * See also the structs jnamval_number_range and jnamval_number in jnamval_util.h
+ * for more details.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
+ */
+bool
+jnamval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jnamval_number *number)
+{
+    intmax_t max = 0;
+    intmax_t min = 0;
+
+    /* firewall */
+    if (option == NULL || *option == '\0') {
+	err(3, __func__, "NULL or empty option given"); /*ooo*/
+	not_reached();
+    }
+    if (number == NULL) {
+	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
+	not_reached();
+    } else {
+	memset(number, 0, sizeof(struct jnamval_number));
+
+	/* don't assume everything is 0 */
+	number->exact = false;
+	number->range.min = 0;
+	number->range.max = 0;
+	number->range.inclusive = false;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
+    }
+
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
+	return false;
+    }
+
+    if (!strchr(optarg, ':')) {
+	if (string_to_intmax(optarg, &number->number)) {
+	    number->exact = true;
+	    number->range.min = 0;
+	    number->range.max = 0;
+	    number->range.inclusive = false;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
+	} else {
+	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
+	    not_reached();
+	}
+    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    /*
+	     * NOTE: we can't check that min >= max because a negative number in the
+	     * maximum means that the range is up through the count - max matches
+	     */
+	    number->range.min = min;
+	    number->range.max = max;
+	    number->range.inclusive = true;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    /* XXX - this debug message is problematic wrt the negative number
+	     * option
+	     */
+	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
+		    number->range.max);
+	}
+    } else if (sscanf(optarg, "%jd:", &min) == 1) {
+	number->number = 0;
+	number->exact = false;
+	number->range.min = min;
+	number->range.max = number->range.min;
+	number->range.greater_than_equal = true;
+	number->range.less_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+    } else if (sscanf(optarg, ":%jd", &max) == 1) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    number->range.max = max;
+	    number->range.min = number->range.max;
+	    number->number = 0;
+	    number->exact = false;
+	    number->range.less_than_equal = true;
+	    number->range.greater_than_equal = false;
+	    number->range.inclusive = false;
+	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+	}
+    } else {
+	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
+	not_reached();
+    }
+
+    return true;
+}
+
+/* jnamval_number_in_range   - check if number is in required range
+ *
+ * given:
+ *
+ *	number		- number to check
+ *	total_matches	- total number of matches found
+ *	range		- pointer to struct jnamval_number with range
+ *
+ * Returns true if the number is in range.
+ *
+ * NOTE: if range is NULL it will return false.
+ */
+bool
+jnamval_number_in_range(intmax_t number, intmax_t total_matches, struct jnamval_number *range)
+{
+    /* firewall check */
+    if (range == NULL) {
+	return false;
+    }
+
+    /* if exact is set and range->number == number then return true. */
+    if (range->exact && range->number == number) {
+	return true;
+    } else if (range->range.inclusive) {
+	/* if the number must be inclusive in range then we have to make sure
+	 * that number >= min and <= max.
+	 *
+	 * NOTE: we have to make a special check for negative numbers because a
+	 * negative number is up through the count of matches - the negative max
+	 * number (rather if there are 10 matches and the string -l 5:-3 is
+	 * specified then the items 5, 6, 7, 8 are to be printed).
+	 */
+	if (number >= range->range.min) {
+	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
+		return true;
+	    } else if (number <= range->range.max) {
+		return true;
+	    } else {
+		return false;
+	    }
+	} else {
+	    return false;
+	}
+    } else if (range->range.less_than_equal) {
+	/* if number has to be less than equal we check number <= the maximum
+	 * number (range->range.max).
+	 */
+	if (number <= range->range.max) {
+	    return true;
+	} else {
+	    return false;
+	}
+    } else if (range->range.greater_than_equal) {
+	/* if number has to be greater than or equal to the number then we check
+	 * that number >= minimum number (range->range.min).
+	 */
+	if (number >= range->range.min) {
+	    return true;
+	} else {
+	    return false;
+	}
+    }
+
+    return false; /* no match */
+}
+
+/* jnamval_parse_st_tokens_option    - parse -b [num]{s,t}/-b tab option
+ *
+ * This function parses the -b option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_token_spaces    - pointer to number of token spaces or tabs
+ *	print_token_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jnamval_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_token_spaces == NULL) {
+	err(3, __func__, "NULL num_token_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_token_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_token_spaces == 0 */
+	*num_token_spaces = 0;
+	/* make *print_token_tab == false */
+	*print_token_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_token_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_token_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_token_tab = false;
+	    dbg(DBG_LOW, "will print %ju space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -b <num>[ts]"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	*print_token_tab = true;
+	*num_token_spaces = 1;
+	dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+	    *num_token_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_token_spaces)) {
+	err(3, __func__, "couldn't parse -b <num>[ts]"); /*ooo*/
+	not_reached();
+    } else {
+	*print_token_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+    }
+}
+
+/* jnamval_parse_st_indent_option    - parse -I [num]{s,t}/-b indent option
+ *
+ * This function parses the -I option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	indent_level	    - pointer to number of indent spaces or tabs
+ *	indent_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jnamval_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (indent_level == NULL) {
+	err(3, __func__, "NULL indent_level"); /*ooo*/
+	not_reached();
+    } else if (indent_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *indent_level == 0 */
+	*indent_level = 0;
+	/* make *ident_tab == false */
+	*indent_tab = false;
+    }
+
+
+    if (sscanf(optarg, "%ju%c", indent_level, &ch) == 2) {
+	if (ch == 't') {
+	    *indent_tab = true;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else if (ch == 's') {
+	    *indent_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -I"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *indent_tab = true;
+	    *indent_level = 1;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+    } else if (!string_to_uintmax(optarg, indent_level)) {
+	err(3, __func__, "couldn't parse -I spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*indent_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+    }
+}
+
+/* jnamval_parse_st_level_option    - parse -L [num]{s,t}/-b level option
+ *
+ * This function parses the -L option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
+ *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jnamval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_level_spaces == NULL) {
+	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_level_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_level_spaces == 0 */
+	*num_level_spaces = 0;
+	/* make *print_level_tab == false */
+	*print_level_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_level_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_level_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -L"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *print_level_tab = true;
+	    *num_level_spaces = 1;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
+	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*print_level_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    }
+}
+
+/*
+ * jnamval_parse_value_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JNAMVAL_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jnamval_parse_value_type_option(char *optarg)
+{
+    uintmax_t type = JNAMVAL_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+    char *p = NULL;
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    }
+    p = optarg;
+
+    /* Determine if the arg is a valid type.  */
+    if (!strcmp(p, "int")) {
+	type = JNAMVAL_TYPE_INT;
+    } else if (!strcmp(p, "float")) {
+	type = JNAMVAL_TYPE_FLOAT;
+    } else if (!strcmp(p, "exp")) {
+	type = JNAMVAL_TYPE_EXP;
+    } else if (!strcmp(p, "num")) {
+	type = JNAMVAL_TYPE_NUM;
+    } else if (!strcmp(p, "bool")) {
+	type = JNAMVAL_TYPE_BOOL;
+    } else if (!strcmp(p, "str")) {
+	type = JNAMVAL_TYPE_STR;
+    } else if (!strcmp(p, "null")) {
+	type = JNAMVAL_TYPE_NULL;
+    } else if (!strcmp(p, "simple")) {
+	type = JNAMVAL_TYPE_SIMPLE;
+    } else {
+	/* unknown or unsupported type */
+	err(3, __func__, "unknown or unsupported type '%s'", p); /*ooo*/
+	not_reached();
+    }
+
+    return type;
+}
+
+/*
+ * free_jnamval	    - free jnamval struct
+ *
+ * given:
+ *
+ *	jnamval	    - a struct jnamval **
+ *
+ * This function will do nothing other than warn on NULL pointer (even though
+ * it's safe to free a NULL pointer though if jnamval itself was NULL it would be
+ * an error to dereference it).
+ *
+ * We pass a struct jnamval ** so that in the caller jnamval can be set to NULL to
+ * remove the need to repeatedly set it to NULL each time this function is
+ * called. This way we remove the need to do more than just call this function.
+ */
+void
+free_jnamval(struct jnamval **jnamval)
+{
+    struct jnamval_match *match = NULL; /* to iterate through matches list */
+    struct jnamval_match *next_match = NULL; /* next in list */
+
+    /* firewall */
+    if (jnamval == NULL || *jnamval == NULL) {
+	warn(__func__, "passed NULL struct jnamval ** or *jnamval is NULL");
+	return;
+    }
+
+    free_jnamval_patterns_list(*jnamval); /* free patterns list first */
+
+    /* we have to free matches attached to jnamval itself too */
+    for (match = (*jnamval)->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+
+    free(*jnamval);
+    *jnamval = NULL;
+}
+
+
+/* parse_jnamval_name_args - add name_args to patterns list
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our struct jnamval
+ *	argv	    - argv from main()
+ *
+ * This function will not return on NULL pointers.
+ *
+ * NOTE: by patterns we refer to name_args.
+ *
+ * XXX - the pattern concept is currently incorrect and needs to be fixed - XXX
+ */
+void
+parse_jnamval_name_args(struct jnamval *jnamval, char **argv)
+{
+    int i;  /* to iterate through argv */
+
+    /* firewall */
+    if (argv == NULL) {
+	err(15, __func__, "argv is NULL"); /*ooo*/
+	not_reached();
+    }
+
+    for (i = 1; argv[i] != NULL; ++i) {
+	jnamval->pattern_specified = true;
+
+	if (add_jnamval_pattern(jnamval, jnamval->use_regexps, jnamval->use_substrings, argv[i]) == NULL) {
+	    err(25, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
+		    jnamval->use_substrings?"OK":"ignored", argv[i]);
+	    not_reached();
+	}
+    }
+}
+
+
+/*
+ * add_jnamval_pattern
+ *
+ * Add jnamval pattern to the jnamval struct pattern list.
+ *
+ * given:
+ *
+ *	jnamval		- pointer to the jnamval struct
+ *	use_regexp	- whether to use regexp or not
+ *	use_substrings	- if -s was specified, make this a substring match
+ *	str		- the pattern to be added to the list
+ *
+ * NOTE: this function will not return if jnamval is NULL. If str is NULL
+ * this function will not return but if str is empty it will add an empty
+ * string to the list. However the caller will usually check that it's not empty
+ * prior to calling this function.
+ *
+ * Returns a pointer to the newly allocated struct jnamval_pattern * that was
+ * added to the jnamval patterns list.
+ *
+ * Duplicate patterns will not be added (case sensitive).
+ */
+struct jnamval_pattern *
+add_jnamval_pattern(struct jnamval *jnamval, bool use_regexp, bool use_substrings, char *str)
+{
+    struct jnamval_pattern *pattern = NULL;
+    struct jnamval_pattern *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jnamval == NULL) {
+	err(26, __func__, "passed NULL jnamval struct");
+	not_reached();
+    }
+    if (str == NULL) {
+	err(27, __func__, "passed NULL str");
+	not_reached();
+    }
+
+    /*
+     * first make sure the pattern is not already added to the list as the same
+     * type
+     */
+    for (pattern = jnamval->patterns; pattern != NULL; pattern = pattern->next) {
+	if (pattern->pattern && pattern->use_regexp == use_regexp) {
+	    /* XXX - add support for regexps - XXX */
+	    if ((!jnamval->ignore_case && !strcmp(pattern->pattern, str))||
+		(jnamval->ignore_case && strcasecmp(pattern->pattern, str))) {
+		return pattern;
+	    }
+	}
+    }
+    /*
+     * XXX either change the debug level or remove this message once
+     * processing is complete
+     */
+    if (use_regexp) {
+	dbg(DBG_LOW,"%s regex requested: '%s'", jnamval->search_value?"value":"name", str);
+    } else {
+	dbg(DBG_LOW,"%s pattern requested: '%s'", jnamval->search_value?"value":"name", str);
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    pattern = calloc(1, sizeof *pattern);
+    if (pattern == NULL) {
+	errp(28, __func__, "unable to allocate struct jnamval_pattern *");
+	not_reached();
+    }
+
+    errno = 0;
+    pattern->pattern = strdup(str);
+    if (pattern->pattern == NULL) {
+	errp(29, __func__, "unable to strdup string '%s' for patterns list", str);
+	not_reached();
+    }
+
+    pattern->use_regexp = use_regexp;
+    pattern->use_value = jnamval->search_value;
+    pattern->use_substrings = use_substrings;
+    /* increment how many patterns have been specified */
+    ++jnamval->number_of_patterns;
+    /* let jnamval know that a pattern was indeed specified */
+    jnamval->pattern_specified = true;
+    pattern->matches_found = 0; /* 0 matches found at first */
+
+    dbg(DBG_LOW, "adding %s pattern '%s' to patterns list", pattern->use_value?"value":"name", pattern->pattern);
+
+    for (tmp = jnamval->patterns; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	jnamval->patterns = pattern;
+    } else {
+	tmp->next = pattern;
+    }
+
+    return pattern;
+}
+
+
+/* free_jnamval_patterns_list	- free patterns list in a struct jnamval *
+ *
+ * given:
+ *
+ *	jnamval	    - the jnamval struct
+ *
+ * If the jnamval patterns list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL jnamval.
+ *
+ * NOTE: this function calls free_jnamval_matches_list() on all the patterns
+ * prior to freeing the pattern itself.
+ */
+void
+free_jnamval_patterns_list(struct jnamval *jnamval)
+{
+    struct jnamval_pattern *pattern = NULL; /* to iterate through patterns list */
+    struct jnamval_pattern *next_pattern = NULL; /* next in list */
+
+    if (jnamval == NULL) {
+	err(30, __func__, "passed NULL jnamval struct");
+	not_reached();
+    }
+
+    for (pattern = jnamval->patterns; pattern != NULL; pattern = next_pattern) {
+	next_pattern = pattern->next;
+
+	/* first free any matches */
+	free_jnamval_matches_list(pattern);
+
+	/* now free the pattern string itself */
+	if (pattern->pattern) {
+	    free(pattern->pattern);
+	    pattern->pattern = NULL;
+	}
+
+	/* finally free the pattern and set to NULL for the next pass */
+	free(pattern);
+	pattern = NULL;
+    }
+
+    jnamval->patterns = NULL;
+}
+
+
+/*
+ * add_jnamval_match
+ *
+ * Add jnamval pattern match to the jnamval struct pattern match list.
+ *
+ * given:
+ *
+ *	jnamval		- pointer to the jnamval struct
+ *	pattern		- the pattern that matched
+ *	name		- struct json * name that matched
+ *	value		- struct json * value that matched
+ *	name_str	- the matching value, either a value or name
+ *	value_str	- the matching value, the opposite of name_str
+ *	level		- the depth or level for the -l / -L options (level 0 is top of tree)
+ *	string		- boolean to indicate if the match is a string
+ *	name_type	- enum item_type indicating the type of name node (JTYPE_* in json_parse.h)
+ *	value_type	- enum item_type indicating the type of value node (JTYPE_* in json_parse.h)
+ *
+ * NOTE: this function will not return if any of the pointers are NULL (except
+ * the name and value - for now) including the pointers in the pattern struct.
+ *
+ * Returns a pointer to the newly allocated struct jnamval_match * that was
+ * added to the jnamval matched patterns list.
+ *
+ * NOTE: depending on jnamval->search_value the name and value nodes will be in a
+ * different order. Specifically the name is what matched, whether a value in
+ * the json tree or name, and the value is what will be printed. At least once
+ * this feature is done :-)
+ */
+struct jnamval_match *
+add_jnamval_match(struct jnamval *jnamval, struct jnamval_pattern *pattern, struct json *name,
+	struct json *value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type)
+{
+    struct jnamval_match *match = NULL;
+    struct jnamval_match *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jnamval == NULL) {
+	err(31, __func__, "passed NULL jnamval struct");
+	not_reached();
+    }
+
+    if (name_str == NULL) {
+	err(32, __func__, "passed NULL name_str");
+	not_reached();
+    }
+    if (value_str == NULL) {
+	err(33, __func__, "value_str is NULL");
+	not_reached();
+    }
+
+    /*
+     * search for an exact match and only increment the count if found.
+     *
+     * NOTE: this means that when printing the output we have to go potentially
+     * print the match more than once; if -c is specified we print only the
+     * count.
+     */
+    for (tmp = pattern?pattern->matches:jnamval->matches; tmp; tmp = tmp->next) {
+	if (name_type == tmp->name_type) {
+	    /* XXX - add support for regexps - XXX */
+	    if (((!jnamval->ignore_case && !strcmp(tmp->match, value_str) && !strcmp(tmp->match, value_str)))||
+		(jnamval->ignore_case && !strcasecmp(tmp->match, value_str) && !strcasecmp(tmp->match, value_str))) {
+		    dbg(DBG_LOW, "incrementing count of match '%s' to %ju", tmp->match, tmp->count + 1);
+		    jnamval->total_matches++;
+		    tmp->count++;
+		    return tmp;
+	    }
+	}
+    }
+
+    /* if we get here we have to add the match to the matches list */
+    errno = 0; /* pre-clear errno for errp() */
+    match = calloc(1, sizeof *match);
+    if (match == NULL) {
+	errp(34, __func__, "unable to allocate struct jnamval_match *");
+	not_reached();
+    }
+
+    /* duplicate the match (name_str) */
+    errno = 0; /* pre-clear errno for errp() */
+    match->match = strdup(name_str);
+    if (match->match == NULL) {
+	errp(35, __func__, "unable to strdup string '%s' for match list", name_str);
+	not_reached();
+    }
+
+    /* duplicate the value of the match, either name or value */
+    errno = 0; /* pre-clear errno for errp() */
+    match->value = strdup(value_str);
+    if (match->match == NULL) {
+	errp(36, __func__, "unable to strdup value string '%s' for match list", value_str);
+	not_reached();
+    }
+    /* set level of the match for -l / -L options */
+    match->level = level;
+
+    /* set count to 1 */
+    match->count = 1;
+
+    /* record the pattern that was matched. It's okay if it is NULL. */
+    match->pattern = pattern; /* DO NOT FREE THIS! */
+
+    /* set struct json * nodes */
+    match->node_name = name;
+    match->node_value = value;
+
+    /* set which match number this is, incrementing the pattern's total matches */
+    if (pattern) {
+	match->number = pattern->matches_found++;
+    }
+
+    /* increment total matches of ALL patterns (name_args) in jnamval struct */
+    jnamval->total_matches++;
+
+    /* record types */
+    match->name_type = name_type;
+    match->value_type = value_type;
+
+    dbg(DBG_LOW, "adding match '%s' to pattern '%s' to match list",
+	    jnamval->search_value?match->value:match->match, name_str);
+
+    for (tmp = pattern?pattern->matches:jnamval->matches; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	if (pattern != NULL) {
+	    pattern->matches = match;
+	} else {
+	    jnamval->matches = match;
+	}
+    } else {
+	tmp->next = match;
+    }
+
+    /* a match is found, set jnamval->match_found to true */
+    jnamval->match_found = true;
+
+    return match;
+}
+
+/* free_jnamval_matches_list   - free matches list in a struct jnamval_pattern *
+ *
+ * given:
+ *
+ *	pattern	    - the jnamval pattern
+ *
+ * If the jnamval patterns match list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL pattern.
+ */
+void
+free_jnamval_matches_list(struct jnamval_pattern *pattern)
+{
+    struct jnamval_match *match = NULL; /* to iterate through matches list */
+    struct jnamval_match *next_match = NULL; /* next in list */
+
+    if (pattern == NULL) {
+	err(37, __func__, "passed NULL pattern struct");
+	not_reached();
+    }
+
+    for (match = pattern->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+    pattern->matches = NULL;
+}
+
+/* is_jnamval_match	- if the name or value is a match based on type
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our struct jnamval
+ *	pattern	    - pointer to the pattern
+ *	name	    - char const * that is the matching name (if pattern == NULL)
+ *	node	    - struct json node
+ *	str	    - the string to compare
+ *
+ * Returns true if a match; else false.
+ *
+ * This function will not return if jnamval or node or str is NULL. The pattern
+ * and name pointers can be NULL unless both are NULL.
+ */
+bool
+is_jnamval_match(struct jnamval *jnamval, struct jnamval_pattern *pattern, char const *name, struct json *node, char const *str)
+{
+    /* firewall */
+    if (jnamval == NULL) {
+	err(38, __func__, "jnamval is NULL");
+	not_reached();
+    } else if ((pattern == NULL || pattern->pattern == NULL) && name == NULL) {
+	err(39, __func__, "pattern and name are both NULL");
+	not_reached();
+    } else if (node == NULL) {
+	err(40, __func__, "node is NULL");
+	not_reached();
+    } else if (str == NULL) {
+	err(41, __func__, "str is NULL");
+	not_reached();
+    }
+
+    /* set up name if NULL to be pattern->pattern */
+    if (name == NULL) {
+	name = pattern->pattern;
+    }
+
+    /* check that name != NULL */
+    if (name == NULL) {
+	err(42, __func__, "name is NULL");
+	not_reached();
+    }
+
+    /*
+     * if there is a match found add it to the matches list
+     *
+     * XXX - an issue that must be worked out is that if one does something
+     * like:
+     *
+     *	    jnamval -Y int -j h2g2.json 42
+     *
+     * they will get not just the integer values but the string "42". The
+     * problem is that in that file there is a string "42" and due to the bug in
+     * string matching and possibly the traversing of the tree (how it's done)
+     * this matches as all this function does is check the type of node and
+     * compare that it's equal. The string node should not actually be examined
+     * if the type does not match but this has to be fixed at a later time.
+     */
+    switch (node->type) {
+
+	case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+	    break;
+
+	case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	    {
+		struct json_number *item = &(node->item.number);
+
+		if (item != NULL && item->converted) {
+		    if (!jnamval->search_value || jnamval_match_num(jnamval->json_types) ||
+			(item->is_integer&&jnamval_match_int(jnamval->json_types))||
+			(item->is_floating && jnamval_match_float(jnamval->json_types)) ||
+			(item->is_e_notation && jnamval_match_exp(jnamval->json_types))) {
+			    if (jnamval->use_substrings) {
+				if (strstr(str, name) ||
+				    (jnamval->ignore_case&&strcasestr(str, name))) {
+					return true;
+				}
+			    } else {
+				if (!strcmp(name, str) ||
+				    (jnamval->ignore_case&&!strcasecmp(name, str))) {
+					return true;
+				}
+			    }
+			}
+		}
+	    }
+	    break;
+
+	case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+	    {
+		struct json_string *item = &(node->item.string);
+
+		if (item != NULL && item->converted) {
+		    if (!jnamval->search_value || jnamval_match_string(jnamval->json_types)) {
+			if (jnamval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jnamval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jnamval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+	    {
+		struct json_boolean *item = &(node->item.boolean);
+
+		if (item != NULL && item->converted) {
+		    if (!jnamval->search_value || jnamval_match_bool(jnamval->json_types)) {
+			if (jnamval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jnamval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+
+			} else {
+			    if (!strcmp(name, str) ||
+				(jnamval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+	    {
+		struct json_null *item = &(node->item.null);
+
+		if (item != NULL && item->converted) {
+		    if (!jnamval->search_value || jnamval_match_null(jnamval->json_types)) {
+			if (jnamval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jnamval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jnamval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+	    }
+	    break;
+
+	case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+	    {
+		struct json_member *item = &(node->item.member);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+	    {
+		struct json_object *item = &(node->item.object);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+	    {
+		struct json_array *item = &(node->item.array);
+
+		/* XXX - check if anything has to be done here as a quick test
+		 * suggests nothing has to be done - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+	    {
+		struct json_elements *item = &(node->item.elements);
+
+		/* XXX - check if anything has to be done here - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	default:
+	    break;
+	}
+    }
+    /* nothing found, return false */
+    return false;
+}
+
+
+/*
+ * jnamval_json_search
+ *
+ * Print information about a JSON node, depending on the booleans in struct
+ * jnamval if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * given:
+ *	jnamval	    pointer to our struct jnamval
+ *	name_node   pointer to a JSON parser tree name node to try and match or add
+ *	value_node  pointer to a JSON parser tree value node to try and match or add
+ *	is_value    whether node is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	...	    extra args are ignored, required extra args if <=
+ *		    json_verbosity_level:
+ *
+ *			stream		stream to print on
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * Example use - print a JSON parse tree
+ *
+ *	jnamval_json_search(node, true, depth, JSON_DBG_MED);
+ *	jnamval_json_search(node, false, depth, JSON_DBG_FORCED;
+ *	jnamval_json_search(node, false, depth, JSON_DBG_MED);
+ *
+ * While the ... variable arg are ignored, we need to declare
+ * then in order to be in vcallback form for use by json_tree_walk().
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jnamval == NULL or node == NULL.
+ */
+void
+jnamval_json_search(struct jnamval *jnamval, struct json *name_node, struct json *value_node, bool is_value, unsigned int depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /* firewall */
+    if (jnamval == NULL || (name_node == NULL&&value_node == NULL)) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, depth);
+
+    /*
+     * call va_list argument list function
+     */
+    vjnamval_json_search(jnamval, name_node, value_node, is_value, depth, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+
+/*
+ * vjnamval_json_search
+ *
+ * Search for matches in a JSON node, depending on the booleans in struct
+ * jnamval if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * This is a variable argument list interface to jnamval_json_search().
+ *
+ * See jnamval_json_tree_search() to go through the entire tree.
+ *
+ * given:
+ *	jnamval	    pointer to our struct json
+ *	name_node   pointer to a JSON parser tree name node to search
+ *	value_node  pointer to a JSON parser tree value node to search
+ *	is_value    boolean to indicate if this is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	ap	    variable argument list, required ap args:
+ *
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * NOTE: This function does nothing if jnamval == NULL or jnamval->patterns ==
+ * NULL or if none of the names/values match any of the patterns or node ==
+ * NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is incomplete and does not do everything correctly. Any
+ * problems will be fixed in a future commit.
+ */
+void
+vjnamval_json_search(struct jnamval *jnamval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap)
+{
+    FILE *stream = NULL;	/* stream to print on */
+    int json_dbg_lvl = JSON_DBG_DEFAULT;	/* JSON debug level if json_dbg_used */
+    struct jnamval_pattern *pattern = NULL; /* to iterate through patterns list */
+    va_list ap2;		/* copy of va_list ap */
+
+    /*
+     * firewall - nothing to do for NULL jnamval or NULL patterns list or NULL
+     * nodes
+     */
+    if (jnamval == NULL || jnamval->patterns == NULL || name_node == NULL || value_node == NULL) {
+	return;
+    }
+
+    /*
+     * duplicate va_list ap
+     */
+    va_copy(ap2, ap);
+
+    /*
+     * obtain the stream, json_dbg_used, and json_dbg args
+     */
+    stream = stdout;
+    if (stream == NULL) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+    json_dbg_lvl = va_arg(ap2, int);
+
+    /*
+     * XXX: This is buggy in a number of ways and the is_value will possibly
+     * have to change. Strings in particular are problematic here and it does
+     * not work right. Also -t can end up searching by value without -Y even
+     * though it's not supposed to. What does work is that specifying a type in
+     * general can prevent one or the other from showing up. Nevertheless to
+     * develop the type checks this has to be done until it can be fixed. This
+     * is very much a work in progress.
+     */
+    if (((!jnamval->search_value && is_value) || (!is_value && jnamval->search_value))) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+
+    /* only search for matches if level constraints allow it */
+    if (!jnamval->levels_constrained || jnamval_number_in_range(depth, jnamval->number_of_patterns, &jnamval->jnamval_levels))
+    {
+	for (pattern = jnamval->patterns; pattern != NULL; pattern = pattern->next) {
+	    /* XXX: for each pattern we have to find a match and then add it to
+	     * the matches list of that pattern. After that we can go through
+	     * the matches found and print out the matches as desired by the
+	     * user. We will not add matches if the constraints do not allow it.
+	     *
+	     * However note that we currently do not have a working way to check
+	     * if the node is a value or name so what ends up happening is that
+	     * a value can match as a name and vice versa. See above comment.
+	     */
+
+	    /* get the name and value */
+	    struct json *name = jnamval->search_value?value_node:name_node;
+	    struct json *value = jnamval->search_value?name_node:value_node;
+
+	    /*
+	     * Get strings of name and value. NULL is checked prior to use,
+	     * below
+	     */
+	    char const *str = name  != NULL ? json_get_type_str(name, jnamval->match_encoded) : NULL;
+	    char const *val = value != NULL ? json_get_type_str(value, jnamval->match_encoded) : NULL;
+
+	    if (name != NULL) {
+		switch (name->type) {
+
+		    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+			break;
+
+		    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+					{
+					    if (val != NULL) {
+						if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						    if (add_jnamval_match(jnamval, pattern, name, value,
+							str, val, depth, jnamval->search_value?JTYPE_STRING:JTYPE_NUMBER,
+							jnamval->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
+							    err(43, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					}
+				    }
+				    break;
+				    default:
+					/* XXX - determine if other types need to be handled */
+				    break;
+				    }
+			    }
+			}
+			break;
+
+		    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_NUMBER:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name,
+						jnamval->search_value?val:str)) {
+						    if (add_jnamval_match(jnamval, pattern, name, value,
+							str, val, depth,
+							name->type, value->type) == NULL) {
+							    err(44, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						if (add_jnamval_match(jnamval, pattern, name, value, str, val,
+						    depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
+							err(45, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_BOOL:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						if (add_jnamval_match(jnamval, pattern, name, value, str, val,
+						    depth, jnamval->search_value?JTYPE_BOOL:JTYPE_STRING,
+						    jnamval->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
+							err(46, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_NULL:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						if (add_jnamval_match(jnamval, pattern, name, value, str, val,
+						    depth, jnamval->search_value?JTYPE_NULL:JTYPE_STRING,
+						    jnamval->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
+							err(47, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+
+				    }
+				    break;
+				    default:
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						if (add_jnamval_match(jnamval, pattern, name, value, str, val,
+						    depth, jnamval->search_value?JTYPE_STRING:JTYPE_BOOL,
+						    jnamval->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
+							err(48, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jnamval_match(jnamval, pattern, pattern->pattern, name, str)) {
+						if (add_jnamval_match(jnamval, pattern, name, value, str, val,
+						    depth, jnamval->search_value?JTYPE_STRING:JTYPE_NULL,
+						    jnamval->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
+							err(49, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+			{
+			    struct json_member *item = &(name->item.member);
+
+			    /* XXX - fix to check for match of the member and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+			{
+			    struct json_object *item = &(name->item.object);
+
+			    /* XXX - fix to check for match of the object and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+			{
+			    struct json_array *item = &(name->item.array);
+
+			    /* XXX - fix to check for match of the array and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+			{
+			    struct json_elements *item = &(name->item.elements);
+
+			    /* XXX - fix to check for match of the element and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    default:
+			break;
+		}
+	    }
+	}
+    }
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap2);
+    return;
+}
+
+
+/*
+ * jnamval_json_tree_search - search nodes of an entire JSON parse tree
+ *
+ * This function uses the jnamval_json_tree_walk() interface to walk
+ * the JSON parse tree and print requested information about matching nodes.
+ *
+ * given:
+ *	jnamval	    pointer to our struct jnamval
+ *	node	    pointer to a JSON parser tree node to free
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	...	extra args are ignored, required extra args:
+ *
+ *		json_dbg_lvl   print message if JSON_DBG_FORCED
+ *			       OR if <= json_verbosity_level
+ *
+ * Example uses - print an entire JSON parse tree
+ *
+ *	jnamval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jnamval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jnamval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_MED);
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jnamval == NULL, jnamval->patterns == NULL
+ * or node == NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is a wrapper to jnamval_json_tree_walk() with the callback
+ * vjnamval_json_search().
+ */
+void
+jnamval_json_tree_search(struct jnamval *jnamval, struct json *node, unsigned int max_depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /*
+     * firewall - nothing to do for a NULL node
+     */
+    if (jnamval == NULL || jnamval->patterns == NULL || node == NULL) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, max_depth);
+
+    /*
+     * walk the JSON parse tree
+     */
+    jnamval_json_tree_walk(jnamval, node, node, max_depth, false, 0, vjnamval_json_search, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+/*
+ * jnamval_json_tree_walk - walk a JSON parse tree calling a function on each node in va_list form
+ *
+ * This is the va_list form of json_tree_walk().
+ *
+ * Walk a JSON parse tree, Depth-first Post-order (LRN) order.  See:
+ *
+ *	https://en.wikipedia.org/wiki/Tree_traversal#Post-order,_LRN
+ *
+ * Example use - walk an entire JSON parse tree, looking for matches and
+ * printing requested information on those matches.
+ *
+ *	jnamval_json_tree_walk(jnamval, tree, JSON_DEFAULT_MAX_DEPTH, 0, json_free);
+ *
+ * given:
+ *	node	    pointer to a JSON parse tree
+ *	is_value    if it's a value or name
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	vcallback   function to operate JSON parse tree node in va_list form
+ *	ap	    variable argument list
+ *
+ * The vcallback() function must NOT call va_arg() nor call va_end() on the
+ * va_list argument directly.  Instead they must call va_copy() and then use
+ * va_arg() and va_end() on the va_list copy.
+ *
+ * Although in C ALL functions are pointers which means one can call foo()
+ * as foo() or (*foo)() we use the latter format for the callback function
+ * to make it clearer that it is in fact a function that's passed in so
+ * that we can use this function to do more than one thing. This is also
+ * why we call it vcallback and not something else.
+ *
+ * If max_depth is >= 0 and the tree depth > max_depth, then this function return.
+ * In this case it will NOT operate on the node, or will be descend and further
+ * into the tree.
+ *
+ * NOTE: This function warns but does not do anything if an arg is NULL.
+ *
+ * NOTE: this function might be incomplete or does something that is incorrect.
+ * If this is the case it will be fixed in a future update.
+ */
+void
+jnamval_json_tree_walk(struct jnamval *jnamval, struct json *lnode, struct json *rnode, bool is_value,
+	unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jnamval *, struct json *, struct json *, bool,
+	unsigned int, va_list), va_list ap)
+{
+    int i;
+
+    /*
+     * firewall
+     */
+    if (lnode == NULL || rnode == NULL) {
+	warn(__func__, "node is NULL");
+	return ;
+    }
+    if (vcallback == NULL) {
+	warn(__func__, "vcallback is NULL");
+	return ;
+    }
+
+    /*
+     * do nothing if we are too deep
+     */
+    if (max_depth != JSON_INFINITE_DEPTH && depth > max_depth) {
+	warn(__func__, "tree walk descent stopped, tree depth: %u > max_depth: %u", depth, max_depth);
+	return;
+    }
+
+    /* if depth is 0 it can't be a value */
+    if (depth == 0) {
+	is_value = false;
+    }
+
+    /*
+     * walk based on type of node
+     */
+    switch (lnode->type) {
+
+    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	/* perform function operation on this terminal parse tree node, all of
+	 * which have to be a value */
+	(*vcallback)(jnamval, lnode, rnode, true, depth, ap);
+	break;
+
+    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+
+	/* perform function operation on this terminal parse tree node */
+	(*vcallback)(jnamval, lnode, rnode, is_value, depth, ap);
+	break;
+
+    case JTYPE_MEMBER:	/* JSON item is a member */
+	{
+	    struct json_member *item = &(lnode->item.member);
+
+	    /* perform function operation on JSON member name (left branch) node */
+	    jnamval_json_tree_walk(jnamval, item->name, item->value, false, max_depth, depth+1, vcallback, ap);
+
+	    /* perform function operation on JSON member value (right branch) node */
+	    jnamval_json_tree_walk(jnamval, item->name, item->value, true, max_depth, depth+1, vcallback, ap);
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jnamval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_OBJECT:	/* JSON item is a { members } */
+	{
+	    struct json_object *item = &(lnode->item.object);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jnamval_json_tree_walk(jnamval, item->set[i], item->set[i], is_value, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jnamval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ARRAY:	/* JSON item is a [ elements ] */
+	{
+	    struct json_array *item = &(lnode->item.array);
+
+	    /* perform function operation on each object member in order */
+
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jnamval_json_tree_walk(jnamval, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* just call callback on the array node */
+	(*vcallback)(jnamval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ELEMENTS:	/* JSON items is zero or more JSON values */
+	{
+	    struct json_elements *item = &(lnode->item.elements);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jnamval_json_tree_walk(jnamval, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jnamval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    default:
+	warn(__func__, "node type is unknown: %d", lnode->type);
+	/* nothing we can traverse */
+	break;
+    }
+    return;
+}
+
+
+/* jnamval_print_count	- print total matches if -c used
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our struct jnamval
+ *
+ * This function will not return on NULL jnamval.
+ *
+ * This function returns false if -c was not used and true if it was.
+ */
+bool
+jnamval_print_count(struct jnamval *jnamval)
+{
+    /* firewall */
+    if (jnamval == NULL) {
+	err(50, __func__, "jnamval is NULL");
+	not_reached();
+    }
+
+    if (jnamval->count_only) {
+	print("%ju\n", jnamval->total_matches);
+	return true;
+    }
+
+    return false;
+}
+
+
+/* jnamval_print_final_comma	- print final comma if -C used
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our struct jnamval
+ *
+ * This function will not return on NULL jnamval.
+ *
+ * This function does nothing if -C was not used or if -c was used.
+ */
+void
+jnamval_print_final_comma(struct jnamval *jnamval)
+{
+    /* firewall */
+    if (jnamval == NULL) {
+	err(51, __func__, "jnamval is NULL");
+	not_reached();
+    }
+
+    if (jnamval->print_final_comma && !jnamval->count_only) {
+	print("%c", ',');
+    }
+}
+
+
+/* jnamval_print_brace - print a brace if -B used
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our jnamval struct
+ *	open	    - boolean indicating if we need an open or close brace
+ *
+ * This function returns void.
+ *
+ * This function will not return on NULL jnamval.
+ */
+void
+jnamval_print_brace(struct jnamval *jnamval, bool open)
+{
+    /* firewall */
+    if (jnamval == NULL) {
+	err(52, __func__, "jnamval is NULL");
+	not_reached();
+    }
+
+    if (jnamval->print_braces && !jnamval->count_only) {
+	print("%c\n", open?'{':'}');
+    }
+}
+
+
+/* jnamval_print_match	    - print a single match
+ *
+ * given:
+ *
+ *	jnamval	    - our struct jnamval with patterns list
+ *	pattern	    - the pattern with the match
+ *	match	    - the match to print
+ *
+ * NOTE: this function will not return if NULL pointers.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jnamval_print_match(struct jnamval *jnamval, struct jnamval_pattern *pattern, struct jnamval_match *match)
+{
+    uintmax_t i = 0;			    /* to iterate through count of each match */
+    uintmax_t j = 0;			    /* temporary iterator */
+
+    /* firewall */
+    if (jnamval == NULL) {
+	err(53, __func__, "jnamval is NULL");
+	not_reached();
+    } else if (match == NULL) {
+	err(54, __func__, "match is NULL");
+	not_reached();
+    } else if (pattern == NULL) {
+	err(55, __func__, "pattern is NULL");
+	not_reached();
+    }
+
+    /* if the name of the match is NULL it is a fatal error */
+    if (match->match == NULL) {
+	err(56, __func__, "match->match is NULL");
+	not_reached();
+    } else if (*match->match == '\0') {
+	/* warn on empty name for now and then go to next match */
+	warn(__func__, "empty match name");
+	return;
+    }
+
+    if (match->value == NULL) {
+	err(57, __func__, "match '%s' has NULL value", match->match);
+	not_reached();
+    } else if (*match->value == '\0') {
+	/* for now we only warn on empty value */
+	warn(__func__, "empty value for match '%s'", match->match);
+	return;
+    }
+
+    /*
+     * if we get here we have to print the name and/or match
+     */
+    for (i = 0; i < match->count; ++i) {
+	/* print the match in the way requested
+	 *
+	 * XXX - the count is probably incorrect as it means the printing could
+	 * be out of order
+	 *
+	 * XXX - add final constraint checks
+	 *
+	 * XXX - part of the below is buggy in some cases. This must be fixed.
+	 *
+	 * XXX - more functions will have to be added to print the matches.
+	 * Currently the jnamval_match struct is a work in progress. More will
+	 * have to be done depending on the type that matched (this includes not
+	 * only the jnamval type but the JSON type too).
+	 */
+
+	/* first print JSON levels if requested */
+	if (jnamval->print_json_levels) {
+	    print("%ju", match->level);
+
+	    for (j = 0; j < jnamval->num_level_spaces; ++j) {
+		printf("%s", jnamval->print_level_tab?"\t":" ");
+	    }
+	    if (jnamval->indent_levels) {
+		if (jnamval->indent_spaces) {
+		    for (j = 0; j < match->level * jnamval->indent_spaces; ++j) {
+			print("%s", jnamval->indent_tab?"\t":" ");
+		    }
+		}
+	    }
+
+	}
+
+	/*
+	 * if we're printing name and value or the syntax we have extra things
+	 * to do
+	 */
+	if (jnamval_print_name_value(jnamval->print_json_types) || jnamval->print_syntax) {
+	    /* if we print syntax there are some extra things we have to do */
+	    if (jnamval->print_syntax) {
+
+		/* XXX - this doesn't print arrays and other more complicated types - XXX */
+		print("\"%s\"", match->match);
+
+		for (j = 0; j < jnamval->num_token_spaces; ++j) {
+		    print("%s", jnamval->print_token_tab?"\t":" ");
+		}
+
+		print("%s", ":");
+
+		for (j = 0; j < jnamval->num_token_spaces; ++j) {
+		    print("%s", jnamval->print_token_tab?"\t":" ");
+		}
+
+		print("%s%s%s%s\n",
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
+	    } else { /* if we're not printing syntax */
+		/* print the name, quoting it if necessary */
+		print("%s%s%s",
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"",
+			match->match,
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"");
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jnamval->num_token_spaces; ++j) {
+		    print("%s", jnamval->print_token_tab?"\t":" ");
+		}
+
+		/*
+		 * we're not printing the syntax but if colons are requested we
+		 * have to print them
+		 */
+		if (jnamval->print_colons) {
+		    print("%s", ":");
+		}
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jnamval->num_token_spaces; ++j) {
+		    print("%s", jnamval->print_token_tab?"\t":" ");
+		}
+
+		/* finally print the value.
+		 *
+		 * NOTE the check for printing syntax or entire file is not
+		 * necessary as such.
+		 */
+		print("%s%s%s\n",
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"");
+	    }
+	} else if (jnamval_print_name(jnamval->print_json_types) || jnamval_print_value(jnamval->print_json_types)) {
+	    /*
+	     * here we will print just the name or value, quoting and doing
+	     * other things as necessary.
+	     *
+	     * NOTE the check for printing syntax or entire file is not
+	     * necessary as such.
+	     */
+	    print("%s%s%s\n",
+		  (jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jnamval_print_name(jnamval->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jnamval_print_value(jnamval->print_json_types)))?"\"":"",
+		  jnamval_print_name(jnamval->print_json_types)?match->match:match->value,
+		  (jnamval->quote_strings||jnamval->print_syntax||jnamval->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jnamval_print_name(jnamval->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jnamval_print_value(jnamval->print_json_types)))?"\"":"");
+	}
+    }
+}
+
+/* jnamval_print_matches	    - print all matches found
+ *
+ * given:
+ *
+ *	jnamval	    - our struct jnamval with patterns list
+ *
+ * NOTE: this function will not return if jnamval is NULL.
+ *
+ * NOTE: this function will only warn if patterns and matches are both NULL.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * NOTE: this function uses jnamval_print_match() to print each match.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jnamval_print_matches(struct jnamval *jnamval)
+{
+    struct jnamval_pattern *pattern = NULL;  /* to iterate through patterns list */
+    struct jnamval_match *match = NULL;	    /* to iterate through matches of each pattern in the patterns list */
+
+    /* firewall */
+    if (jnamval == NULL) {
+	err(58, __func__, "jnamval is NULL");
+	not_reached();
+    } else if (jnamval->patterns == NULL && jnamval->matches == NULL) {
+	warn(__func__, "NULL patterns and matches list");
+	return;
+    }
+
+    /* if -c used just print total number of matches */
+    if (jnamval_print_count(jnamval)) {
+	return;
+    }
+
+    /* if -c was not used we have more to do */
+
+    /*
+     * although printing syntax is not yet fully implemented (though a
+     * reasonable amount of it is), we will check for -B and print the braces so
+     * that after the syntax printing is implemented nothing has to be done with
+     * -B. The function jnamval_print_braces() will not do anything if -B was not
+     * used.
+     */
+    jnamval_print_brace(jnamval, true);
+
+    for (pattern = jnamval->patterns; pattern != NULL; pattern = pattern->next) {
+	for (match = pattern->matches; match != NULL; match = match->next) {
+	    jnamval_print_match(jnamval, pattern, match);
+	}
+    }
+
+    /*
+     * although printing syntax is not yet fully implemented, we will check for
+     * -B and print the braces so that after the syntax printing is implemented
+     * nothing has to be done with -B. The function jnamval_print_braces() will
+     * not do anything if -B was not used.
+     */
+    if (jnamval->print_braces && !jnamval->count_only) {
+	jnamval_print_brace(jnamval, false);
+    }
+    /*
+     * as well, even though -j is not yet fully implemented, we will check for
+     * -C and print the final comma if requested so that once -j fully
+     * implemented we shouldn't have to do anything else with this option. Don't
+     * print final comma if -c used.
+     */
+    jnamval_print_final_comma(jnamval);
+
+    /* if we need a newline print it */
+    if ((jnamval->print_braces || jnamval->print_final_comma) && !jnamval->count_only) {
+	puts("");
+    }
+}
+
+/* run_jnamval_check_tool    - run the JSON check tool from -S path
+ *
+ * given:
+ *
+ *	jnamval	    - pointer to our struct jnamval (has everything needed)
+ *	argv	    - main()'s argv
+ *
+ * This function does not return on NULL jnamval. It does check for NULL
+ * jnamval->check_tool_path and jnamval->check_tool_args as it's not required to
+ * be set: the jnamval_sanity_chks() function only verifies that IF it is set it
+ * exists and is executable and if the args are specified that the -S is also
+ * specified (and the path is an executable file).
+ *
+ * This function does not return on NULL jnamval->file_contents.
+ *
+ * It does NOT check for the path existing as an executable file as the
+ * jnamval_sanity_chks() does that and if it somehow failed it's an error anyway.
+ */
+void
+run_jnamval_check_tool(struct jnamval *jnamval, char **argv)
+{
+    int exit_code = 0;			/* exit code for -S path execution */
+
+    /* firewall */
+    if (jnamval == NULL) {
+	err(59, __func__, "NULL jnamval");
+	not_reached();
+    } else if (jnamval->file_contents == NULL) {
+	err(60, __func__, "NULL jnamval->file_contents");
+	not_reached();
+    }
+
+    /* run tool if -S used */
+    if (jnamval->check_tool_path != NULL) {
+	/* try running via shell_cmd() first */
+	if (jnamval->check_tool_args != NULL) {
+	    dbg(DBG_MED, "about to execute: %s %s -- %s >/dev/null 2>&1",
+		    jnamval->check_tool_path, jnamval->check_tool_args, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% % -- %", jnamval->check_tool_path, jnamval->check_tool_args, argv[0]);
+	} else {
+	    dbg(DBG_MED, "about to execute: %s %s >/dev/null 2>&1", jnamval->check_tool_path, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% %", jnamval->check_tool_path, argv[0]);
+	}
+	if(exit_code != 0) {
+	    if (jnamval->check_tool_args != NULL) {
+		err(7, __func__, "JSON check tool '%s' with args '%s' failed with exit code: %d",/*ooo*/
+			jnamval->check_tool_path, jnamval->check_tool_args, exit_code);
+	    } else {
+		err(7, __func__, "JSON check tool '%s' without args failed with exit code: %d",/*ooo*/
+			jnamval->check_tool_path, exit_code);
+	    }
+	    not_reached();
+	}
+	/* now open a write-only pipe */
+	if (jnamval->check_tool_args != NULL) {
+	    jnamval->check_tool_stream = pipe_open(__func__, true, true, "% % %", jnamval->check_tool_path,
+		    jnamval->check_tool_args, argv[0]);
+	} else {
+	    jnamval->check_tool_stream = pipe_open(__func__, true, true, "% %", jnamval->check_tool_path, argv[0]);
+	}
+	if (jnamval->check_tool_stream == NULL) {
+	    if (jnamval->check_tool_args != NULL) {
+		err(7, __func__, "opening pipe to JSON check tool '%s' with args '%s' failed", /*ooo*/
+			jnamval->check_tool_path, jnamval->check_tool_args);
+	    } else {
+		err(7, __func__, "opening pipe to JSON check tool '%s' without args failed", jnamval->check_tool_path); /*ooo*/
+	    }
+	    not_reached();
+	} else {
+	    /* process the pipe */
+	    int exit_status = 0;
+
+	    /*
+	     * write the file contents, which we know to be a valid JSON
+	     * document that is NUL terminated, to the pipe.
+	     */
+	    fpr(jnamval->check_tool_stream, __func__, "%s", jnamval->file_contents);
+
+	    /*
+	     * close down the pipe to the child process and obtain the status of the pipe child process
+	     */
+	    exit_status = pclose(jnamval->check_tool_stream);
+
+	    /*
+	     * examine the exit status of the child process and error if the child had a non-zero exit
+	     */
+	    if (WEXITSTATUS(exit_status) != 0) {
+		free_jnamval(&jnamval);
+		err(7, __func__, "pipe child process exited non-zero"); /*ooo*/
+		not_reached();
+	    } else {
+		dbg(DBG_MED, "pipe child process exited OK");
+	    }
+	}
+	jnamval->check_tool_stream = NULL;
+    }
+}
+
+

--- a/jparse/jnamval_util.h
+++ b/jparse/jnamval_util.h
@@ -1,0 +1,324 @@
+/* jnamval_util - utility functions for JSON printer jnamval
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JNAMVAL_UTIL_H)
+#    define  INCLUDE_JNAMVAL_UTIL_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g and -G, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* defines */
+
+/* -t types */
+#define JNAMVAL_TYPE_NONE    (0)
+#define JNAMVAL_TYPE_INT	    (1)
+#define JNAMVAL_TYPE_FLOAT   (2)
+#define JNAMVAL_TYPE_EXP	    (4)
+#define JNAMVAL_TYPE_NUM	    (8)
+#define JNAMVAL_TYPE_BOOL    (16)
+#define JNAMVAL_TYPE_STR	    (32)
+#define JNAMVAL_TYPE_NULL    (64)
+#define JNAMVAL_TYPE_OBJECT  (128)
+#define JNAMVAL_TYPE_ARRAY   (256)
+#define JNAMVAL_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JNAMVAL_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JNAMVAL_TYPE_SIMPLE  (JNAMVAL_TYPE_NUM|JNAMVAL_TYPE_BOOL|JNAMVAL_TYPE_STR|JNAMVAL_TYPE_NULL)
+/* JNAMVAL_TYPE_COMPOUND is bitwise OR of object and array */
+#define JNAMVAL_TYPE_COMPOUND (JNAMVAL_TYPE_OBJECT|JNAMVAL_TYPE_ARRAY)
+
+/* print types for -p option */
+#define JNAMVAL_PRINT_NAME   (1)
+#define JNAMVAL_PRINT_VALUE  (2)
+#define JNAMVAL_PRINT_BOTH   (JNAMVAL_PRINT_NAME | JNAMVAL_PRINT_VALUE)
+
+
+/* structs */
+
+/* structs for various options */
+/* number ranges for the options -l, -n and -n */
+struct jnamval_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
+};
+struct jnamval_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
+
+    /* for number ranges */
+    struct jnamval_number_range range;	/* for ranges */
+};
+
+/* jnamval_array - a struct for when an array matches, used in jnamval_match below
+ *
+ * XXX - this struct might or might not have to change - XXX
+ */
+struct jnamval_array
+{
+    struct json_array *array;
+
+    struct jnamval_match *match;	    /* what matched this array */
+};
+/*
+ * jnamval_match - a struct for a linked list of patterns matched in each pattern
+ * requested.
+ *
+ * XXX - this struct is a work in progress - XXX
+ */
+struct jnamval_match
+{
+    char *match;		    /* string that matched */
+    char *value;		    /* name or value string of that which matched */
+
+    uintmax_t count;		    /* how many of this match are found */
+    uintmax_t level;		    /* the level of the json member for -l */
+    uintmax_t number;		    /* which match this is */
+    enum item_type name_type;	    /* match type of name */
+    enum item_type value_type;	    /* match type of value */
+
+    struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
+    struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
+
+    struct jnamval_array *array;	    /* will not be NULL if match is an array. */
+
+    struct jnamval_pattern *pattern; /* pointer to the pattern that matched. DO NOT FREE! */
+    struct jnamval_match *next; /* next match found */
+};
+
+/*
+ * jnamval_pattern - struct for a linked list of patterns requested, held in
+ * struct jnamval
+ *
+ * XXX - the pattern concept is incorrect due to a misunderstanding - XXX
+ */
+struct jnamval_pattern
+{
+    char *pattern;		    /* the actual pattern or regexp string */
+    bool use_regexp;		    /* whether -g was used */
+    bool use_value;		    /* whether -Y was used, implying to search values */
+    bool use_substrings;	    /* if -s was used */
+    uintmax_t matches_found;	    /* number of matches found so far with this pattern */
+
+    struct jnamval_pattern *next;    /* the next in the list */
+
+    struct jnamval_match *matches;   /* matches found */
+};
+
+/*
+ * jnamval - struct that holds most of the options, other settings and other data
+ */
+struct jnamval
+{
+    /* JSON file related */
+    bool is_stdin;				/* reading from stdin */
+    FILE *json_file;				/* FILE * to json file */
+    char *file_contents;			/* file contents */
+
+    /* string related options */
+    bool encode_strings;			/* -e used */
+    bool quote_strings;				/* -Q used */
+
+
+    /* number ranges */
+    /* max number of matches */
+    bool max_matches_requested;			/* -n used */
+    struct jnamval_number jnamval_max_matches;	/* -n count specified */
+    /* min number of matches */
+    bool min_matches_requested;			/* -N used */
+    struct jnamval_number jnamval_min_matches;	/* -N count specified */
+    /* level constraints */
+    bool levels_constrained;			/* -l specified */
+    struct jnamval_number jnamval_levels;		/* -l level specified */
+
+    /* printing related options */
+    bool print_json_types_option;		/* -p explicitly used */
+    uintmax_t print_json_types;			/* -p type specified */
+    bool print_token_spaces;			/* -b specified */
+    uintmax_t num_token_spaces;			/* -b specified number of spaces or tabs */
+    bool print_token_tab;			/* -b tab (or -b <num>[t]) specified */
+    bool print_json_levels;			/* -L specified */
+    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
+    bool print_level_tab;			/* -L tab option */
+    bool print_colons;				/* -P specified */
+    bool print_final_comma;			/* -C specified */
+    bool print_braces;				/* -B specified */
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
+    bool indent_tab;				/* -I <num>[{t|s}] specified */
+    bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* search related bools */
+    bool json_types_specified;			/* -t used */
+    uintmax_t json_types;			/* -t type */
+    bool print_entire_file;			/* no name_arg specified */
+    bool match_found;				/* true if a pattern is specified and there is a match */
+    bool ignore_case;				/* true if -i, case-insensitive */
+    bool pattern_specified;			/* true if a pattern was specified */
+    bool search_value;				/* -Y used, search for value, not name */
+    bool search_or_mode;			/* -o used: search with OR mode */
+    bool search_anywhere;			/* -r used: search under anywhere */
+    bool match_encoded;				/* -E used, match encoded name */
+    bool use_substrings;			/* -s used, matching substrings okay */
+    bool use_regexps;				/* -g used, allow grep-like regexps */
+    bool count_only;				/* -c used, only show count */
+    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
+
+    /* check tool related things */
+    bool check_tool_specified;			/* bool indicating -S was used */
+    FILE *check_tool_stream;			/* FILE * stream for -S path */
+    char *check_tool_path;			/* -S tool path used */
+    char *check_tool_args;			/* -A tool args used */
+
+    /* any patterns specified */
+    /* XXX - the pattern concept is incorrect - XXX */
+    struct jnamval_pattern *patterns;		/* linked list of patterns specified */
+    uintmax_t number_of_patterns;		/* patterns specified */
+    /* matches found - subject to change */
+    struct jnamval_match *matches;		/* for entire file i.e. no name_arg */
+    uintmax_t total_matches;			/* total matches of all patterns (name_args) */
+
+    struct json *json_tree;			/* json tree if valid merely as a convenience */
+};
+
+
+/* function prototypes */
+struct jnamval *alloc_jnamval(void);
+
+/* JSON types - -t option*/
+uintmax_t jnamval_parse_types_option(char *optarg);
+bool jnamval_match_none(uintmax_t types);
+bool jnamval_match_int(uintmax_t types);
+bool jnamval_match_float(uintmax_t types);
+bool jnamval_match_exp(uintmax_t types);
+bool jnamval_match_exp(uintmax_t types);
+bool jnamval_match_bool(uintmax_t types);
+bool jnamval_match_num(uintmax_t types);
+bool jnamval_match_string(uintmax_t types);
+bool jnamval_match_null(uintmax_t types);
+bool jnamval_match_object(uintmax_t types);
+bool jnamval_match_array(uintmax_t types);
+bool jnamval_match_any(uintmax_t types);
+bool jnamval_match_simple(uintmax_t types);
+bool jnamval_match_compound(uintmax_t types);
+
+/* -Y type option */
+uintmax_t jnamval_parse_value_type_option(char *optarg);
+
+/* what to print - -p option */
+uintmax_t jnamval_parse_print_option(char *optarg);
+bool jnamval_print_name(uintmax_t types);
+bool jnamval_print_value(uintmax_t types);
+bool jnamval_print_name_value(uintmax_t types);
+
+/* for number range options: -l, -n, -n */
+bool jnamval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jnamval_number *number);
+bool jnamval_number_in_range(intmax_t number, intmax_t total_matches, struct jnamval_number *range);
+
+/* for -b option */
+void jnamval_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab);
+
+/* for -I option */
+void jnamval_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
+
+/* for -L option */
+void jnamval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
+
+/*
+ * patterns (name_args) specified
+ *
+ * XXX - the concept of the patterns is incorrect in that it's not individual
+ * patterns but rather the second, third and Nth patterns are under the previous
+ * patterns in the file.
+ */
+void parse_jnamval_name_args(struct jnamval *jnamval, char **argv);
+struct jnamval_pattern *add_jnamval_pattern(struct jnamval *jnamval, bool use_regexp, bool use_substrings, char *str);
+void free_jnamval_patterns_list(struct jnamval *jnamval);
+
+/* matches found of each pattern */
+struct jnamval_match *add_jnamval_match(struct jnamval *jnamval, struct jnamval_pattern *pattern,
+	struct json *node_name, struct json *node_value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type);
+void free_jnamval_matches_list(struct jnamval_pattern *pattern);
+
+/* functions to find matches in the JSON tree */
+bool is_jnamval_match(struct jnamval *jnamval, struct jnamval_pattern *pattern, char const *name, struct json *node, char const *str);
+void jnamval_json_search(struct jnamval *jnamval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, ...);
+void vjnamval_json_search(struct jnamval *jnamval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap);
+void jnamval_json_tree_search(struct jnamval *jnamval, struct json *node, unsigned int max_depth, ...);
+void jnamval_json_tree_walk(struct jnamval *jnamval, struct json *lnode, struct json *rnode, bool is_value,
+		unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jnamval *, struct json *, struct json *, bool,
+		unsigned int, va_list), va_list ap);
+
+/* functions to print matches */
+bool jnamval_print_count(struct jnamval *jnamval);
+void jnamval_print_final_comma(struct jnamval *jnamval);
+void jnamval_print_brace(struct jnamval *jnamval, bool open);
+void jnamval_print_match(struct jnamval *jnamval, struct jnamval_pattern *pattern, struct jnamval_match *match);
+void jnamval_print_matches(struct jnamval *jnamval);
+
+
+/* for the -S check tool and -A check tool args */
+void run_jnamval_check_tool(struct jnamval *jnamval, char **argv);
+
+/* to free the entire struct jnamval */
+void free_jnamval(struct jnamval **jnamval);
+
+
+#endif /* !defined INCLUDE_JNAMVAL_UTIL_H */

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -2,43 +2,41 @@
 
 ## Introduction
 
-There is a general lack of JSON aware command line tools that allows
-someone to obtain information from within a JSON document.  By
-"obtaining information" we refer to the ability to extract data,
-either as a whole, or in part, that contained within a [JSON
+NOTE: Please see [json_README.md](./json_README.md) for some important **JSON
+terms** used in this document!
+
+There is a general lack of JSON aware command line tools that allows someone to
+obtain information from within a JSON document.  By "obtaining information" we
+refer to the ability to extract data, either as a whole, or in part, that
+contained within a [JSON document](./json_README.md#json-document).
+
+There exists a multiple JSON APIs (Application Program Interfaces) for various
+programming languages: JavaScript, C, Java, Python, Perl, Go, Rust, PHP, etc.
+This [mkiocccentry repo](https://https://github.com/ioccc-src/mkiocccentry)
+contains a rich JSON parser API C programs can use, as well as a semantic JSON
+check interface for C.  However all those APIs require the user to "program" in
+a specific language in order to do something as simple as obtain a selective
+[JSON values](./json_README.md#json-value) from a [JSON
 document](./json_README.md#json-document).
 
-There exists a multiple JSON APIs (Application Program Interfaces)
-for various programming languages: JavaScript, C, Java, Python,
-Perl, Go, Rust, PHP, etc.   This [mkiocccentry
-repo](https://https://github.com/ioccc-src/mkiocccentry) contains
-a rich JSON parser API C program may use, as well as a semantical
-JSON check interface for C.  However all those APIs require the
-user to "program" in a specific language in order to do something
-as simple as obtain a selective [JSON values](./json_README.md#json-value)
-from a [JSON document](./json_README.md#json-document).
-
-Please see [json_README.md](./json_README.md) for some
-important **JSON terms** used in this document!
 
 
 ## Scope
 
 In this document, we will concern ourselves with only [Valid
 JSON](./json_README.md#valid-json) in the form of a [JSON
-document](./json_README.md#json-document).  This is necessary because
-we can only extract information with any degree of certainty from
-[Valid JSON](./json_README.md#valid-json).
+document](./json_README.md#json-document).  This is necessary because we can
+only extract information with any degree of certainty from [Valid
+JSON](./json_README.md#valid-json).
 
 We consider command line utilities that read information from a [JSON
-document](./json_README.md#json-document).  We are not considering
-utilities that either create or modify JSON in this document.
+document](./json_README.md#json-document).  In this document we are not
+considering utilities that either create or modify JSON.
 
-If a command line utility is given an **invalid JSON document**,
-the utility shall exit non-zero with an error message indicating
-that the [JSON document](./json_README.md#json-document) was not
-valid JSON.  Therefore are mainly concerns with reading various
-information from an existing [JSON
+If a command line utility is given an **invalid JSON document**, the utility
+shall exit non-zero with an error message indicating that the [JSON
+document](./json_README.md#json-document) was not valid JSON.  Therefore we're
+only concerned with reading various information from an existing [JSON
 document](./json_README.md#json-document) that contains [Valid
 JSON](./json_README.md#valid-json).
 
@@ -55,12 +53,13 @@ In this document, we assume that all utilities have the following options:
 	-q		Quiet mode, do not print to stdout (def: print stuff to stdout)
 ```
 
-Additional command line options will be added on a utility-by-utility basis.
+Additional command line options will be added on a utility by utility basis.
 
-In this document, we assume that all utilities have the following options:
 
 
 ## Common exit codes
+
+In this document, we assume that all utilities have the following exit codes:
 
 ```
 Exit codes:
@@ -88,16 +87,16 @@ We present 3 **Command line utilities**:
 
 ## jfmt utility
 
-Given a [JSON document](./json_README.md#json-document), we need a
-utility to print the JSON in a "canonical"-like well formatted JSON.
-The goal of such formatting is to make is easier for a human to see
-the JSON structure.
+Given a [JSON document](./json_README.md#json-document), we need a utility to
+print the JSON in "canonical"-like well formatted JSON.  The goal of such
+formatting is to make is easier for a human to see the JSON structure. This
+might be likened to a beautifier (at least in so far as it is possible for JSON
+to be beautified :-) ).
 
 The **jfmt** utility will write the entire [JSON
-document](./json_README.md#json-document) to a file, (defaulting
-to standard output) in a "canonical"-like well formatted JSON.  The
-output of the **jfmt** utility **MUST** be [Valid
-JSON](./json_README.md#valid-json).
+document](./json_README.md#json-document) to a file, (defaulting to standard
+output) in "canonical"-like well formatted JSON.  The output of the **jfmt**
+utility **MUST** be [Valid JSON](./json_README.md#valid-json).
 
 Consider the following `top_level_array2.json` [JSON document](./json_README.md#json-document):
 
@@ -106,8 +105,8 @@ Consider the following `top_level_array2.json` [JSON document](./json_README.md#
 ```
 
 One way to format `top_level_array2.json` is the way that
-[jsonlint.com](https://jsonlint.com) formats such a document.
-Another is to put each JSON element on its own line:
+[jsonlint.com](https://jsonlint.com) formats such a document.  Another is to put
+each JSON element on its own line:
 
 ```json
 [
@@ -145,19 +144,18 @@ Another is to put each JSON element on its own line:
 ]
 ```
 
-And we write "easier for a human to see the JSON structure"  because
-some [JSON documents](./json_README.md#json-document) are large,
-deep and complex enough to make an attempt to format them difficult
-for a human to understand them.
+We write "easier for a human to see the JSON structure"  because some [JSON
+documents](./json_README.md#json-document) are large, deep and complex enough to
+make an attempt to format them difficult for a human to understand them.
 
 Should one wish to have more than one style of output, then:
 
 ```
-	-s style	use JSON output style (def: use common style
+	-s style	use JSON output style (def: use common style)
 ```
 
-could be added as an option to the **jfmt** command line to
-change from the default JSON style.
+could be added as an option to the **jfmt** command line to change from the
+default JSON style.
 
 
 ### jfmt command line options
@@ -166,7 +164,7 @@ In addition to the [Common command line options](#common-command-line-options),
 we recommend the following command line options for **jfmt**:
 
 ```
-	-L <num>[{t|s}]	Print JSON level followed writespace (def: don't print)
+	-L <num>[{t|s}]	Print JSON level followed by whitespace (def: don't print whitespace)
 	-L tab		Alias for: '-L 1t'
 
 			Trailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces.
@@ -197,23 +195,22 @@ while tab and 8 spaces might be too much.
 
 Additional command line options may be added.
 
-For example, one might wish to add additional command line options
-to vary the style of JSON formatting.  This could be done, however,
-every one of those formatting style variations, increases the
-complexity of testing.
+For example, one might wish to add additional command line options to vary the
+style of JSON formatting.  This could be done, however, every one of those
+formatting style variations, increases the complexity of testing.
 
 We recommend command line simplicity be considered for the **jfmt** utility.
 
-We also recommend that the `jfmt(1)` man page contain a warning that
-users should not depend on the exact output of **jfmt** and that
-future versions of the utility may change the way [Valid JSON](./json_README.md#valid-json)
-is format JSON.
+We also recommend that the `jfmt(1)` man page contain a warning that users
+should not depend on the exact output of **jfmt** and that future versions of
+the utility might change the way [Valid JSON](./json_README.md#valid-json) is
+formatted.
 
 
 ### jfmt exit codes
 
-In addition to the [Common exit codes](#common-exit-codes),
-we recommend the following exit codes for **jfmt**:
+In addition to the [Common exit codes](#common-exit-codes), we recommend the
+following exit code for **jfmt**:
 
 ```
     1	error in writing to ofile
@@ -225,8 +222,8 @@ and should fall into the "_>= 10_" range.
 
 ### jfmt examples
 
-In these examples, we write JSON in an inconsistent style.
-Feel free to improve on this style.
+In these examples, we write JSON in an inconsistent style.  Feel free to improve
+on this style.
 
 
 #### jfmt example 0
@@ -248,8 +245,8 @@ should print on standard output (pretend we have 4 space indenting):
 }
 ```
 
-It is not clear how best to indent.  This might be more clear if
-the `-L stuff` is used to also print the JSON tree levels.
+It is not clear how best to indent.  This might be more clear if the `-L stuff`
+is used to also print the JSON tree levels.
 
 
 #### jfmt example 1
@@ -284,12 +281,12 @@ should print on standard output:
 }
 ```
 
-Again, it is unclear how best to indent things such as "[{ .. }]" as
-these compound [JSON values](./json_README.md#json-value) are at different
-JSON tree levels.
+Again, it is unclear how best to indent things such as "[{ .. }]" as these
+compound [JSON values](./json_README.md#json-value) are at different JSON tree
+levels.
 
 It would be better if the formatted lines of **jfmt** corresponded,
-line by line` with the use of `-L stuff` (printing JSON tree levels).
+line by line with the use of `-L stuff` (printing JSON tree levels).
 
 
 #### jfmt example 2
@@ -298,9 +295,9 @@ line by line` with the use of `-L stuff` (printing JSON tree levels).
 jfmt -L 4s jparse/test_jparse/test_JSON/good/foo.json
 ```
 
-This is a useful way for the user to better understand JSON levels.
-Assuming we don't make a mistake in reading the debugging output from `jparse -J 3`
-we guess that this might print:
+This is a useful way for the user to better understand JSON levels.  Assuming we
+don't make a mistake in reading the debugging output from `jparse -J 3` we guess
+that this might print:
 
 ```
 1    {
@@ -316,19 +313,18 @@ we guess that this might print:
 
 ## jval utility
 
-Given a [JSON document](./json_README.md#json-document), we need a
-utility that prints [JSON values](./json_README.md#json-value) that
-match or do not match certain values or value ranges.
+Given a [JSON document](./json_README.md#json-document), we need a utility that
+prints [JSON values](./json_README.md#json-value) that match or do not match
+certain values or value ranges.
 
-While **jval** command, without any "_args_" on the command line will
-cause the printing of any [JSON values](./json_README.md#json-value)
-that are not otherwise restricted by a `-t type` or `-l lvl` option.
+The **jval** command, without any "_args_" on the command line, will cause the
+printing of any [JSON values](./json_README.md#json-value) that are not
+otherwise restricted by a `-t type` or `-l lvl` option.
 
-The presence of "_args_" creates match conditions that may further
-restrict which [JSON values](./json_README.md#json-value) are printed.
-When using the **jval** command with "_args_", match criteria is setup
-to further select which [JSON values](./json_README.md#json-value)
-are printed.
+The presence of "_args_" creates match conditions that may further restrict
+which [JSON values](./json_README.md#json-value) are printed.  When using the
+**jval** command with "_args_", match criteria is setup to further select which
+[JSON values](./json_README.md#json-value) are printed.
 
 
 ### jval command line options
@@ -337,7 +333,7 @@ In addition to the [Common command line options](#common-command-line-options),
 we recommend the following command line options for **jval**:
 
 ```
-	-L <num>[{t|s}]	Print JSON level followed writespace (def: don't print)
+	-L <num>[{t|s}]	Print JSON level followed by whitespace (def: don't print whitespace)
 	-L tab		Alias for: '-L 1t'
 
 			Trailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces.
@@ -362,16 +358,16 @@ we recommend the following command line options for **jval**:
 			If lvl is num:num (e.g. '-l 3:5'), level must be inclusively in the range.
 
 	-Q		Print JSON strings surrounded by double quotes (def: do not)
-	-D		print JSON strings as decoded strings (def: print JSON strings as encoded strings)
+	-D		Print JSON strings as decoded strings (def: print JSON strings as encoded strings)
 	-d		Match the JSON decoded values (def: match as given in the JSON document)
-	-i		invert match, print values that do not match (def: print values that do match)
-	-s		match subsrrings (def: match entire values)
-	-f		fold case (def: case matters when matching strings)
-	-c		print total match count only (def: print values)
+	-i		Invert match: print values that do not match (def: print values that do match)
+	-s		Match substrings (def: match entire values)
+	-f		Fold case (def: case matters when matching strings)
+	-c		Print total match count only (def: print values)
 
 			Using -c with either -C or -L is an error.
 
-	-C		print match count followed matched value (def: print values)
+	-C		Print match count followed by matched value (def: print values)
 
 			Using -C with either -c or -L is an error.
 
@@ -393,49 +389,52 @@ we recommend the following command line options for **jval**:
 	[arg]		match argument(s)
 ```
 
-By default, matching is performed on how the value is represented in the JSON document.
+By default, matching is performed based on how the value is represented in the
+JSON document.
 
 Because of the complexity of trying to describe a complex JSON value on
 the command line, let alone the problem of describing complex value ranges,
 the `-t type` does **NOT** include complex JSON types.
 
-If no "_arg_" is given on the command line then any value may be
-considered, unless `-i` inverts the match in which case no value
-is to be considered.
+If no "_arg_" is given on the command line then any value may be considered,
+unless `-i` inverts the match in which case no value is to be considered.
 
 When **jval** looks for a match, it is done in the following general order:
 
-0. Check JSON tree level (-l default matches any level)
-1. For all JSON nodes that previously matched, check node type (-t default matches simple types)
-2. For all JSON nodes that previously matched, check for "_arg_" value match (no args match all values)
-3. For all JSON nodes that previously matched, check for -n op=num and -S op=str matches (def: do not)
+0. Check JSON tree level (`-l` default matches any level).
+1. For all JSON nodes that previously matched, check node type (`-t` default
+matches simple types).
+2. For all JSON nodes that previously matched, check for "_arg_" value match (no
+args match all values).
+3. For all JSON nodes that previously matched, check for `-n op=num` and `-S
+op=str` matches (def: do not).
 4. If `-i` invert all matches (def: do not)
 
 
 ### jval exit codes
 
-In addition to the [Common exit codes](#common-exit-codes),
-we recommend the following exit codes for **jval**:
+In addition to the [Common exit codes](#common-exit-codes), we recommend the
+following exit codes for **jval**:
 
 ```
     1	no matchs found
 ...
     3	invalid command line, invalid option, option missing argument, invalid number of args
 ...
-    6	-n op=num however num cannot be represetned as a numerical value
+    6	-n op=num: however num cannot be represetned as a numerical value
 ```
 
 Other exit codes probably should fall under the "_internal error_" category
 and should fall into the "_>= 10_" range.
 
-[JSON values](./json_README.md#json-value) are printed in order
-that they are encoded in the JSON parse tree.
+[JSON values](./json_README.md#json-value) are printed in order that they are
+encoded in the JSON parse tree.
 
 
 ### jval examples
 
-Level values are a guess made while looking at the output of `jparse -J 3`.
-The actual level values depend on the actual JSON parse tree.
+Level values are a guess made while looking at the output of `jparse -J 3`.  The
+actual level values depend on the actual JSON parse tree.
 
 
 #### jval example 0
@@ -444,7 +443,7 @@ The actual level values depend on the actual JSON parse tree.
 jval jparse/test_jparse/test_JSON/good/42.json
 ```
 
-As there are no _arg_s, all values match:
+As there are no args, all values match:
 
 ```
 foo
@@ -491,8 +490,8 @@ JSON tree[3]:	lvl: 8	type: JTYPE_NUMBER	val+8: 42
 ```
 
 This is correct.  Remember that in JSON member structure, there is a convenience
-pointer to the [JSON name](./json_README.md#json-name).  This this is **NOT**
-the level _bar_:
+pointer to the [JSON name](./json_README.md#json-name).  This is **NOT** the
+level _bar_:
 
 ```
 JSON tree[3]:	lvl: 7	type: JTYPE_MEMBER	name: "bar"		<<-- NOT THIS LEVEL !!!
@@ -514,7 +513,8 @@ be used to help the user understand JSON tree levels when using `-l lvl`.
 jval -Q jparse/test_jparse/test_JSON/good/top_level_array.json
 ```
 
-Here, `-Q` prints [JSON strings](./json_README.md#json-string) within double quotes:
+Here, `-Q` prints [JSON strings](./json_README.md#json-string) within double
+quotes:
 
 ```
 "hi"
@@ -539,18 +539,19 @@ null
 "b"
 ```
 
-The use of double quotes helps distinguish, for example, a JSON
-`null` from a [JSON string](./json_README.md#json-string) of "null".
+The use of double quotes helps distinguish, for example, a JSON `null` from a
+[JSON string](./json_README.md#json-string) of `"null"`.
 
-It is important to note that what **jval** prints is the actual characters
-from the [JSON document](./json_README.md#json-document), not some
-machine interpreted value.  For example, even though in JSON, `2.0` could be
-represented as in integer, what **jval** must print is the literal
-characters from the [JSON document](./json_README.md#json-document).
-This can be done by printing from structure elements such as `as_str`,
-or if a decoded string is needed, from the `str` element and `-D` was given.
+It is important to note that what **jval** prints is the actual characters from
+the [JSON document](./json_README.md#json-document), not some machine
+interpreted value.  For example, even though in JSON, `2.0` could be represented
+as in integer, what **jval** must print is the literal characters from the [JSON
+document](./json_README.md#json-document).  This can be done by printing from
+structure elements such as `as_str`, or if a decoded string is needed (`-D`),
+from the `str` element.
 
-Consider the following [JSON document](./json_README.md#json-document), `hi-hello.json`:
+Consider the following [JSON document](./json_README.md#json-document),
+`hi-hello.json`:
 
 ```json
 "hi\nhello"
@@ -568,7 +569,7 @@ should print the [JSON encoded string](./json_README.md#json-encoded-string):
 "hi\nhello"
 ```
 
-Whereas the command:
+whereas the command:
 
 ```sh
 jval -Q -D hi-hello.json
@@ -603,7 +604,7 @@ will print:
 ```
 
 Care must be taken as to which [JSON values](./json_README.md#json-value) are printed.
-Just because a value as an integer value does not mean that value should be printed
+Just because a value is an integer value does not mean that value should be printed
 under the `-t int` option.
 
 The `struct json_number` elements `is_floating` and `is_e_notation` need to be considered.
@@ -653,9 +654,9 @@ will only print:
 
 #### jval example 4
 
-The presence of "_args_" creates match conditions that may further
-restrict which [JSON values](./json_README.md#json-value) are printed.
-The default match criteria is when the  "_arg_" is an exact match:
+The presence of "_args_" creates match conditions that can further restrict
+which [JSON values](./json_README.md#json-value) are printed.  The default match
+criteria is when the  "_arg_" is an exact match:
 
 ```sh
 jval jparse/test_jparse/test_JSON/good/h2g2.json 42
@@ -684,12 +685,12 @@ we see why there are 3 lines:
 42
 ```
 
-The 2nd _"42"_, with `-Q`, shows that it is a [JSON
-string](./json_README.md#json-string) and not an integer.  This
-points out that, by default, "_arg_" matching is based on the strings
-in the [JSON document](./json_README.md#json-document).
+The second `"42"`, with `-Q`, shows that it is a [JSON
+string](./json_README.md#json-string) and not an integer.  This points out that,
+by default, "_arg_" matching is based on the strings in the [JSON
+document](./json_README.md#json-document).
 
-Combined with `-t type`, allows for further restriction:
+Combined with `-t type`, it allows for further restriction. For instance:
 
 ```sh
 jval -Q -t str jparse/test_jparse/test_JSON/good/h2g2.json 42
@@ -704,8 +705,8 @@ produces:
 
 #### jval example 5
 
-Multiple "_arg_", by default, setup multiple ways for a match.
-One may think of multiple "_args_" are matching in an "OR"-like way.
+Multiple "_arg_"s, by default, setup multiple ways for a match.  One may think
+of multiple "_args_" are matching in an "OR"-like way.
 
 ```sh
 jval -Q -t str jparse/test_jparse/test_JSON/good/h2g2.json 42 number
@@ -737,8 +738,8 @@ produces:
 
 #### jval example 6
 
-The **jval** offers 2 ways to count mactches instead of simply printing
- [JSON values](./json_README.md#json-value) that match:
+The **jval** offers two to count matches instead of simply printing [JSON
+values](./json_README.md#json-value) that match:
 
  ```sh
  jval -Q -t str -c jparse/test_jparse/test_JSON/good/h2g2.json 42 number name
@@ -752,7 +753,7 @@ The **jval** offers 2 ways to count mactches instead of simply printing
 
 because there are 5 total matches.
 
-With `-C`, the match count per "_arg_" may be printed:
+With `-C`, the match count per "_arg_" will be printed:
 
  ```sh
  jval -Q -t str -C jparse/test_jparse/test_JSON/good/h2g2.json 42 number name foo
@@ -781,9 +782,9 @@ produces:
 ```
 
 Using `-C` with no "_args_" is a special case.  The [JSON
-value](./json_README.md#json-value) is printed after a tab.  So
-with `-C` and no  "_args_" we may see the counts of the individual
-[JSON values](./json_README.md#json-value):
+value](./json_README.md#json-value) is printed after a tab.  So with `-C` and no
+"_args_" we will see the counts of the individual [JSON
+values](./json_README.md#json-value):
 
 ```sh
 jval -C -Q jparse/test_jparse/test_JSON/good/foo.json
@@ -794,9 +795,8 @@ jval -C -Q jparse/test_jparse/test_JSON/good/foo.json
 4	"bar"
 ```
 
-Observe in this case, the `-Q` is useful because what is bring
-printed are counts with [JSON values](./json_README.md#json-value),
-not "_args_".
+Observe in this case, the `-Q` is useful because what is being printed counts as
+[JSON values](./json_README.md#json-value), not "_args_".
 
 Consider this case:
 
@@ -817,8 +817,9 @@ Here the `-Q` is useful to distinguish between the integer and the
 
 #### jval example 7
 
-The `-i` option inverts matches, so **jval** would print
-[JSON values](./json_README.md#json-value) that do not match an "_arg_":
+The `-i` option inverts matches, so **jval** would print [JSON
+values](./json_README.md#json-value) that do **not match an "_arg_"**:
+
 
 ```sh
 jval -i jparse/test_jparse/test_JSON/good/foo.json bar
@@ -842,7 +843,7 @@ produces:
 ```
 ```
 
-The `-t type` restricts the inversion of the match.  So:
+(no output). The `-t type` restricts the inversion of the match.  So:
 
 ```sh
 jval -i -t int jparse/test_jparse/test_JSON/good/top_level_array.json 23209 1 2 3
@@ -857,7 +858,7 @@ produces:
 ```
 
 because those are the [JSON values](./json_README.md#json-value) of type "int"
-that is **NOT** match one of the "_args_".
+that does **NOT** match one of the "_args_".
 
 
 #### jval example 8
@@ -881,7 +882,7 @@ false
 6.67430e-11
 ```
 
-Each of those [JSON values](./json_README.md#json-value) have an "_e_" in them.
+Each of those [JSON values](./json_README.md#json-value) have an `e` in them.
 
 Had the type been restricted to strings:
 
@@ -889,7 +890,7 @@ Had the type been restricted to strings:
 json -s -t str jparse/test_jparse/test_JSON/good/top_level_array.json e
 ```
 
-only the [JSON strings](./json_README.md#json-string) with an "_e_" would have been printed:
+only the [JSON strings](./json_README.md#json-string) with an `e` would have been printed:
 
 ```
 hello
@@ -918,8 +919,8 @@ hello"
 
 #### jval example 10
 
-By default, **jval** matches [JSON strings](./json_README.md#json-string)
-where the case of the string matters:
+By default, **jval** matches [JSON strings](./json_README.md#json-string) where
+the case of the string matters:
 
 ```sh
 jval -Q -s jparse/test_jparse/test_JSON/good/hello-world.json Hello
@@ -932,6 +933,9 @@ will print:
 "
 ```
 
+As far as why there is a `"` on a line by itself: note the newline at the end
+of the string in the JSON file.
+
 However:
 
 ```sh
@@ -943,7 +947,7 @@ produces nothing:
 ```
 ```
 
-The use of `-f` causes string matching to be case independent:
+The use of `-f` causes string matching to be case insensitive:
 
 ```sh
 jval -Q -s jparse/test_jparse/test_JSON/good/h2g2.json killers
@@ -972,9 +976,9 @@ Bag End, Bagshot Row, Hobbiton, Westfarthing, the Shire, Middle-earth
 Bilbo Baggins
 ```
 
-Observe that the regular expression, by default, matches sub-strings.
+Observe that the regular expression given will match substrings.
 
-With `-f` the regular expression matching becomes case independent:
+With `-f` the regular expression matching becomes case insensitive:
 
 ```sh
 jval -g -f party.json 'b.*bag'
@@ -987,8 +991,8 @@ Bag End, Bagshot Row, Hobbiton, Westfarthing, the Shire, Middle-earth
 Bilbo Baggins
 ```
 
-The use of regular expression anchors may force the match of the
-entire [JSON value](./json_README.md#json-value):
+The use of regular expression anchors may force the match of the entire [JSON
+value](./json_README.md#json-value):
 
 ```sh
 jval -g party.json '^P.*t$'
@@ -1004,10 +1008,10 @@ Proudfeet
 
 #### jval example 12
 
-Numerical matching (use of `-eq`, `-lt`, `-le`, `-gt`, `-ge`) solves
-the problem of trying to match various ways to encode a [JSON
-number](./json_README.md#json-number).  Thus with `-eq 200` matching
-with the numerical value of _200_ would match [JSON
+Numerical matching (use of `-eq`, `-lt`, `-le`, `-gt`, `-ge`) solves the problem
+of trying to match various ways to encode a [JSON
+number](./json_README.md#json-number).  Thus with `-eq 200` matching with the
+numerical value of _200_ would match [JSON
 numbers](./json_README.md#json-number) such as in
 `jparse/test_jparse/test_JSON/good/200.json`:
 
@@ -1045,7 +1049,7 @@ would produce:
 200
 ```
 
-Also consider:
+Also consider that:
 
 ```sh
 jval jparse/test_jparse/test_JSON/good/two-array.json 2
@@ -1065,7 +1069,7 @@ produces:
 20.0e-1
 ```
 
-Whereas:
+whereas:
 
 ```sh
 jval -t int -n eq=2 jparse/test_jparse/test_JSON/good/two-array.json
@@ -1147,14 +1151,15 @@ produces:
 
 The use of multiple `-n eq=val` tests multiple values.
 
-Only values that can be represented by a machine can be matched.
-The following command:
+Only values that can be represented by a machine can be matched.  The following
+command:
 
 ```sh
 jval -n eq=1e10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 jparse/test_jparse/test_JSON/good/googolplex.json
 ```
 
-will print an error message to standard error and exit with a value of 6.
+will print an error message to standard error and exit with a value of 6 because
+a googolplex is too big for C types.
 
 
 #### jval example 13
@@ -1172,11 +1177,12 @@ produces:
 ```
 
 This is because the `-S` is able to match more than [JSON
-strings](./json_README.md#json-string), it is able to match any
-simple [JSON value](./json_README.md#json-value) type (i.e., JSON
-int,float,exp,bool,str,null).  All such JSON nodes have a
-`as_str` element which is an allocated string of the JSON object
-in question.  The `-S` is able match, for example,
+strings](./json_README.md#json-string): it is able to match any simple [JSON
+value](./json_README.md#json-value) type (i.e., JSON
+int,float,exp,bool,str,null).
+
+All such JSON nodes have an `as_str` element which is an allocated string of the
+JSON object in question that the `-S` is able match, for example.
 
 Consider this command:
 
@@ -1185,7 +1191,7 @@ jval -S eq=200 jparse/test_jparse/test_JSON/good/200.json
 ```
 
 Because `-S` can, for non-[JSON strings](./json_README.md#json-string),
-the `as_str` element, this command produces:
+check the `as_str` element, the above command produces:
 
 ```
 200
@@ -1205,9 +1211,8 @@ produces:
 200.000
 ```
 
-When multiple `-S op` where `op` is one of "lt", "le", "gt", or
-"ge", pairs of  `-S op` string matches are combined as an AND-ed
-pair of string matches.
+When multiple `-S op` where `op` is one of `lt`, `le`, `gt`, or `ge`, pairs of
+`-S op` string matches are combined as an AND-ed pair of string matches.
 
 Consider the following command:
 
@@ -1215,21 +1220,21 @@ Consider the following command:
 jval -R gele -S ge=c -S le=b jparse/test_jparse/test_JSON/good/JSON_misfeature_number_7.json
 ```
 
-The strings that are >= "a" _AND_ <= "c" are printed:
+The strings that are `>= "a"` _AND_ `<= "c"` are printed:
 
 ```
 avalue
 bvalue
 ```
 
-With 4 such operations, two _AND_ed match pairs are formed:
+With 4 such operations, two `AND`ed match pairs are formed:
 
 ```sh
 jval -S gt=a -S lt=c -S gt=m -S lt=o jparse/test_jparse/test_JSON/good/JSON_misfeature_number_7.json
 ```
 
-The strings that are > "a" _AND_ < "c", _OR_
-strings that are > "m" _AND_ < "o" produces:
+The strings that are `> "a"` _AND_ `< "c"`, _OR_
+strings that are `> "m"` _AND_ `< "o"` produces:
 
 ```
 avalue
@@ -1245,9 +1250,8 @@ For example:
 jval -S gt=a -S eq=zvalue -S lt=c -S gt=m -S lt=o jparse/test_jparse/test_JSON/good/JSON_misfeature_number_7.json
 ```
 
-The strings that are > "a" _AND_ < "c", _OR_
-strings that are > "m" _AND_ < "o", _OR_
-strings that are == "zvalue" will produce:
+The strings that are `> "a"` _AND_ `< "c"`, _OR_ strings that are `> "m"` _AND_
+`< "o"`, _OR_ strings that are `== "zvalue"` will produce:
 
 ```
 avalue
@@ -1263,7 +1267,7 @@ Half-open ranges may be formed by using a odd number:
 jval -S lt=name2 jparse/test_jparse/test_JSON/good/JSON_misfeature_number_7.json
 ```
 
-This produces all strings that are < "name2":
+This produces all strings that are `< "name2"`:
 
 ```
 name1
@@ -1274,15 +1278,14 @@ bvalue
 
 #### jval example 14
 
-When multiple `-n op` where `op` is one of "lt", "le", "gt", or
-"ge", pairs of  `-n op` numeric matches are combined as an AND-ed
-pair of numeric matches.
+When multiple `-n op` where `op` is one of `lt`, `le`, `gt`, or `ge`, pairs of
+`-n op` numeric matches are combined as an AND-ed pair of numeric matches.
 
 ```sh
 jval -n ge=1 -n le=3 jparse/test_jparse/test_JSON/good/top_level_array.json
 ```
 
-produces all numeric values >= 1 _AND_ values <= 3:
+produces all numeric values `>= 1` _AND_ values `<= 3`:
 
 ```
 1
@@ -1298,7 +1301,7 @@ For example:
 jval -n ge=1 -n eq=5 -n le=3 jparse/test_jparse/test_JSON/good/top_level_array.json
 ```
 
-produces all numeric values >= 1 _AND_ values <= 3 as well as values == 5:
+produces all numeric values `>= 1` _AND_ values `<= 3` as well as values `== 5`:
 
 ```
 1
@@ -1308,9 +1311,8 @@ produces all numeric values >= 1 _AND_ values <= 3 as well as values == 5:
 5
 ```
 
-For a half open interval, use an odd number such as for all values < 1:
+For a half open interval, use an odd number such as for all values `< 1`:
 
-And:
 
 ```sh
 jval -n lt=1 jparse/test_jparse/test_JSON/good/top_level_array.json
@@ -1326,15 +1328,15 @@ produces:
 ## jnamval
 
 The **jnamval** utility operates only on [JSON
-members](./json_README.md#json-member).  This utility is concerned
-only with [JSON member names](./json_README.md#json-member-name)
-and their associated [JSON member values](./json_README.md#json-member-value) only.
+members](./json_README.md#json-member).  This utility is concerned only with
+[JSON member names](./json_README.md#json-member-name) and their associated
+[JSON member values](./json_README.md#json-member-value) only.
 
 
 ### jnamval command line options
 
-The options for the **jnamval** utility are very similar to the
-[jval utility](#jval-utility).
+The options for the **jnamval** utility are very similar to the [jval
+utility](#jval-utility).
 
 In addition to the [Common command line options](#common-command-line-options),
 and the [jval command line options](#jval-command-line-options),
@@ -1352,8 +1354,8 @@ we recommend the following command line options for **jnamval**:
 				compound	alias for 'member,object,array'
 				any		alias for 'simple,compound'
 
-	-N		March based on JSON member names (def: match JSON member values)
-	-H		March name heirarchies (def: with -H match any JSON member name, else JSON member value)
+	-N		Match based on JSON member names (def: match JSON member values)
+	-H		Match name heirarchies (def: with -H match any JSON member name, else JSON member value)
 
 			Use of -H implies -N.
 
@@ -1365,9 +1367,9 @@ we recommend the following command line options for **jnamval**:
 				j		print JSON member om JSON syntax
 
 				name		alias for n
-				value		alais for v
-				both		alais for b
-				json		alais for j
+				value		alias for v
+				both		alias for b
+				json		alias for j
 ```
 
 The `-t type` applies to the type of the [JSON member

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -1,6 +1,6 @@
 # Command line utilities that read JSON
 
-## Introduction
+## Introduction to this document
 
 NOTE: Please see [json_README.md](./json_README.md) for some important **JSON
 terms** used in this document!
@@ -21,7 +21,7 @@ document](./json_README.md#json-document).
 
 
 
-## Scope
+## Scope of this document
 
 In this document, we will concern ourselves with only [Valid
 JSON](./json_README.md#valid-json) in the form of a [JSON
@@ -93,9 +93,9 @@ formatting is to make is easier for a human to see the JSON structure. This
 might be likened to a beautifier (at least in so far as it is possible for JSON
 to be beautified :-) ).
 
-The **jfmt** utility will write the entire [JSON
+The `jfmt` utility will write the entire [JSON
 document](./json_README.md#json-document) to a file, (defaulting to standard
-output) in "canonical"-like well formatted JSON.  The output of the **jfmt**
+output) in "canonical"-like well formatted JSON.  The output of the `jfmt`
 utility **MUST** be [Valid JSON](./json_README.md#valid-json).
 
 Consider the following `top_level_array2.json` [JSON document](./json_README.md#json-document):
@@ -154,14 +154,14 @@ Should one wish to have more than one style of output, then:
 	-s style	use JSON output style (def: use common style)
 ```
 
-could be added as an option to the **jfmt** command line to change from the
+could be added as an option to the `jfmt` command line to change from the
 default JSON style.
 
 
 ### jfmt command line options
 
 In addition to the [Common command line options](#common-command-line-options),
-we recommend the following command line options for **jfmt**:
+we recommend the following command line options for `jfmt`:
 
 ```
 	-L <num>[{t|s}]	Print JSON level followed by whitespace (def: don't print whitespace)
@@ -199,10 +199,10 @@ For example, one might wish to add additional command line options to vary the
 style of JSON formatting.  This could be done, however, every one of those
 formatting style variations, increases the complexity of testing.
 
-We recommend command line simplicity be considered for the **jfmt** utility.
+We recommend command line simplicity be considered for the `jfmt` utility.
 
 We also recommend that the `jfmt(1)` man page contain a warning that users
-should not depend on the exact output of **jfmt** and that future versions of
+should not depend on the exact output of `jfmt` and that future versions of
 the utility might change the way [Valid JSON](./json_README.md#valid-json) is
 formatted.
 
@@ -210,7 +210,7 @@ formatted.
 ### jfmt exit codes
 
 In addition to the [Common exit codes](#common-exit-codes), we recommend the
-following exit code for **jfmt**:
+following exit code for `jfmt`:
 
 ```
     1	error in writing to ofile
@@ -285,7 +285,7 @@ Again, it is unclear how best to indent things such as "[{ .. }]" as these
 compound [JSON values](./json_README.md#json-value) are at different JSON tree
 levels.
 
-It would be better if the formatted lines of **jfmt** corresponded,
+It would be better if the formatted lines of `jfmt` corresponded,
 line by line with the use of `-L stuff` (printing JSON tree levels).
 
 
@@ -317,20 +317,20 @@ Given a [JSON document](./json_README.md#json-document), we need a utility that
 prints [JSON values](./json_README.md#json-value) that match or do not match
 certain values or value ranges.
 
-The **jval** command, without any "_args_" on the command line, will cause the
+The `jval` command, without any "_args_" on the command line, will cause the
 printing of any [JSON values](./json_README.md#json-value) that are not
 otherwise restricted by a `-t type` or `-l lvl` option.
 
 The presence of "_args_" creates match conditions that may further restrict
 which [JSON values](./json_README.md#json-value) are printed.  When using the
-**jval** command with "_args_", match criteria is setup to further select which
+`jval` command with "_args_", match criteria is setup to further select which
 [JSON values](./json_README.md#json-value) are printed.
 
 
 ### jval command line options
 
 In addition to the [Common command line options](#common-command-line-options),
-we recommend the following command line options for **jval**:
+we recommend the following command line options for `jval`:
 
 ```
 	-L <num>[{t|s}]	Print JSON level followed by whitespace (def: don't print whitespace)
@@ -399,7 +399,7 @@ the `-t type` does **NOT** include complex JSON types.
 If no "_arg_" is given on the command line then any value may be considered,
 unless `-i` inverts the match in which case no value is to be considered.
 
-When **jval** looks for a match, it is done in the following general order:
+When `jval` looks for a match, it is done in the following general order:
 
 0. Check JSON tree level (`-l` default matches any level).
 1. For all JSON nodes that previously matched, check node type (`-t` default
@@ -414,7 +414,7 @@ op=str` matches (def: do not).
 ### jval exit codes
 
 In addition to the [Common exit codes](#common-exit-codes), we recommend the
-following exit codes for **jval**:
+following exit codes for `jval`:
 
 ```
     1	no matchs found
@@ -542,10 +542,10 @@ null
 The use of double quotes helps distinguish, for example, a JSON `null` from a
 [JSON string](./json_README.md#json-string) of `"null"`.
 
-It is important to note that what **jval** prints is the actual characters from
+It is important to note that what `jval` prints is the actual characters from
 the [JSON document](./json_README.md#json-document), not some machine
 interpreted value.  For example, even though in JSON, `2.0` could be represented
-as in integer, what **jval** must print is the literal characters from the [JSON
+as in integer, what `jval` must print is the literal characters from the [JSON
 document](./json_README.md#json-document).  This can be done by printing from
 structure elements such as `as_str`, or if a decoded string is needed (`-D`),
 from the `str` element.
@@ -738,7 +738,7 @@ produces:
 
 #### jval example 6
 
-The **jval** offers two to count matches instead of simply printing [JSON
+The `jval` offers two to count matches instead of simply printing [JSON
 values](./json_README.md#json-value) that match:
 
  ```sh
@@ -817,7 +817,7 @@ Here the `-Q` is useful to distinguish between the integer and the
 
 #### jval example 7
 
-The `-i` option inverts matches, so **jval** would print [JSON
+The `-i` option inverts matches, so `jval` would print [JSON
 values](./json_README.md#json-value) that do **not match an "_arg_"**:
 
 
@@ -899,7 +899,7 @@ hello
 
 #### jval example 9
 
-By default, **jval** matches [JSON strings](./json_README.md#json-string)
+By default, `jval` matches [JSON strings](./json_README.md#json-string)
 based on their [JSON encoded string](./json_README.md#json-encoded-string)
 values.  With `-d`, such matching is on the [JSON decoded
 string](./json_README.md#json-decoded-string) value:
@@ -919,7 +919,7 @@ hello"
 
 #### jval example 10
 
-By default, **jval** matches [JSON strings](./json_README.md#json-string) where
+By default, `jval` matches [JSON strings](./json_README.md#json-string) where
 the case of the string matters:
 
 ```sh
@@ -963,7 +963,7 @@ produces:
 
 #### jval example 11
 
-The `-g` option causes **jval** to use regular expressions to match:
+The `-g` option causes `jval` to use regular expressions to match:
 
 ```sh
 jval -g party.json 'B.*Bag'
@@ -1327,20 +1327,20 @@ produces:
 
 ## jnamval
 
-The **jnamval** utility operates only on [JSON
-members](./json_README.md#json-member).  This utility is concerned only with
+The `jnamval` utility operates only on [JSON
+members](./json_README.md#json-member).  This utility is only concerned with
 [JSON member names](./json_README.md#json-member-name) and their associated
-[JSON member values](./json_README.md#json-member-value) only.
+[JSON member values](./json_README.md#json-member-value).
 
 
 ### jnamval command line options
 
-The options for the **jnamval** utility are very similar to the [jval
+The options for the `jnamval` utility are very similar to the [jval
 utility](#jval-utility).
 
 In addition to the [Common command line options](#common-command-line-options),
 and the [jval command line options](#jval-command-line-options),
-we recommend the following command line options for **jnamval**:
+we recommend the following additional command line options for `jnamval`:
 
 ```
         -t type         Match only JSON values of a given comma-separated type (def: simple)
@@ -1364,7 +1364,7 @@ we recommend the following command line options for **jnamval**:
 				n		print JSON member names
 				v		print JSON member values
 				b		print JSON member names and values
-				j		print JSON member om JSON syntax
+				j		print JSON member with JSON syntax
 
 				name		alias for n
 				value		alias for v
@@ -1373,42 +1373,58 @@ we recommend the following command line options for **jnamval**:
 ```
 
 The `-t type` applies to the type of the [JSON member
-value](./json_README.md#json-member-value) in a given [JSON
-members](./json_README.md#json-member).  Because of the difficulty
-in expressing [JSON member values](./json_README.md#json-member-value)
-for types member, object, array, compound, and any, those types
-can only be used if there are no "_args_" on the command line.
+values](./json_README.md#json-member-value) in given [JSON
+members](./json_README.md#json-member).  Because of the difficulty in expressing
+[JSON member values](./json_README.md#json-member-value) for types member,
+object, array, compound, and any, those types can only be used if there are no
+"_args_" on the command line.
 
-By default, **jnamval** prints [JSON member
+By default, `jnamval` prints [JSON member
 values](./json_README.md#json-member-value), just like the [jval
-utility](#jval-utility) only prints [JSON
-values](./json_README.md#json-value).  With the use of `-p parts`
-[JSON member names](./json_README.md#json-member-name) and/or [JSON
-member values](./json_README.md#json-member-value) may be printed.
-Furthermore, with `-p j` or `-p json`, the JSON syntax may be printed
-like the [jfmt utility](#jfmt-utility) does.
+utility](#jval-utility) only prints [JSON values](./json_README.md#json-value).
+With the use of `-p parts` [JSON member
+names](./json_README.md#json-member-name) and/or [JSON member
+values](./json_README.md#json-member-value) can be printed.  Furthermore, with
+`-p j` or `-p json`, the JSON syntax can be printed like the [jfmt
+utility](#jfmt-utility) does.
 
-By default, **jnamval** uses "_args_" to search the values, ranges,
-numerical values, and numerical ranges.  Multiple "_args_" on the
-command line, by default, behave the same way as the [jval
-utility](#jval-utility).  With `-H`, the meaning of more than "_arg_"
-changes to searching for a given [JSON
+By default, `jnamval` uses "_args_" to search the values, ranges, numerical
+values, and numerical ranges.  Multiple "_args_" on the command line, by
+default, behave the same way as the [jval utility](#jval-utility).  With `-H`,
+the meaning of more than one "_arg_" changes to searching for a given [JSON
 members](./json_README.md#json-member) hierarchy.
 
-When **jnamval** looks for a match, it is done in the following general order:
+When `jnamval` looks for a match, it is done in the following general order:
 
-0. Check JSON tree level (-l default matches any level)
-1. For all JSON nodes that previously matched, check JSON member nodes
-2. For all JSON nodes that previously matched, check for "_arg_" value match (no args match all values)
-3. For all JSON nodes that previously matched, check for -n op=num and -S op=str matches (def: do not)
-4. If `-i` invert all matches (def: do not)
+0. Check JSON tree level (`-l` default matches any level).
+1. For all JSON nodes that previously matched, check JSON member nodes.
+2. For all JSON nodes that previously matched, check for "_arg_" value match (no
+args indicates that all values should match).
+3. For all JSON nodes that previously matched, check for `-n op=num` and `-S
+op=str` matches (def: don't).
+4. If `-i` invert all matches (def: don't invert).
 
 
 
 ### jnamval exit codes
 
-The exit codes for **jnamval** (that are < 10) are identical to
-the [jval exit codes](#jval-exit-codes).
+The exit codes for `jnamval` (that are < 10) are identical to
+the [jval exit codes](#jval-exit-codes) which we include here again to help with
+development and documentation purposes.
+
+In addition to the [Common exit codes](#common-exit-codes), we recommend the
+following exit codes for `jnamval`:
+
+```
+    1	no matchs found
+...
+    3	invalid command line, invalid option, option missing argument, invalid number of args
+...
+    6	-n op=num: however num cannot be represetned as a numerical value
+```
+
+Other exit codes probably should fall under the "_internal error_" category
+and should fall into the "_>= 10_" range.
 
 
 ### jnamval examples
@@ -1417,42 +1433,44 @@ Level values are a guess made while looking at the output of `jparse -J 3`.
 The actual level values depend on the actual JSON parse tree.
 
 We presume that the same concepts described in [jval examples](#jval-examples)
-apply directly or indirectly to **jnamval**.  We will focus on command line
-options unique to **jnamval** as well as some variations from how
+apply directly or indirectly to `jnamval`.  We will focus on command line
+options unique to `jnamval` as well as some variations from how
 [jval](#jval) operates.
 
 
 #### jnamval example 0
 
-Unlike [jval](#jval), **jnamval** operates only on [JSON
+Unlike [jval](#jval), `jnamval` operates only on [JSON
 members](./json_README.md#json-member):
+
+Because `-t type` defaults to simple, and `-p parts` defaults
+to [JSON member values](./json_README.md#json-member-value),
+this command:
 
 ```sh
 jnamval jparse/test_jparse/test_JSON/good/42.json
 ```
 
-Because `-t type` defaults to simple, and `-p parts` defaults
-to [JSON member values](./json_README.md#json-member-value),
-this command produces:
+produces:
 
 ```
 42
 ```
 
-Only 1 of the 3 [JSON members](./json_README.md#json-member)
-had a [JSON member value](./json_README.md#json-member-value)
-that was of a simple type.
+This is because only 1 of the 3 [JSON members](./json_README.md#json-member) had
+a [JSON member value](./json_README.md#json-member-value) that was of a simple
+type.
 
 
 #### jnamval example 1
 
-The `-p type` option can change what **jnamval** prints from the
+The `-p type` option can change what `jnamval` prints from the
 default [JSON member value](./json_README.md#json-member-value).
 
 For example:
 
 ```sh
-jnamval -t json jparse/test_jparse/test_JSON/good/42.json
+jnamval -p json jparse/test_jparse/test_JSON/good/42.json
 ```
 
 produces:
@@ -1461,7 +1479,7 @@ produces:
 { "bar" : 42 }
 ```
 
-We recommend that when printing with `-t json`, the resulting JSON
+We recommend that when printing with `-p json`, the resulting JSON
 be formatted to fit in a single line with spaces between the JSON
 syntax tokens.
 
@@ -1480,7 +1498,7 @@ produces:
 And for example:
 
 ```sh
-jnamval -t both -Q jparse/test_jparse/test_JSON/good/42.json
+jnamval -p both -Q jparse/test_jparse/test_JSON/good/42.json
 ```
 
 produces:
@@ -1489,26 +1507,25 @@ produces:
 "bar" : 42
 ```
 
-Observe that the `-t both` prints the [JSON member
+Observe that the `-p both` prints the [JSON member
 name](./json_README.md#json-member-name) followed by a space,
-followed by a "_:_} (ASCII colon), followed by the [JSON member
+followed by a `:`(ASCII colon), followed by the [JSON member
 value](./json_README.md#json-member-value).
 
 
 #### jnamval example 2
 
-With **jnamval**, the `-t type` includes compound types such as:
+The `jnamval` `-t type` option includes compound types such as:
 
 - member for [JSON members](./json_README.md#json-member)
 - object for [JSON objects](.json_README.md#json-object)
-- array for [JSON array](.json_README.md#json-array)
-- any for any part of JSON
+- array for [JSON arrays](.json_README.md#json-array)
+- any for every part of JSON
 
-We recommend that when printing with compound types, the resulting
-JSON be formatted to fit in a single line with spaces between the
-JSON syntax tokens.
+We recommend that when printing with compound types, the resulting JSON be
+formatted to fit in a single line with spaces between the JSON syntax tokens.
 
-Consider this command:
+Consider this command for example:
 
 ```sh
 jnamval -t array jparse/test_jparse/test_JSON/good/42.json
@@ -1524,20 +1541,19 @@ This should produce:
 
 #### jnamval example 3
 
-While **jnamval** is able to search for [JSON member
-values](./json_README.md#json-member-value) in the same
-way as [jval](#jval), the use of "_args_" as match criteria
-is limited to only JSON simple types.
+While `jnamval` is able to search for [JSON member
+values](./json_README.md#json-member-value) in the same way as [jval](#jval),
+the use of "_args_" as match criteria is limited to only JSON simple types.
 
-The use of `-t type` where type is a compound type is allowed ONLY
-when there are no "_args_" after the "_file.json_" OR when `-N` is used.
+The use of `-t type` where type is a compound type is allowed ONLY when there
+are no "_args_" after the "_file.json_" OR if `-N` is used.
 
 When `-N` is used, we search for [JSON member
 names](./json_README.md#json-member-name), which are [JSON
-strings](./json_README.md#json-string), so any search "_args_" to
-the [JSON member names](./json_README.md#json-member-name).  This
-allows for a  `-t type` where type is a compound type with "_args_"
-after the "_file.json_".
+strings](./json_README.md#json-string), so any search "_args_" make `jnamval`
+search for the [JSON member names](./json_README.md#json-member-name).  This
+allows for a  `-t type` where the type is a compound type with "_args_" after
+the "_file.json_".
 
 For example:
 
@@ -1551,7 +1567,8 @@ produces:
 [ { "name" : "Bilbo Baggins", "age" : 111, "inheritance" : false }, { "name": "Frodo Baggins", "age": 33, "inheritance" : true } ]
 ```
 
-If one wanted to pretty print the results, pipe the output into [jfmt](#jfmt):
+If one wanted to pretty print the results, they should pipe the output into
+[jfmt](#jfmt):
 
 ```sh
 jnamval -N -t array jparse/test_jparse/test_JSON/good/party.json hobbit | jfmt -
@@ -1578,22 +1595,26 @@ produces:
 #### jnamval example 4
 
 With `-N` and "_args_" one may search for certain [JSON member
-values](./json_README.md#json-member-value) that match and print
-their corresponding [JSON member names](./json_README.md#json-member-name):
+names](./json_README.md#json-member-name) and print the matching corresponding
+[JSON member names](./json_README.md#json-member-value):
 
 ```sh
-jnamval -N -s -i -Q jparse/test_jparse/test_JSON/good/party.json gandalf
+jnamval -N -s -i -Q jparse/test_jparse/test_JSON/good/party.json name alias
 ```
 
 produces:
 
 ```
-"name"
-"alias"
+"Gandalf"
+"Gandalf the Grey"
+"Mithrandir"
+"Tharkûn"
+"Olórin"
+"Incánus"
 ```
 
 With `-N -t any` and no "_args_", one may simply print the list of [JSON member
-values](./json_README.md#json-member-value):
+names](./json_README.md#json-member-value):
 
 ```sh
 jnamval -N -t any -Q jparse/test_jparse/test_JSON/good/dyfi_geo_10km.geo.json
@@ -1616,10 +1637,9 @@ produces:
 "type"
 ```
 
-
 #### jnamval example 5
 
-The `-H` option (which implies `-N`) causes "_arg_" to only match a hierarchy
+The `-H` option (which implies `-N`) causes "_args_" to only match a hierarchy
 of [JSON members](./json_README.md#json-member).
 
 Consider this command:
@@ -1628,18 +1648,18 @@ Consider this command:
 jnamval -H jparse/test_jparse/test_JSON/good/dyfi_geo_10km.geo.json features properties stddev
 ```
 
-A search for a [JSON members](./json_README.md#json-member) with a
+A search for [JSON members](./json_README.md#json-member) with a
 [JSON member name](./json_README.md#json-member-name) of "_features_" is performed.
 
 For every [JSON member name](./json_README.md#json-member-name) of "_features_"
-that is found, a search under the given JSON node is then made for
-[JSON members](./json_README.md#json-member) with a
-[JSON member name](./json_README.md#json-member-name) "_properties_".
+that is found, a search under the respective JSON node is then made for [JSON
+members](./json_README.md#json-member) with a [JSON member
+name](./json_README.md#json-member-name) "_properties_".
 
-Then for every [JSON member name](./json_README.md#json-member-name) of "_properties_"
-that is found, a search under the given JSON node is then made for a
-[JSON members](./json_README.md#json-member) with a
-[JSON member name](./json_README.md#json-member-name) of "_stddev_" is name.
+Then for every [JSON member name](./json_README.md#json-member-name) of
+"_properties_" that is found, a search under the given JSON node is then made
+for a [JSON members](./json_README.md#json-member) with a [JSON member
+name](./json_README.md#json-member-name) of "_stddev_" is name.
 
 Since "_stddev_" is the last "_arg_", then the [JSON member
 value](./json_README.md#json-member-value) is examined to determine
@@ -1650,11 +1670,10 @@ the command produces:
 0.33
 ```
 
-The check of the [JSON member value](./json_README.md#json-member-value)
-is only performed on the last "_arg_".  All prior "_args_", to be
-in a hierarchy, had to be some form on compound type otherwise their
-value would not be able to contain lower level [JSON
-member](./json_README.md#json-member).
+The check of the [JSON member value](./json_README.md#json-member-value) is only
+performed on the last "_arg_".  All prior "_args_", to be in a hierarchy, had to
+be some form of compound type as otherwise their value would not be able to
+contain lower level [JSON member](./json_README.md#json-member).
 
 While this command:
 
@@ -1705,4 +1724,5 @@ produces:
 1
 ```
 
-because there is only one "guest_list guest_number" hierarchy with a numeric value of 2.
+because there is only one "guest_list guest_number" hierarchy with a numeric
+value of 2.

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -1,0 +1,804 @@
+/*
+ * jval - JSON value printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jval.h"
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (1)	/* number of required arguments on the command line */
+
+
+/*
+ * static globals
+ */
+static bool quiet = false;				/* true ==> quiet mode */
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the usage_msg([0-9]?)+ strings.
+ */
+static const char * const usage_msg0 =
+    "usage: %s [-h] [-V] [-v level] [-J level] [-e] [-q] [-Q] [-t type] [-n count]\n"
+    "\t\t[-N num] [-p {n,v,b}] [-b <num>{[t|s]}] [-L <num>{[t|s]}] [-P] [-C] [-B]\n"
+    "\t\t[-I <num>{[t|s]}] [-j] [-E] [-i] [-s] [-g] [-c] [-m depth] [-K] [-Y type]\n"
+    "\t\t[-o] [-r] [-S path] [-A args] file.json [name_arg ...]\n"
+    "\n"
+    "\t-h\t\tPrint help and exit\n"
+    "\t-V\t\tPrint version and exit\n"
+    "\t-v level\tVerbosity level (def: %d)\n"
+    "\t-J level\tJSON verbosity level (def: %d)\n"
+    "\n"
+    "\t-e\t\tPrint JSON strings as encoded strings (def: decode JSON strings)\n"
+    "\t-q\t\tQuiet mode (def: print stuff to stdout)\n"
+    "\t-Q\t\tPrint JSON strings surrounded by double quotes (def: do not)\n"
+    "\t-t type\t\tMatch only one of the these comma-separated types (def: simple):\n"
+    "\n"
+    "\t\t\t\tint\t\tinteger values\n"
+    "\t\t\t\tfloat\t\tfloating point values\n"
+    "\t\t\t\texp\t\texponential notation values\n"
+    "\t\t\t\tnum\t\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\t\tboolean values\n"
+    "\t\t\t\tstr\t\tstring values\n"
+    "\t\t\t\tnull\t\tnull values\n"
+    "\t\t\t\tsimple\t\talias for 'int,float,exp,bool,str,null' (the default)\n"
+    "\t\t\t\tmember\t\tJSON members\n"
+    "\t\t\t\tobject\t\tJSON objects\n"
+    "\t\t\t\tarray\t\tJSON arrays\n"
+    "\t\t\t\tcompound\talias for 'object,array'\n"
+    "\t\t\t\tany\t\tany type of value\n"
+    "\n"
+    "\t\t\tMatches are based on JSON names unless -Y is used in which case JSON values are matched.\n";
+
+static const char * const usage_msg1 =
+    "\t-l lvl\t\tPrint values at specific JSON levels (def: print any level)\n"
+    "\n"
+    "\t\t\tIf lvl is a number (e.g.: -l 3), level must == number.\n"
+    "\t\t\tIf lvl is a number followed by : (e.g. '-l 3:'), level must be >= number.\n"
+    "\t\t\tIf lvl is a : followed by a number (e.g. '-l :3'), level must be <= number.\n"
+    "\t\t\tIf lvl is num:num (e.g. '-l 3:5'), level must be inclusively in the range.\n"
+    "\n"
+    "\t-n count\tPrint up to count matches (def: print all matches)\n"
+    "\n"
+    "\t\t\tIf count is a number (e.g. '-n 3'), the matches must == number\n"
+    "\t\t\tIf count is a number followed by : (e.g. '-n 3:'), matches must be >= number.\n"
+    "\t\t\tIf count is a : followed by a number (e.g. '-n :3'), matches must be <= number.\n"
+    "\t\t\tIf count is num:num (e.g. '-n 3:5'), matches must be inclusively in the range.\n"
+    "\t\t\tA number < 0 refers printing from last match (e.g. '-n -1' will print last match).\n"
+    "\n"
+    "\t-N num\t\tPrint only if there are only a given number of matches (def: do not limit)\n"
+    "\n"
+    "\t\t\tIf num is only a number (e.g. '-l 1'), there must be only that many matches.\n"
+    "\t\t\tIf num is a number followed by : (e.g. '-l 3:'), there must >= num matches.\n"
+    "\t\t\tIf num is a : followed by a number (e.g. '-n :3'), there must <= num matches.\n"
+    "\t\t\tIf num is num:num (e.g. '-n 3:5'), the number of matches must be inclusively in the range.\n"
+    "\n"
+    "\t-p {n,v,b}\tPrint JSON key, value or both (def: print JSON values or JSON names if -Y is used)\n"
+    "\t-p name\t\tAlias for '-p n'\n"
+    "\t-p value\tAlias for '-p v'\n"
+    "\t-p both\t\tAlias for '-p n,v'\n"
+    "\n"
+    "\t\t\tIt is an error to use -p n or -p v with -j.\n"
+    "\n"
+    "\t-b <num>[{t|s}]\tPrint specified number of tabs or spaces between JSON tokens printed via -j (def: 1 space)\n"
+    "\t-b tab\t\tAlias for '-b 1t'\n"
+    "\n"
+    "\t\t\tNot specifying a character after the number implies spaces.\n"
+    "\t\t\tThis option is only useful with -j or -p b or -p both.\n"
+    "\t\t\tIt is an error to use -b without -p b or -p both.\n"
+    "\n"
+    "\t-L <num>[{t|s}]\tPrint JSON level (root is 0) followed by a number of tabs or spaces (def: don't print levels)\n"
+    "\t-L tab\t\tAlias for: '-L 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies <num> tabs whereas trailing 's' implies <num> spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n";
+
+static const char * const usage_msg2 =
+    "\t-P\t\tWhen printing both i.e. '-p both', separate name/value by a : (colon) (def: do not)\n"
+    "\n"
+    "\t\t\tWhen -P is used with -b, the same whitespace is used round the : (colon).\n"
+    "\n"
+    "\t-C\t\tWhen printing JSON syntax, always print a comma after final line (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -C without -j has no effect.\n"
+    "\n"
+    "\t-B\t\tWhen printing JSON syntax, start with a '{' line and end with a '}' line.\n"
+    "\n"
+    "\t\t\tUse of -B without -j has no effect.\n"
+    "\t\t\tUse of both -B and -c is an error.\n"
+    "\n"
+    "\t-I <num>{[t|s]}\tWhen printing JSON syntax, indent levels (def: do not indent)\n"
+    "\t-I tab\t\tAlias for '-I 1t'\n"
+    "\n"
+    "\t\t\tTrailing 't' implies indent with number of tabs whereas trailing 's' implies spaces.\n"
+    "\t\t\tNot specifying 's' or 't' implies spaces.\n"
+    "\n"
+    "\t-j\t\tPrint using JSON syntax (def: do not)\n"
+    "\n"
+    "\t\t\tUse of -j implies '-p both -b 1s -e -Q -I 4 -t any'.\n"
+    "\t\t\tSubsequent use of options after -j will change the effect of -j.\n"
+    "\t\t\tUse of both -p and -j is an error.\n"
+    "\n"
+    "\t-E\t\tMatch the JSON encoded name (def: match the JSON decoded name)\n"
+    "\t-i\t\tIgnore case of name (def: case matters)\n"
+    "\t-s\t\tSubstrings are used to match (def: the full name must match)\n"
+    "\t-g\t\tMatch using grep-like extended regular expressions (def: match strings or substrings if -s)\n"
+    "\n"
+    "\t\t\tTo match from the beginning, start name_arg with '^'.\n"
+    "\t\t\tTo match to the end, end name_arg with '$'.\n"
+    "\t\t\tUse of -g and -s is an error.\n"
+    "\n"
+    "\t-c\t\tOnly show count of matches found\n"
+    "\n"
+    "\t\t\tUse of -c with -B, -L, -j, or -I is an error.\n"
+    "\n"
+    "\t-m max_depth\tSet the maximum JSON level depth to max_depth (0 == infinite depth, def: %d)\n"
+    "\n"
+    "\t\t\tA 0 max_depth implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n"
+    "\n"
+    "\t-K\t\tRun tests on jval constraints\n";
+
+static const char * const usage_msg3 =
+    "\t-Y type\t\tSearch for a JSON value of a given comma-separated type (def: search for JSON names)\n"
+    "\n"
+    "\t\t\t\tint\tinteger values\n"
+    "\t\t\t\tfloat\tfloating point values\n"
+    "\t\t\t\texp\texponential notation values\n"
+    "\t\t\t\tnum\talias for 'int,float,exp'\n"
+    "\t\t\t\tbool\tboolean values\n"
+    "\t\t\t\tstr\tstring values\n"
+    "\t\t\t\tnull\tnull values\n"
+    "\t\t\t\tsimple\talias for 'int,float,exp,bool,str,null'\n"
+    "\n"
+    "\t\t\tUse of -Y requires one and only one name_arg.\n"
+    "\t\t\tUse of -Y changes the default from -p value to -p name.\n"
+    "\n"
+    "\t-o\t\tSearch by OR mode like grep -E 'foo|bar' (def: don't)\n"
+    "\t-r\t\tSearch under anywhere (def: don't)\n"
+    "\n"
+    "\t-S path\t\tRun JSON check tool, path, with file.json arg, abort of non-zero exit (def: do not run)\n"
+    "\t-A args\t\tRun JSON check tool with additional args passed to the tool after file.json (def: none)\n"
+    "\n"
+    "\t\t\tUse of -A requires use of -S.\n";
+
+/*
+ * NOTE: this next one should be the last number; if any additional usage message strings
+ * have to be added the first additional one should be the number this is and this one
+ * should be changed to be the final string before this one + 1. Similarly if a
+ * string can be removed this one should have its number changed to be + 1 from
+ * the last one before it.
+ */
+static const char * const usage_msg4 =
+    "\tfile.json\tJSON file to parse (- ==> read from stdin)\n"
+    "\tname_arg\tsearch file.json for JSON name(s) (or one value if -Y) (def: match all)\n"
+    "\n"
+    "Exit codes:\n"
+    "    0\tall is OK: file is valid JSON, match(es) found or no name_arg given OR test mode OK\n"
+    "    1\tfile is valid JSON, name_arg given but no matches found\n"
+    "    2\t-h and help string printed or -V and version string printed\n"
+    "    3\tinvalid command line, invalid option or option missing an argument\n"
+    "    4\tfile does not exist, not a file, or unable to read the file\n"
+    "    5\tfile contents is not valid JSON\n"
+    "    6\ttest mode failed\n"
+    "    7\tJSON check tool failed\n"
+    " >=10\tinternal error\n"
+    "\n"
+    "JSON parser version: %s\n"
+    "jval version: %s";
+
+/*
+ * functions
+ */
+static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
+
+/*
+ * usage - print usage to stderr
+ *
+ * Example:
+ *      usage(3, program, "wrong number of arguments");;
+ *
+ * given:
+ *	exitcode        value to exit with
+ *	str		top level usage message
+ *	prog		our program name
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *       Normally one should NOT include newlines in warn messages.
+ *
+ * This function does not return.
+ */
+static void
+usage(int exitcode, char const *prog, char const *str)
+{
+    /*
+     * firewall
+     */
+    if (prog == NULL) {
+	prog = "((NULL prog))";
+	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
+    }
+    if (str == NULL) {
+	str = "((NULL str))";
+	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
+    }
+
+    /*
+     * print the formatted usage stream
+     */
+    if (*str != '\0') {
+	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
+    }
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg0, prog, DBG_DEFAULT, JSON_DBG_DEFAULT);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg1);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg2, JSON_DEFAULT_MAX_DEPTH);
+    fprintf_usage(DO_NOT_EXIT, stderr, usage_msg3);
+    fprintf_usage(exitcode, stderr, usage_msg4, json_parser_version, JVAL_VERSION);
+    exit(exitcode); /*ooo*/
+    not_reached();
+}
+
+
+int
+main(int argc, char **argv)
+{
+    char const *program = NULL;		/* our name */
+    extern char *optarg;
+    extern int optind;
+    struct jval *jval = NULL;	/* struct of all our options and other things */
+    struct jval_pattern *pattern = NULL; /* iterate through patterns list to search for matches */
+    size_t len = 0;			/* length of file contents */
+    bool is_valid = false;		/* if file is valid json */
+    int exit_code = 0;			/* for the end */
+    int i;
+
+    jval = alloc_jval();		/* allocate our struct jval * */
+    /*
+     * the alloc_jval() will never return a NULL pointer but check just in
+     * case
+     */
+    if (jval == NULL) {
+	err(23, "jval", "failed to allocate jval struct");
+	not_reached();
+    }
+
+    /*
+     * parse args
+     */
+    program = argv[0];
+    while ((i = getopt(argc, argv, ":hVv:J:l:eQt:qjn:N:p:b:L:PCBI:jEim:cg:KY:sorS:A:")) != -1) {
+	switch (i) {
+	case 'h':		/* -h - print help to stderr and exit 0 */
+	    free_jval(&jval);
+	    usage(2, program, "");	/*ooo*/
+	    not_reached();
+	    break;
+	case 'V':		/* -V - print version and exit */
+	    free_jval(&jval);
+	    print("%s\n", JVAL_VERSION);
+	    exit(2);		/*ooo*/
+	    not_reached();
+	    break;
+	case 'v':		/* -v verbosity */
+	    /*
+	     * parse verbosity
+	     */
+	    verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'J':		/* -J json_verbosity */
+	    /*
+	     * parse JSON verbosity level
+	     */
+	    json_verbosity_level = parse_verbosity(program, optarg);
+	    break;
+	case 'l':
+	    jval->levels_constrained = true;
+	    jval_parse_number_range("-l", optarg, false, &jval->jval_levels);
+	    break;
+	case 'e':
+	    jval->encode_strings = true;
+	    dbg(DBG_LOW, "-e specified, will encode strings");
+	    break;
+	case 'Q':
+	    jval->quote_strings = true;
+	    dbg(DBG_LOW, "-Q specified, will quote strings");
+	    break;
+	case 't':
+	    jval->json_types_specified = true;
+	    jval->json_types = jval_parse_types_option(optarg);
+	    break;
+	case 'n':
+	    jval_parse_number_range("-n", optarg, true, &jval->jval_max_matches);
+	    jval->max_matches_requested = true;
+	    break;
+	case 'N':
+	    jval_parse_number_range("-N", optarg, false, &jval->jval_min_matches);
+	    jval->min_matches_requested = true;
+	    break;
+	case 'p':
+	    jval->print_json_types_option = true;
+	    jval->print_json_types = jval_parse_print_option(optarg);
+	    break;
+	case 'b':
+	    jval->print_token_spaces = true;
+	    jval_parse_st_tokens_option(optarg, &jval->num_token_spaces, &jval->print_token_tab);
+	    break;
+	case 'L':
+	    jval->print_json_levels = true; /* print JSON levels */
+	    jval_parse_st_level_option(optarg, &jval->num_level_spaces, &jval->print_level_tab);
+	    break;
+	case 'P':
+	    jval->print_colons = true;
+	    dbg(DBG_LOW, "-P specified, will print colons");
+	    break;
+	case 'C':
+	    jval->print_final_comma = true;
+	    dbg(DBG_LOW, "-C specified, will print final comma");
+	    break;
+	case 'B':
+	    jval->print_braces = true;
+	    dbg(DBG_LOW, "-B specified, will print braces");
+	    break;
+	case 'I':
+	    jval->indent_levels = true;
+	    jval_parse_st_indent_option(optarg, &jval->indent_spaces, &jval->indent_tab);
+	    break;
+	case 'i':
+	    jval->ignore_case = true; /* make case cruel :-) */
+	    dbg(DBG_LOW, "-i specified, making matches case-insensitive");
+	    break;
+	case 'j':
+	    jval->print_syntax = true;
+	    dbg(DBG_LOW, "-j, implying -p both");
+	    jval->print_json_types = jval_parse_print_option("both");
+	    dbg(DBG_LOW, "-j, implying -b 1");
+	    jval_parse_st_tokens_option("1", &jval->num_token_spaces, &jval->print_token_tab);
+	    dbg(DBG_LOW, "-j, implying -e -Q");
+	    jval->encode_strings = true;
+	    jval->quote_strings = true;
+	    dbg(DBG_LOW, "-j, implying -t any");
+	    /* don't set jval->json_types_specified as that's for explicit use of -t */
+	    jval->json_types = jval_parse_types_option("any");
+	    break;
+	case 'E':
+	    jval->match_encoded = true;
+	    dbg(DBG_LOW, "-E specified, will match encoded strings, not decoded strings");
+	    break;
+	case 's':
+	    jval->use_substrings = true;
+	    dbg(DBG_LOW, "-s specified, will match substrings");
+	    break;
+	case 'g':   /* allow grep-like ERE */
+	    jval->use_regexps = true;
+	    dbg(DBG_LOW, "-g specified, name_args will be regexps");
+	    break;
+	case 'c':
+	    jval->count_only = true;
+	    dbg(DBG_LOW, "-c specified, will only show count of matches");
+	    break;
+	case 'q':
+	    quiet = true;
+	    msg_warn_silent = true;
+	    break;
+	case 'm': /* set maximum depth to traverse json tree */
+	    if (!string_to_uintmax(optarg, &jval->max_depth)) {
+		free_jval(&jval);
+		err(3, "jval", "couldn't parse -m depth"); /*ooo*/
+		not_reached();
+	    }
+	    break;
+	case 'K': /* run test code */
+	    if (!jval_run_tests()) {
+		free_jval(&jval);
+		exit(6); /*ooo*/
+	    }
+	    else {
+		free_jval(&jval);
+		exit(0); /*ooo*/
+	    }
+	    break;
+	case 'Y':
+	    /*
+	     * Why is this option -Y? Why not Y? Because Y, that's why Y! Why
+	     * besides, all the other good options were already taken. :-)
+	     * Specifically the letter Y has a V in it and V would have been the
+	     * obvious choice but both v and V are taken. This is why you'll
+	     * have to believe us when we tell you that this is a good enough
+	     * reason why Y! :-)
+	     */
+	    jval->search_value = true;
+	    jval->json_types = jval_parse_value_type_option(optarg);
+	    break;
+	case 'o': /* search with OR mode */
+	    jval->search_or_mode = true;
+	    break;
+	case 'r': /* search under anywhere */
+	    jval->search_anywhere = true;  /* Why is -o before -r? To spell out OR when -o itself is OR! :-) */
+	    break;
+	case 'S':
+	    /* -S path to tool */
+	    jval->check_tool_specified = true;
+	    jval->check_tool_path = optarg;
+	    dbg(DBG_LOW, "set tool path to: '%s'", jval->check_tool_path);
+	    break;
+	case 'A':
+	    /*
+	     * -A args to tool. Requires use of -S. */
+	    jval->check_tool_args = optarg;
+	    dbg(DBG_LOW, "set tool args to: '%s'", jval->check_tool_args);
+	    break;
+	case ':':   /* option requires an argument */
+	case '?':   /* illegal option */
+	default:    /* anything else but should not actually happen */
+	    check_invalid_option(program, i, optopt);
+	    usage(3, program, ""); /*ooo*/
+	    not_reached();
+	    break;
+	}
+    }
+
+
+    /*
+     * check for conflicting options prior to changing argc and argv so that the
+     * user will know to correct the options before being told that they have
+     * the wrong number of arguments (if they do). Not everything can be checked
+     * prior to doing this though.
+     */
+
+    /* run specific sanity checks on options etc. */
+    jval->json_file = jval_sanity_chks(jval, program, &argc, &argv);
+
+
+    /*
+     * jval_sanity_chks() should never return a NULL FILE * but we check
+     * anyway
+     */
+    if (jval->json_file == NULL) {
+	/*
+	 * NOTE: don't make this exit code 3 as it's an internal error if the
+	 * jval_sanity_chks() returns a NULL pointer.
+	 */
+	err(24, "jval", "could not open regular readable file");
+	not_reached();
+    }
+
+    /* Before we can process the -S option, if it specified (which we know is
+     * sane), we have to read in the JSON file (either stdin or otherwise) and
+     * then verify that the JSON is valid.
+     *
+     * Read in entire file BEFORE trying to parse it as json as the parser
+     * function will close the file if not stdin.
+     *
+     * NOTE: why doesn't the jval_sanity_chks() function do this? Because this
+     * is not so much about a sane environment as much as being unable to
+     * continue after verify the command line is correct.
+     */
+    jval->file_contents = read_all(jval->json_file, &len);
+    if (jval->file_contents == NULL) {
+	err(4, "jval", "could not read in file: %s", argv[0]); /*ooo*/
+	not_reached();
+    }
+    /* clear EOF status and rewind for parse_json_stream() */
+    clearerr(jval->json_file);
+    rewind(jval->json_file);
+
+    /* run -S tool */
+    run_jval_check_tool(jval, argv);
+
+    jval->json_tree = parse_json_stream(jval->json_file, argv[0], &is_valid);
+    if (!is_valid || jval->json_tree == NULL) {
+	if (jval->json_file != stdin) {
+	    fclose(jval->json_file);  /* close file prior to exiting */
+	    jval->json_file = NULL;   /* set to NULL even though we're exiting as a safety precaution */
+	}
+
+	/* free our jval struct */
+	free_jval(&jval);
+	err(5, "jval", "%s invalid JSON", argv[0]); /*ooo*/
+	not_reached();
+    }
+
+    dbg(DBG_MED, "valid JSON");
+
+
+    /* search for any patterns */
+    jval_json_tree_search(jval, jval->json_tree, jval->max_depth);
+
+    /* report, if debug level high enough, what will be searched for. */
+    if (jval->patterns != NULL && !jval->print_entire_file) {
+	for (pattern = jval->patterns; pattern != NULL; pattern = pattern->next) {
+	    if (pattern->pattern != NULL && *pattern->pattern) {
+
+		if (pattern->use_regexp) {
+		    dbg(DBG_LOW, "searching for %s regexp '%s'", pattern->use_value?"value":"name", pattern->pattern);
+		} else {
+		    dbg(DBG_LOW, "searching for %s %s '%s' (substrings %s)", pattern->use_value?"value":"name",
+			pattern->use_regexp?"regexp":"pattern", pattern->pattern,
+			pattern->use_substrings?"OK":"ignored");
+		}
+	    }
+	}
+    }
+
+    /*
+     * we can't have this in the sanity checks function very easily as we don't
+     * want to read in the entire contents from that function
+     *
+     * XXX - printing the entire file is incorrect here as it needs to print it
+     * according to the options - XXX
+     */
+    if (!jval->print_entire_file || jval->count_only) {
+	jval_print_matches(jval);
+    } else if (jval->file_contents != NULL) {
+	dbg(DBG_MED, "no pattern requested and no -c, will print entire file");
+	fpr(stdout, "jval", "%s", jval->file_contents);
+    }
+
+    /* free tree */
+    json_tree_free(jval->json_tree, jval->max_depth);
+
+    /* All Done!!! -- Jessica Noll, Age 2 */
+    if (jval->match_found || !jval->pattern_specified || jval->print_entire_file) {
+	exit_code = 0;
+    } else {
+	exit_code = 1;
+    }
+    if (jval != NULL) {
+	free_jval(&jval);	/* free jval struct */
+    }
+
+    exit(exit_code); /*ooo*/
+}
+
+/* jval_sanity_chks	- sanity checks on jval tool options
+ *
+ * given:
+ *
+ *	jval	    - pointer to our jval struct
+ *	program	    - program name
+ *	argc	    - pointer to argc from main()
+ *	argv	    - pointer to argv from main()
+ *
+ * This function runs any important checks on the jval internal state. It also
+ * runs checks that a file arg is specified and that the right number of options
+ * are specified done after options are parsed.
+ *
+ * If passed a NULL pointer or anything is not sane this function will not
+ * return.
+ *
+ * This function returns a FILE *, the file to read the json from. It will not
+ * return if this cannot be done (i.e. it will never return a NULL pointer
+ * though main() still checks to be defensive).
+ *
+ * NOTE: this function does NOT check for valid JSON.
+ *
+ * NOTE: jval->check_tool_path and jval->check_tool_args can be NULL.
+ *
+ * NOTE: this function must be in jval.c, not jval_util.h, because it uses
+ * the usage() function which needs to be in this file.
+ */
+FILE *
+jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv)
+{
+    /* firewall */
+    if (jval == NULL) {
+	err(25, __func__, "NULL jval");
+	not_reached();
+    } else if (argc == NULL) {
+	err(26, __func__, "NULL argc");
+	not_reached();
+    } else if (argv == NULL || *argv == NULL || **argv == NULL) {
+	err(27, __func__, "NULL argv");
+	not_reached();
+    } else if (program == NULL) {
+	err(28, __func__, "NULL program");
+	not_reached();
+    }
+
+    /*
+     * first check for invalid option combinations which if any found it is a
+     * command line error.
+     */
+
+    /* use of -g conflicts with -s and is an error. */
+    if (jval->use_regexps && jval->use_substrings) {
+	free_jval(&jval);
+	err(3, __func__, "cannot use both -g and -s"); /*ooo*/
+	not_reached();
+    }
+
+    /* check that if -b [num]t is used then -p both is true */
+    if (jval->print_token_tab && !jval_print_name_value(jval->print_json_types)) {
+	free_jval(&jval);
+	err(3, "jparse", "use of -b [num]t cannot be used without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * check that if -j was used that printing both name and value is used. -j
+     * does this but it's possible the user explicitly used -p after -j but if
+     * they did not specify 'b' or 'both' it is an error.
+     */
+    if (jval->print_syntax && !jval_print_name_value(jval->print_json_types)) {
+	free_jval(&jval);
+	err(3, "jparse", "cannot use -j without printing both name and value"); /*ooo*/
+	not_reached();
+    }
+
+
+    /* use of -c with any of any of -B, -L, -j and -I is an error */
+    if (jval->count_only) {
+	if (jval->print_braces) {
+	    err(3, __func__, "cannot use -B and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jval->print_json_levels) {
+	    err(3, __func__, "cannot use -L and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jval->print_syntax) {
+	    err(3, __func__, "cannot use -j and -c together"); /*ooo*/
+	    not_reached();
+	}
+	if (jval->indent_levels) {
+	    err(3, __func__, "cannot use -I and -c together"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * shift argc and argv for further processing. They're a pointer to those in
+     * main() so we have to dereference them here because main() also requires
+     * that they are shifted.
+     */
+    (*argc) -= optind;
+    (*argv) += optind;
+
+    /* must have at least one arg */
+    if ((*argv)[0] == NULL) {
+	usage(3, program, "wrong number of arguments"); /*ooo*/
+	not_reached();
+    }
+
+    /* if argv[0] != "-" we will attempt to open a regular readable file */
+    if (strcmp((*argv)[0], "-") != 0) {
+        /* check that the path exists and is a regular readable file */
+	if (!exists((*argv)[0])) {
+	    free_jval(&jval);
+	    err(4, __func__, "%s: file does not exist", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_file((*argv)[0])) {
+	    free_jval(&jval);
+	    err(4, __func__, "%s: not a regular file", (*argv)[0]); /*ooo*/
+	    not_reached();
+	} else if (!is_read((*argv)[0])) {
+	    free_jval(&jval);
+	    err(4, __func__, "%s: unreadable file", (*argv[0])); /*ooo*/
+	    not_reached();
+	}
+
+	errno = 0; /* pre-clear errno for errp() */
+	jval->json_file = fopen((*argv)[0], "r");
+	if (jval->json_file == NULL) {
+	    free_jval(&jval);
+	    errp(4, __func__, "%s: could not open for reading", (*argv)[0]); /*ooo*/
+	    not_reached();
+	}
+    } else { /* argv[0] is "-": will read from stdin */
+	jval->is_stdin = true;
+	jval->json_file = stdin;
+    }
+
+    dbg(DBG_LOW, "maximum depth to traverse: %ju%s", jval->max_depth, (jval->max_depth == 0?" (no limit)":
+		jval->max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
+
+    if (jval->search_value && *argc != 2 && jval->number_of_patterns != 1) {
+	free_jval(&jval);
+	err(29, __func__, "-Y requires exactly one name_arg");
+	not_reached();
+    } else if (!jval->search_value && (*argv)[1] == NULL && !jval->count_only) {
+	jval->print_entire_file = true;   /* technically this boolean is redundant */
+    }
+
+
+    /*
+     * if -S specified then we need to verify that the tool is a regular
+     * executable file
+     */
+    if (jval->check_tool_path != NULL) {
+	if (!exists(jval->check_tool_path)) {
+	    err(3, __func__, "jval tool path does not exist: %s", jval->check_tool_path);/*ooo*/
+	    not_reached();
+	} else if (!is_file(jval->check_tool_path)) {
+	    err(3, __func__, "jval tool not a regular file: %s", jval->check_tool_path); /*ooo*/
+	    not_reached();
+	} else if (!is_exec(jval->check_tool_path)) {
+	    err(3, __func__, "jval tool not an executable file: %s", jval->check_tool_path); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * if -A args is specified then we must have an -S tool as well */
+    if (jval->check_tool_args != NULL) {
+	if (jval->check_tool_path == NULL) {
+	    /* it is an error if -A args specified without -S path */
+	    free_jval(&jval);
+	    err(3, __func__, "-A used without -S"); /*ooo*/
+	    not_reached();
+	} else if (jval->check_tool_args == NULL) {
+	    free_jval(&jval);
+	    err(3, __func__, "-A args NULL"); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    /*
+     * final processing: some options require the use of others but they are not
+     * an error if they not used together; the one simply has no effect. Also
+     * once options are parsed we have to check name_args and verify some things
+     * after that.
+     */
+
+    /* without -j, -B has no effect */
+    if (jval->print_braces && !jval->print_syntax) {
+	jval->print_braces = false;
+    }
+
+    /* without -j, -C has no effect */
+    if (jval->print_final_comma && !jval->print_syntax) {
+	jval->print_final_comma = false;
+    }
+
+    /* parse name_args first */
+    parse_jval_name_args(jval, *argv);
+
+    /* now verify final options that require looking at name_args first */
+    if (jval->search_value && jval->number_of_patterns != 1) {
+	/*
+	 * special handling to make sure that if -Y is specified then only one
+	 * arg is specified after the file
+	 */
+	free_jval(&jval);
+	err(3, __func__, "-Y requires exactly one name_arg"); /*ooo*/
+	not_reached();
+    }
+
+    if (jval->count_only && jval->patterns == NULL) {
+	err(3, __func__, "use of -c without any patterns is an error"); /*ooo*/
+	not_reached();
+    }
+
+    /*
+     * verify that if patterns list is not NULL that we're not printing the
+     * entire file
+     */
+    if (jval->patterns != NULL && jval->print_entire_file) {
+	free_jval(&jval);
+	err(3, __func__, "printing the entire file not supported when searching for a pattern");/*ooo*/
+	not_reached();
+    }
+
+    /* all good: return the (presumably) json FILE * */
+    return jval->json_file;
+}

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -1,0 +1,73 @@
+/* jval - JSON value printer
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JVAL_H)
+#    define  INCLUDE_JVAL_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <strings.h> /* for -i, strcasecmp */
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jval_test - test functions
+ */
+#include "jval_test.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* jval version string */
+#define JVAL_VERSION "0.0.0 2023-07-16"		/* format: major.minor YYYY-MM-DD */
+
+/* jval functions - see jval_util.h for most */
+
+/* sanity checks on environment for specific options and the tool arguments */
+FILE *jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv);
+
+#endif /* !defined INCLUDE_JVAL_H */

--- a/jparse/jval_test.c
+++ b/jparse/jval_test.c
@@ -1,0 +1,426 @@
+/*
+ * jval_test - test functions for the jval tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#include "jval_test.h"
+
+/* jval_run_tests	- run test functions
+ *
+ * given:
+ *
+ *	void	    - no args: this function is selfish :-)
+ *
+ * Returns false if any test failed. Will only return after all tests are run.
+ */
+bool
+jval_run_tests(void)
+{
+    struct jval_number number;    /* number range */
+    bool test = false;		    /* whether current test passes or fails */
+    bool okay = true;	    /* if any test fails set to true, is return value */
+    uintmax_t bits = 0;	    /* for bits tests */
+
+    /* set up exact match of 5 */
+    jval_parse_number_range("-l", "5", false, &number);
+
+    /* make sure number matches exactly */
+    test = jval_test_number_range_opts(true, 5, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure number does NOT match */
+    test = jval_test_number_range_opts(false, 6, 7, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up inclusive range of >= 5 && <= 10 */
+    jval_parse_number_range("-l", "5:10", false, &number);
+    /* make sure that number is in the range >= 5 && <= 10 */
+    test = jval_test_number_range_opts(true, 6, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to >= max */
+    test = jval_test_number_range_opts(false, 11, 12, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jval_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
+     * last match)
+     */
+    jval_parse_number_range("-n", "5:-3", true, &number);
+    /* make sure that number is in the range >= 5 && <= 10 - 3 */
+    test = jval_test_number_range_opts(true, 7, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to >=
+     * total_matches
+     */
+    test = jval_test_number_range_opts(false, 11, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number is NOT in the range >= 5 && <= 10 - 3 due to being
+     * > total_matches - -max
+     */
+    test = jval_test_number_range_opts(false, 8, 10, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number is NOT in the range >= 5 && <= 10 due to < min */
+    test = jval_test_number_range_opts(false, 4, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+
+    /* set up minimum number */
+    jval_parse_number_range("-l", "10:", false, &number);
+    /* make sure that number 10 is in the range >= 10 */
+    test = jval_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 11 is in the range >= 10 */
+    test = jval_test_number_range_opts(true, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 9 is NOT >= 10 */
+    test = jval_test_number_range_opts(false, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* set up maximum number */
+    jval_parse_number_range("-l", ":10", false, &number);
+    /* make sure that number 10 is in the range <= 10 */
+    test = jval_test_number_range_opts(true, 10, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+    /* make sure that number 9 is in the range <= 10 */
+    test = jval_test_number_range_opts(true, 9, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* make sure that number 11 is NOT <= 10 */
+    test = jval_test_number_range_opts(false, 11, 42, __LINE__, &number);
+    if (!test) {
+	okay = false;
+    }
+
+    /* now check bits */
+
+    /* set bits to JVAL_PRINT_BOTH */
+    bits = jval_parse_print_option("both");
+
+    /* check that JVAL_PRINT_BOTH is equal to bits */
+    test = jval_test_bits(true, bits, __LINE__, jval_print_name_value, "JVAL_PRINT_BOTH");
+    if (!test) {
+	okay = false;
+    }
+
+    /* set bits to JVAL_PRINT_NAME */
+    bits = jval_parse_print_option("name");
+    /* check that only JVAL_PRINT_NAME is set: both and value are not set */
+    test = jval_test_bits(true, bits, __LINE__, jval_print_name, "JVAL_PRINT_NAME") &&
+	   jval_test_bits(false, bits, __LINE__, jval_print_value, "JVAL_PRINT_VALUE") &&
+	   jval_test_bits(false, bits, __LINE__, jval_print_name_value, "JVAL_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+    /* set bits to JVAL_PRINT_VALUE */
+    bits = jval_parse_print_option("v");
+    /* check that only JVAL_PRINT_VALUE is set: both and name are not set */
+    test = jval_test_bits(true, bits, __LINE__, jval_print_value, "JVAL_PRINT_VALUE") &&
+	   jval_test_bits(false, bits, __LINE__, jval_print_name, "JVAL_PRINT_NAME") &&
+	   jval_test_bits(false, bits, __LINE__, jval_print_name_value, "JVAL_PRINT_BOTH");
+
+    if (!test) {
+	okay = false;
+    }
+
+    /* test -t option bits */
+
+    /* first int,float,exp */
+    bits = jval_parse_types_option("int,float,exp");
+    /* check that any number will match */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_float, "JVAL_TYPE_FLOAT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_exp, "JVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* just exponents */
+    bits = jval_parse_types_option("exp");
+    /* check that int and float will fail but exp will succeed */
+    test = jval_test_bits(false, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_float, "JVAL_TYPE_FLOAT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_exp, "JVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test all types */
+    bits = jval_parse_types_option("any");
+    /* verify that it is the any bit */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_any, "JVAL_TYPE_ANY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test compound */
+    bits = jval_parse_types_option("compound");
+    /* verify that the compound type is set by compound match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_compound, "JVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the compound type is set by matching all types */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_object, "JVAL_TYPE_OBJECT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_array, "JVAL_TYPE_ARRAY");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test simple */
+    bits = jval_parse_types_option("simple");
+    /* verify that the simple type is set by simple match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_simple, "JVAL_TYPE_SIMPLE");
+    if (!test) {
+	okay = false;
+    }
+    /* verify that the simple type is set by matching each type */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_num, "JVAL_TYPE_NUM") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_bool, "JVAL_TYPE_BOOL") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_string, "JVAL_TYPE_STR") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_null, "JVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int */
+    bits = jval_parse_types_option("int");
+    /* verify that the int type is set by int match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test float */
+    bits = jval_parse_types_option("float");
+    /* verify that the float type is set by float match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_float, "JVAL_TYPE_FLOAT");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test exp */
+    bits = jval_parse_types_option("exp");
+    /* verify that the exp type is set by exp match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_exp, "JVAL_TYPE_EXP");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test bool */
+    bits = jval_parse_types_option("bool");
+    /* verify that the bool type is set by bool match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_bool, "JVAL_TYPE_BOOL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test string */
+    bits = jval_parse_types_option("str");
+    /* verify that the string type is set by string match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_string, "JVAL_TYPE_STR");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test null */
+    bits = jval_parse_types_option("null");
+    /* verify that the null type is set by null match function */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_null, "JVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /* test int,str,null */
+    bits = jval_parse_types_option("int,str,null");
+    /* verify that the int,str,null types are set by match functions */
+    test = jval_test_bits(true, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_string, "JVAL_TYPE_STR") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_null, "JVAL_TYPE_NULL");
+    if (!test) {
+	okay = false;
+    }
+
+    /*
+     * test that none of the bits are set not via the match none function but by
+     * each match function
+     */
+    bits = JVAL_TYPE_NONE;
+    test = jval_test_bits(false, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_float, "JVAL_TYPE_FLOAT") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_exp, "JVAL_TYPE_EXP") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_num, "JVAL_TYPE_NUM") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_bool, "JVAL_TYPE_BOOL") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_string, "JVAL_TYPE_STR") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_null, "JVAL_TYPE_NULL") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_object, "JVAL_TYPE_OBJECT") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_array, "JVAL_TYPE_ARRAY") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_any, "JVAL_TYPE_ANY") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_simple, "JVAL_TYPE_SIMPLE") &&
+	   jval_test_bits(false, bits, __LINE__, jval_match_compound, "JVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+    /* check all types */
+    bits = jval_parse_types_option("int,float,exp,num,bool,str,null,object,array,any,simple,compound");
+    test = jval_test_bits(true, bits, __LINE__, jval_match_int, "JVAL_TYPE_INT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_float, "JVAL_TYPE_FLOAT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_exp, "JVAL_TYPE_EXP") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_num, "JVAL_TYPE_NUM") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_bool, "JVAL_TYPE_BOOL") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_string, "JVAL_TYPE_STR") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_null, "JVAL_TYPE_NULL") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_object, "JVAL_TYPE_OBJECT") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_array, "JVAL_TYPE_ARRAY") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_any, "JVAL_TYPE_ANY") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_simple, "JVAL_TYPE_SIMPLE") &&
+	   jval_test_bits(true, bits, __LINE__, jval_match_compound, "JVAL_TYPE_COMPOUND");
+    if (!test) {
+	okay = false;
+    }
+
+
+
+    return okay;
+}
+
+/* jval_test_number_range_opts
+ *
+ * Test that the number range functionality works okay.
+ *
+ * given:
+ *
+ *	option	     	option that this is testing
+ *	expected     	whether test should return true or false
+ *	number		number to test
+ *	total_matches	number of total matches
+ *	line		line number of code which called this function
+ *	range		range to verify number against
+ *
+ * Returns true if test is okay.
+ *
+ * NOTE: this will not return on NULL pointers.
+ */
+bool
+jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jval_number *range)
+{
+    bool test = false;	    /* result of test */
+
+    if (range == NULL) {
+	err(15, __func__, "NULL range, cannot test");
+	not_reached();
+    }
+
+    test = jval_number_in_range(number, total_matches, range);
+    print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
+    if (range->exact) {
+	print("expect exact match for number %jd: ", number);
+    } else if (range->range.inclusive) {
+	if (range->range.max < 0) {
+	    /* if max is < 0 then it's up through the total_matches - max item */
+	    print("expect number %jd to be >= %jd && <= (%jd - %jd): ", number, range->range.min, total_matches,
+		    -range->range.max);
+	} else {
+	    print("expect number %jd to be >= %jd && <= %jd: ", number, range->range.min, range->range.max);
+	}
+    } else if (range->range.greater_than_equal) {
+	print("expect number %jd to be >= %ju: ", number, range->range.min);
+    } else if (range->range.less_than_equal) {
+	print("expect number %jd to be <= %jd: ", number, range->range.max);
+    }
+
+    print("test %s\n", expected == test?"OK":"failed");
+
+    return expected == test;
+}
+
+/* jval_test_bits    -	test bits code
+ *
+ * given:
+ *
+ *	expected	- whether test should fail or not
+ *	set_bits	- the bits actually set
+ *	line		- line number of code that called this function
+ *	check_func	- pointer to function of appropriate check
+ *	name		- name of bits to check
+ *
+ * Returns true if the test succeeds otherwise false.
+ *
+ * NOTE: this function will not return on NULL function pointer or NULL name.
+ */
+bool
+jval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name)
+{
+    bool okay = true;	/* assume test will pass */
+    bool test = false;	/* return value of function call */
+
+    /* firewall */
+    if (check_func == NULL) {
+	err(16, __func__, "NULL check_func");
+	not_reached();
+    } else if (name == NULL) {
+	err(17, __func__, "NULL name");
+	not_reached();
+    }
+
+    print("in function %s from line %jd (bits %ju): expects %s %s set: ", __func__, line, set_bits,
+	    name, expected?"to be":"to NOT be");
+    test = check_func(set_bits);
+
+    if (test != expected) {
+	okay = false;
+    }
+    print("test %s\n", okay?"OK":"failed");
+
+    return okay;
+}

--- a/jparse/jval_test.h
+++ b/jparse/jval_test.h
@@ -1,0 +1,68 @@
+/* jval_test - test functions for the jval tool
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JVAL_TEST_H)
+#    define  INCLUDE_JVAL_TEST_H
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/*
+ * jval_util - jval utility functions
+ */
+#include "jval_util.h"
+
+bool jval_run_tests(void);
+bool jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
+	intmax_t line, struct jval_number *range);
+bool jval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
+
+#endif /* !defined INCLUDE_JVAL_TEST_H */

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -1,0 +1,2780 @@
+/*
+ * jval_util - utility functions for JSON printer jval
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include "jval_util.h"
+
+/* alloc_jval	    - allocate a struct jval *, clear it out and set defaults
+ *
+ * This function returns a newly allocated and cleared struct jval *.
+ *
+ * This function will never return a NULL pointer.
+ */
+struct jval *
+alloc_jval(void)
+{
+    /* allocate our struct jval */
+    struct jval *jval = calloc(1, sizeof *jval);
+
+    /* verify jval != NULL */
+    if (jval == NULL) {
+	err(22, __func__, "failed to allocate jval struct");
+	not_reached();
+    }
+
+    /* explicitly clear everything out and set defaults */
+
+    /* JSON file member variables */
+    jval->is_stdin = false;			/* true if it's stdin */
+    jval->file_contents = NULL;		/* file.json contents */
+    jval->json_file = NULL;			/* JSON file * */
+
+    /* string related options */
+    jval->encode_strings = false;		/* -e used */
+    jval->quote_strings = false;		/* -Q used */
+
+
+    /* number range options, see struct jval_number_range in jval_util.h for details */
+
+    /* max matches number range */
+    jval->jval_max_matches.number = 0;
+    jval->jval_max_matches.exact = false;
+    jval->jval_max_matches.range.min = 0;
+    jval->jval_max_matches.range.max = 0;
+    jval->jval_max_matches.range.less_than_equal = false;
+    jval->jval_max_matches.range.greater_than_equal = false;
+    jval->jval_max_matches.range.inclusive = false;
+    jval->max_matches_requested = false;
+
+    /* min matches number range */
+    jval->jval_min_matches.number = 0;
+    jval->jval_min_matches.exact = false;
+    jval->jval_min_matches.range.min = 0;
+    jval->jval_min_matches.range.max = 0;
+    jval->jval_min_matches.range.less_than_equal = false;
+    jval->jval_min_matches.range.greater_than_equal = false;
+    jval->jval_min_matches.range.inclusive = false;
+    jval->min_matches_requested = false;
+
+    /* levels number range */
+    jval->jval_levels.number = 0;
+    jval->jval_levels.exact = false;
+    jval->jval_levels.range.min = 0;
+    jval->jval_levels.range.max = 0;
+    jval->jval_levels.range.less_than_equal = false;
+    jval->jval_levels.range.greater_than_equal = false;
+    jval->jval_levels.range.inclusive = false;
+    jval->levels_constrained = false;
+
+    /* print related options */
+    jval->print_json_types_option = false;		/* -p explicitly used */
+    jval->print_json_types = JVAL_PRINT_VALUE;	/* -p type specified */
+    jval->print_token_spaces = false;			/* -b specified */
+    jval->num_token_spaces = 1;			/* -b specified number of spaces or tabs */
+    jval->print_token_tab = false;			/* -b tab (or -b <num>[t]) specified */
+    jval->print_json_levels = false;			/* -L specified */
+    jval->num_level_spaces = 0;			/* number of spaces or tab for -L */
+    jval->print_level_tab = false;			/* -L tab option */
+    jval->print_colons = false;			/* -P specified */
+    jval->print_final_comma = false;			/* -C specified */
+    jval->print_braces = false;			/* -B specified */
+    jval->indent_levels = false;			/* -I used */
+    jval->indent_spaces = 0;				/* -I number of tabs or spaces */
+    jval->indent_tab = false;				/* -I <num>[{t|s}] specified */
+    jval->print_syntax = false;			/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* misc options */
+    jval->count_only = false;				/* -c used, only show count */
+
+
+    /* search related bools */
+    /* json types to look for */
+    jval->json_types_specified = false;		/* -t used */
+    jval->json_types = JVAL_TYPE_SIMPLE;		/* -t type specified, default simple */
+    jval->print_entire_file = false;			/* no name_arg specified */
+    jval->match_found = false;			/* true if a pattern is specified and there is a match */
+    jval->ignore_case = false;			/* true if -i, case-insensitive */
+    jval->pattern_specified = false;			/* true if a pattern was specified */
+    jval->search_value = false;			/* -Y search by value, not name. Uses print type */
+    /*
+     * Why is -o specified before -r? This is so that it spells out 'or' which
+     * is what -o means. Obviously! :-)
+     */
+    jval->search_or_mode = false;			/* -o used: search with OR mode */
+    jval->search_anywhere = false;			/* -r used: search under anywhere */
+
+    jval->match_encoded = false;			/* -E used, match encoded name */
+    jval->use_substrings = false;			/* -s used, matching substrings okay */
+    jval->use_regexps = false;			/* -g used, allow grep-like regexps */
+    jval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+
+
+    /* check tool related */
+    jval->check_tool_specified = false;		/* bool indicating -S was used */
+    jval->check_tool_stream = NULL;			/* FILE * stream for -S tool */
+    jval->check_tool_path = NULL;			/* -S tool_path */
+    jval->check_tool_args = NULL;			/* -A tool_args */
+
+    /* finally the linked list of patterns for matches */
+    /* XXX - the pattern concept is incorrect */
+    jval->patterns = NULL;
+    jval->number_of_patterns = 0;
+    /* matches - subject to change */
+    jval->matches = NULL;
+    jval->total_matches = 0;
+
+    return jval;
+}
+
+
+/*
+ * jval_match_none	- if no types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types == 0.
+ */
+bool
+jval_match_none(uintmax_t types)
+{
+    return types == JVAL_TYPE_NONE;
+}
+
+/*
+ * jval_match_int	- if ints should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_INT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_int(uintmax_t types)
+{
+    return (types & JVAL_TYPE_INT) != 0;
+}
+/*
+ * jval_match_float	- if floats should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_FLOAT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_float(uintmax_t types)
+{
+    return (types & JVAL_TYPE_FLOAT) != 0;
+}
+/*
+ * jval_match_exp	- if exponents should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_EXP set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_exp(uintmax_t types)
+{
+    return (types & JVAL_TYPE_EXP) != 0;
+}
+/*
+ * jval_match_num	- if numbers of any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_NUM (or any of the number types) set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_num(uintmax_t types)
+{
+    return ((types & JVAL_TYPE_NUM)||(types & JVAL_TYPE_INT) || (types & JVAL_TYPE_FLOAT) ||
+	    (types & JVAL_TYPE_EXP))!= 0;
+}
+/*
+ * jval_match_bool	- if booleans should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_BOOL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_bool(uintmax_t types)
+{
+    return (types & JVAL_TYPE_BOOL) != 0;
+}
+/*
+ * jval_match_string	    - if strings should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_STR set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_string(uintmax_t types)
+{
+    return (types & JVAL_TYPE_STR) != 0;
+}
+/*
+ * jval_match_null	- if null should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_NULL set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_null(uintmax_t types)
+{
+    return (types & JVAL_TYPE_NULL) != 0;
+}
+/*
+ * jval_match_object	    - if objects should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_OBJECT set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_object(uintmax_t types)
+{
+    return (types & JVAL_TYPE_OBJECT) != 0;
+}
+/*
+ * jval_match_array	    - if arrays should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types has JVAL_TYPE_ARRAY set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_array(uintmax_t types)
+{
+    return (types & JVAL_TYPE_ARRAY) != 0;
+}
+/*
+ * jval_match_any	- if any type should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Returns true if types is equal to JVAL_TYPE_ANY.
+ *
+ * Why does it have to equal JVAL_TYPE_ANY if it checks for any type? Because
+ * the point is that if JVAL_TYPE_ANY is set it can be any type but not
+ * specific types. For the specific types those bits have to be set instead. If
+ * JVAL_TYPE_ANY is set then any type can be set but if types is say
+ * JVAL_TYPE_INT then checking for JVAL_TYPE_INT & JVAL_TYPE_ANY would be
+ * != 0 (as it's a bitwise OR of all the types) which would suggest that any
+ * type is okay even if JVAL_TYPE_INT was the only type.
+ */
+bool
+jval_match_any(uintmax_t types)
+{
+    return types == JVAL_TYPE_ANY;
+}
+/*
+ * jval_match_simple	- if simple types should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * Simple is defined as a number, a bool, a string or a null.
+ *
+ * Returns true if types has JVAL_TYPE_SIMPLE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_simple(uintmax_t types)
+{
+    return (types & JVAL_TYPE_SIMPLE) != 0;
+}
+/*
+ * jval_match_compound   - if compounds should match
+ *
+ * given:
+ *
+ *	types	- types set
+ *
+ * A compound is defined as an object or array.
+ *
+ * Returns true if types has JVAL_TYPE_COMPOUND set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_match_compound(uintmax_t types)
+{
+    return (types & JVAL_TYPE_COMPOUND) != 0;
+}
+
+/*
+ * jval_parse_types_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JVAL_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jval_parse_types_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t type = JVAL_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    } else {
+	/* pre-clear errno for errp() */
+	errno = 0;
+	dup = strdup(optarg);
+	if (dup == NULL) {
+	    errp(23, __func__, "strdup(%s) failed", optarg);
+	    not_reached();
+	}
+    }
+
+    /*
+     * Go through comma-separated list of types, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might be - I've thought of a number of ways already).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "int")) {
+	    type |= JVAL_TYPE_INT;
+	} else if (!strcmp(p, "float")) {
+	    type |= JVAL_TYPE_FLOAT;
+	} else if (!strcmp(p, "exp")) {
+	    type |= JVAL_TYPE_EXP;
+	} else if (!strcmp(p, "num")) {
+	    type |= JVAL_TYPE_NUM;
+	} else if (!strcmp(p, "bool")) {
+	    type |= JVAL_TYPE_BOOL;
+	} else if (!strcmp(p, "str")) {
+	    type |= JVAL_TYPE_STR;
+	} else if (!strcmp(p, "null")) {
+	    type |= JVAL_TYPE_NULL;
+	} else if (!strcmp(p, "object")) {
+	    type |= JVAL_TYPE_OBJECT;
+	} else if (!strcmp(p, "array")) {
+	    type |= JVAL_TYPE_ARRAY;
+	} else if (!strcmp(p, "simple")) {
+	    type |= JVAL_TYPE_SIMPLE;
+	} else if (!strcmp(p, "compound")) {
+	    type |= JVAL_TYPE_COMPOUND;
+	} else if (!strcmp(p, "any")) {
+	    type |= JVAL_TYPE_ANY;
+	} else {
+	    /* unknown type */
+	    err(3, __func__, "unknown type '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+    return type;
+}
+
+/*
+ * jval_print_name	- if only names should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JVAL_PRINT_NAME set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_print_name(uintmax_t types)
+{
+    return ((types & JVAL_PRINT_NAME) && !(types & JVAL_PRINT_VALUE)) != 0;
+}
+/*
+ * jval_print_value	- if only values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types only has JVAL_PRINT_VALUE set.
+ *
+ * NOTE: why do we return that the bitwise AND is not != 0 rather than just the
+ * bitwise AND? Because in some cases (like the test routines) we compare the
+ * expected true value to the result of the function. But depending on the bits
+ * set it might not end up being 1 so it ends up not comparing true to true but
+ * another value to true which it might not be. This could be done a different
+ * way where the test would be something like:
+ *
+ *	if ((test && !expected) || (expected && !test))
+ *
+ * but this seems like needless complications.
+ */
+bool
+jval_print_value(uintmax_t types)
+{
+    return ((types & JVAL_PRINT_VALUE) && !(types & JVAL_PRINT_NAME)) != 0;
+}
+/*
+ * jval_print_both	- if names AND values should be printed
+ *
+ * given:
+ *
+ *	types	- print types set
+ *
+ * Returns true if types has JVAL_PRINT_BOTH set.
+ */
+bool
+jval_print_name_value(uintmax_t types)
+{
+    return types == JVAL_PRINT_BOTH;
+}
+
+
+/*
+ * jval_parse_print_option	- parse -p option list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -p option
+ *
+ * Returns: bitvector of types to print.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JVAL_PRINT_VALUE (as if '-p v').
+ */
+uintmax_t
+jval_parse_print_option(char *optarg)
+{
+    char *p = NULL;	    /* for strtok_r() */
+    char *saveptr = NULL;   /* for strtok_r() */
+    char *dup = NULL;	    /* strdup()d copy of optarg */
+
+    uintmax_t print_json_types = 0; /* default is to print values */
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return JVAL_PRINT_VALUE;
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    dup = strdup(optarg);
+    if (dup == NULL) {
+	errp(24, __func__, "strdup(%s) failed", optarg);
+	not_reached();
+    }
+
+    /*
+     * Go through comma-separated list of what to print, setting each as a bitvector
+     *
+     * NOTE: the way this is done might change if it proves there is a better
+     * way (and there might very well be).
+     */
+    for (p = strtok_r(dup, ",", &saveptr); p; p = strtok_r(NULL, ",", &saveptr)) {
+	if (!strcmp(p, "v") || !strcmp(p, "value")) {
+	    print_json_types |= JVAL_PRINT_VALUE;
+	} else if (!strcmp(p, "n") || !strcmp(p, "name")) {
+	    print_json_types |= JVAL_PRINT_NAME;
+	} else if (!strcmp(p, "b") || !strcmp(p, "both")) {
+	    print_json_types |= JVAL_PRINT_BOTH;
+	} else {
+	    /* unknown keyword */
+	    err(3, __func__, "unknown keyword '%s'", p); /*ooo*/
+	    not_reached();
+	}
+    }
+
+    if (jval_print_name_value(print_json_types)) {
+	dbg(DBG_LOW, "will print both name and value");
+    }
+    else if (jval_print_name(print_json_types)) {
+	dbg(DBG_LOW, "will only print name");
+    }
+    else if (jval_print_value(print_json_types)) {
+	dbg(DBG_LOW, "will only print value");
+    }
+
+    if (dup != NULL) {
+	free(dup);
+	dup = NULL;
+    }
+
+    return print_json_types;
+}
+
+/* jval_parse_number_range	- parse a number range for options -l, -N, -n
+ *
+ * given:
+ *
+ *	option		- option string (e.g. "-l"). Used for error and debug messages.
+ *	optarg		- the option argument
+ *	allow_negative	- true if max can be < 0
+ *	number		- pointer to struct number
+ *
+ * Returns true if successfully parsed.
+ *
+ * The following rules apply:
+ *
+ * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
+ * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
+ *     (1a) the last number can be negative in which case it's up through the
+ *	    count - max.
+ * (2) a minimum number, that is num >= minimum, is <num>:
+ * (3) a maximum number, that is num <= maximum, is :<num>
+ * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
+ * (5) anything else is an error
+ *
+ * See also the structs jval_number_range and jval_number in jval_util.h
+ * for more details.
+ *
+ * NOTE: this function does not return on syntax error or NULL number.
+ */
+bool
+jval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jval_number *number)
+{
+    intmax_t max = 0;
+    intmax_t min = 0;
+
+    /* firewall */
+    if (option == NULL || *option == '\0') {
+	err(3, __func__, "NULL or empty option given"); /*ooo*/
+	not_reached();
+    }
+    if (number == NULL) {
+	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
+	not_reached();
+    } else {
+	memset(number, 0, sizeof(struct jval_number));
+
+	/* don't assume everything is 0 */
+	number->exact = false;
+	number->range.min = 0;
+	number->range.max = 0;
+	number->range.inclusive = false;
+	number->range.less_than_equal = false;
+	number->range.greater_than_equal = false;
+    }
+
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
+	return false;
+    }
+
+    if (!strchr(optarg, ':')) {
+	if (string_to_intmax(optarg, &number->number)) {
+	    number->exact = true;
+	    number->range.min = 0;
+	    number->range.max = 0;
+	    number->range.inclusive = false;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
+	} else {
+	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
+	    not_reached();
+	}
+    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    /*
+	     * NOTE: we can't check that min >= max because a negative number in the
+	     * maximum means that the range is up through the count - max matches
+	     */
+	    number->range.min = min;
+	    number->range.max = max;
+	    number->range.inclusive = true;
+	    number->range.less_than_equal = false;
+	    number->range.greater_than_equal = false;
+	    /* XXX - this debug message is problematic wrt the negative number
+	     * option
+	     */
+	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
+		    number->range.max);
+	}
+    } else if (sscanf(optarg, "%jd:", &min) == 1) {
+	number->number = 0;
+	number->exact = false;
+	number->range.min = min;
+	number->range.max = number->range.min;
+	number->range.greater_than_equal = true;
+	number->range.less_than_equal = false;
+	number->range.inclusive = false;
+	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
+    } else if (sscanf(optarg, ":%jd", &max) == 1) {
+	/* if allow_negative is false we won't allow negative max in range. */
+	if (!allow_negative && max < 0) {
+	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
+	    not_reached();
+	} else {
+	    number->range.max = max;
+	    number->range.min = number->range.max;
+	    number->number = 0;
+	    number->exact = false;
+	    number->range.less_than_equal = true;
+	    number->range.greater_than_equal = false;
+	    number->range.inclusive = false;
+	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
+	}
+    } else {
+	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
+	not_reached();
+    }
+
+    return true;
+}
+
+/* jval_number_in_range   - check if number is in required range
+ *
+ * given:
+ *
+ *	number		- number to check
+ *	total_matches	- total number of matches found
+ *	range		- pointer to struct jval_number with range
+ *
+ * Returns true if the number is in range.
+ *
+ * NOTE: if range is NULL it will return false.
+ */
+bool
+jval_number_in_range(intmax_t number, intmax_t total_matches, struct jval_number *range)
+{
+    /* firewall check */
+    if (range == NULL) {
+	return false;
+    }
+
+    /* if exact is set and range->number == number then return true. */
+    if (range->exact && range->number == number) {
+	return true;
+    } else if (range->range.inclusive) {
+	/* if the number must be inclusive in range then we have to make sure
+	 * that number >= min and <= max.
+	 *
+	 * NOTE: we have to make a special check for negative numbers because a
+	 * negative number is up through the count of matches - the negative max
+	 * number (rather if there are 10 matches and the string -l 5:-3 is
+	 * specified then the items 5, 6, 7, 8 are to be printed).
+	 */
+	if (number >= range->range.min) {
+	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
+		return true;
+	    } else if (number <= range->range.max) {
+		return true;
+	    } else {
+		return false;
+	    }
+	} else {
+	    return false;
+	}
+    } else if (range->range.less_than_equal) {
+	/* if number has to be less than equal we check number <= the maximum
+	 * number (range->range.max).
+	 */
+	if (number <= range->range.max) {
+	    return true;
+	} else {
+	    return false;
+	}
+    } else if (range->range.greater_than_equal) {
+	/* if number has to be greater than or equal to the number then we check
+	 * that number >= minimum number (range->range.min).
+	 */
+	if (number >= range->range.min) {
+	    return true;
+	} else {
+	    return false;
+	}
+    }
+
+    return false; /* no match */
+}
+
+/* jval_parse_st_tokens_option    - parse -b [num]{s,t}/-b tab option
+ *
+ * This function parses the -b option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_token_spaces    - pointer to number of token spaces or tabs
+ *	print_token_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jval_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_token_spaces == NULL) {
+	err(3, __func__, "NULL num_token_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_token_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_token_spaces == 0 */
+	*num_token_spaces = 0;
+	/* make *print_token_tab == false */
+	*print_token_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_token_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_token_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_token_tab = false;
+	    dbg(DBG_LOW, "will print %ju space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -b <num>[ts]"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	*print_token_tab = true;
+	*num_token_spaces = 1;
+	dbg(DBG_LOW, "will print %ju tab%s between name and value", *num_token_spaces,
+	    *num_token_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_token_spaces)) {
+	err(3, __func__, "couldn't parse -b <num>[ts]"); /*ooo*/
+	not_reached();
+    } else {
+	*print_token_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s between name and value", *num_token_spaces,
+		*num_token_spaces==1?"":"s");
+    }
+}
+
+/* jval_parse_st_indent_option    - parse -I [num]{s,t}/-b indent option
+ *
+ * This function parses the -I option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	indent_level	    - pointer to number of indent spaces or tabs
+ *	indent_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jval_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (indent_level == NULL) {
+	err(3, __func__, "NULL indent_level"); /*ooo*/
+	not_reached();
+    } else if (indent_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *indent_level == 0 */
+	*indent_level = 0;
+	/* make *ident_tab == false */
+	*indent_tab = false;
+    }
+
+
+    if (sscanf(optarg, "%ju%c", indent_level, &ch) == 2) {
+	if (ch == 't') {
+	    *indent_tab = true;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else if (ch == 's') {
+	    *indent_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -I"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *indent_tab = true;
+	    *indent_level = 1;
+	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
+    } else if (!string_to_uintmax(optarg, indent_level)) {
+	err(3, __func__, "couldn't parse -I spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*indent_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
+    }
+}
+
+/* jval_parse_st_level_option    - parse -L [num]{s,t}/-b level option
+ *
+ * This function parses the -L option. It's necessary to have it this way
+ * because some options like -j imply it and rather than duplicate code we just
+ * have it here once.
+ *
+ * given:
+ *
+ *	optarg		    - option argument to -b option (can be faked)
+ *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
+ *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
+ *
+ * Function returns void.
+ *
+ * NOTE: syntax errors are an error just like it was when it was in main().
+ *
+ * NOTE: this function does not return on NULL pointers.
+ */
+void
+jval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
+{
+    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
+
+    /* firewall checks */
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, __func__, "NULL or empty optarg"); /*ooo*/
+	not_reached();
+    } else if (num_level_spaces == NULL) {
+	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
+	not_reached();
+    } else if (print_level_tab == NULL) {
+	err(3, __func__, "NULL print_token_tab"); /*ooo*/
+	not_reached();
+    } else {
+	/* ensure that the variables are empty */
+
+	/* make *num_level_spaces == 0 */
+	*num_level_spaces = 0;
+	/* make *print_level_tab == false */
+	*print_level_tab = false;
+    }
+
+    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
+	if (ch == 't') {
+	    *print_level_tab = true;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else if (ch == 's') {
+	    *print_level_tab = false; /* ensure it's false in case specified previously */
+	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+	} else {
+	    err(3, __func__, "syntax error for -L"); /*ooo*/
+	    not_reached();
+	}
+    } else if (!strcmp(optarg, "tab")) {
+	    *print_level_tab = true;
+	    *num_level_spaces = 1;
+	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
+	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
+	not_reached();
+    } else {
+	*print_level_tab = false; /* ensure it's false in case specified previously */
+	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
+    }
+}
+
+/*
+ * jval_parse_value_option	- parse -t types list
+ *
+ * given:
+ *
+ *	optarg	    - option argument to -t option
+ *
+ * Returns: bitvector of types requested.
+ *
+ * NOTE: if optarg is NULL (which should never happen) or empty it returns the
+ * default, JVAL_TYPE_SIMPLE (as if '-t simple').
+ */
+uintmax_t
+jval_parse_value_type_option(char *optarg)
+{
+    uintmax_t type = JVAL_TYPE_SIMPLE; /* default is simple: num, bool, str and null */
+    char *p = NULL;
+
+    if (optarg == NULL || !*optarg) {
+	/* NULL or empty optarg, assume simple */
+	return type;
+    }
+    p = optarg;
+
+    /* Determine if the arg is a valid type.  */
+    if (!strcmp(p, "int")) {
+	type = JVAL_TYPE_INT;
+    } else if (!strcmp(p, "float")) {
+	type = JVAL_TYPE_FLOAT;
+    } else if (!strcmp(p, "exp")) {
+	type = JVAL_TYPE_EXP;
+    } else if (!strcmp(p, "num")) {
+	type = JVAL_TYPE_NUM;
+    } else if (!strcmp(p, "bool")) {
+	type = JVAL_TYPE_BOOL;
+    } else if (!strcmp(p, "str")) {
+	type = JVAL_TYPE_STR;
+    } else if (!strcmp(p, "null")) {
+	type = JVAL_TYPE_NULL;
+    } else if (!strcmp(p, "simple")) {
+	type = JVAL_TYPE_SIMPLE;
+    } else {
+	/* unknown or unsupported type */
+	err(3, __func__, "unknown or unsupported type '%s'", p); /*ooo*/
+	not_reached();
+    }
+
+    return type;
+}
+
+/*
+ * free_jval	    - free jval struct
+ *
+ * given:
+ *
+ *	jval	    - a struct jval **
+ *
+ * This function will do nothing other than warn on NULL pointer (even though
+ * it's safe to free a NULL pointer though if jval itself was NULL it would be
+ * an error to dereference it).
+ *
+ * We pass a struct jval ** so that in the caller jval can be set to NULL to
+ * remove the need to repeatedly set it to NULL each time this function is
+ * called. This way we remove the need to do more than just call this function.
+ */
+void
+free_jval(struct jval **jval)
+{
+    struct jval_match *match = NULL; /* to iterate through matches list */
+    struct jval_match *next_match = NULL; /* next in list */
+
+    /* firewall */
+    if (jval == NULL || *jval == NULL) {
+	warn(__func__, "passed NULL struct jval ** or *jval is NULL");
+	return;
+    }
+
+    free_jval_patterns_list(*jval); /* free patterns list first */
+
+    /* we have to free matches attached to jval itself too */
+    for (match = (*jval)->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+
+    free(*jval);
+    *jval = NULL;
+}
+
+
+/* parse_jval_name_args - add name_args to patterns list
+ *
+ * given:
+ *
+ *	jval	    - pointer to our struct jval
+ *	argv	    - argv from main()
+ *
+ * This function will not return on NULL pointers.
+ *
+ * NOTE: by patterns we refer to name_args.
+ *
+ * XXX - the pattern concept is currently incorrect and needs to be fixed - XXX
+ */
+void
+parse_jval_name_args(struct jval *jval, char **argv)
+{
+    int i;  /* to iterate through argv */
+
+    /* firewall */
+    if (argv == NULL) {
+	err(15, __func__, "argv is NULL"); /*ooo*/
+	not_reached();
+    }
+
+    for (i = 1; argv[i] != NULL; ++i) {
+	jval->pattern_specified = true;
+
+	if (add_jval_pattern(jval, jval->use_regexps, jval->use_substrings, argv[i]) == NULL) {
+	    err(25, __func__, "failed to add pattern (substrings %s) '%s' to patterns list",
+		    jval->use_substrings?"OK":"ignored", argv[i]);
+	    not_reached();
+	}
+    }
+}
+
+
+/*
+ * add_jval_pattern
+ *
+ * Add jval pattern to the jval struct pattern list.
+ *
+ * given:
+ *
+ *	jval		- pointer to the jval struct
+ *	use_regexp	- whether to use regexp or not
+ *	use_substrings	- if -s was specified, make this a substring match
+ *	str		- the pattern to be added to the list
+ *
+ * NOTE: this function will not return if jval is NULL. If str is NULL
+ * this function will not return but if str is empty it will add an empty
+ * string to the list. However the caller will usually check that it's not empty
+ * prior to calling this function.
+ *
+ * Returns a pointer to the newly allocated struct jval_pattern * that was
+ * added to the jval patterns list.
+ *
+ * Duplicate patterns will not be added (case sensitive).
+ */
+struct jval_pattern *
+add_jval_pattern(struct jval *jval, bool use_regexp, bool use_substrings, char *str)
+{
+    struct jval_pattern *pattern = NULL;
+    struct jval_pattern *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jval == NULL) {
+	err(26, __func__, "passed NULL jval struct");
+	not_reached();
+    }
+    if (str == NULL) {
+	err(27, __func__, "passed NULL str");
+	not_reached();
+    }
+
+    /*
+     * first make sure the pattern is not already added to the list as the same
+     * type
+     */
+    for (pattern = jval->patterns; pattern != NULL; pattern = pattern->next) {
+	if (pattern->pattern && pattern->use_regexp == use_regexp) {
+	    /* XXX - add support for regexps - XXX */
+	    if ((!jval->ignore_case && !strcmp(pattern->pattern, str))||
+		(jval->ignore_case && strcasecmp(pattern->pattern, str))) {
+		return pattern;
+	    }
+	}
+    }
+    /*
+     * XXX either change the debug level or remove this message once
+     * processing is complete
+     */
+    if (use_regexp) {
+	dbg(DBG_LOW,"%s regex requested: '%s'", jval->search_value?"value":"name", str);
+    } else {
+	dbg(DBG_LOW,"%s pattern requested: '%s'", jval->search_value?"value":"name", str);
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    pattern = calloc(1, sizeof *pattern);
+    if (pattern == NULL) {
+	errp(28, __func__, "unable to allocate struct jval_pattern *");
+	not_reached();
+    }
+
+    errno = 0;
+    pattern->pattern = strdup(str);
+    if (pattern->pattern == NULL) {
+	errp(29, __func__, "unable to strdup string '%s' for patterns list", str);
+	not_reached();
+    }
+
+    pattern->use_regexp = use_regexp;
+    pattern->use_value = jval->search_value;
+    pattern->use_substrings = use_substrings;
+    /* increment how many patterns have been specified */
+    ++jval->number_of_patterns;
+    /* let jval know that a pattern was indeed specified */
+    jval->pattern_specified = true;
+    pattern->matches_found = 0; /* 0 matches found at first */
+
+    dbg(DBG_LOW, "adding %s pattern '%s' to patterns list", pattern->use_value?"value":"name", pattern->pattern);
+
+    for (tmp = jval->patterns; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	jval->patterns = pattern;
+    } else {
+	tmp->next = pattern;
+    }
+
+    return pattern;
+}
+
+
+/* free_jval_patterns_list	- free patterns list in a struct jval *
+ *
+ * given:
+ *
+ *	jval	    - the jval struct
+ *
+ * If the jval patterns list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL jval.
+ *
+ * NOTE: this function calls free_jval_matches_list() on all the patterns
+ * prior to freeing the pattern itself.
+ */
+void
+free_jval_patterns_list(struct jval *jval)
+{
+    struct jval_pattern *pattern = NULL; /* to iterate through patterns list */
+    struct jval_pattern *next_pattern = NULL; /* next in list */
+
+    if (jval == NULL) {
+	err(30, __func__, "passed NULL jval struct");
+	not_reached();
+    }
+
+    for (pattern = jval->patterns; pattern != NULL; pattern = next_pattern) {
+	next_pattern = pattern->next;
+
+	/* first free any matches */
+	free_jval_matches_list(pattern);
+
+	/* now free the pattern string itself */
+	if (pattern->pattern) {
+	    free(pattern->pattern);
+	    pattern->pattern = NULL;
+	}
+
+	/* finally free the pattern and set to NULL for the next pass */
+	free(pattern);
+	pattern = NULL;
+    }
+
+    jval->patterns = NULL;
+}
+
+
+/*
+ * add_jval_match
+ *
+ * Add jval pattern match to the jval struct pattern match list.
+ *
+ * given:
+ *
+ *	jval		- pointer to the jval struct
+ *	pattern		- the pattern that matched
+ *	name		- struct json * name that matched
+ *	value		- struct json * value that matched
+ *	name_str	- the matching value, either a value or name
+ *	value_str	- the matching value, the opposite of name_str
+ *	level		- the depth or level for the -l / -L options (level 0 is top of tree)
+ *	string		- boolean to indicate if the match is a string
+ *	name_type	- enum item_type indicating the type of name node (JTYPE_* in json_parse.h)
+ *	value_type	- enum item_type indicating the type of value node (JTYPE_* in json_parse.h)
+ *
+ * NOTE: this function will not return if any of the pointers are NULL (except
+ * the name and value - for now) including the pointers in the pattern struct.
+ *
+ * Returns a pointer to the newly allocated struct jval_match * that was
+ * added to the jval matched patterns list.
+ *
+ * NOTE: depending on jval->search_value the name and value nodes will be in a
+ * different order. Specifically the name is what matched, whether a value in
+ * the json tree or name, and the value is what will be printed. At least once
+ * this feature is done :-)
+ */
+struct jval_match *
+add_jval_match(struct jval *jval, struct jval_pattern *pattern, struct json *name,
+	struct json *value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type)
+{
+    struct jval_match *match = NULL;
+    struct jval_match *tmp = NULL;
+
+    /*
+     * firewall
+     */
+    if (jval == NULL) {
+	err(31, __func__, "passed NULL jval struct");
+	not_reached();
+    }
+
+    if (name_str == NULL) {
+	err(32, __func__, "passed NULL name_str");
+	not_reached();
+    }
+    if (value_str == NULL) {
+	err(33, __func__, "value_str is NULL");
+	not_reached();
+    }
+
+    /*
+     * search for an exact match and only increment the count if found.
+     *
+     * NOTE: this means that when printing the output we have to go potentially
+     * print the match more than once; if -c is specified we print only the
+     * count.
+     */
+    for (tmp = pattern?pattern->matches:jval->matches; tmp; tmp = tmp->next) {
+	if (name_type == tmp->name_type) {
+	    /* XXX - add support for regexps - XXX */
+	    if (((!jval->ignore_case && !strcmp(tmp->match, value_str) && !strcmp(tmp->match, value_str)))||
+		(jval->ignore_case && !strcasecmp(tmp->match, value_str) && !strcasecmp(tmp->match, value_str))) {
+		    dbg(DBG_LOW, "incrementing count of match '%s' to %ju", tmp->match, tmp->count + 1);
+		    jval->total_matches++;
+		    tmp->count++;
+		    return tmp;
+	    }
+	}
+    }
+
+    /* if we get here we have to add the match to the matches list */
+    errno = 0; /* pre-clear errno for errp() */
+    match = calloc(1, sizeof *match);
+    if (match == NULL) {
+	errp(34, __func__, "unable to allocate struct jval_match *");
+	not_reached();
+    }
+
+    /* duplicate the match (name_str) */
+    errno = 0; /* pre-clear errno for errp() */
+    match->match = strdup(name_str);
+    if (match->match == NULL) {
+	errp(35, __func__, "unable to strdup string '%s' for match list", name_str);
+	not_reached();
+    }
+
+    /* duplicate the value of the match, either name or value */
+    errno = 0; /* pre-clear errno for errp() */
+    match->value = strdup(value_str);
+    if (match->match == NULL) {
+	errp(36, __func__, "unable to strdup value string '%s' for match list", value_str);
+	not_reached();
+    }
+    /* set level of the match for -l / -L options */
+    match->level = level;
+
+    /* set count to 1 */
+    match->count = 1;
+
+    /* record the pattern that was matched. It's okay if it is NULL. */
+    match->pattern = pattern; /* DO NOT FREE THIS! */
+
+    /* set struct json * nodes */
+    match->node_name = name;
+    match->node_value = value;
+
+    /* set which match number this is, incrementing the pattern's total matches */
+    if (pattern) {
+	match->number = pattern->matches_found++;
+    }
+
+    /* increment total matches of ALL patterns (name_args) in jval struct */
+    jval->total_matches++;
+
+    /* record types */
+    match->name_type = name_type;
+    match->value_type = value_type;
+
+    dbg(DBG_LOW, "adding match '%s' to pattern '%s' to match list",
+	    jval->search_value?match->value:match->match, name_str);
+
+    for (tmp = pattern?pattern->matches:jval->matches; tmp && tmp->next; tmp = tmp->next)
+	; /* on its own line to silence useless and bogus warning -Wempty-body */
+
+    if (!tmp) {
+	if (pattern != NULL) {
+	    pattern->matches = match;
+	} else {
+	    jval->matches = match;
+	}
+    } else {
+	tmp->next = match;
+    }
+
+    /* a match is found, set jval->match_found to true */
+    jval->match_found = true;
+
+    return match;
+}
+
+/* free_jval_matches_list   - free matches list in a struct jval_pattern *
+ *
+ * given:
+ *
+ *	pattern	    - the jval pattern
+ *
+ * If the jval patterns match list is empty this function will do nothing.
+ *
+ * NOTE: this function does not return on a NULL pattern.
+ */
+void
+free_jval_matches_list(struct jval_pattern *pattern)
+{
+    struct jval_match *match = NULL; /* to iterate through matches list */
+    struct jval_match *next_match = NULL; /* next in list */
+
+    if (pattern == NULL) {
+	err(37, __func__, "passed NULL pattern struct");
+	not_reached();
+    }
+
+    for (match = pattern->matches; match != NULL; match = next_match) {
+	next_match = match->next;
+	if (match->match) {
+	    free(match->match);
+	    match->match = NULL;
+	}
+
+	if (match->value) {
+	    free(match->value);
+	    match->value = NULL;
+	}
+
+	/* DO NOT FREE match->pattern! */
+	free(match);
+	match = NULL;
+    }
+
+    pattern->matches = NULL;
+}
+
+/* is_jval_match	- if the name or value is a match based on type
+ *
+ * given:
+ *
+ *	jval	    - pointer to our struct jval
+ *	pattern	    - pointer to the pattern
+ *	name	    - char const * that is the matching name (if pattern == NULL)
+ *	node	    - struct json node
+ *	str	    - the string to compare
+ *
+ * Returns true if a match; else false.
+ *
+ * This function will not return if jval or node or str is NULL. The pattern
+ * and name pointers can be NULL unless both are NULL.
+ */
+bool
+is_jval_match(struct jval *jval, struct jval_pattern *pattern, char const *name, struct json *node, char const *str)
+{
+    /* firewall */
+    if (jval == NULL) {
+	err(38, __func__, "jval is NULL");
+	not_reached();
+    } else if ((pattern == NULL || pattern->pattern == NULL) && name == NULL) {
+	err(39, __func__, "pattern and name are both NULL");
+	not_reached();
+    } else if (node == NULL) {
+	err(40, __func__, "node is NULL");
+	not_reached();
+    } else if (str == NULL) {
+	err(41, __func__, "str is NULL");
+	not_reached();
+    }
+
+    /* set up name if NULL to be pattern->pattern */
+    if (name == NULL) {
+	name = pattern->pattern;
+    }
+
+    /* check that name != NULL */
+    if (name == NULL) {
+	err(42, __func__, "name is NULL");
+	not_reached();
+    }
+
+    /*
+     * if there is a match found add it to the matches list
+     *
+     * XXX - an issue that must be worked out is that if one does something
+     * like:
+     *
+     *	    jval -Y int -j h2g2.json 42
+     *
+     * they will get not just the integer values but the string "42". The
+     * problem is that in that file there is a string "42" and due to the bug in
+     * string matching and possibly the traversing of the tree (how it's done)
+     * this matches as all this function does is check the type of node and
+     * compare that it's equal. The string node should not actually be examined
+     * if the type does not match but this has to be fixed at a later time.
+     */
+    switch (node->type) {
+
+	case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+	    break;
+
+	case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	    {
+		struct json_number *item = &(node->item.number);
+
+		if (item != NULL && item->converted) {
+		    if (!jval->search_value || jval_match_num(jval->json_types) ||
+			(item->is_integer&&jval_match_int(jval->json_types))||
+			(item->is_floating && jval_match_float(jval->json_types)) ||
+			(item->is_e_notation && jval_match_exp(jval->json_types))) {
+			    if (jval->use_substrings) {
+				if (strstr(str, name) ||
+				    (jval->ignore_case&&strcasestr(str, name))) {
+					return true;
+				}
+			    } else {
+				if (!strcmp(name, str) ||
+				    (jval->ignore_case&&!strcasecmp(name, str))) {
+					return true;
+				}
+			    }
+			}
+		}
+	    }
+	    break;
+
+	case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+	    {
+		struct json_string *item = &(node->item.string);
+
+		if (item != NULL && item->converted) {
+		    if (!jval->search_value || jval_match_string(jval->json_types)) {
+			if (jval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+	    {
+		struct json_boolean *item = &(node->item.boolean);
+
+		if (item != NULL && item->converted) {
+		    if (!jval->search_value || jval_match_bool(jval->json_types)) {
+			if (jval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+
+			} else {
+			    if (!strcmp(name, str) ||
+				(jval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+		}
+	    }
+	    break;
+
+	case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+	    {
+		struct json_null *item = &(node->item.null);
+
+		if (item != NULL && item->converted) {
+		    if (!jval->search_value || jval_match_null(jval->json_types)) {
+			if (jval->use_substrings) {
+			    if (strstr(str, name) ||
+				(jval->ignore_case && strcasestr(str, name))) {
+				    return true;
+			    }
+			} else {
+			    if (!strcmp(name, str) ||
+				(jval->ignore_case && !strcasecmp(name, str))) {
+				    return true;
+			    }
+			}
+		    }
+	    }
+	    break;
+
+	case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+	    {
+		struct json_member *item = &(node->item.member);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+	    {
+		struct json_object *item = &(node->item.object);
+
+		/* XXX - check if anything has to be done here */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+	    {
+		struct json_array *item = &(node->item.array);
+
+		/* XXX - check if anything has to be done here as a quick test
+		 * suggests nothing has to be done - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+	    {
+		struct json_elements *item = &(node->item.elements);
+
+		/* XXX - check if anything has to be done here - XXX */
+		UNUSED_ARG(item);
+	    }
+	    break;
+
+	default:
+	    break;
+	}
+    }
+    /* nothing found, return false */
+    return false;
+}
+
+
+/*
+ * jval_json_search
+ *
+ * Print information about a JSON node, depending on the booleans in struct
+ * jval if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * given:
+ *	jval	    pointer to our struct jval
+ *	name_node   pointer to a JSON parser tree name node to try and match or add
+ *	value_node  pointer to a JSON parser tree value node to try and match or add
+ *	is_value    whether node is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	...	    extra args are ignored, required extra args if <=
+ *		    json_verbosity_level:
+ *
+ *			stream		stream to print on
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * Example use - print a JSON parse tree
+ *
+ *	jval_json_search(node, true, depth, JSON_DBG_MED);
+ *	jval_json_search(node, false, depth, JSON_DBG_FORCED;
+ *	jval_json_search(node, false, depth, JSON_DBG_MED);
+ *
+ * While the ... variable arg are ignored, we need to declare
+ * then in order to be in vcallback form for use by json_tree_walk().
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jval == NULL or node == NULL.
+ */
+void
+jval_json_search(struct jval *jval, struct json *name_node, struct json *value_node, bool is_value, unsigned int depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /* firewall */
+    if (jval == NULL || (name_node == NULL&&value_node == NULL)) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, depth);
+
+    /*
+     * call va_list argument list function
+     */
+    vjval_json_search(jval, name_node, value_node, is_value, depth, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+
+/*
+ * vjval_json_search
+ *
+ * Search for matches in a JSON node, depending on the booleans in struct
+ * jval if the tree node matches the name or value in any pattern in the
+ * struct json.
+ *
+ * This is a variable argument list interface to jval_json_search().
+ *
+ * See jval_json_tree_search() to go through the entire tree.
+ *
+ * given:
+ *	jval	    pointer to our struct json
+ *	name_node   pointer to a JSON parser tree name node to search
+ *	value_node  pointer to a JSON parser tree value node to search
+ *	is_value    boolean to indicate if this is a value or name
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	ap	    variable argument list, required ap args:
+ *
+ *			json_dbg_lvl	print message if JSON_DBG_FORCED
+ *					OR if <= json_verbosity_level
+ *
+ * NOTE: This function does nothing if jval == NULL or jval->patterns ==
+ * NULL or if none of the names/values match any of the patterns or node ==
+ * NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is incomplete and does not do everything correctly. Any
+ * problems will be fixed in a future commit.
+ */
+void
+vjval_json_search(struct jval *jval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap)
+{
+    FILE *stream = NULL;	/* stream to print on */
+    int json_dbg_lvl = JSON_DBG_DEFAULT;	/* JSON debug level if json_dbg_used */
+    struct jval_pattern *pattern = NULL; /* to iterate through patterns list */
+    va_list ap2;		/* copy of va_list ap */
+
+    /*
+     * firewall - nothing to do for NULL jval or NULL patterns list or NULL
+     * nodes
+     */
+    if (jval == NULL || jval->patterns == NULL || name_node == NULL || value_node == NULL) {
+	return;
+    }
+
+    /*
+     * duplicate va_list ap
+     */
+    va_copy(ap2, ap);
+
+    /*
+     * obtain the stream, json_dbg_used, and json_dbg args
+     */
+    stream = stdout;
+    if (stream == NULL) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+    json_dbg_lvl = va_arg(ap2, int);
+
+    /*
+     * XXX: This is buggy in a number of ways and the is_value will possibly
+     * have to change. Strings in particular are problematic here and it does
+     * not work right. Also -t can end up searching by value without -Y even
+     * though it's not supposed to. What does work is that specifying a type in
+     * general can prevent one or the other from showing up. Nevertheless to
+     * develop the type checks this has to be done until it can be fixed. This
+     * is very much a work in progress.
+     */
+    if (((!jval->search_value && is_value) || (!is_value && jval->search_value))) {
+	va_end(ap2); /* stdarg variable argument list clean up */
+	return;
+    }
+
+    /* only search for matches if level constraints allow it */
+    if (!jval->levels_constrained || jval_number_in_range(depth, jval->number_of_patterns, &jval->jval_levels))
+    {
+	for (pattern = jval->patterns; pattern != NULL; pattern = pattern->next) {
+	    /* XXX: for each pattern we have to find a match and then add it to
+	     * the matches list of that pattern. After that we can go through
+	     * the matches found and print out the matches as desired by the
+	     * user. We will not add matches if the constraints do not allow it.
+	     *
+	     * However note that we currently do not have a working way to check
+	     * if the node is a value or name so what ends up happening is that
+	     * a value can match as a name and vice versa. See above comment.
+	     */
+
+	    /* get the name and value */
+	    struct json *name = jval->search_value?value_node:name_node;
+	    struct json *value = jval->search_value?name_node:value_node;
+
+	    /*
+	     * Get strings of name and value. NULL is checked prior to use,
+	     * below
+	     */
+	    char const *str = name  != NULL ? json_get_type_str(name, jval->match_encoded) : NULL;
+	    char const *val = value != NULL ? json_get_type_str(value, jval->match_encoded) : NULL;
+
+	    if (name != NULL) {
+		switch (name->type) {
+
+		    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+			break;
+
+		    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+					{
+					    if (val != NULL) {
+						if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						    if (add_jval_match(jval, pattern, name, value,
+							str, val, depth, jval->search_value?JTYPE_STRING:JTYPE_NUMBER,
+							jval->search_value?JTYPE_NUMBER:JTYPE_STRING) == NULL) {
+							    err(43, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+						}
+					}
+				    }
+				    break;
+				    default:
+					/* XXX - determine if other types need to be handled */
+				    break;
+				    }
+			    }
+			}
+			break;
+
+		    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_NUMBER:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name,
+						jval->search_value?val:str)) {
+						    if (add_jval_match(jval, pattern, name, value,
+							str, val, depth,
+							name->type, value->type) == NULL) {
+							    err(44, __func__, "adding match '%s' to pattern failed", str);
+							    not_reached();
+						    }
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						if (add_jval_match(jval, pattern, name, value, str, val,
+						    depth, JTYPE_STRING, JTYPE_STRING) == NULL) {
+							err(45, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_BOOL:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						if (add_jval_match(jval, pattern, name, value, str, val,
+						    depth, jval->search_value?JTYPE_BOOL:JTYPE_STRING,
+						    jval->search_value?JTYPE_STRING:JTYPE_BOOL) == NULL) {
+							err(46, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    case JTYPE_NULL:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						if (add_jval_match(jval, pattern, name, value, str, val,
+						    depth, jval->search_value?JTYPE_NULL:JTYPE_STRING,
+						    jval->search_value?JTYPE_STRING:JTYPE_NULL) == NULL) {
+							err(47, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+
+				    }
+				    break;
+				    default:
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						if (add_jval_match(jval, pattern, name, value, str, val,
+						    depth, jval->search_value?JTYPE_STRING:JTYPE_BOOL,
+						    jval->search_value?JTYPE_BOOL:JTYPE_STRING) == NULL) {
+							err(48, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+			{
+			    if (str != NULL) {
+				switch (value->type) {
+				    case JTYPE_STRING:
+				    {
+					if (val != NULL) {
+					    if (is_jval_match(jval, pattern, pattern->pattern, name, str)) {
+						if (add_jval_match(jval, pattern, name, value, str, val,
+						    depth, jval->search_value?JTYPE_STRING:JTYPE_NULL,
+						    jval->search_value?JTYPE_NULL:JTYPE_STRING) == NULL) {
+							err(49, __func__, "adding match '%s' to pattern failed", str);
+							not_reached();
+						}
+					    }
+					}
+				    }
+				    break;
+				    default: /* only string is valid */
+					break;
+				}
+			    }
+			}
+			break;
+
+		    case JTYPE_MEMBER:	/* JSON item is a member - see struct json_member */
+			{
+			    struct json_member *item = &(name->item.member);
+
+			    /* XXX - fix to check for match of the member and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_OBJECT:	/* JSON item is a { members } - see struct json_object */
+			{
+			    struct json_object *item = &(name->item.object);
+
+			    /* XXX - fix to check for match of the object and add to
+			     * the matches list if it fits within constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ARRAY:	/* JSON item is a [ elements ] - see struct json_array */
+			{
+			    struct json_array *item = &(name->item.array);
+
+			    /* XXX - fix to check for match of the array and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    case JTYPE_ELEMENTS:	/* JSON elements is zero or more JSON values - see struct json_elements */
+			{
+			    struct json_elements *item = &(name->item.elements);
+
+			    /* XXX - fix to check for match of the element and add it
+			     * to the matches list if it fits within the constraints - XXX */
+			    UNUSED_ARG(item);
+			}
+			break;
+
+		    default:
+			break;
+		}
+	    }
+	}
+    }
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap2);
+    return;
+}
+
+
+/*
+ * jval_json_tree_search - search nodes of an entire JSON parse tree
+ *
+ * This function uses the jval_json_tree_walk() interface to walk
+ * the JSON parse tree and print requested information about matching nodes.
+ *
+ * given:
+ *	jval	    pointer to our struct jval
+ *	node	    pointer to a JSON parser tree node to free
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	...	extra args are ignored, required extra args:
+ *
+ *		json_dbg_lvl   print message if JSON_DBG_FORCED
+ *			       OR if <= json_verbosity_level
+ *
+ * Example uses - print an entire JSON parse tree
+ *
+ *	jval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_FORCED);
+ *	jval_json_tree_search(tree, JSON_DEFAULT_MAX_DEPTH, JSON_DBG_MED);
+ *
+ * NOTE: If the pointer to allocated storage == NULL,
+ *	 this function does nothing.
+ *
+ * NOTE: This function does nothing if jval == NULL, jval->patterns == NULL
+ * or node == NULL.
+ *
+ * NOTE: This function does nothing if the node type is invalid.
+ *
+ * NOTE: this function is a wrapper to jval_json_tree_walk() with the callback
+ * vjval_json_search().
+ */
+void
+jval_json_tree_search(struct jval *jval, struct json *node, unsigned int max_depth, ...)
+{
+    va_list ap;		/* variable argument list */
+
+    /*
+     * firewall - nothing to do for a NULL node
+     */
+    if (jval == NULL || jval->patterns == NULL || node == NULL) {
+	return;
+    }
+
+    /*
+     * stdarg variable argument list setup
+     */
+    va_start(ap, max_depth);
+
+    /*
+     * walk the JSON parse tree
+     */
+    jval_json_tree_walk(jval, node, node, max_depth, false, 0, vjval_json_search, ap);
+
+    /*
+     * stdarg variable argument list clean up
+     */
+    va_end(ap);
+    return;
+}
+
+/*
+ * jval_json_tree_walk - walk a JSON parse tree calling a function on each node in va_list form
+ *
+ * This is the va_list form of json_tree_walk().
+ *
+ * Walk a JSON parse tree, Depth-first Post-order (LRN) order.  See:
+ *
+ *	https://en.wikipedia.org/wiki/Tree_traversal#Post-order,_LRN
+ *
+ * Example use - walk an entire JSON parse tree, looking for matches and
+ * printing requested information on those matches.
+ *
+ *	jval_json_tree_walk(jval, tree, JSON_DEFAULT_MAX_DEPTH, 0, json_free);
+ *
+ * given:
+ *	node	    pointer to a JSON parse tree
+ *	is_value    if it's a value or name
+ *	max_depth   maximum tree depth to descend, or 0 ==> infinite depth
+ *			NOTE: Use JSON_INFINITE_DEPTH for infinite depth
+ *			NOTE: Consider use of JSON_DEFAULT_MAX_DEPTH for good default.
+ *	depth	    current tree depth (0 ==> top of tree)
+ *	vcallback   function to operate JSON parse tree node in va_list form
+ *	ap	    variable argument list
+ *
+ * The vcallback() function must NOT call va_arg() nor call va_end() on the
+ * va_list argument directly.  Instead they must call va_copy() and then use
+ * va_arg() and va_end() on the va_list copy.
+ *
+ * Although in C ALL functions are pointers which means one can call foo()
+ * as foo() or (*foo)() we use the latter format for the callback function
+ * to make it clearer that it is in fact a function that's passed in so
+ * that we can use this function to do more than one thing. This is also
+ * why we call it vcallback and not something else.
+ *
+ * If max_depth is >= 0 and the tree depth > max_depth, then this function return.
+ * In this case it will NOT operate on the node, or will be descend and further
+ * into the tree.
+ *
+ * NOTE: This function warns but does not do anything if an arg is NULL.
+ *
+ * NOTE: this function might be incomplete or does something that is incorrect.
+ * If this is the case it will be fixed in a future update.
+ */
+void
+jval_json_tree_walk(struct jval *jval, struct json *lnode, struct json *rnode, bool is_value,
+	unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jval *, struct json *, struct json *, bool,
+	unsigned int, va_list), va_list ap)
+{
+    int i;
+
+    /*
+     * firewall
+     */
+    if (lnode == NULL || rnode == NULL) {
+	warn(__func__, "node is NULL");
+	return ;
+    }
+    if (vcallback == NULL) {
+	warn(__func__, "vcallback is NULL");
+	return ;
+    }
+
+    /*
+     * do nothing if we are too deep
+     */
+    if (max_depth != JSON_INFINITE_DEPTH && depth > max_depth) {
+	warn(__func__, "tree walk descent stopped, tree depth: %u > max_depth: %u", depth, max_depth);
+	return;
+    }
+
+    /* if depth is 0 it can't be a value */
+    if (depth == 0) {
+	is_value = false;
+    }
+
+    /*
+     * walk based on type of node
+     */
+    switch (lnode->type) {
+
+    case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
+    case JTYPE_NULL:	/* JSON item is a null - see struct json_null */
+    case JTYPE_BOOL:	/* JSON item is a boolean - see struct json_boolean */
+    case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */
+	/* perform function operation on this terminal parse tree node, all of
+	 * which have to be a value */
+	(*vcallback)(jval, lnode, rnode, true, depth, ap);
+	break;
+
+    case JTYPE_STRING:	/* JSON item is a string - see struct json_string */
+
+	/* perform function operation on this terminal parse tree node */
+	(*vcallback)(jval, lnode, rnode, is_value, depth, ap);
+	break;
+
+    case JTYPE_MEMBER:	/* JSON item is a member */
+	{
+	    struct json_member *item = &(lnode->item.member);
+
+	    /* perform function operation on JSON member name (left branch) node */
+	    jval_json_tree_walk(jval, item->name, item->value, false, max_depth, depth+1, vcallback, ap);
+
+	    /* perform function operation on JSON member value (right branch) node */
+	    jval_json_tree_walk(jval, item->name, item->value, true, max_depth, depth+1, vcallback, ap);
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_OBJECT:	/* JSON item is a { members } */
+	{
+	    struct json_object *item = &(lnode->item.object);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jval_json_tree_walk(jval, item->set[i], item->set[i], is_value, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ARRAY:	/* JSON item is a [ elements ] */
+	{
+	    struct json_array *item = &(lnode->item.array);
+
+	    /* perform function operation on each object member in order */
+
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jval_json_tree_walk(jval, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* just call callback on the array node */
+	(*vcallback)(jval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    case JTYPE_ELEMENTS:	/* JSON items is zero or more JSON values */
+	{
+	    struct json_elements *item = &(lnode->item.elements);
+
+	    /* perform function operation on each object member in order */
+	    if (item->set != NULL) {
+		for (i=0; i < item->len; ++i) {
+		    jval_json_tree_walk(jval, item->set[i], item->set[i], true, max_depth, depth, vcallback, ap);
+		}
+	    }
+	}
+
+	/* finally perform function operation on the parent node */
+	(*vcallback)(jval, lnode, rnode, is_value, depth+1, ap);
+	break;
+
+    default:
+	warn(__func__, "node type is unknown: %d", lnode->type);
+	/* nothing we can traverse */
+	break;
+    }
+    return;
+}
+
+
+/* jval_print_count	- print total matches if -c used
+ *
+ * given:
+ *
+ *	jval	    - pointer to our struct jval
+ *
+ * This function will not return on NULL jval.
+ *
+ * This function returns false if -c was not used and true if it was.
+ */
+bool
+jval_print_count(struct jval *jval)
+{
+    /* firewall */
+    if (jval == NULL) {
+	err(50, __func__, "jval is NULL");
+	not_reached();
+    }
+
+    if (jval->count_only) {
+	print("%ju\n", jval->total_matches);
+	return true;
+    }
+
+    return false;
+}
+
+
+/* jval_print_final_comma	- print final comma if -C used
+ *
+ * given:
+ *
+ *	jval	    - pointer to our struct jval
+ *
+ * This function will not return on NULL jval.
+ *
+ * This function does nothing if -C was not used or if -c was used.
+ */
+void
+jval_print_final_comma(struct jval *jval)
+{
+    /* firewall */
+    if (jval == NULL) {
+	err(51, __func__, "jval is NULL");
+	not_reached();
+    }
+
+    if (jval->print_final_comma && !jval->count_only) {
+	print("%c", ',');
+    }
+}
+
+
+/* jval_print_brace - print a brace if -B used
+ *
+ * given:
+ *
+ *	jval	    - pointer to our jval struct
+ *	open	    - boolean indicating if we need an open or close brace
+ *
+ * This function returns void.
+ *
+ * This function will not return on NULL jval.
+ */
+void
+jval_print_brace(struct jval *jval, bool open)
+{
+    /* firewall */
+    if (jval == NULL) {
+	err(52, __func__, "jval is NULL");
+	not_reached();
+    }
+
+    if (jval->print_braces && !jval->count_only) {
+	print("%c\n", open?'{':'}');
+    }
+}
+
+
+/* jval_print_match	    - print a single match
+ *
+ * given:
+ *
+ *	jval	    - our struct jval with patterns list
+ *	pattern	    - the pattern with the match
+ *	match	    - the match to print
+ *
+ * NOTE: this function will not return if NULL pointers.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jval_print_match(struct jval *jval, struct jval_pattern *pattern, struct jval_match *match)
+{
+    uintmax_t i = 0;			    /* to iterate through count of each match */
+    uintmax_t j = 0;			    /* temporary iterator */
+
+    /* firewall */
+    if (jval == NULL) {
+	err(53, __func__, "jval is NULL");
+	not_reached();
+    } else if (match == NULL) {
+	err(54, __func__, "match is NULL");
+	not_reached();
+    } else if (pattern == NULL) {
+	err(55, __func__, "pattern is NULL");
+	not_reached();
+    }
+
+    /* if the name of the match is NULL it is a fatal error */
+    if (match->match == NULL) {
+	err(56, __func__, "match->match is NULL");
+	not_reached();
+    } else if (*match->match == '\0') {
+	/* warn on empty name for now and then go to next match */
+	warn(__func__, "empty match name");
+	return;
+    }
+
+    if (match->value == NULL) {
+	err(57, __func__, "match '%s' has NULL value", match->match);
+	not_reached();
+    } else if (*match->value == '\0') {
+	/* for now we only warn on empty value */
+	warn(__func__, "empty value for match '%s'", match->match);
+	return;
+    }
+
+    /*
+     * if we get here we have to print the name and/or match
+     */
+    for (i = 0; i < match->count; ++i) {
+	/* print the match in the way requested
+	 *
+	 * XXX - the count is probably incorrect as it means the printing could
+	 * be out of order
+	 *
+	 * XXX - add final constraint checks
+	 *
+	 * XXX - part of the below is buggy in some cases. This must be fixed.
+	 *
+	 * XXX - more functions will have to be added to print the matches.
+	 * Currently the jval_match struct is a work in progress. More will
+	 * have to be done depending on the type that matched (this includes not
+	 * only the jval type but the JSON type too).
+	 */
+
+	/* first print JSON levels if requested */
+	if (jval->print_json_levels) {
+	    print("%ju", match->level);
+
+	    for (j = 0; j < jval->num_level_spaces; ++j) {
+		printf("%s", jval->print_level_tab?"\t":" ");
+	    }
+	    if (jval->indent_levels) {
+		if (jval->indent_spaces) {
+		    for (j = 0; j < match->level * jval->indent_spaces; ++j) {
+			print("%s", jval->indent_tab?"\t":" ");
+		    }
+		}
+	    }
+
+	}
+
+	/*
+	 * if we're printing name and value or the syntax we have extra things
+	 * to do
+	 */
+	if (jval_print_name_value(jval->print_json_types) || jval->print_syntax) {
+	    /* if we print syntax there are some extra things we have to do */
+	    if (jval->print_syntax) {
+
+		/* XXX - this doesn't print arrays and other more complicated types - XXX */
+		print("\"%s\"", match->match);
+
+		for (j = 0; j < jval->num_token_spaces; ++j) {
+		    print("%s", jval->print_token_tab?"\t":" ");
+		}
+
+		print("%s", ":");
+
+		for (j = 0; j < jval->num_token_spaces; ++j) {
+		    print("%s", jval->print_token_tab?"\t":" ");
+		}
+
+		print("%s%s%s%s\n",
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->next || (pattern->next&&pattern->next->matches) || i+1<match->count?",":"");
+	    } else { /* if we're not printing syntax */
+		/* print the name, quoting it if necessary */
+		print("%s%s%s",
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"",
+			match->match,
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->name_type == JTYPE_STRING?"\"":"");
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jval->num_token_spaces; ++j) {
+		    print("%s", jval->print_token_tab?"\t":" ");
+		}
+
+		/*
+		 * we're not printing the syntax but if colons are requested we
+		 * have to print them
+		 */
+		if (jval->print_colons) {
+		    print("%s", ":");
+		}
+
+		/* print spaces or tabs according to command line */
+		for (j = 0; j < jval->num_token_spaces; ++j) {
+		    print("%s", jval->print_token_tab?"\t":" ");
+		}
+
+		/* finally print the value.
+		 *
+		 * NOTE the check for printing syntax or entire file is not
+		 * necessary as such.
+		 */
+		print("%s%s%s\n",
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"",
+			match->value,
+			(jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+			match->value_type == JTYPE_STRING?"\"":"");
+	    }
+	} else if (jval_print_name(jval->print_json_types) || jval_print_value(jval->print_json_types)) {
+	    /*
+	     * here we will print just the name or value, quoting and doing
+	     * other things as necessary.
+	     *
+	     * NOTE the check for printing syntax or entire file is not
+	     * necessary as such.
+	     */
+	    print("%s%s%s\n",
+		  (jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jval_print_name(jval->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jval_print_value(jval->print_json_types)))?"\"":"",
+		  jval_print_name(jval->print_json_types)?match->match:match->value,
+		  (jval->quote_strings||jval->print_syntax||jval->print_entire_file)&&
+		  ((match->name_type == JTYPE_STRING&&jval_print_name(jval->print_json_types))||
+		   (match->value_type == JTYPE_STRING&&jval_print_value(jval->print_json_types)))?"\"":"");
+	}
+    }
+}
+
+/* jval_print_matches	    - print all matches found
+ *
+ * given:
+ *
+ *	jval	    - our struct jval with patterns list
+ *
+ * NOTE: this function will not return if jval is NULL.
+ *
+ * NOTE: this function will only warn if patterns and matches are both NULL.
+ *
+ * NOTE: if any pointer in a match is NULL this function will not return as it
+ * indicates incorrect behaviour in the program as it should never have got this
+ * far in the first place.
+ *
+ * NOTE: this function uses jval_print_match() to print each match.
+ *
+ * XXX: the concept of more than one pattern is not correct. This has to be
+ * fixed.
+ */
+void
+jval_print_matches(struct jval *jval)
+{
+    struct jval_pattern *pattern = NULL;  /* to iterate through patterns list */
+    struct jval_match *match = NULL;	    /* to iterate through matches of each pattern in the patterns list */
+
+    /* firewall */
+    if (jval == NULL) {
+	err(58, __func__, "jval is NULL");
+	not_reached();
+    } else if (jval->patterns == NULL && jval->matches == NULL) {
+	warn(__func__, "NULL patterns and matches list");
+	return;
+    }
+
+    /* if -c used just print total number of matches */
+    if (jval_print_count(jval)) {
+	return;
+    }
+
+    /* if -c was not used we have more to do */
+
+    /*
+     * although printing syntax is not yet fully implemented (though a
+     * reasonable amount of it is), we will check for -B and print the braces so
+     * that after the syntax printing is implemented nothing has to be done with
+     * -B. The function jval_print_braces() will not do anything if -B was not
+     * used.
+     */
+    jval_print_brace(jval, true);
+
+    for (pattern = jval->patterns; pattern != NULL; pattern = pattern->next) {
+	for (match = pattern->matches; match != NULL; match = match->next) {
+	    jval_print_match(jval, pattern, match);
+	}
+    }
+
+    /*
+     * although printing syntax is not yet fully implemented, we will check for
+     * -B and print the braces so that after the syntax printing is implemented
+     * nothing has to be done with -B. The function jval_print_braces() will
+     * not do anything if -B was not used.
+     */
+    if (jval->print_braces && !jval->count_only) {
+	jval_print_brace(jval, false);
+    }
+    /*
+     * as well, even though -j is not yet fully implemented, we will check for
+     * -C and print the final comma if requested so that once -j fully
+     * implemented we shouldn't have to do anything else with this option. Don't
+     * print final comma if -c used.
+     */
+    jval_print_final_comma(jval);
+
+    /* if we need a newline print it */
+    if ((jval->print_braces || jval->print_final_comma) && !jval->count_only) {
+	puts("");
+    }
+}
+
+/* run_jval_check_tool    - run the JSON check tool from -S path
+ *
+ * given:
+ *
+ *	jval	    - pointer to our struct jval (has everything needed)
+ *	argv	    - main()'s argv
+ *
+ * This function does not return on NULL jval. It does check for NULL
+ * jval->check_tool_path and jval->check_tool_args as it's not required to
+ * be set: the jval_sanity_chks() function only verifies that IF it is set it
+ * exists and is executable and if the args are specified that the -S is also
+ * specified (and the path is an executable file).
+ *
+ * This function does not return on NULL jval->file_contents.
+ *
+ * It does NOT check for the path existing as an executable file as the
+ * jval_sanity_chks() does that and if it somehow failed it's an error anyway.
+ */
+void
+run_jval_check_tool(struct jval *jval, char **argv)
+{
+    int exit_code = 0;			/* exit code for -S path execution */
+
+    /* firewall */
+    if (jval == NULL) {
+	err(59, __func__, "NULL jval");
+	not_reached();
+    } else if (jval->file_contents == NULL) {
+	err(60, __func__, "NULL jval->file_contents");
+	not_reached();
+    }
+
+    /* run tool if -S used */
+    if (jval->check_tool_path != NULL) {
+	/* try running via shell_cmd() first */
+	if (jval->check_tool_args != NULL) {
+	    dbg(DBG_MED, "about to execute: %s %s -- %s >/dev/null 2>&1",
+		    jval->check_tool_path, jval->check_tool_args, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% % -- %", jval->check_tool_path, jval->check_tool_args, argv[0]);
+	} else {
+	    dbg(DBG_MED, "about to execute: %s %s >/dev/null 2>&1", jval->check_tool_path, argv[0]);
+	    exit_code = shell_cmd(__func__, true, true, "% %", jval->check_tool_path, argv[0]);
+	}
+	if(exit_code != 0) {
+	    if (jval->check_tool_args != NULL) {
+		err(7, __func__, "JSON check tool '%s' with args '%s' failed with exit code: %d",/*ooo*/
+			jval->check_tool_path, jval->check_tool_args, exit_code);
+	    } else {
+		err(7, __func__, "JSON check tool '%s' without args failed with exit code: %d",/*ooo*/
+			jval->check_tool_path, exit_code);
+	    }
+	    not_reached();
+	}
+	/* now open a write-only pipe */
+	if (jval->check_tool_args != NULL) {
+	    jval->check_tool_stream = pipe_open(__func__, true, true, "% % %", jval->check_tool_path,
+		    jval->check_tool_args, argv[0]);
+	} else {
+	    jval->check_tool_stream = pipe_open(__func__, true, true, "% %", jval->check_tool_path, argv[0]);
+	}
+	if (jval->check_tool_stream == NULL) {
+	    if (jval->check_tool_args != NULL) {
+		err(7, __func__, "opening pipe to JSON check tool '%s' with args '%s' failed", /*ooo*/
+			jval->check_tool_path, jval->check_tool_args);
+	    } else {
+		err(7, __func__, "opening pipe to JSON check tool '%s' without args failed", jval->check_tool_path); /*ooo*/
+	    }
+	    not_reached();
+	} else {
+	    /* process the pipe */
+	    int exit_status = 0;
+
+	    /*
+	     * write the file contents, which we know to be a valid JSON
+	     * document that is NUL terminated, to the pipe.
+	     */
+	    fpr(jval->check_tool_stream, __func__, "%s", jval->file_contents);
+
+	    /*
+	     * close down the pipe to the child process and obtain the status of the pipe child process
+	     */
+	    exit_status = pclose(jval->check_tool_stream);
+
+	    /*
+	     * examine the exit status of the child process and error if the child had a non-zero exit
+	     */
+	    if (WEXITSTATUS(exit_status) != 0) {
+		free_jval(&jval);
+		err(7, __func__, "pipe child process exited non-zero"); /*ooo*/
+		not_reached();
+	    } else {
+		dbg(DBG_MED, "pipe child process exited OK");
+	    }
+	}
+	jval->check_tool_stream = NULL;
+    }
+}
+
+

--- a/jparse/jval_util.h
+++ b/jparse/jval_util.h
@@ -1,0 +1,324 @@
+/* jval_util - utility functions for JSON printer jval
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This tool is being developed by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * The JSON parser was co-developed in 2022 by Cody and Landon.
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+#if !defined(INCLUDE_JVAL_UTIL_H)
+#    define  INCLUDE_JVAL_UTIL_H
+
+#define _GNU_SOURCE /* feature test macro for strcasestr() */
+#include <stdlib.h>
+#include <unistd.h>
+#include <regex.h> /* for -g and -G, regular expression matching */
+#include <string.h>
+
+/*
+ * dbg - info, debug, warning, error, and usage message facility
+ */
+#include "../dbg/dbg.h"
+
+/*
+ * dyn_array - dynamic array facility
+ */
+#include "../dyn_array/dyn_array.h"
+
+/*
+ * util - entry common utility functions for the IOCCC toolkit
+ */
+#include "util.h"
+
+/*
+ * json_parse - JSON parser support code
+ */
+#include "json_parse.h"
+
+/*
+ * json_util - general JSON parser utility support functions
+ */
+#include "json_util.h"
+
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
+
+/* defines */
+
+/* -t types */
+#define JVAL_TYPE_NONE    (0)
+#define JVAL_TYPE_INT	    (1)
+#define JVAL_TYPE_FLOAT   (2)
+#define JVAL_TYPE_EXP	    (4)
+#define JVAL_TYPE_NUM	    (8)
+#define JVAL_TYPE_BOOL    (16)
+#define JVAL_TYPE_STR	    (32)
+#define JVAL_TYPE_NULL    (64)
+#define JVAL_TYPE_OBJECT  (128)
+#define JVAL_TYPE_ARRAY   (256)
+#define JVAL_TYPE_ANY	    (511) /* bitwise OR of the above values */
+/* JVAL_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
+#define JVAL_TYPE_SIMPLE  (JVAL_TYPE_NUM|JVAL_TYPE_BOOL|JVAL_TYPE_STR|JVAL_TYPE_NULL)
+/* JVAL_TYPE_COMPOUND is bitwise OR of object and array */
+#define JVAL_TYPE_COMPOUND (JVAL_TYPE_OBJECT|JVAL_TYPE_ARRAY)
+
+/* print types for -p option */
+#define JVAL_PRINT_NAME   (1)
+#define JVAL_PRINT_VALUE  (2)
+#define JVAL_PRINT_BOTH   (JVAL_PRINT_NAME | JVAL_PRINT_VALUE)
+
+
+/* structs */
+
+/* structs for various options */
+/* number ranges for the options -l, -n and -n */
+struct jval_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
+};
+struct jval_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
+
+    /* for number ranges */
+    struct jval_number_range range;	/* for ranges */
+};
+
+/* jval_array - a struct for when an array matches, used in jval_match below
+ *
+ * XXX - this struct might or might not have to change - XXX
+ */
+struct jval_array
+{
+    struct json_array *array;
+
+    struct jval_match *match;	    /* what matched this array */
+};
+/*
+ * jval_match - a struct for a linked list of patterns matched in each pattern
+ * requested.
+ *
+ * XXX - this struct is a work in progress - XXX
+ */
+struct jval_match
+{
+    char *match;		    /* string that matched */
+    char *value;		    /* name or value string of that which matched */
+
+    uintmax_t count;		    /* how many of this match are found */
+    uintmax_t level;		    /* the level of the json member for -l */
+    uintmax_t number;		    /* which match this is */
+    enum item_type name_type;	    /* match type of name */
+    enum item_type value_type;	    /* match type of value */
+
+    struct json *node_name;	    /* struct json * node name. DO NOT FREE! */
+    struct json *node_value;	    /* struct json * node value. DO NOT FREE! */
+
+    struct jval_array *array;	    /* will not be NULL if match is an array. */
+
+    struct jval_pattern *pattern; /* pointer to the pattern that matched. DO NOT FREE! */
+    struct jval_match *next; /* next match found */
+};
+
+/*
+ * jval_pattern - struct for a linked list of patterns requested, held in
+ * struct jval
+ *
+ * XXX - the pattern concept is incorrect due to a misunderstanding - XXX
+ */
+struct jval_pattern
+{
+    char *pattern;		    /* the actual pattern or regexp string */
+    bool use_regexp;		    /* whether -g was used */
+    bool use_value;		    /* whether -Y was used, implying to search values */
+    bool use_substrings;	    /* if -s was used */
+    uintmax_t matches_found;	    /* number of matches found so far with this pattern */
+
+    struct jval_pattern *next;    /* the next in the list */
+
+    struct jval_match *matches;   /* matches found */
+};
+
+/*
+ * jval - struct that holds most of the options, other settings and other data
+ */
+struct jval
+{
+    /* JSON file related */
+    bool is_stdin;				/* reading from stdin */
+    FILE *json_file;				/* FILE * to json file */
+    char *file_contents;			/* file contents */
+
+    /* string related options */
+    bool encode_strings;			/* -e used */
+    bool quote_strings;				/* -Q used */
+
+
+    /* number ranges */
+    /* max number of matches */
+    bool max_matches_requested;			/* -n used */
+    struct jval_number jval_max_matches;	/* -n count specified */
+    /* min number of matches */
+    bool min_matches_requested;			/* -N used */
+    struct jval_number jval_min_matches;	/* -N count specified */
+    /* level constraints */
+    bool levels_constrained;			/* -l specified */
+    struct jval_number jval_levels;		/* -l level specified */
+
+    /* printing related options */
+    bool print_json_types_option;		/* -p explicitly used */
+    uintmax_t print_json_types;			/* -p type specified */
+    bool print_token_spaces;			/* -b specified */
+    uintmax_t num_token_spaces;			/* -b specified number of spaces or tabs */
+    bool print_token_tab;			/* -b tab (or -b <num>[t]) specified */
+    bool print_json_levels;			/* -L specified */
+    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
+    bool print_level_tab;			/* -L tab option */
+    bool print_colons;				/* -P specified */
+    bool print_final_comma;			/* -C specified */
+    bool print_braces;				/* -B specified */
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
+    bool indent_tab;				/* -I <num>[{t|s}] specified */
+    bool print_syntax;				/* -j used, will imply -p b -b 1 -c -e -Q -I 4 -t any */
+
+    /* search related bools */
+    bool json_types_specified;			/* -t used */
+    uintmax_t json_types;			/* -t type */
+    bool print_entire_file;			/* no name_arg specified */
+    bool match_found;				/* true if a pattern is specified and there is a match */
+    bool ignore_case;				/* true if -i, case-insensitive */
+    bool pattern_specified;			/* true if a pattern was specified */
+    bool search_value;				/* -Y used, search for value, not name */
+    bool search_or_mode;			/* -o used: search with OR mode */
+    bool search_anywhere;			/* -r used: search under anywhere */
+    bool match_encoded;				/* -E used, match encoded name */
+    bool use_substrings;			/* -s used, matching substrings okay */
+    bool use_regexps;				/* -g used, allow grep-like regexps */
+    bool count_only;				/* -c used, only show count */
+    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
+
+    /* check tool related things */
+    bool check_tool_specified;			/* bool indicating -S was used */
+    FILE *check_tool_stream;			/* FILE * stream for -S path */
+    char *check_tool_path;			/* -S tool path used */
+    char *check_tool_args;			/* -A tool args used */
+
+    /* any patterns specified */
+    /* XXX - the pattern concept is incorrect - XXX */
+    struct jval_pattern *patterns;		/* linked list of patterns specified */
+    uintmax_t number_of_patterns;		/* patterns specified */
+    /* matches found - subject to change */
+    struct jval_match *matches;		/* for entire file i.e. no name_arg */
+    uintmax_t total_matches;			/* total matches of all patterns (name_args) */
+
+    struct json *json_tree;			/* json tree if valid merely as a convenience */
+};
+
+
+/* function prototypes */
+struct jval *alloc_jval(void);
+
+/* JSON types - -t option*/
+uintmax_t jval_parse_types_option(char *optarg);
+bool jval_match_none(uintmax_t types);
+bool jval_match_int(uintmax_t types);
+bool jval_match_float(uintmax_t types);
+bool jval_match_exp(uintmax_t types);
+bool jval_match_exp(uintmax_t types);
+bool jval_match_bool(uintmax_t types);
+bool jval_match_num(uintmax_t types);
+bool jval_match_string(uintmax_t types);
+bool jval_match_null(uintmax_t types);
+bool jval_match_object(uintmax_t types);
+bool jval_match_array(uintmax_t types);
+bool jval_match_any(uintmax_t types);
+bool jval_match_simple(uintmax_t types);
+bool jval_match_compound(uintmax_t types);
+
+/* -Y type option */
+uintmax_t jval_parse_value_type_option(char *optarg);
+
+/* what to print - -p option */
+uintmax_t jval_parse_print_option(char *optarg);
+bool jval_print_name(uintmax_t types);
+bool jval_print_value(uintmax_t types);
+bool jval_print_name_value(uintmax_t types);
+
+/* for number range options: -l, -n, -n */
+bool jval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jval_number *number);
+bool jval_number_in_range(intmax_t number, intmax_t total_matches, struct jval_number *range);
+
+/* for -b option */
+void jval_parse_st_tokens_option(char *optarg, uintmax_t *num_token_spaces, bool *print_token_tab);
+
+/* for -I option */
+void jval_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
+
+/* for -L option */
+void jval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
+
+/*
+ * patterns (name_args) specified
+ *
+ * XXX - the concept of the patterns is incorrect in that it's not individual
+ * patterns but rather the second, third and Nth patterns are under the previous
+ * patterns in the file.
+ */
+void parse_jval_name_args(struct jval *jval, char **argv);
+struct jval_pattern *add_jval_pattern(struct jval *jval, bool use_regexp, bool use_substrings, char *str);
+void free_jval_patterns_list(struct jval *jval);
+
+/* matches found of each pattern */
+struct jval_match *add_jval_match(struct jval *jval, struct jval_pattern *pattern,
+	struct json *node_name, struct json *node_value, char const *name_str, char const *value_str, uintmax_t level,
+	enum item_type name_type, enum item_type value_type);
+void free_jval_matches_list(struct jval_pattern *pattern);
+
+/* functions to find matches in the JSON tree */
+bool is_jval_match(struct jval *jval, struct jval_pattern *pattern, char const *name, struct json *node, char const *str);
+void jval_json_search(struct jval *jval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, ...);
+void vjval_json_search(struct jval *jval, struct json *name_node, struct json *value_node, bool is_value,
+	unsigned int depth, va_list ap);
+void jval_json_tree_search(struct jval *jval, struct json *node, unsigned int max_depth, ...);
+void jval_json_tree_walk(struct jval *jval, struct json *lnode, struct json *rnode, bool is_value,
+		unsigned int max_depth, unsigned int depth, void (*vcallback)(struct jval *, struct json *, struct json *, bool,
+		unsigned int, va_list), va_list ap);
+
+/* functions to print matches */
+bool jval_print_count(struct jval *jval);
+void jval_print_final_comma(struct jval *jval);
+void jval_print_brace(struct jval *jval, bool open);
+void jval_print_match(struct jval *jval, struct jval_pattern *pattern, struct jval_match *match);
+void jval_print_matches(struct jval *jval);
+
+
+/* for the -S check tool and -A check tool args */
+void run_jval_check_tool(struct jval *jval, char **argv);
+
+/* to free the entire struct jval */
+void free_jval(struct jval **jval);
+
+
+#endif /* !defined INCLUDE_JVAL_UTIL_H */

--- a/jparse/test_jparse/jfmt_test.sh
+++ b/jparse/test_jparse/jfmt_test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# jfmt_test.sh - test jfmt tool on valid and invalid JSON files
+#
+# Run jfmt on simple one-line JSON files or on whole JSON documents to test the
+# JSON parser.
+#
+# When used with "-d json_tree -s subdir", two directories are expected:
+#
+#	json_tree/tree/subdir/good
+#	json_tree/tree/subdir/bad
+#
+# All files under json_tree/tree/subdir/good must be valid JSON.  If any file under
+# that directory tests as an invalid JSON file, this script will exit non-zero.
+#
+# All files under json_tree/tree/subdir/bad must be valid JSON.  If any file under
+# that directory tests as a valid JSON file, this script will exit non-zero.
+#
+# Without "-d json_tree -s subdir" a list of files in the command line are
+# tested to see if they are valid JSON files.  With no arguments, or - the
+# contents of stdin is tested.
+#
+# "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+#
+# The JSON parser was co-developed in 2022 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# The jfmt tool and this test script is being developed by Cody Boone Ferguson.
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# "Share and Enjoy!"
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+
+
+# setup
+#
+export JFMT_TEST_VERSION="0.0.0 2023-07-16"
+export CHK_TEST_FILE="./jparse/test_jfmt/json_teststr.txt"
+export JFMT="./jparse/jfmt"
+export JSON_TREE="./jfmt/test_jfmt/test_JSON"
+export SUBDIR="."
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jfmt] [-d json_tree] [-s subdir] [file ..]
+
+    -h			print help and exit
+    -V			print version and exit
+    -v level		set verbosity level for this script: (def level: 0)
+    -D dbg_level	set verbosity level for tests (def: level: 0)
+    -J level		set JSON parser verbosity level (def level: 0)
+    -q			quiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)
+    -j /path/to/jfmt	path to jfmt tool (def: $JFMT)
+    -d json_tree	read files under json_tree/subdir/good and json_tree/subdir/bad (def: $JSON_TREE)
+			    These subdirectories are expected:
+				json_tree/tree/subdir/bad
+				json_tree/tree/subdir/good
+    -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
+    [file ...]		read JSON documents, one per line, from these files, - means stdin (def: $CHK_TEST_FILE)
+			NOTE: To use stdin, end the command line with: -- -
+
+Exit codes:
+     0   all tests are OK
+     1   at least one test failed
+     2	 -h and help string printed or -V and version string printed
+     3   invalid command line
+     4	 jfmt not a regular executable file
+     5	 couldn't create writable log file
+     6	 missing directory or directories
+     7	 missing JSON file
+  >= 10  internal error
+
+jfmt_test.sh version: $JFMT_TEST_VERSION"
+
+export V_FLAG="0"
+export DBG_LEVEL="0"
+export JSON_DBG_LEVEL="0"
+export Q_FLAG=""
+export LOGFILE="./jfmt_test.log"
+export EXIT_CODE=0
+export FILE_FAILURE_SUMMARY=""
+
+# parse args
+#
+while getopts :hVv:D:J:qj:d:s: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$JFMT_TEST_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    D)	DBG_LEVEL="$OPTARG";
+	;;
+    J)	JSON_DBG_LEVEL="$OPTARG";
+	;;
+    q)	Q_FLAG="-q";
+	;;
+    j)	JFMT="$OPTARG";
+	;;
+    d)	JSON_TREE="$OPTARG"
+	;;
+    s)  SUBDIR="$OPTARG"
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    *)
+	;;
+    esac
+done
+if [[ $V_FLAG -ge 1 ]]; then
+    echo "$0: debug[1]: -v: $V_FLAG" 1>&2
+    echo "$0: debug[1]: -D: $DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -J: $JSON_DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -s: $SUBDIR" 1>&2
+    if [[ -z $Q_FLAG ]]; then
+	echo "$0: debug[1]: -q: false" 1>&2
+    else
+	echo "$0: debug[1]: -q: true" 1>&2
+    fi
+    echo "$0: debug[1]: jfmt: $JFMT" 1>&2
+fi
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+export JSON_GOOD_TREE="$JSON_TREE/$SUBDIR/good"
+export JSON_BAD_TREE="$JSON_TREE/$SUBDIR/bad"
+
+# firewall
+#
+if [[ ! -e $JFMT ]]; then
+    echo "$0: ERROR: jfmt not found: $JFMT"
+    exit 4
+fi
+if [[ ! -f $JFMT ]]; then
+    echo "$0: ERROR: jfmt not a regular file: $JFMT"
+    exit 4
+fi
+if [[ ! -x $JFMT ]]; then
+    echo "$0: ERROR: jfmt not executable: $JFMT"
+    exit 4
+fi
+
+# check that json_tree is a readable directory
+#
+if [[ ! -e $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+
+# good tree
+#
+if [[ ! -e $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jfmt directory not found: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jfmt not a directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jfmt not readable directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+
+# bad tree
+#
+if [[ ! -e $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jfmt directory not found: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jfmt not a directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jfmt not readable directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+
+
+# remove logfile so that each run starts out with an empty file
+#
+rm -f "$LOGFILE"
+touch "$LOGFILE"
+if [[ ! -f "${LOGFILE}" ]]; then
+    echo "$0: ERROR: couldn't create log file" 1>&2
+    exit 5
+fi
+if [[ ! -w "${LOGFILE}" ]]; then
+    echo "$0: ERROR: log file not writable" 1>&2
+    exit 5
+fi
+
+# run_jfmt_test_mode - run jfmt -K test mode
+#
+# usage:
+#	run_jfmt_test_mode jfmt dbg_level json_dbg_level quiet_mode
+#
+run_jfmt_test_mode()
+{
+    # parse args
+    #
+    if [[ $# -ne 4 ]]; then
+	echo "$0: ERROR: expected 4 args to run_jfmt_test_mode, found $#" 1>&2
+	exit 10
+    fi
+    declare jfmt="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_jfmt_test_mode: jfmt: $jfmt" 1>&2
+	echo "$0: debug[9]: in run_jfmt_test_mode: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jfmt_test_mode: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jfmt_test_mode: quiet_mode: $quiet_mode" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jfmt -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jfmt -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jfmt" -v "$dbg_level" -J "$json_dbg_level" -K >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jfmt -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jfmt -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jfmt" -v "$dbg_level" -J "$json_dbg_level" -q -K >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	    echo "$0: in test that must pass: jfmt OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jfmt OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+    else
+	if [[ $V_FLAG -ge 1 ]]; then
+	    echo "$0: in test that must pass: jfmt FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: in run_jfmt_test_mode: jfmt exit code: $status" 1>&2 >> "${LOGFILE}"
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+
+# run_file_test - run a single jfmt test on a file
+#
+# usage:
+#	run_file_test jfmt dbg_level json_dbg_level quiet_mode json_doc_file pass|fail
+#
+#	jfmt			path to the jfmt program
+#	dbg_level		internal test debugging level to use as in: jfmt -v dbg_level
+#	json_dbg_level		JSON parser debug level to use in: jfmt -J json_dbg_level
+#	quiet_mode		quiet mode to use in: jfmt -q
+#	json_doc_file		JSON document as a string to give to jfmt
+#	pass|fail		string saying if jfmt must return valid json or invalid json
+#
+run_file_test()
+{
+    # parse args
+    #
+    if [[ $# -ne 6 ]]; then
+	echo "$0: ERROR: expected 6 args to run_file_test, found $#" 1>&2
+	exit 11
+    fi
+    declare jfmt="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+    declare json_doc_file="$5"
+    declare pass_fail="$6"
+
+    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
+	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
+	EXIT_CODE=12
+	return
+    fi
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_file_test: jfmt: $jfmt" 1>&2
+	echo "$0: debug[9]: in run_file_test: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: quiet_mode: $quiet_mode" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_doc_file: $json_doc_file" 1>&2
+	echo "$0: debug[9]: in run_file_test: pass_fail: $pass_fail" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jfmt -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jfmt -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jfmt" -v "$dbg_level" -J "$json_dbg_level" -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jfmt -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jfmt -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jfmt" -v "$dbg_level" -J "$json_dbg_level" -q -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	if [[ $pass_fail = pass ]]; then
+	    echo "$0: in test that must pass: jfmt OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jfmt OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jfmt FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jfmt exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	fi
+    else
+	if [[ $pass_fail = pass ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must pass: jfmt FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jfmt exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jfmt OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jfmt exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+# run tests that must pass
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jfmt tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JFMT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
+done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
+
+# run jfmt test mode itself
+
+run_jfmt_test_mode "$JFMT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG"
+
+#
+# run tests that must fail
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jfmt tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JFMT" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
+done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
+
+
+if [[ -n "$FILE_FAILURE_SUMMARY" ]]; then
+    echo "The following files failed: " | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+    echo "$FILE_FAILURE_SUMMARY" | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+fi
+
+# All Done!!! -- Jessica Noll, Age 2
+#
+if [[ $V_FLAG -ge 1 ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+	echo "$0: debug[1]: all tests PASSED" 1>&2
+	echo "$0: debug[1]: all tests PASSED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: see $LOGFILE for details" 1>&2
+    else
+	echo "$0: ERROR: debug[1]: some tests FAILED" 1>&2
+	echo "$0: ERROR: debug[1]: some tests FAILED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: Notice: see $LOGFILE for details" 1>&2
+    fi
+fi
+exit "$EXIT_CODE"

--- a/jparse/test_jparse/jnamval_test.sh
+++ b/jparse/test_jparse/jnamval_test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# jnamval_test.sh - test jnamval tool on valid and invalid JSON files
+#
+# Run jnamval on simple one-line JSON files or on whole JSON documents to test the
+# JSON parser.
+#
+# When used with "-d json_tree -s subdir", two directories are expected:
+#
+#	json_tree/tree/subdir/good
+#	json_tree/tree/subdir/bad
+#
+# All files under json_tree/tree/subdir/good must be valid JSON.  If any file under
+# that directory tests as an invalid JSON file, this script will exit non-zero.
+#
+# All files under json_tree/tree/subdir/bad must be valid JSON.  If any file under
+# that directory tests as a valid JSON file, this script will exit non-zero.
+#
+# Without "-d json_tree -s subdir" a list of files in the command line are
+# tested to see if they are valid JSON files.  With no arguments, or - the
+# contents of stdin is tested.
+#
+# "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+#
+# The JSON parser was co-developed in 2022 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# The jnamval tool and this test script is being developed by Cody Boone Ferguson.
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# "Share and Enjoy!"
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+
+
+# setup
+#
+export JNAMVAL_TEST_VERSION="0.0.0 2023-07-16"
+export CHK_TEST_FILE="./jparse/test_jnamval/json_teststr.txt"
+export JNAMVAL="./jparse/jnamval"
+export JSON_TREE="./jnamval/test_jnamval/test_JSON"
+export SUBDIR="."
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jnamval] [-d json_tree] [-s subdir] [file ..]
+
+    -h			print help and exit
+    -V			print version and exit
+    -v level		set verbosity level for this script: (def level: 0)
+    -D dbg_level	set verbosity level for tests (def: level: 0)
+    -J level		set JSON parser verbosity level (def level: 0)
+    -q			quiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)
+    -j /path/to/jnamval	path to jnamval tool (def: $JNAMVAL)
+    -d json_tree	read files under json_tree/subdir/good and json_tree/subdir/bad (def: $JSON_TREE)
+			    These subdirectories are expected:
+				json_tree/tree/subdir/bad
+				json_tree/tree/subdir/good
+    -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
+    [file ...]		read JSON documents, one per line, from these files, - means stdin (def: $CHK_TEST_FILE)
+			NOTE: To use stdin, end the command line with: -- -
+
+Exit codes:
+     0   all tests are OK
+     1   at least one test failed
+     2	 -h and help string printed or -V and version string printed
+     3   invalid command line
+     4	 jnamval not a regular executable file
+     5	 couldn't create writable log file
+     6	 missing directory or directories
+     7	 missing JSON file
+  >= 10  internal error
+
+jnamval_test.sh version: $JNAMVAL_TEST_VERSION"
+
+export V_FLAG="0"
+export DBG_LEVEL="0"
+export JSON_DBG_LEVEL="0"
+export Q_FLAG=""
+export LOGFILE="./jnamval_test.log"
+export EXIT_CODE=0
+export FILE_FAILURE_SUMMARY=""
+
+# parse args
+#
+while getopts :hVv:D:J:qj:d:s: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$JNAMVAL_TEST_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    D)	DBG_LEVEL="$OPTARG";
+	;;
+    J)	JSON_DBG_LEVEL="$OPTARG";
+	;;
+    q)	Q_FLAG="-q";
+	;;
+    j)	JNAMVAL="$OPTARG";
+	;;
+    d)	JSON_TREE="$OPTARG"
+	;;
+    s)  SUBDIR="$OPTARG"
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    *)
+	;;
+    esac
+done
+if [[ $V_FLAG -ge 1 ]]; then
+    echo "$0: debug[1]: -v: $V_FLAG" 1>&2
+    echo "$0: debug[1]: -D: $DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -J: $JSON_DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -s: $SUBDIR" 1>&2
+    if [[ -z $Q_FLAG ]]; then
+	echo "$0: debug[1]: -q: false" 1>&2
+    else
+	echo "$0: debug[1]: -q: true" 1>&2
+    fi
+    echo "$0: debug[1]: jnamval: $JNAMVAL" 1>&2
+fi
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+export JSON_GOOD_TREE="$JSON_TREE/$SUBDIR/good"
+export JSON_BAD_TREE="$JSON_TREE/$SUBDIR/bad"
+
+# firewall
+#
+if [[ ! -e $JNAMVAL ]]; then
+    echo "$0: ERROR: jnamval not found: $JNAMVAL"
+    exit 4
+fi
+if [[ ! -f $JNAMVAL ]]; then
+    echo "$0: ERROR: jnamval not a regular file: $JNAMVAL"
+    exit 4
+fi
+if [[ ! -x $JNAMVAL ]]; then
+    echo "$0: ERROR: jnamval not executable: $JNAMVAL"
+    exit 4
+fi
+
+# check that json_tree is a readable directory
+#
+if [[ ! -e $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+
+# good tree
+#
+if [[ ! -e $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jnamval directory not found: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jnamval not a directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jnamval not readable directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+
+# bad tree
+#
+if [[ ! -e $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jnamval directory not found: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jnamval not a directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jnamval not readable directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+
+
+# remove logfile so that each run starts out with an empty file
+#
+rm -f "$LOGFILE"
+touch "$LOGFILE"
+if [[ ! -f "${LOGFILE}" ]]; then
+    echo "$0: ERROR: couldn't create log file" 1>&2
+    exit 5
+fi
+if [[ ! -w "${LOGFILE}" ]]; then
+    echo "$0: ERROR: log file not writable" 1>&2
+    exit 5
+fi
+
+# run_jnamval_test_mode - run jnamval -K test mode
+#
+# usage:
+#	run_jnamval_test_mode jnamval dbg_level json_dbg_level quiet_mode
+#
+run_jnamval_test_mode()
+{
+    # parse args
+    #
+    if [[ $# -ne 4 ]]; then
+	echo "$0: ERROR: expected 4 args to run_jnamval_test_mode, found $#" 1>&2
+	exit 10
+    fi
+    declare jnamval="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_jnamval_test_mode: jnamval: $jnamval" 1>&2
+	echo "$0: debug[9]: in run_jnamval_test_mode: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jnamval_test_mode: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jnamval_test_mode: quiet_mode: $quiet_mode" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jnamval -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jnamval -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jnamval" -v "$dbg_level" -J "$json_dbg_level" -K >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jnamval -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jnamval -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jnamval" -v "$dbg_level" -J "$json_dbg_level" -q -K >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	    echo "$0: in test that must pass: jnamval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jnamval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+    else
+	if [[ $V_FLAG -ge 1 ]]; then
+	    echo "$0: in test that must pass: jnamval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: in run_jnamval_test_mode: jnamval exit code: $status" 1>&2 >> "${LOGFILE}"
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+
+# run_file_test - run a single jnamval test on a file
+#
+# usage:
+#	run_file_test jnamval dbg_level json_dbg_level quiet_mode json_doc_file pass|fail
+#
+#	jnamval			path to the jnamval program
+#	dbg_level		internal test debugging level to use as in: jnamval -v dbg_level
+#	json_dbg_level		JSON parser debug level to use in: jnamval -J json_dbg_level
+#	quiet_mode		quiet mode to use in: jnamval -q
+#	json_doc_file		JSON document as a string to give to jnamval
+#	pass|fail		string saying if jnamval must return valid json or invalid json
+#
+run_file_test()
+{
+    # parse args
+    #
+    if [[ $# -ne 6 ]]; then
+	echo "$0: ERROR: expected 6 args to run_file_test, found $#" 1>&2
+	exit 11
+    fi
+    declare jnamval="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+    declare json_doc_file="$5"
+    declare pass_fail="$6"
+
+    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
+	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
+	EXIT_CODE=12
+	return
+    fi
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_file_test: jnamval: $jnamval" 1>&2
+	echo "$0: debug[9]: in run_file_test: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: quiet_mode: $quiet_mode" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_doc_file: $json_doc_file" 1>&2
+	echo "$0: debug[9]: in run_file_test: pass_fail: $pass_fail" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jnamval -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jnamval -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jnamval" -v "$dbg_level" -J "$json_dbg_level" -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jnamval -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jnamval -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jnamval" -v "$dbg_level" -J "$json_dbg_level" -q -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	if [[ $pass_fail = pass ]]; then
+	    echo "$0: in test that must pass: jnamval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jnamval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jnamval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jnamval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	fi
+    else
+	if [[ $pass_fail = pass ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must pass: jnamval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jnamval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jnamval OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jnamval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+# run tests that must pass
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jnamval tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JNAMVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
+done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
+
+# run jnamval test mode itself
+
+run_jnamval_test_mode "$JNAMVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG"
+
+#
+# run tests that must fail
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jnamval tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JNAMVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
+done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
+
+
+if [[ -n "$FILE_FAILURE_SUMMARY" ]]; then
+    echo "The following files failed: " | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+    echo "$FILE_FAILURE_SUMMARY" | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+fi
+
+# All Done!!! -- Jessica Noll, Age 2
+#
+if [[ $V_FLAG -ge 1 ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+	echo "$0: debug[1]: all tests PASSED" 1>&2
+	echo "$0: debug[1]: all tests PASSED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: see $LOGFILE for details" 1>&2
+    else
+	echo "$0: ERROR: debug[1]: some tests FAILED" 1>&2
+	echo "$0: ERROR: debug[1]: some tests FAILED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: Notice: see $LOGFILE for details" 1>&2
+    fi
+fi
+exit "$EXIT_CODE"

--- a/jparse/test_jparse/jval_test.sh
+++ b/jparse/test_jparse/jval_test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# jval_test.sh - test jval tool on valid and invalid JSON files
+#
+# Run jval on simple one-line JSON files or on whole JSON documents to test the
+# JSON parser.
+#
+# When used with "-d json_tree -s subdir", two directories are expected:
+#
+#	json_tree/tree/subdir/good
+#	json_tree/tree/subdir/bad
+#
+# All files under json_tree/tree/subdir/good must be valid JSON.  If any file under
+# that directory tests as an invalid JSON file, this script will exit non-zero.
+#
+# All files under json_tree/tree/subdir/bad must be valid JSON.  If any file under
+# that directory tests as a valid JSON file, this script will exit non-zero.
+#
+# Without "-d json_tree -s subdir" a list of files in the command line are
+# tested to see if they are valid JSON files.  With no arguments, or - the
+# contents of stdin is tested.
+#
+# "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+#
+# The JSON parser was co-developed in 2022 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# The jval tool and this test script is being developed by Cody Boone Ferguson.
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# "Share and Enjoy!"
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+
+
+# setup
+#
+export JVAL_TEST_VERSION="0.0.0 2023-07-16"
+export CHK_TEST_FILE="./jparse/test_jval/json_teststr.txt"
+export JVAL="./jparse/jval"
+export JSON_TREE="./jval/test_jval/test_JSON"
+export SUBDIR="."
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jval] [-d json_tree] [-s subdir] [file ..]
+
+    -h			print help and exit
+    -V			print version and exit
+    -v level		set verbosity level for this script: (def level: 0)
+    -D dbg_level	set verbosity level for tests (def: level: 0)
+    -J level		set JSON parser verbosity level (def level: 0)
+    -q			quiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)
+    -j /path/to/jval	path to jval tool (def: $JVAL)
+    -d json_tree	read files under json_tree/subdir/good and json_tree/subdir/bad (def: $JSON_TREE)
+			    These subdirectories are expected:
+				json_tree/tree/subdir/bad
+				json_tree/tree/subdir/good
+    -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
+    [file ...]		read JSON documents, one per line, from these files, - means stdin (def: $CHK_TEST_FILE)
+			NOTE: To use stdin, end the command line with: -- -
+
+Exit codes:
+     0   all tests are OK
+     1   at least one test failed
+     2	 -h and help string printed or -V and version string printed
+     3   invalid command line
+     4	 jval not a regular executable file
+     5	 couldn't create writable log file
+     6	 missing directory or directories
+     7	 missing JSON file
+  >= 10  internal error
+
+jval_test.sh version: $JVAL_TEST_VERSION"
+
+export V_FLAG="0"
+export DBG_LEVEL="0"
+export JSON_DBG_LEVEL="0"
+export Q_FLAG=""
+export LOGFILE="./jval_test.log"
+export EXIT_CODE=0
+export FILE_FAILURE_SUMMARY=""
+
+# parse args
+#
+while getopts :hVv:D:J:qj:d:s: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$JVAL_TEST_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    D)	DBG_LEVEL="$OPTARG";
+	;;
+    J)	JSON_DBG_LEVEL="$OPTARG";
+	;;
+    q)	Q_FLAG="-q";
+	;;
+    j)	JVAL="$OPTARG";
+	;;
+    d)	JSON_TREE="$OPTARG"
+	;;
+    s)  SUBDIR="$OPTARG"
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    *)
+	;;
+    esac
+done
+if [[ $V_FLAG -ge 1 ]]; then
+    echo "$0: debug[1]: -v: $V_FLAG" 1>&2
+    echo "$0: debug[1]: -D: $DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -J: $JSON_DBG_LEVEL" 1>&2
+    echo "$0: debug[1]: -s: $SUBDIR" 1>&2
+    if [[ -z $Q_FLAG ]]; then
+	echo "$0: debug[1]: -q: false" 1>&2
+    else
+	echo "$0: debug[1]: -q: true" 1>&2
+    fi
+    echo "$0: debug[1]: jval: $JVAL" 1>&2
+fi
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+export JSON_GOOD_TREE="$JSON_TREE/$SUBDIR/good"
+export JSON_BAD_TREE="$JSON_TREE/$SUBDIR/bad"
+
+# firewall
+#
+if [[ ! -e $JVAL ]]; then
+    echo "$0: ERROR: jval not found: $JVAL"
+    exit 4
+fi
+if [[ ! -f $JVAL ]]; then
+    echo "$0: ERROR: jval not a regular file: $JVAL"
+    exit 4
+fi
+if [[ ! -x $JVAL ]]; then
+    echo "$0: ERROR: jval not executable: $JVAL"
+    exit 4
+fi
+
+# check that json_tree is a readable directory
+#
+if [[ ! -e $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_TREE ]]; then
+    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+    exit 6
+fi
+
+# good tree
+#
+if [[ ! -e $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jval directory not found: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jval not a directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_GOOD_TREE ]]; then
+    echo "$0: ERROR: json_tree/good for jval not readable directory: $JSON_GOOD_TREE" 1>&2
+    exit 6
+fi
+
+# bad tree
+#
+if [[ ! -e $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jval directory not found: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -d $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jval not a directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+if [[ ! -r $JSON_BAD_TREE ]]; then
+    echo "$0: ERROR: json_tree/bad for jval not readable directory: $JSON_BAD_TREE" 1>&2
+    exit 6
+fi
+
+
+# remove logfile so that each run starts out with an empty file
+#
+rm -f "$LOGFILE"
+touch "$LOGFILE"
+if [[ ! -f "${LOGFILE}" ]]; then
+    echo "$0: ERROR: couldn't create log file" 1>&2
+    exit 5
+fi
+if [[ ! -w "${LOGFILE}" ]]; then
+    echo "$0: ERROR: log file not writable" 1>&2
+    exit 5
+fi
+
+# run_jval_test_mode - run jval -K test mode
+#
+# usage:
+#	run_jval_test_mode jval dbg_level json_dbg_level quiet_mode
+#
+run_jval_test_mode()
+{
+    # parse args
+    #
+    if [[ $# -ne 4 ]]; then
+	echo "$0: ERROR: expected 4 args to run_jval_test_mode, found $#" 1>&2
+	exit 10
+    fi
+    declare jval="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_jval_test_mode: jval: $jval" 1>&2
+	echo "$0: debug[9]: in run_jval_test_mode: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jval_test_mode: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_jval_test_mode: quiet_mode: $quiet_mode" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jval -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jval -v $dbg_level -J $json_dbg_level -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jval" -v "$dbg_level" -J "$json_dbg_level" -K >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must pass: $jval -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must pass: $jval -v $dbg_level -J $json_dbg_level -q -K >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jval" -v "$dbg_level" -J "$json_dbg_level" -q -K >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	    echo "$0: in test that must pass: jval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+    else
+	if [[ $V_FLAG -ge 1 ]]; then
+	    echo "$0: in test that must pass: jval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: in run_jval_test_mode: jval exit code: $status" 1>&2 >> "${LOGFILE}"
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+
+# run_file_test - run a single jval test on a file
+#
+# usage:
+#	run_file_test jval dbg_level json_dbg_level quiet_mode json_doc_file pass|fail
+#
+#	jval			path to the jval program
+#	dbg_level		internal test debugging level to use as in: jval -v dbg_level
+#	json_dbg_level		JSON parser debug level to use in: jval -J json_dbg_level
+#	quiet_mode		quiet mode to use in: jval -q
+#	json_doc_file		JSON document as a string to give to jval
+#	pass|fail		string saying if jval must return valid json or invalid json
+#
+run_file_test()
+{
+    # parse args
+    #
+    if [[ $# -ne 6 ]]; then
+	echo "$0: ERROR: expected 6 args to run_file_test, found $#" 1>&2
+	exit 11
+    fi
+    declare jval="$1"
+    declare dbg_level="$2"
+    declare json_dbg_level="$3"
+    declare quiet_mode="$4"
+    declare json_doc_file="$5"
+    declare pass_fail="$6"
+
+    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
+	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
+	EXIT_CODE=12
+	return
+    fi
+
+    # debugging
+    #
+    if [[ $V_FLAG -ge 9 ]]; then
+	echo "$0: debug[9]: in run_file_test: jval: $jval" 1>&2
+	echo "$0: debug[9]: in run_file_test: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_file_test: quiet_mode: $quiet_mode" 1>&2
+	echo "$0: debug[9]: in run_file_test: json_doc_file: $json_doc_file" 1>&2
+	echo "$0: debug[9]: in run_file_test: pass_fail: $pass_fail" 1>&2
+    fi
+
+    if [[ -z $quiet_mode ]]; then
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jval -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jval -v $dbg_level -J $json_dbg_level -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jval" -v "$dbg_level" -J "$json_dbg_level" -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    else
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jval -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" 1>&2
+	fi
+	echo "$0: debug[3]: about to run test that must $pass_fail: $jval -v $dbg_level -J $json_dbg_level -q -- $json_doc_file >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$jval" -v "$dbg_level" -J "$json_dbg_level" -q -- "$json_doc_file" >> "${LOGFILE}" 2>&1
+    fi
+    status="$?"
+
+    # examine test result
+    #
+    if [[ $status -eq 0 ]]; then
+	if [[ $pass_fail = pass ]]; then
+	    echo "$0: in test that must pass: jval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jval OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	fi
+    else
+	if [[ $pass_fail = pass ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must pass: jval FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    FILE_FAILURE_SUMMARY="$FILE_FAILURE_SUMMARY
+	    FILE: $json_doc_file"
+	    EXIT_CODE=1
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jval OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_file_test: jval exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	fi
+    fi
+    echo >> "${LOGFILE}"
+
+    # return
+    #
+    return
+}
+
+# run tests that must pass
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jval tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
+done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
+
+# run jval test mode itself
+
+run_jval_test_mode "$JVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG"
+
+#
+# run tests that must fail
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: about to run jval tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+fi
+while read -r file; do
+    run_file_test "$JVAL" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
+done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
+
+
+if [[ -n "$FILE_FAILURE_SUMMARY" ]]; then
+    echo "The following files failed: " | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+    echo "$FILE_FAILURE_SUMMARY" | tee -a -- "${LOGFILE}"
+    echo "--" | tee -a -- "${LOGFILE}"
+fi
+
+# All Done!!! -- Jessica Noll, Age 2
+#
+if [[ $V_FLAG -ge 1 ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+	echo "$0: debug[1]: all tests PASSED" 1>&2
+	echo "$0: debug[1]: all tests PASSED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: see $LOGFILE for details" 1>&2
+    else
+	echo "$0: ERROR: debug[1]: some tests FAILED" 1>&2
+	echo "$0: ERROR: debug[1]: some tests FAILED" >> "${LOGFILE}"
+	echo 1>&2
+	echo "$0: Notice: see $LOGFILE for details" 1>&2
+    fi
+fi
+exit "$EXIT_CODE"

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -2576,7 +2576,10 @@ is_decimal_str(char const *str, size_t *retlen)
  *	ptr	    - pointer to buffer containing an integer in ASCII
  *	len	    - length, starting at ptr
  *
- * XXX - update this comment explaining what we consider a floating point notation - XXX
+ * A floating point notation is like that of C but as the only use of this
+ * function is the JSON parser it might be a bit different. The JSON parser
+ * conversion routine, which only will be called on floating point or
+ * e-notations, has more checks that are JSON specific.
  *
  * returns:
  *
@@ -2719,7 +2722,10 @@ is_floating_notation_str(char const *str, size_t *retlen)
  *	ptr	    - pointer to buffer containing an integer in ASCII
  *	len	    - length, starting at ptr
  *
- * XXX - update this comment explaining what we consider an exponent notation - XXX
+ * e-notation is like that of C but as the only use of this function is the JSON
+ * parser it might be a bit different. The JSON parser conversion routine, which
+ * only will be called on floating point or e-notations, has more checks that
+ * are JSON specific.
  *
  * returns:
  *


### PR DESCRIPTION
An important key term is TEMPORARY PLACEHOLDER. The files are actually
copies of what were once jprint related but for each tool jprint / 
JPRINT were changed to their new tool counterparts. This is done this 
way because some of the code is common and this way they are in the
repo. A lot of code will be removed but some will be kept. Much will 
also be changed. Option parsing in particular is useful but this will
also have some changes.

As it will take more work to get them in order I have kept the other
things in too for now but this GREATLY simplifies starting the tools
which seems like a worthy thing to do.  A very nice way that this
simplifies starting the tools is that the parsing of the JSON file is
already done. Along with this some of the options being the same and 
some of the structs being the same (though they will have to be modified
and some will be removed) it will help get started.

Respective test scripts for each tool have also been added which are 
also updated copies of the old script for jprint. These are not run yet
because there is no point in running them yet and it would only slow
down make test.

With the exception of the scripts the required changes will be done soon
\- hopefully sometime in the coming week (real weeks start on Monday) -
but what this means is that TEMPORARILY the tools function as the
incomplete no longer useful jprint. By required changes I mean that the
unnecessary code will be removed and option parsing / usage strings will
be updated (whether the option parsing is completed in the next week is
indeterminate).

Updated jparse/Makefile and run make depend.

Update .gitignore: fixed references of jprint and add the other tools.

This is certainly not perfect, is incomplete and has incorrect options 
and concepts but again this will simplify the starting of the tools.