### PR TITLE
Improve JSON validity convenience macros

### DIFF
--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -35,9 +35,9 @@
 /*
  * convenience macros
  */
-#define PARSED_JSON_NODE(item) ((item)->parsed == true)
-#define CONVERTED_PARSED_JSON_NODE(item) (((item)->parsed == true) && ((item)->converted == true))
-#define VALID_JSON_NODE(item) (((item)->parsed == true) || ((item)->converted == true))
+#define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
+#define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
+#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))
 
 
 /*


### PR DESCRIPTION
They now check that the node != NULL. They look now like:

    #define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
    #define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
    #define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))

Although the explicit check of == true for booleans is not my style I kept them in as looking at the macro without looking at the structs it might not be as clear that it's a boolean but this way it's clear.