### PR TITLE
Fix bug in vjson_fprint for number conv checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.36 2023-07-21
+
+Fix bug in `vjson_fprint()` where numbers that were converted and parsed were
+not printed as the check accidentally was using the wrong macro that checks if
+converted is true and parsed is false. It should be it checks for both are true
+and then the next check in the else if checks if parsed is true and converted is
+false.
+
+
 ## Release 1.0.35 2023-07-19
 
 Add initial version of man pages of `jfmt(1)`, `jval(1)` and `jnamval(1)` to

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.0 2023-07-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.1 2023-07-21"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.1.0 2023-07-15"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.0 2023-07-21"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1474,7 +1474,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 	    /*
 	     * case: converted number
 	     */
-	    if (CONVERTED_JSON_NODE(item)) {
+	    if (CONVERTED_PARSED_JSON_NODE(item)) {
 
 		/*
 		 * case: converted negative number


### PR DESCRIPTION
The function used the wrong macro so that before printing the number it checked if only converted was true (so parsed is false) when it should check for if both are true. The other condition in the else if needs to (and did and still does) check for if converted is false and parsed is true meaning the number is valid but cannot be represented in a C type.

This was discovered by issue #785 in part but also because the file used as an example did not trigger a problem with jval or jnamval.

This does not resolve the issue noted, #785, but it at least will allow the file to be used in the way it needs to be. The issue is an enhancement as much as it is a bug.