### PR TITLE
Improve parsed,converted flags in debug output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,26 @@ seems like it might be a good place to do that.
 Fixed `warning: incompatible pointer to integer conversion passing 'struct json
 *' to parameter of type 'enum item_type'` in `json_util.c`.
 
+Add `:` suffix to parsed/converted boolean in debug output of `JTYPE_STRING` and
+`JTYPE_NUMBER` (via `fprnumber()`) in `vjson_fprint()`. For `parsed` if
+converted is also false add a `:` else a `,`. Print a `:` after converted flag.
+This separates the parsed/converted status from the actual information of the
+type. Here's an example log output for numbers:
+
+```
+JSON tree[3]:	lvl: 1	type: JTYPE_NUMBER	{p,c:-Fddildldi}: value:	-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0
+JSON tree[3]:	lvl: 1	type: JTYPE_NUMBER	{p:FE}: value:	1e100000000
+```
+
+Note for the first line it has `p,c:` as the number was both parsed and
+converted but for the second line it has just `p:` as the number could not
+be converted. The flags follow the `:`. Now one might argue that the bools are
+part of the numbers but the other data is the number itself.
+
+For strings it's likewise just the rest is string data, not number data:
+
+Updated json parser and jparse version strings to "1.1.2 2023-07-24".
+
 
 ## Release 1.0.38 2023-07-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.39 2023-07-24
+
+Minor fixes to JSON convenience macros that check for a valid or parsed node.
+Now they check that `item` != NULL first. I kept the `== true` checks that were
+added to them for the booleans even though it doesn't match my style simply
+because as a macro it might not be clear immediately that it's a boolean so it
+seems like it might be a good place to do that.
+
+Fixed `warning: incompatible pointer to integer conversion passing 'struct json
+*' to parameter of type 'enum item_type'` in `json_util.c`.
+
+
 ## Release 1.0.38 2023-07-23
 
 Fixed `jnum_chk` by correcting the output of `jnum_gen`.

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.1 2023-07-21"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.2 2023-07-24"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.1.0 2023-07-21"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.2 2023-07-24"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -35,9 +35,9 @@
 /*
  * convenience macros
  */
-#define PARSED_JSON_NODE(item) ((item)->parsed == true)
-#define CONVERTED_PARSED_JSON_NODE(item) (((item)->parsed == true) && ((item)->converted == true))
-#define VALID_JSON_NODE(item) (((item)->parsed == true) || ((item)->converted == true))
+#define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
+#define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
+#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))
 
 
 /*

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1375,16 +1375,16 @@ json_fprint(struct json *node, unsigned int depth, ...)
  *
  * given:
  *	stream	    open stream on which to print information about a json_number
- *	prestr	    string to print 1st
+ *	prestr	    first string to print
  *	info	    pointer to struct json_number for which to print in stream
- *	midstr	    string to print 3rd
- *	poststr	    if non-NULL, 4th string to print, NULL ==> print "((NULL))"
+ *	midstr	    third string to print
+ *	poststr	    if non-NULL, fourth string to print, NULL ==> print "((NULL))"
  */
 static void
 fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, char *poststr)
 {
     /*
-     * firewall - just be -J 3 or more
+     * firewall - must be -J 3 or more
      */
     if (json_verbosity_level < JSON_DBG_MED) {
 	return;
@@ -1410,7 +1410,7 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
     }
 
     /*
-     * print the 1st prestr
+     * print the first prestr
      */
     fprint(stream, "%s", prestr);
 
@@ -1421,10 +1421,11 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
      */
     if (json_verbosity_level > JSON_DBG_MED) {
 
-	/* -J 4 and more output */
-	fprint(stream, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+	/* -J 4 and higher output */
+	fprint(stream, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
 			PARSED_JSON_NODE(item)?"p":"",
-			CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+			CONVERTED_PARSED_JSON_NODE(item)?",":":",
+			CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 			item->is_negative?"-":"",
 			item->is_floating?"F":"",
 			item->is_e_notation?"E":"",
@@ -1456,9 +1457,10 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
 			item->as_longdouble_int?"ldi":"");
     } else {
 
-	/* -J 3 */ fprint(stream, "%s%s%s%s%s%s",
+	/* -J 3 */ fprint(stream, "%s%s%s%s%s%s%s",
 			PARSED_JSON_NODE(item)?"p":"",
-			CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+			CONVERTED_PARSED_JSON_NODE(item)?",":":",
+			CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 			item->is_negative?"-":"", item->is_floating?"F":"",
 			item->is_e_notation?"E":"",
 			item->is_integer?"I":"");
@@ -1504,12 +1506,12 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
     }
 
     /*
-     * print the 3rd midstr
+     * print the third string (midstr)
      */
     fprint(stream, "%s", midstr);
 
     /*
-     * print the 4th poststr
+     * print the fourth poststr
      */
     fprint(stream, "%s", poststr);
     return;
@@ -1652,9 +1654,10 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 		/*
 		 * print string preamble
 		 */
-		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
+		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
 				PARSED_JSON_NODE(item)?"p":"",
-				CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+				CONVERTED_PARSED_JSON_NODE(item)?",":":",
+				CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 				item->quote ? "q" : "",
 				item->same ? "=" : "",
 				item->has_nul ? "0" : "",

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1612,7 +1612,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
     switch (node->type) {
 
     case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
-	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node));
+	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node->type));
 	break;
 
     case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */


### PR DESCRIPTION

As parsed and converted booleans are not strictly part of the numbers or
strings but rather just booleans indicating if it's validly parsed and 
converted these boolean flags ('p' and 'c') now are suffixed with a ':'.
If both are true then it will look like 'p,c:' but if just parsed is
true, for example, it will look like 'p:'.

Originally I had the thought of comma separating all flags but this 
would be problematic as for each one it would have to check if there is
another flag to print and that would greatly complicate things as there
are a lot of flags to inspect.