### PR TITLE
jval and jnamval -S and -n options now a list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,13 +32,16 @@ For strings it's likewise just the rest is string data, not number data:
 
 Updated json parser and jparse version strings to "1.1.2 2023-07-24".
 
+New definition of recently removed macro `CONVERTED_JSON_NODE`:
+
+```c
+#define CONVERTED_JSON_NODE(item) ((item) != NULL && (item)->converted == true)
+```
+
 Updated `jval` and `jnamval` to parse the options `-n` and `-S` as a list as
 each option can be specified more than once. A list seems the most natural
-approach though a dynamic array might be considered later. The `-S` list is
-tested fully but the `-n` list is not as there seems to be an issue with the
-convenience macro changes. That will have to be fixed later. New versions for
-each tool: version string updated to "0.0.3 2023-07-24".
-
+approach though a dynamic array might be considered later.
+New version for both tools: "0.0.3 2023-07-24".
 
 ## Release 1.0.38 2023-07-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,26 @@ seems like it might be a good place to do that.
 Fixed `warning: incompatible pointer to integer conversion passing 'struct json
 *' to parameter of type 'enum item_type'` in `json_util.c`.
 
+Add `:` suffix to parsed/converted boolean in debug output of `JTYPE_STRING` and
+`JTYPE_NUMBER` (via `fprnumber()`) in `vjson_fprint()`. For `parsed` if
+converted is also false add a `:` else a `,`. Print a `:` after converted flag.
+This separates the parsed/converted status from the actual information of the
+type. Here's an example log output for numbers:
+
+```
+JSON tree[3]:	lvl: 1	type: JTYPE_NUMBER	{p,c:-Fddildldi}: value:	-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0
+JSON tree[3]:	lvl: 1	type: JTYPE_NUMBER	{p:FE}: value:	1e100000000
+```
+
+Note for the first line it has `p,c:` as the number was both parsed and
+converted but for the second line it has just `p:` as the number could not
+be converted. The flags follow the `:`. Now one might argue that the bools are
+part of the numbers but the other data is the number itself.
+
+For strings it's likewise just the rest is string data, not number data:
+
+Updated json parser and jparse version strings to "1.1.2 2023-07-24".
+
 
 ## Release 1.0.38 2023-07-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,13 @@ For strings it's likewise just the rest is string data, not number data:
 
 Updated json parser and jparse version strings to "1.1.2 2023-07-24".
 
+Updated `jval` and `jnamval` to parse the options `-n` and `-S` as a list as
+each option can be specified more than once. A list seems the most natural
+approach though a dynamic array might be considered later. The `-S` list is
+tested fully but the `-n` list is not as there seems to be an issue with the
+convenience macro changes. That will have to be fixed later. New versions for
+each tool: version string updated to "0.0.3 2023-07-24".
+
 
 ## Release 1.0.38 2023-07-23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.39 2023-07-24
+
+Minor fixes to JSON convenience macros that check for a valid or parsed node.
+Now they check that `item` != NULL first. I kept the `== true` checks that were
+added to them for the booleans even though it doesn't match my style simply
+because as a macro it might not be clear immediately that it's a boolean so it
+seems like it might be a good place to do that.
+
+Fixed `warning: incompatible pointer to integer conversion passing 'struct json
+*' to parameter of type 'enum item_type'` in `json_util.c`.
+
+
 ## Release 1.0.38 2023-07-23
 
 Fixed `jnum_chk` by correcting the output of `jnum_gen`.

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -261,7 +261,7 @@ main(int argc, char **argv)
 	    jnamval->num_cmp_used = true;
 	    if (jnamval_parse_cmp_op(jnamval, "n", optarg) == NULL) {
 		free_jnamval(&jnamval);
-		err(35, "jnamval", "couldn't parse -n option");
+		err(24, "jnamval", "couldn't parse -n option");
 		not_reached();
 	    }
 	    break;
@@ -269,7 +269,7 @@ main(int argc, char **argv)
 	    jnamval->string_cmp_used = true;
 	    if (jnamval_parse_cmp_op(jnamval, "S", optarg) == NULL) {
 		free_jnamval(&jnamval);
-		err(35, "jnamval", "couldn't parse -S option");
+		err(25, "jnamval", "couldn't parse -S option");
 		not_reached();
 	    }
 	    break;
@@ -338,7 +338,7 @@ main(int argc, char **argv)
 	 * NOTE: don't make this exit code 3 as it's an internal error if the
 	 * jnamval_sanity_chks() returns a NULL pointer.
 	 */
-	err(24, "jnamval", "could not open regular readable file");
+	err(26, "jnamval", "could not open regular readable file");
 	not_reached();
     }
 
