### PR TITLE
Fixed fprintf parameter in json_util.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.39 2023-07-24
+
+Minor fixes to JSON convenience macros that check for a valid or parsed node.
+Now they check that `item` != NULL first. I kept the `== true` checks that were
+added to them for the booleans even though it doesn't match my style simply
+because as a macro it might not be clear immediately that it's a boolean so it
+seems like it might be a good place to do that.
+
+Fixed `warning: incompatible pointer to integer conversion passing 'struct json
+*' to parameter of type 'enum item_type'` in `json_util.c`.
+
+
 ## Release 1.0.38 2023-07-23
 
 Fixed `jnum_chk` by correcting the output of `jnum_gen`.

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -35,9 +35,9 @@
 /*
  * convenience macros
  */
-#define PARSED_JSON_NODE(item) ((item)->parsed == true)
-#define CONVERTED_PARSED_JSON_NODE(item) (((item)->parsed == true) && ((item)->converted == true))
-#define VALID_JSON_NODE(item) (((item)->parsed == true) || ((item)->converted == true))
+#define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
+#define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
+#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))
 
 
 /*

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1612,7 +1612,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
     switch (node->type) {
 
     case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
-	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node));
+	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node->type));
 	break;
 
     case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */


### PR DESCRIPTION
 
In vjson_fprint() the node type JTYPE_UNSET was printing the json type 
name but it passed to the function the node itself rather than the node
type.