@@ -445,16 +445,16 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
 {
     /* firewall */
     if (jnamval == NULL) {
-	err(25, __func__, "NULL jnamval");
+	err(27, __func__, "NULL jnamval");
 	not_reached();
     } else if (argc == NULL) {
-	err(26, __func__, "NULL argc");
+	err(28, __func__, "NULL argc");
 	not_reached();
     } else if (argv == NULL || *argv == NULL || **argv == NULL) {
-	err(27, __func__, "NULL argv");
+	err(29, __func__, "NULL argv");
 	not_reached();
     } else if (program == NULL) {
-	err(28, __func__, "NULL program");
+	err(30, __func__, "NULL program");
 	not_reached();
     }
 

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -259,11 +259,19 @@ main(int argc, char **argv)
 	    break;
 	case 'n': /* -n op=num */
 	    jnamval->num_cmp_used = true;
-	    jnamval_parse_cmp_op(jnamval, "n", optarg, &jnamval->num_cmp);
+	    if (jnamval_parse_cmp_op(jnamval, "n", optarg) == NULL) {
+		free_jnamval(&jnamval);
+		err(35, "jnamval", "couldn't parse -n option");
+		not_reached();
+	    }
 	    break;
 	case 'S': /* -S op=str */
 	    jnamval->string_cmp_used = true;
-	    jnamval_parse_cmp_op(jnamval, "S", optarg, &jnamval->string_cmp);
+	    if (jnamval_parse_cmp_op(jnamval, "S", optarg) == NULL) {
+		free_jnamval(&jnamval);
+		err(35, "jnamval", "couldn't parse -S option");
+		not_reached();
+	    }
 	    break;
 	case 'o': /* search with OR mode */
 	    if (strcmp(optarg, "-")) { /* check if we will write to stdout */

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.2 2023-07-22"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.3 2023-07-24"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -1164,19 +1164,19 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
     } else if (!strcmp(option, "n")) {
 	mode = "num";
     } else {
-	err(32, __func__, "invalid option used for function: -%s", option);
+	err(31, __func__, "invalid option used for function: -%s", option);
 	not_reached();
     }
 
     p = strchr(optarg, '=');
     if (p == NULL) {
-	err(33, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(32, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     } else if (p == optarg) {
-	err(34, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(33, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     } else if (p[1] == '\0') {
-	err(35, __func__, "nothing found after =: use -%s {eq,lt,le,gt,ge}=%s", option, mode);
+	err(34, __func__, "nothing found after =: use -%s {eq,lt,le,gt,ge}=%s", option, mode);
 	not_reached();
     }
 
@@ -1191,7 +1191,7 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
     } else if (!strncmp(optarg, "ge=", 3)) {
 	op = JNAMVAL_CMP_GE;
     } else {
-	err(36, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(35, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     }
 
@@ -1199,7 +1199,7 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
 	errno = 0;
 	item = json_conv_string(optarg + 3, strlen(optarg + 3), *(optarg +3) == '"' ? true : false);
 	if (item == NULL) {
-	    err(37, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
+	    err(36, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
 	    not_reached();
 	} else {
 	    cmp = calloc(1, sizeof *cmp);
@@ -1232,25 +1232,25 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
 	    err(40, __func__, "syntax error in -%s: no number found: <%s>", option, optarg + 3);
 	    not_reached();
 	} else {
+	    cmp = calloc(1, sizeof *cmp);
+	    if (cmp == NULL) {
+		err(41, __func__, "failed to allocate struct jval_cmp_op *");
+		not_reached();
+	    }
 	    cmp->number = &(item->item.number);
 	    if (!CONVERTED_PARSED_JSON_NODE(cmp->number)) {
 		err(7, __func__, "failed to convert or parse number: <%s> for option -%s but number pointer not NULL!",/*ooo*/
 			optarg + 3, option);
 		not_reached();
-	    } else if (PARSED_JSON_NODE(cmp->number)) {
+	    } else if (PARSED_JSON_NODE(cmp->number) && !CONVERTED_JSON_NODE(cmp->number)) {
 		err(7, __func__, "failed to convert number: <%s> for option -%s", optarg +3 , option); /*ooo*/
-		not_reached();
-	    }
-	    cmp = calloc(1, sizeof *cmp);
-	    if (cmp == NULL) {
-		err(37, __func__, "failed to allocate struct jnamval_cmp_op *");
 		not_reached();
 	    }
 
 	    cmp->op = op;
 
-	    cmp->next = jnamval->string_cmp;
-	    jnamval->string_cmp = cmp;
+	    cmp->next = jnamval->num_cmp;
+	    jnamval->num_cmp = cmp;
 
 	    /* XXX - add function that prints out what compare operation - XXX */
 	    json_dbg(JSON_DBG_NONE, __func__, "number to compare: <%s>", cmp->number->as_str);
@@ -1277,7 +1277,7 @@ free_jnamval_cmp_op_lists(struct jnamval *jnamval)
 
     /* firewall */
     if (jnamval == NULL) {
-	err(35, __func__, "jnamval is NULL");
+	err(42, __func__, "jnamval is NULL");
 	not_reached();
     }
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -95,15 +95,11 @@ alloc_jnamval(void)
 
     /* for -S */
     jnamval->string_cmp_used = false;
-    jnamval->string_cmp.string = NULL;
-    jnamval->string_cmp.number = NULL;
-    jnamval->string_cmp.op = 0;
+    jnamval->string_cmp = NULL;
 
     /* for -n */
     jnamval->num_cmp_used = false;
-    jnamval->num_cmp.string = NULL;
-    jnamval->num_cmp.number = 0;
-    jnamval->num_cmp.op = 0;
+    jnamval->num_cmp = NULL;
 
     /* parsing related */
     jnamval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
@@ -1056,6 +1052,9 @@ free_jnamval(struct jnamval **jnamval)
 	(*jnamval)->outfile_path = NULL;
     }
 
+    /* free the compare lists too */
+    free_jnamval_cmp_op_lists(*jnamval);
+
     free(*jnamval);
     *jnamval = NULL;
 }
@@ -1126,23 +1125,25 @@ parse_jnamval_args(struct jnamval *jnamval, char **argv)
  *	option	    - the option letter (without the '-') that triggered this
  *		      function
  *	optarg	    - option arg to the option
- *	cmp	    - pointer to our struct jnamval_cmp_op depending on the option used
  *
  *
  *  This function fills out either the jnamval->string_cmp or jnamval->num_cmp if the
- *  syntax is correct.
+ *  syntax is correct. Or more correctly it adds to the list as more than one
+ *  can be specified.
  *
  *  This function will not return on error in conversion or syntax error or NULL
  *  pointers.
  *
  *  This function returns void.
  */
-void
-jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, struct jnamval_cmp_op *cmp)
+struct jnamval_cmp_op *
+jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
 {
     char *p = NULL;		    /* to find the = separator */
     char *mode = NULL;		    /* if -S then "str" else "num" */
     struct json *item = NULL;	    /* to get the converted value */
+    struct jnamval_cmp_op *cmp = NULL;	/* compare operation struct */
+    int op = JNAMVAL_CMP_OP_NONE;	/* assume invalid op */
 
     /* firewall */
     if (jnamval == NULL) {
@@ -1155,10 +1156,6 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, 
     }
     if (optarg == NULL) {
 	err(30, __func__, "NULL optarg");
-	not_reached();
-    }
-    if (cmp == NULL) {
-	err(31, __func__, "NULL cmp pointer");
 	not_reached();
     }
 
@@ -1184,15 +1181,15 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, 
     }
 
     if (!strncmp(optarg, "eq=", 3)) {
-	cmp->op = JNAMVAL_CMP_EQ;
+	op = JNAMVAL_CMP_EQ;
     } else if (!strncmp(optarg, "lt=", 3)) {
-	cmp->op = JNAMVAL_CMP_LT;
+	op = JNAMVAL_CMP_LT;
     } else if (!strncmp(optarg, "le=", 3)) {
-	cmp->op = JNAMVAL_CMP_LE;
+	op = JNAMVAL_CMP_LE;
     } else if (!strncmp(optarg, "gt=", 3)){
-	cmp->op = JNAMVAL_CMP_GT;
+	op = JNAMVAL_CMP_GT;
     } else if (!strncmp(optarg, "ge=", 3)) {
-	cmp->op = JNAMVAL_CMP_GE;
+	op = JNAMVAL_CMP_GE;
     } else {
 	err(36, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
@@ -1205,6 +1202,11 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, 
 	    err(37, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
 	    not_reached();
 	} else {
+	    cmp = calloc(1, sizeof *cmp);
+	    if (cmp == NULL) {
+		err(37, __func__, "failed to allocate struct jval_cmp_op *");
+		not_reached();
+	    }
 	    cmp->string = &(item->item.string);
 	    if (cmp->string == NULL) {
 		err(38, __func__, "failed to convert string: <%s> for -%s: cmp->string is NULL", optarg + 3, option);
@@ -1214,7 +1216,15 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, 
 			optarg + 3, option);
 		not_reached();
 	    }
+
+	    cmp->op = op;
+
+	    cmp->next = jnamval->string_cmp;
+	    jnamval->string_cmp = cmp;
+
+	    /* XXX - add function that prints out what compare operation - XXX */
 	    json_dbg(JSON_DBG_NONE, __func__, "string to compare: <%s>", cmp->string->str);
+
 	}
     } else if (!strcmp(option, "n")) { /* -n */
 	item = json_conv_number(optarg + 3, strlen(optarg + 3));
@@ -1231,8 +1241,63 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, 
 		err(7, __func__, "failed to convert number: <%s> for option -%s", optarg +3 , option); /*ooo*/
 		not_reached();
 	    }
+	    cmp = calloc(1, sizeof *cmp);
+	    if (cmp == NULL) {
+		err(37, __func__, "failed to allocate struct jnamval_cmp_op *");
+		not_reached();
+	    }
 
-	    /* TODO - add debug call if converted / parsed ? - TODO */
+	    cmp->op = op;
+
+	    cmp->next = jnamval->string_cmp;
+	    jnamval->string_cmp = cmp;
+
+	    /* XXX - add function that prints out what compare operation - XXX */
+	    json_dbg(JSON_DBG_NONE, __func__, "number to compare: <%s>", cmp->number->as_str);
 	}
+    }
+
+    return cmp;
+}
+
+/* free_jnamval_cmp_op_lists - free the compare lists
+ *
+ * given:
+ *
+ *  jnamval	- pointer to our struct jnamval
+ *
+ * This function frees out both the number and string compare lists.
+ *
+ * This function will not return on NULL jnamval.
+ */
+void
+free_jnamval_cmp_op_lists(struct jnamval *jnamval)
+{
+    struct jnamval_cmp_op *op, *next_op;
+
+    /* firewall */
+    if (jnamval == NULL) {
+	err(35, __func__, "jnamval is NULL");
+	not_reached();
+    }
+
+    /* first the string compare list */
+    for (op = jnamval->string_cmp; op != NULL; op = next_op) {
+	next_op = op->next;
+
+	/* XXX - free json node - XXX */
+
+	free(op);
+	op = NULL;
+    }
+
+    /* now the number compare list */
+    for (op = jnamval->num_cmp; op != NULL; op = next_op) {
+	next_op = op->next;
+
+	/* XXX - free json node - XXX */
+
+	free(op);
+	op = NULL;
     }
 }

--- a/jparse/jnamval_util.h
+++ b/jparse/jnamval_util.h
@@ -83,12 +83,12 @@
 #define JNAMVAL_PRINT_BOTH   (JNAMVAL_PRINT_NAME | JNAMVAL_PRINT_VALUE)
 
 
-
-#define JNAMVAL_CMP_EQ	(1)
-#define JNAMVAL_CMP_LT	(2)
-#define JNAMVAL_CMP_LE	(3)
-#define JNAMVAL_CMP_GT	(4)
-#define JNAMVAL_CMP_GE	(5)
+#define JNAMVAL_CMP_OP_NONE (0)
+#define JNAMVAL_CMP_EQ	    (1)
+#define JNAMVAL_CMP_LT	    (2)
+#define JNAMVAL_CMP_LE	    (3)
+#define JNAMVAL_CMP_GT	    (4)
+#define JNAMVAL_CMP_GE	    (5)
 
 /* structs */
 
@@ -100,7 +100,11 @@ struct jnamval_cmp_op
     struct json_number *number;	    /* for -n as signed number */
     struct json_string *string;	    /* for -S str */
 
+    bool is_string;	    /* true if -S */
+    bool is_number;	    /* true if -n */
     uintmax_t op;	    /* the operation - see JNAMVAL_CMP macros above */
+
+    struct jnamval_cmp_op *next;    /* next in the list */
 };
 
 /* number ranges for the options -l, -n and -n */
@@ -170,9 +174,9 @@ struct jnamval
     uintmax_t total_matches;			/* for -c */
 
     bool string_cmp_used;			/* for -S */
-    struct jnamval_cmp_op string_cmp;		/* for -S str */
+    struct jnamval_cmp_op *string_cmp;		/* for -S str */
     bool num_cmp_used;				/* for -n */
-    struct jnamval_cmp_op num_cmp;			/* for -n num */
+    struct jnamval_cmp_op *num_cmp;			/* for -n num */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     struct json *json_tree;			/* json tree if valid merely as a convenience */
 };
@@ -211,7 +215,7 @@ bool jnamval_parse_number_range(const char *option, char *optarg, bool allow_neg
 bool jnamval_number_in_range(intmax_t number, intmax_t total_matches, struct jnamval_number *range);
 
 /* for -S and -n */
-void jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg, struct jnamval_cmp_op *cmp);
+struct jnamval_cmp_op *jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg);
 
 /* for -L option */
 void jnamval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
@@ -225,6 +229,8 @@ bool jnamval_print_count(struct jnamval *jnamval);
  */
 void parse_jnamval_args(struct jnamval *jnamval, char **argv);
 
+/* free compare lists */
+void free_jnamval_cmp_op_lists(struct jnamval *jnamval);
 /* to free the entire struct jnamval */
 void free_jnamval(struct jnamval **jnamval);
 

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.1 2023-07-21"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.2 2023-07-24"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.1.0 2023-07-21"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.2 2023-07-24"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -35,9 +35,9 @@
 /*
  * convenience macros
  */
-#define PARSED_JSON_NODE(item) ((item)->parsed == true)
-#define CONVERTED_PARSED_JSON_NODE(item) (((item)->parsed == true) && ((item)->converted == true))
-#define VALID_JSON_NODE(item) (((item)->parsed == true) || ((item)->converted == true))
+#define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
+#define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
+#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))
 
 
 /*

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -37,6 +37,7 @@
  */
 #define PARSED_JSON_NODE(item) ((item) != NULL && ((item)->parsed == true))
 #define CONVERTED_PARSED_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) && ((item)->converted == true)))
+#define CONVERTED_JSON_NODE(item) ((item) != NULL && (item)->converted == true)
 #define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))
 
 

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1375,16 +1375,16 @@ json_fprint(struct json *node, unsigned int depth, ...)
  *
  * given:
  *	stream	    open stream on which to print information about a json_number
- *	prestr	    string to print 1st
+ *	prestr	    first string to print
  *	info	    pointer to struct json_number for which to print in stream
- *	midstr	    string to print 3rd
- *	poststr	    if non-NULL, 4th string to print, NULL ==> print "((NULL))"
+ *	midstr	    third string to print
+ *	poststr	    if non-NULL, fourth string to print, NULL ==> print "((NULL))"
  */
 static void
 fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, char *poststr)
 {
     /*
-     * firewall - just be -J 3 or more
+     * firewall - must be -J 3 or more
      */
     if (json_verbosity_level < JSON_DBG_MED) {
 	return;
@@ -1410,7 +1410,7 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
     }
 
     /*
-     * print the 1st prestr
+     * print the first prestr
      */
     fprint(stream, "%s", prestr);
 
@@ -1421,10 +1421,11 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
      */
     if (json_verbosity_level > JSON_DBG_MED) {
 
-	/* -J 4 and more output */
-	fprint(stream, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+	/* -J 4 and higher output */
+	fprint(stream, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
 			PARSED_JSON_NODE(item)?"p":"",
-			CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+			CONVERTED_PARSED_JSON_NODE(item)?",":":",
+			CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 			item->is_negative?"-":"",
 			item->is_floating?"F":"",
 			item->is_e_notation?"E":"",
@@ -1456,9 +1457,10 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
 			item->as_longdouble_int?"ldi":"");
     } else {
 
-	/* -J 3 */ fprint(stream, "%s%s%s%s%s%s",
+	/* -J 3 */ fprint(stream, "%s%s%s%s%s%s%s",
 			PARSED_JSON_NODE(item)?"p":"",
-			CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+			CONVERTED_PARSED_JSON_NODE(item)?",":":",
+			CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 			item->is_negative?"-":"", item->is_floating?"F":"",
 			item->is_e_notation?"E":"",
 			item->is_integer?"I":"");
@@ -1504,12 +1506,12 @@ fprnumber(FILE *stream, char *prestr, struct json_number *item, char *midstr, ch
     }
 
     /*
-     * print the 3rd midstr
+     * print the third string (midstr)
      */
     fprint(stream, "%s", midstr);
 
     /*
-     * print the 4th poststr
+     * print the fourth poststr
      */
     fprint(stream, "%s", poststr);
     return;
@@ -1652,9 +1654,10 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
 		/*
 		 * print string preamble
 		 */
-		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
+		fprint(stream, "\tlen{%s%s%s%s%s%s%s%s%s%s}: %ju\tvalue:\t",
 				PARSED_JSON_NODE(item)?"p":"",
-				CONVERTED_PARSED_JSON_NODE(item)?"c":"",
+				CONVERTED_PARSED_JSON_NODE(item)?",":":",
+				CONVERTED_PARSED_JSON_NODE(item)?"c:":"",
 				item->quote ? "q" : "",
 				item->same ? "=" : "",
 				item->has_nul ? "0" : "",

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -1612,7 +1612,7 @@ vjson_fprint(struct json *node, unsigned int depth, va_list ap)
     switch (node->type) {
 
     case JTYPE_UNSET:	/* JSON item has not been set - must be the value 0 */
-	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node));
+	fprint(stream, "\tWarning: JTYPE_UNSET: %s", json_type_name(node->type));
 	break;
 
     case JTYPE_NUMBER:	/* JSON item is number - see struct json_number */

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -237,11 +237,19 @@ main(int argc, char **argv)
 	    break;
 	case 'n': /* -n op=num */
 	    jval->num_cmp_used = true;
-	    jval_parse_cmp_op(jval, "n", optarg, &jval->num_cmp);
+	    if (jval_parse_cmp_op(jval, "n", optarg) == NULL) {
+		free_jval(&jval);
+		err(35, "jval", "failed to parse -n option");
+		not_reached();
+	    }
 	    break;
 	case 'S': /* -S op=str */
 	    jval->string_cmp_used = true;
-	    jval_parse_cmp_op(jval, "S", optarg, &jval->string_cmp);
+	    if (jval_parse_cmp_op(jval, "S", optarg) == NULL) {
+		free_jval(&jval);
+		err(36, "jval", "failed to parse -S option");
+		not_reached();
+	    }
 	    break;
 	case 'o': /* search with OR mode */
 	    if (strcmp(optarg, "-")) { /* check if we will write to stdout */

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -239,7 +239,7 @@ main(int argc, char **argv)
 	    jval->num_cmp_used = true;
 	    if (jval_parse_cmp_op(jval, "n", optarg) == NULL) {
 		free_jval(&jval);
-		err(35, "jval", "failed to parse -n option");
+		err(24, "jval", "failed to parse -n option");
 		not_reached();
 	    }
 	    break;
@@ -247,7 +247,7 @@ main(int argc, char **argv)
 	    jval->string_cmp_used = true;
 	    if (jval_parse_cmp_op(jval, "S", optarg) == NULL) {
 		free_jval(&jval);
-		err(36, "jval", "failed to parse -S option");
+		err(25, "jval", "failed to parse -S option");
 		not_reached();
 	    }
 	    break;
@@ -305,7 +305,7 @@ main(int argc, char **argv)
 	 * NOTE: don't make this exit code 3 as it's an internal error if the
 	 * jval_sanity_chks() returns a NULL pointer.
 	 */
-	err(24, "jval", "could not open regular readable file");
+	err(26, "jval", "could not open regular readable file");
 	not_reached();
     }
 
@@ -412,16 +412,16 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
 {
     /* firewall */
     if (jval == NULL) {
-	err(25, __func__, "NULL jval");
+	err(27, __func__, "NULL jval");
 	not_reached();
     } else if (argc == NULL) {
-	err(26, __func__, "NULL argc");
+	err(28, __func__, "NULL argc");
 	not_reached();
     } else if (argv == NULL || *argv == NULL || **argv == NULL) {
-	err(27, __func__, "NULL argv");
+	err(29, __func__, "NULL argv");
 	not_reached();
     } else if (program == NULL) {
-	err(28, __func__, "NULL program");
+	err(30, __func__, "NULL program");
 	not_reached();
     }
 

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.2 2023-07-18"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.3 2023-07-24"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -850,19 +850,19 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
     } else if (!strcmp(option, "n")) {
 	mode = "num";
     } else {
-	err(31, __func__, "invalid option used for function: -%s", option);
+	err(30, __func__, "invalid option used for function: -%s", option);
 	not_reached();
     }
 
     p = strchr(optarg, '=');
     if (p == NULL) {
-	err(32, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(31, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     } else if (p == optarg) {
-	err(33, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(32, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     } else if (p[1] == '\0') {
-	err(34, __func__, "nothing found after =: use -%s {eq,lt,le,gt,ge}=%s", option, mode);
+	err(33, __func__, "nothing found after =: use -%s {eq,lt,le,gt,ge}=%s", option, mode);
 	not_reached();
     }
 
@@ -877,7 +877,7 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
     } else if (!strncmp(optarg, "ge=", 3)) {
 	op = JVAL_CMP_GE;
     } else {
-	err(35, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
+	err(34, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
     }
 
@@ -885,12 +885,12 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
 	errno = 0;
 	item = json_conv_string(optarg + 3, strlen(optarg + 3), *(optarg +3) == '"' ? true : false);
 	if (item == NULL) {
-	    err(36, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
+	    err(35, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
 	    not_reached();
 	} else {
 	    cmp = calloc(1, sizeof *cmp);
 	    if (cmp == NULL) {
-		err(37, __func__, "failed to allocate struct jval_cmp_op *");
+		err(36, __func__, "failed to allocate struct jval_cmp_op *");
 		not_reached();
 	    }
 	    cmp->string = &(item->item.string);
@@ -919,7 +919,7 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
 	} else {
 	    cmp = calloc(1, sizeof *cmp);
 	    if (cmp == NULL) {
-		err(37, __func__, "failed to allocate struct jval_cmp_op *");
+		err(40, __func__, "failed to allocate struct jval_cmp_op *");
 		not_reached();
 	    }
 	    cmp->number = &(item->item.number);
@@ -927,7 +927,7 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
 		err(7, __func__, "failed to convert or parse number: <%s> for option -%s but number pointer not NULL!",/*ooo*/
 			optarg + 3, option);
 		not_reached();
-	    } else if (PARSED_JSON_NODE(cmp->number)) {
+	    } else if (PARSED_JSON_NODE(cmp->number) && !CONVERTED_JSON_NODE(cmp->number)) {
 		err(7, __func__, "failed to convert number: <%s> for option -%s", optarg +3 , option); /*ooo*/
 		not_reached();
 	    }
@@ -962,7 +962,7 @@ free_jval_cmp_op_lists(struct jval *jval)
 
     /* firewall */
     if (jval == NULL) {
-	err(35, __func__, "jval is NULL");
+	err(41, __func__, "jval is NULL");
 	not_reached();
     }
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -92,15 +92,11 @@ alloc_jval(void)
 
     /* for -S */
     jval->string_cmp_used = false;
-    jval->string_cmp.string = NULL;
-    jval->string_cmp.number = NULL;
-    jval->string_cmp.op = 0;
+    jval->string_cmp = NULL;
 
     /* for -n */
     jval->num_cmp_used = false;
-    jval->num_cmp.string = NULL;
-    jval->num_cmp.number = 0;
-    jval->num_cmp.op = 0;
+    jval->num_cmp = NULL;
 
     /* parsing related */
     jval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
@@ -741,6 +737,9 @@ free_jval(struct jval **jval)
 	(*jval)->outfile_path = NULL;
     }
 
+    /* free the compare lists too */
+    free_jval_cmp_op_lists(*jval);
+
     free(*jval);
     *jval = NULL;
 }
@@ -811,23 +810,26 @@ parse_jval_args(struct jval *jval, char **argv)
  *	option	    - the option letter (without the '-') that triggered this
  *		      function
  *	optarg	    - option arg to the option
- *	cmp	    - pointer to our struct jval_cmp_op depending on the option used
  *
  *
  *  This function fills out either the jval->string_cmp or jval->num_cmp if the
- *  syntax is correct.
+ *  syntax is correct. Or more correctly it adds to the list as more than one
+ *  can be specified.
+
  *
  *  This function will not return on error in conversion or syntax error or NULL
  *  pointers.
  *
  *  This function returns void.
  */
-void
-jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jval_cmp_op *cmp)
+struct jval_cmp_op *
+jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg)
 {
     char *p = NULL;		    /* to find the = separator */
     char *mode = NULL;		    /* if -S then "str" else "num" */
     struct json *item = NULL;	    /* to get the converted value */
+    struct jval_cmp_op *cmp = NULL; /* to add to list */
+    int op = JVAL_CMP_OP_NONE;	    /* assume no op for syntax wrong */
 
     /* firewall */
     if (jval == NULL) {
@@ -840,10 +842,6 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
     }
     if (optarg == NULL) {
 	err(29, __func__, "NULL optarg");
-	not_reached();
-    }
-    if (cmp == NULL) {
-	err(30, __func__, "NULL cmp pointer");
 	not_reached();
     }
 
@@ -869,15 +867,15 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
     }
 
     if (!strncmp(optarg, "eq=", 3)) {
-	cmp->op = JVAL_CMP_EQ;
+	op = JVAL_CMP_EQ;
     } else if (!strncmp(optarg, "lt=", 3)) {
-	cmp->op = JVAL_CMP_LT;
+	op = JVAL_CMP_LT;
     } else if (!strncmp(optarg, "le=", 3)) {
-	cmp->op = JVAL_CMP_LE;
+	op = JVAL_CMP_LE;
     } else if (!strncmp(optarg, "gt=", 3)){
-	cmp->op = JVAL_CMP_GT;
+	op = JVAL_CMP_GT;
     } else if (!strncmp(optarg, "ge=", 3)) {
-	cmp->op = JVAL_CMP_GE;
+	op = JVAL_CMP_GE;
     } else {
 	err(35, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
 	not_reached();
@@ -890,6 +888,11 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
 	    err(36, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
 	    not_reached();
 	} else {
+	    cmp = calloc(1, sizeof *cmp);
+	    if (cmp == NULL) {
+		err(37, __func__, "failed to allocate struct jval_cmp_op *");
+		not_reached();
+	    }
 	    cmp->string = &(item->item.string);
 	    if (cmp->string == NULL) {
 		err(37, __func__, "failed to convert string: <%s> for -%s: cmp->string is NULL", optarg + 3, option);
@@ -899,6 +902,13 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
 			optarg + 3, option);
 		not_reached();
 	    }
+
+	    cmp->op = op;
+
+	    cmp->next = jval->string_cmp;
+	    jval->string_cmp = cmp;
+
+	    /* XXX - add function that prints out what compare operation - XXX */
 	    json_dbg(JSON_DBG_NONE, __func__, "string to compare: <%s>", cmp->string->str);
 	}
     } else if (!strcmp(option, "n")) { /* -n */
@@ -907,6 +917,11 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
 	    err(39, __func__, "syntax error in -%s: no number found: <%s>", option, optarg + 3);
 	    not_reached();
 	} else {
+	    cmp = calloc(1, sizeof *cmp);
+	    if (cmp == NULL) {
+		err(37, __func__, "failed to allocate struct jval_cmp_op *");
+		not_reached();
+	    }
 	    cmp->number = &(item->item.number);
 	    if (!CONVERTED_PARSED_JSON_NODE(cmp->number)) {
 		err(7, __func__, "failed to convert or parse number: <%s> for option -%s but number pointer not NULL!",/*ooo*/
@@ -916,7 +931,58 @@ jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jv
 		err(7, __func__, "failed to convert number: <%s> for option -%s", optarg +3 , option); /*ooo*/
 		not_reached();
 	    }
+
+	    cmp->op = op;
+
+	    cmp->next = jval->num_cmp;
+	    jval->num_cmp = cmp;
+
+	    /* XXX - add function that prints out what compare operation - XXX */
 	    json_dbg(JSON_DBG_NONE, __func__, "number to compare: <%s>", cmp->number->as_str);
 	}
+    }
+
+    return cmp;
+}
+
+/* free_jval_cmp_op_lists - free the compare lists
+ *
+ * given:
+ *
+ *  jval	- pointer to our struct jval
+ *
+ * This function frees out both the number and string compare lists.
+ *
+ * This function will not return on NULL jval.
+ */
+void
+free_jval_cmp_op_lists(struct jval *jval)
+{
+    struct jval_cmp_op *op, *next_op;
+
+    /* firewall */
+    if (jval == NULL) {
+	err(35, __func__, "jval is NULL");
+	not_reached();
+    }
+
+    /* first the string compare list */
+    for (op = jval->string_cmp; op != NULL; op = next_op) {
+	next_op = op->next;
+
+	/* XXX - free json node - XXX */
+
+	free(op);
+	op = NULL;
+    }
+
+    /* now the number compare list */
+    for (op = jval->num_cmp; op != NULL; op = next_op) {
+	next_op = op->next;
+
+	/* XXX - free json node - XXX */
+
+	free(op);
+	op = NULL;
     }
 }

--- a/jparse/jval_util.h
+++ b/jparse/jval_util.h
@@ -70,11 +70,12 @@
 /* JVAL_TYPE_SIMPLE is bitwise OR of num, bool, str and null */
 #define JVAL_TYPE_SIMPLE  (JVAL_TYPE_NUM|JVAL_TYPE_BOOL|JVAL_TYPE_STR|JVAL_TYPE_NULL)
 
-#define JVAL_CMP_EQ	(1)
-#define JVAL_CMP_LT	(2)
-#define JVAL_CMP_LE	(3)
-#define JVAL_CMP_GT	(4)
-#define JVAL_CMP_GE	(5)
+#define JVAL_CMP_OP_NONE    (0)
+#define JVAL_CMP_EQ	    (1)
+#define JVAL_CMP_LT	    (2)
+#define JVAL_CMP_LE	    (3)
+#define JVAL_CMP_GT	    (4)
+#define JVAL_CMP_GE	    (5)
 
 /* structs */
 
@@ -86,7 +87,11 @@ struct jval_cmp_op
     struct json_number *number;	    /* for -n as signed number */
     struct json_string *string;	    /* for -S str */
 
+    bool is_string;	    /* true if -S */
+    bool is_number;	    /* true if -n */
     uintmax_t op;	    /* the operation - see JVAL_CMP macros above */
+
+    struct jval_cmp_op *next;	/* next in the list */
 };
 
 /* number ranges for the options -l, -n and -n */
@@ -152,9 +157,9 @@ struct jval
     uintmax_t total_matches;			/* for -c */
 
     bool string_cmp_used;			/* for -S */
-    struct jval_cmp_op string_cmp;		/* for -S str */
+    struct jval_cmp_op *string_cmp;		/* for -S str */
     bool num_cmp_used;				/* for -n */
-    struct jval_cmp_op num_cmp;			/* for -n num */
+    struct jval_cmp_op *num_cmp;			/* for -n num */
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     struct json *json_tree;			/* json tree if valid merely as a convenience */
 };
@@ -181,7 +186,7 @@ bool jval_parse_number_range(const char *option, char *optarg, bool allow_negati
 bool jval_number_in_range(intmax_t number, intmax_t total_matches, struct jval_number *range);
 
 /* for -S and -n */
-void jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg, struct jval_cmp_op *cmp);
+struct jval_cmp_op *jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg);
 
 /* for -L option */
 void jval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
@@ -195,6 +200,8 @@ bool jval_print_count(struct jval *jval);
  */
 void parse_jval_args(struct jval *jnamval, char **argv);
 
+/* free compare lists */
+void free_jval_cmp_op_lists(struct jval *jval);
 /* to free the entire struct jval */
 void free_jval(struct jval **jval);
 


### PR DESCRIPTION

As the options can be specified more than once we need a list of the 
options parsed. I am still not clear on when it's OR or AND but that can
be figured out later.

Unfortunately the -n mode does not work correctly in that checking for 
numbers being converted seems to be broken, seemingly from a change in
the convenience macros. I will have to address this another time. The -S 
option is tested meaning added to list and freeing the list works fine.
It is possible that I made a mistake in the -n processing even though
they're mostly the same.

Some details might change later on but with this I believe all options
are parsed completely. This of course could also change but I believe at
this time it's done.
