### PR TITLE
Move common json tool variables to common struct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,27 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.40 2023-07-25
+
+New version for `jfmt`, `jval` and `jnamval`:  "0.0.4 2023-07-25". Moved common
+variables from the structs for each tool (`struct jfmt`, `struct jval` and
+`struct jnamval`) to `json_util.h` and prefix with `json_util` rather than the
+`(jfmt|jval|jnamval)_`. More work needs to be done here as `jval` and `jnamval`
+share variables as well but this will be done in another commit.
+
+The structs `(jfmt|jval|jnamval)_number` are now `json_util_number` in
+`json_util.h` and the associated code has been moved to `json_util.c`.
+
+The code for the common `-L` option to the three tools has also been moved to
+the `json_util.c` file.
+
+Any other options common to the three tools that I have not mentioned here have
+also been moved or so it is believed (it is possible some was missed but these
+will be located in time if any are missing).
+
+
+
+
 ## Release 1.0.39 2023-07-24
 
 Minor fixes to JSON convenience macros that check for a valid or parsed node.

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.3 2023-07-19"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jfmt_test.c
+++ b/jparse/jfmt_test.c
@@ -31,12 +31,12 @@
 bool
 jfmt_run_tests(void)
 {
-    struct jfmt_number number;    /* number range */
+    struct json_util_number number;    /* number range */
     bool test = false;		    /* whether current test passes or fails */
     bool okay = true;	    /* if any test fails set to true, is return value */
 
     /* set up exact match of 5 */
-    jfmt_parse_number_range("-l", "5", false, &number);
+    json_util_parse_number_range("-l", "5", false, &number);
 
     /* make sure number matches exactly */
     test = jfmt_test_number_range_opts(true, 5, 10, __LINE__, &number);
@@ -51,7 +51,7 @@ jfmt_run_tests(void)
     }
 
     /* set up inclusive range of >= 5 && <= 10 */
-    jfmt_parse_number_range("-l", "5:10", false, &number);
+    json_util_parse_number_range("-l", "5:10", false, &number);
     /* make sure that number is in the range >= 5 && <= 10 */
     test = jfmt_test_number_range_opts(true, 6, 10, __LINE__, &number);
     if (!test) {
@@ -72,7 +72,7 @@ jfmt_run_tests(void)
      * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
      * last match)
      */
-    jfmt_parse_number_range("-n", "5:-3", true, &number);
+    json_util_parse_number_range("-n", "5:-3", true, &number);
     /* make sure that number is in the range >= 5 && <= 10 - 3 */
     test = jfmt_test_number_range_opts(true, 7, 10, __LINE__, &number);
     if (!test) {
@@ -102,7 +102,7 @@ jfmt_run_tests(void)
 
 
     /* set up minimum number */
-    jfmt_parse_number_range("-l", "10:", false, &number);
+    json_util_parse_number_range("-l", "10:", false, &number);
     /* make sure that number 10 is in the range >= 10 */
     test = jfmt_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -121,7 +121,7 @@ jfmt_run_tests(void)
     }
 
     /* set up maximum number */
-    jfmt_parse_number_range("-l", ":10", false, &number);
+    json_util_parse_number_range("-l", ":10", false, &number);
     /* make sure that number 10 is in the range <= 10 */
     test = jfmt_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -160,7 +160,7 @@ jfmt_run_tests(void)
  * NOTE: this will not return on NULL pointers.
  */
 bool
-jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jfmt_number *range)
+jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct json_util_number *range)
 {
     bool test = false;	    /* result of test */
 
@@ -169,7 +169,7 @@ jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_match
 	not_reached();
     }
 
-    test = jfmt_number_in_range(number, total_matches, range);
+    test = json_util_number_in_range(number, total_matches, range);
     print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
     if (range->exact) {
 	print("expect exact match for number %jd: ", number);

--- a/jparse/jfmt_test.h
+++ b/jparse/jfmt_test.h
@@ -62,7 +62,7 @@
 
 bool jfmt_run_tests(void);
 bool jfmt_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
-	intmax_t line, struct jfmt_number *range);
+	intmax_t line, struct json_util_number *range);
 bool jfmt_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
 
 #endif /* !defined INCLUDE_JFMT_TEST_H */

--- a/jparse/jfmt_util.c
+++ b/jparse/jfmt_util.c
@@ -44,365 +44,39 @@ alloc_jfmt(void)
     /* explicitly clear everything out and set defaults */
 
     /* JSON file member variables */
-    jfmt->is_stdin = false;			/* true if it's stdin */
-    jfmt->file_contents = NULL;			/* file.json contents */
-    jfmt->json_file = NULL;			/* JSON file * */
+    jfmt->common.is_stdin = false;			/* true if it's stdin */
+    jfmt->common.file_contents = NULL;			/* file.json contents */
+    jfmt->common.json_file = NULL;			/* JSON file * */
 
-    jfmt->outfile_path = NULL;			/* assume no -o used */
-    jfmt->outfile = stdout;			/* default stdout */
-    jfmt->outfile_not_stdout = false;		/* by default we write to stdout */
+    jfmt->common.outfile_path = NULL;			/* assume no -o used */
+    jfmt->common.outfile = stdout;			/* default stdout */
+    jfmt->common.outfile_not_stdout = false;		/* by default we write to stdout */
 
     /* number range options, see struct jfmt_number_range in jfmt_util.h for details */
 
     /* levels number range */
-    jfmt->jfmt_levels.number = 0;
-    jfmt->jfmt_levels.exact = false;
-    jfmt->jfmt_levels.range.min = 0;
-    jfmt->jfmt_levels.range.max = 0;
-    jfmt->jfmt_levels.range.less_than_equal = false;
-    jfmt->jfmt_levels.range.greater_than_equal = false;
-    jfmt->jfmt_levels.range.inclusive = false;
-    jfmt->levels_constrained = false;
+    jfmt->common.json_util_levels.number = 0;
+    jfmt->common.json_util_levels.exact = false;
+    jfmt->common.json_util_levels.range.min = 0;
+    jfmt->common.json_util_levels.range.max = 0;
+    jfmt->common.json_util_levels.range.less_than_equal = false;
+    jfmt->common.json_util_levels.range.greater_than_equal = false;
+    jfmt->common.json_util_levels.range.inclusive = false;
+    jfmt->common.levels_constrained = false;
 
     /* print related options */
-    jfmt->print_json_levels = false;			/* -L specified */
-    jfmt->num_level_spaces = 4;			/* number of spaces or tab for -L */
-    jfmt->print_level_tab = false;			/* -L tab option */
-    jfmt->indent_levels = false;			/* -I used */
-    jfmt->indent_spaces = 4;				/* -I number of tabs or spaces */
-    jfmt->indent_tab = false;				/* -I <num>[{t|s}] specified */
+    jfmt->common.print_json_levels = false;			/* -L specified */
+    jfmt->common.num_level_spaces = 4;			/* number of spaces or tab for -L */
+    jfmt->common.print_level_tab = false;			/* -L tab option */
+    jfmt->common.indent_levels = false;			/* -I used */
+    jfmt->common.indent_spaces = 4;				/* -I number of tabs or spaces */
+    jfmt->common.indent_tab = false;				/* -I <num>[{t|s}] specified */
 
     /* parsing related */
-    jfmt->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+    jfmt->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
 
     return jfmt;
 }
-
-
-/* jfmt_parse_number_range	- parse a number range for options -l, -N, -n
- *
- * given:
- *
- *	option		- option string (e.g. "-l"). Used for error and debug messages.
- *	optarg		- the option argument
- *	allow_negative	- true if max can be < 0
- *	number		- pointer to struct number
- *
- * Returns true if successfully parsed.
- *
- * The following rules apply:
- *
- * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
- * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
- *     (1a) the last number can be negative in which case it's up through the
- *	    count - max.
- * (2) a minimum number, that is num >= minimum, is <num>:
- * (3) a maximum number, that is num <= maximum, is :<num>
- * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
- * (5) anything else is an error
- *
- * See also the structs jfmt_number_range and jfmt_number in jfmt_util.h
- * for more details.
- *
- * NOTE: this function does not return on syntax error or NULL number.
- */
-bool
-jfmt_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jfmt_number *number)
-{
-    intmax_t max = 0;
-    intmax_t min = 0;
-
-    /* firewall */
-    if (option == NULL || *option == '\0') {
-	err(3, __func__, "NULL or empty option given"); /*ooo*/
-	not_reached();
-    }
-    if (number == NULL) {
-	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
-	not_reached();
-    } else {
-	memset(number, 0, sizeof(struct jfmt_number));
-
-	/* don't assume everything is 0 */
-	number->exact = false;
-	number->range.min = 0;
-	number->range.max = 0;
-	number->range.inclusive = false;
-	number->range.less_than_equal = false;
-	number->range.greater_than_equal = false;
-    }
-
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
-	return false;
-    }
-
-    if (!strchr(optarg, ':')) {
-	if (string_to_intmax(optarg, &number->number)) {
-	    number->exact = true;
-	    number->range.min = 0;
-	    number->range.max = 0;
-	    number->range.inclusive = false;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
-	} else {
-	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
-	    not_reached();
-	}
-    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    /*
-	     * NOTE: we can't check that min >= max because a negative number in the
-	     * maximum means that the range is up through the count - max matches
-	     */
-	    number->range.min = min;
-	    number->range.max = max;
-	    number->range.inclusive = true;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    /* XXX - this debug message is problematic wrt the negative number
-	     * option
-	     */
-	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
-		    number->range.max);
-	}
-    } else if (sscanf(optarg, "%jd:", &min) == 1) {
-	number->number = 0;
-	number->exact = false;
-	number->range.min = min;
-	number->range.max = number->range.min;
-	number->range.greater_than_equal = true;
-	number->range.less_than_equal = false;
-	number->range.inclusive = false;
-	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
-    } else if (sscanf(optarg, ":%jd", &max) == 1) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    number->range.max = max;
-	    number->range.min = number->range.max;
-	    number->number = 0;
-	    number->exact = false;
-	    number->range.less_than_equal = true;
-	    number->range.greater_than_equal = false;
-	    number->range.inclusive = false;
-	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
-	}
-    } else {
-	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
-	not_reached();
-    }
-
-    return true;
-}
-
-/* jfmt_number_in_range   - check if number is in required range
- *
- * given:
- *
- *	number		- number to check
- *	total_matches	- total number of matches found
- *	range		- pointer to struct jfmt_number with range
- *
- * Returns true if the number is in range.
- *
- * NOTE: if range is NULL it will return false.
- */
-bool
-jfmt_number_in_range(intmax_t number, intmax_t total_matches, struct jfmt_number *range)
-{
-    /* firewall check */
-    if (range == NULL) {
-	return false;
-    }
-
-    /* if exact is set and range->number == number then return true. */
-    if (range->exact && range->number == number) {
-	return true;
-    } else if (range->range.inclusive) {
-	/* if the number must be inclusive in range then we have to make sure
-	 * that number >= min and <= max.
-	 *
-	 * NOTE: we have to make a special check for negative numbers because a
-	 * negative number is up through the count of matches - the negative max
-	 * number (rather if there are 10 matches and the string -l 5:-3 is
-	 * specified then the items 5, 6, 7, 8 are to be printed).
-	 */
-	if (number >= range->range.min) {
-	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
-		return true;
-	    } else if (number <= range->range.max) {
-		return true;
-	    } else {
-		return false;
-	    }
-	} else {
-	    return false;
-	}
-    } else if (range->range.less_than_equal) {
-	/* if number has to be less than equal we check number <= the maximum
-	 * number (range->range.max).
-	 */
-	if (number <= range->range.max) {
-	    return true;
-	} else {
-	    return false;
-	}
-    } else if (range->range.greater_than_equal) {
-	/* if number has to be greater than or equal to the number then we check
-	 * that number >= minimum number (range->range.min).
-	 */
-	if (number >= range->range.min) {
-	    return true;
-	} else {
-	    return false;
-	}
-    }
-
-    return false; /* no match */
-}
-
-/* jfmt_parse_st_indent_option    - parse -I [num]{s,t}
- *
- * This function parses the -I option. It's necessary to have it this way
- * because some options like -j imply it and rather than duplicate code we just
- * have it here once.
- *
- * given:
- *
- *	optarg		    - option argument to -I option (can be faked)
- *	indent_level	    - pointer to number of indent spaces or tabs
- *	indent_tab	    - pointer to boolean indicating if tab or spaces are to be used
- *
- * Function returns void.
- *
- * NOTE: syntax errors are an error just like it was when it was in main().
- *
- * NOTE: this function does not return on NULL pointers.
- */
-void
-jfmt_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab)
-{
-    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
-
-    /* firewall checks */
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg"); /*ooo*/
-	not_reached();
-    } else if (indent_level == NULL) {
-	err(3, __func__, "NULL indent_level"); /*ooo*/
-	not_reached();
-    } else if (indent_tab == NULL) {
-	err(3, __func__, "NULL print_token_tab"); /*ooo*/
-	not_reached();
-    } else {
-	/* ensure that the variables are empty */
-
-	/* make *indent_level == 0 */
-	*indent_level = 0;
-	/* make *ident_tab == false */
-	*indent_tab = false;
-    }
-
-
-    if (sscanf(optarg, "%ju%c", indent_level, &ch) == 2) {
-	if (ch == 't') {
-	    *indent_tab = true;
-	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
-	} else if (ch == 's') {
-	    *indent_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_LOW, "will indent with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
-	} else {
-	    err(3, __func__, "syntax error for -I"); /*ooo*/
-	    not_reached();
-	}
-    } else if (!strcmp(optarg, "tab")) {
-	    *indent_tab = true;
-	    *indent_level = 1;
-	    dbg(DBG_LOW, "will indent with %ju tab%s after levels", *indent_level, *indent_level==1?"":"s");
-    } else if (!string_to_uintmax(optarg, indent_level)) {
-	err(3, __func__, "couldn't parse -I spaces"); /*ooo*/
-	not_reached();
-    } else {
-	*indent_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_LOW, "will ident with %jd space%s after levels", *indent_level, *indent_level==1?"":"s");
-    }
-}
-
-/* jfmt_parse_st_level_option    - parse -L [num]{s,t}
- *
- * This function parses the -L option. It's necessary to have it this way
- * because some options like -j imply it and rather than duplicate code we just
- * have it here once.
- *
- * given:
- *
- *	optarg		    - option argument to -L option (can be faked)
- *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
- *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
- *
- * Function returns void.
- *
- * NOTE: syntax errors are an error just like it was when it was in main().
- *
- * NOTE: this function does not return on NULL pointers.
- */
-void
-jfmt_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
-{
-    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
-
-    /* firewall checks */
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg"); /*ooo*/
-	not_reached();
-    } else if (num_level_spaces == NULL) {
-	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
-	not_reached();
-    } else if (print_level_tab == NULL) {
-	err(3, __func__, "NULL print_token_tab"); /*ooo*/
-	not_reached();
-    } else {
-	/* ensure that the variables are empty */
-
-	/* make *num_level_spaces == 0 */
-	*num_level_spaces = 0;
-	/* make *print_level_tab == false */
-	*print_level_tab = false;
-    }
-
-    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
-	if (ch == 't') {
-	    *print_level_tab = true;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else if (ch == 's') {
-	    *print_level_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else {
-	    err(3, __func__, "syntax error for -L"); /*ooo*/
-	    not_reached();
-	}
-    } else if (!strcmp(optarg, "tab")) {
-	    *print_level_tab = true;
-	    *num_level_spaces = 1;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
-	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
-	not_reached();
-    } else {
-	*print_level_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    }
-}
-
-
 
 /*
  * free_jfmt	    - free jfmt struct
@@ -429,11 +103,11 @@ free_jfmt(struct jfmt **jfmt)
     }
 
     /* flush output file if open and then close it */
-    if ((*jfmt)->outfile != NULL && (*jfmt)->outfile != stdout) {
-	fflush((*jfmt)->outfile);
-	fclose((*jfmt)->outfile);
-	(*jfmt)->outfile = NULL;
-	(*jfmt)->outfile_path = NULL;
+    if ((*jfmt)->common.outfile != NULL && (*jfmt)->common.outfile != stdout) {
+	fflush((*jfmt)->common.outfile);
+	fclose((*jfmt)->common.outfile);
+	(*jfmt)->common.outfile = NULL;
+	(*jfmt)->common.outfile_path = NULL;
     }
 
     free(*jfmt);

--- a/jparse/jfmt_util.h
+++ b/jparse/jfmt_util.h
@@ -120,33 +120,11 @@ struct jfmt_array
  */
 struct jfmt
 {
-    /* JSON file related */
-    bool is_stdin;				/* reading from stdin */
-    FILE *json_file;				/* FILE * to json file */
-    char *file_contents;			/* file contents */
 
-    /* out file related to -o */
-    char *outfile_path;				/* -o file path */
-    FILE *outfile;				/* FILE * of -o outfile */
-    bool outfile_not_stdout;			/* -o used without stdout */
-
-    /* number ranges */
-    /* level constraints */
-    bool levels_constrained;			/* -l specified */
-    struct jfmt_number jfmt_levels;		/* -l level specified */
+    struct json_util common;			/* data common to all three tools: jfmt, jval, jnamval */
 
     /* printing related options */
-    bool print_json_levels;			/* -L specified */
-    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
-    bool print_level_tab;			/* -L tab option */
-    bool indent_levels;				/* -I specified */
-    uintmax_t indent_spaces;			/* -I specified */
-    bool indent_tab;				/* -I <num>[{t|s}] specified */
 
-    /* search related bools */
-    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
-
-    struct json *json_tree;			/* json tree if valid merely as a convenience */
 };
 
 
@@ -157,11 +135,6 @@ struct jfmt *alloc_jfmt(void);
 bool jfmt_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jfmt_number *number);
 bool jfmt_number_in_range(intmax_t number, intmax_t total_matches, struct jfmt_number *range);
 
-/* for -I option */
-void jfmt_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
-
-/* for -L option */
-void jfmt_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
 
 /* to free the entire struct jfmt */
 void free_jfmt(struct jfmt **jfmt);

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.3 2023-07-24"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_test.c
+++ b/jparse/jnamval_test.c
@@ -31,13 +31,13 @@
 bool
 jnamval_run_tests(void)
 {
-    struct jnamval_number number;    /* number range */
+    struct json_util_number number;    /* number range */
     bool test = false;		    /* whether current test passes or fails */
     bool okay = true;	    /* if any test fails set to true, is return value */
     uintmax_t bits = 0;	    /* for bits tests */
 
     /* set up exact match of 5 */
-    jnamval_parse_number_range("-l", "5", false, &number);
+    json_util_parse_number_range("-l", "5", false, &number);
 
     /* make sure number matches exactly */
     test = jnamval_test_number_range_opts(true, 5, 10, __LINE__, &number);
@@ -52,7 +52,7 @@ jnamval_run_tests(void)
     }
 
     /* set up inclusive range of >= 5 && <= 10 */
-    jnamval_parse_number_range("-l", "5:10", false, &number);
+    json_util_parse_number_range("-l", "5:10", false, &number);
     /* make sure that number is in the range >= 5 && <= 10 */
     test = jnamval_test_number_range_opts(true, 6, 10, __LINE__, &number);
     if (!test) {
@@ -73,7 +73,7 @@ jnamval_run_tests(void)
      * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
      * last match)
      */
-    jnamval_parse_number_range("-n", "5:-3", true, &number);
+    json_util_parse_number_range("-n", "5:-3", true, &number);
     /* make sure that number is in the range >= 5 && <= 10 - 3 */
     test = jnamval_test_number_range_opts(true, 7, 10, __LINE__, &number);
     if (!test) {
@@ -103,7 +103,7 @@ jnamval_run_tests(void)
 
 
     /* set up minimum number */
-    jnamval_parse_number_range("-l", "10:", false, &number);
+    json_util_parse_number_range("-l", "10:", false, &number);
     /* make sure that number 10 is in the range >= 10 */
     test = jnamval_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -122,7 +122,7 @@ jnamval_run_tests(void)
     }
 
     /* set up maximum number */
-    jnamval_parse_number_range("-l", ":10", false, &number);
+    json_util_parse_number_range("-l", ":10", false, &number);
     /* make sure that number 10 is in the range <= 10 */
     test = jnamval_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -386,7 +386,7 @@ jnamval_run_tests(void)
  * NOTE: this will not return on NULL pointers.
  */
 bool
-jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jnamval_number *range)
+jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct json_util_number *range)
 {
     bool test = false;	    /* result of test */
 
@@ -395,7 +395,7 @@ jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_ma
 	not_reached();
     }
 
-    test = jnamval_number_in_range(number, total_matches, range);
+    test = json_util_number_in_range(number, total_matches, range);
     print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
     if (range->exact) {
 	print("expect exact match for number %jd: ", number);

--- a/jparse/jnamval_test.h
+++ b/jparse/jnamval_test.h
@@ -62,7 +62,7 @@
 
 bool jnamval_run_tests(void);
 bool jnamval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
-	intmax_t line, struct jnamval_number *range);
+	intmax_t line, struct json_util_number *range);
 bool jnamval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
 
 #endif /* !defined INCLUDE_JNAMVAL_TEST_H */

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -45,13 +45,13 @@ alloc_jnamval(void)
     /* explicitly clear everything out and set defaults */
 
     /* JSON file member variables */
-    jnamval->is_stdin = false;			/* true if it's stdin */
-    jnamval->file_contents = NULL;			/* file.json contents */
-    jnamval->json_file = NULL;			/* JSON file * */
+    jnamval->common.is_stdin = false;			/* true if it's stdin */
+    jnamval->common.file_contents = NULL;			/* file.json contents */
+    jnamval->common.json_file = NULL;			/* JSON file * */
 
-    jnamval->outfile_path = NULL;			/* assume no -o used */
-    jnamval->outfile = stdout;			/* default stdout */
-    jnamval->outfile_not_stdout = false;		/* by default we write to stdout */
+    jnamval->common.outfile_path = NULL;			/* assume no -o used */
+    jnamval->common.outfile = stdout;			/* default stdout */
+    jnamval->common.outfile_not_stdout = false;		/* by default we write to stdout */
 
     /* string related options */
     jnamval->encode_strings = false;		/* -e used */
@@ -61,22 +61,22 @@ alloc_jnamval(void)
     /* number range options, see struct jnamval_number_range in jnamval_util.h for details */
 
     /* -l - levels number range */
-    jnamval->jnamval_levels.number = 0;
-    jnamval->jnamval_levels.exact = false;
-    jnamval->jnamval_levels.range.min = 0;
-    jnamval->jnamval_levels.range.max = 0;
-    jnamval->jnamval_levels.range.less_than_equal = false;
-    jnamval->jnamval_levels.range.greater_than_equal = false;
-    jnamval->jnamval_levels.range.inclusive = false;
-    jnamval->levels_constrained = false;
+    jnamval->common.json_util_levels.number = 0;
+    jnamval->common.json_util_levels.exact = false;
+    jnamval->common.json_util_levels.range.min = 0;
+    jnamval->common.json_util_levels.range.max = 0;
+    jnamval->common.json_util_levels.range.less_than_equal = false;
+    jnamval->common.json_util_levels.range.greater_than_equal = false;
+    jnamval->common.json_util_levels.range.inclusive = false;
+    jnamval->common.levels_constrained = false;
 
     /* print related options */
     jnamval->print_json_types_option = false;		/* -p explicitly used */
     jnamval->print_json_types = JNAMVAL_PRINT_VALUE;	/* -p type specified */
     jnamval->print_decoded = false;			/* -D not used if false */
-    jnamval->print_json_levels = false;			/* -L specified */
-    jnamval->num_level_spaces = 0;				/* number of spaces or tab for -L */
-    jnamval->print_level_tab = false;			/* -L tab option */
+    jnamval->common.print_json_levels = false;			/* -L specified */
+    jnamval->common.num_level_spaces = 0;				/* number of spaces or tab for -L */
+    jnamval->common.print_level_tab = false;			/* -L tab option */
     jnamval->invert_matches = false;			/* -i used */
     jnamval->count_only = false;				/* -c used, only show count */
     jnamval->count_and_show_values = false;		/* -C used, count and show values */
@@ -102,8 +102,8 @@ alloc_jnamval(void)
     jnamval->num_cmp = NULL;
 
     /* parsing related */
-    jnamval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
-    jnamval->json_tree = NULL;
+    jnamval->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+    jnamval->common.json_tree = NULL;
 
 
     /* matches for -c / -C - subject to change */
@@ -715,260 +715,6 @@ jnamval_parse_print_option(char *optarg)
 }
 
 
-/* jnamval_parse_number_range	- parse a number range for options -l, -N, -n
- *
- * given:
- *
- *	option		- option string (e.g. "-l"). Used for error and debug messages.
- *	optarg		- the option argument
- *	allow_negative	- true if max can be < 0
- *	number		- pointer to struct number
- *
- * Returns true if successfully parsed.
- *
- * The following rules apply:
- *
- * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
- * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
- *     (1a) the last number can be negative in which case it's up through the
- *	    count - max.
- * (2) a minimum number, that is num >= minimum, is <num>:
- * (3) a maximum number, that is num <= maximum, is :<num>
- * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
- * (5) anything else is an error
- *
- * See also the structs jnamval_number_range and jnamval_number in jnamval_util.h
- * for more details.
- *
- * NOTE: this function does not return on syntax error or NULL number.
- */
-bool
-jnamval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jnamval_number *number)
-{
-    intmax_t max = 0;
-    intmax_t min = 0;
-
-    /* firewall */
-    if (option == NULL || *option == '\0') {
-	err(3, __func__, "NULL or empty option given"); /*ooo*/
-	not_reached();
-    }
-    if (number == NULL) {
-	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
-	not_reached();
-    } else {
-	memset(number, 0, sizeof(struct jnamval_number));
-
-	/* don't assume everything is 0 */
-	number->exact = false;
-	number->range.min = 0;
-	number->range.max = 0;
-	number->range.inclusive = false;
-	number->range.less_than_equal = false;
-	number->range.greater_than_equal = false;
-    }
-
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
-	return false;
-    }
-
-    if (!strchr(optarg, ':')) {
-	if (string_to_intmax(optarg, &number->number)) {
-	    number->exact = true;
-	    number->range.min = 0;
-	    number->range.max = 0;
-	    number->range.inclusive = false;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
-	} else {
-	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
-	    not_reached();
-	}
-    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    /*
-	     * NOTE: we can't check that min >= max because a negative number in the
-	     * maximum means that the range is up through the count - max matches
-	     */
-	    number->range.min = min;
-	    number->range.max = max;
-	    number->range.inclusive = true;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    /* XXX - this debug message is problematic wrt the negative number
-	     * option
-	     */
-	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
-		    number->range.max);
-	}
-    } else if (sscanf(optarg, "%jd:", &min) == 1) {
-	number->number = 0;
-	number->exact = false;
-	number->range.min = min;
-	number->range.max = number->range.min;
-	number->range.greater_than_equal = true;
-	number->range.less_than_equal = false;
-	number->range.inclusive = false;
-	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
-    } else if (sscanf(optarg, ":%jd", &max) == 1) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    number->range.max = max;
-	    number->range.min = number->range.max;
-	    number->number = 0;
-	    number->exact = false;
-	    number->range.less_than_equal = true;
-	    number->range.greater_than_equal = false;
-	    number->range.inclusive = false;
-	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
-	}
-    } else {
-	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
-	not_reached();
-    }
-
-    return true;
-}
-
-/* jnamval_number_in_range   - check if number is in required range
- *
- * given:
- *
- *	number		- number to check
- *	total_matches	- total number of matches found
- *	range		- pointer to struct jnamval_number with range
- *
- * Returns true if the number is in range.
- *
- * NOTE: if range is NULL it will return false.
- */
-bool
-jnamval_number_in_range(intmax_t number, intmax_t total_matches, struct jnamval_number *range)
-{
-    /* firewall check */
-    if (range == NULL) {
-	return false;
-    }
-
-    /* if exact is set and range->number == number then return true. */
-    if (range->exact && range->number == number) {
-	return true;
-    } else if (range->range.inclusive) {
-	/* if the number must be inclusive in range then we have to make sure
-	 * that number >= min and <= max.
-	 *
-	 * NOTE: we have to make a special check for negative numbers because a
-	 * negative number is up through the count of matches - the negative max
-	 * number (rather if there are 10 matches and the string -l 5:-3 is
-	 * specified then the items 5, 6, 7, 8 are to be printed).
-	 */
-	if (number >= range->range.min) {
-	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
-		return true;
-	    } else if (number <= range->range.max) {
-		return true;
-	    } else {
-		return false;
-	    }
-	} else {
-	    return false;
-	}
-    } else if (range->range.less_than_equal) {
-	/* if number has to be less than equal we check number <= the maximum
-	 * number (range->range.max).
-	 */
-	if (number <= range->range.max) {
-	    return true;
-	} else {
-	    return false;
-	}
-    } else if (range->range.greater_than_equal) {
-	/* if number has to be greater than or equal to the number then we check
-	 * that number >= minimum number (range->range.min).
-	 */
-	if (number >= range->range.min) {
-	    return true;
-	} else {
-	    return false;
-	}
-    }
-
-    return false; /* no match */
-}
-
-
-/* jnamval_parse_st_level_option    - parse -L [num]{s,t}/-b level option
- *
- * This function parses the -L option.
- *
- * given:
- *
- *	optarg		    - option argument to -L option (can be faked)
- *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
- *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
- *
- * Function returns void.
- *
- * NOTE: syntax errors are an error just like it was when it was in main().
- *
- * NOTE: this function does not return on NULL pointers.
- */
-void
-jnamval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
-{
-    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
-
-    /* firewall checks */
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg"); /*ooo*/
-	not_reached();
-    } else if (num_level_spaces == NULL) {
-	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
-	not_reached();
-    } else if (print_level_tab == NULL) {
-	err(3, __func__, "NULL print_token_tab"); /*ooo*/
-	not_reached();
-    } else {
-	/* ensure that the variables are empty */
-
-	/* make *num_level_spaces == 0 */
-	*num_level_spaces = 0;
-	/* make *print_level_tab == false */
-	*print_level_tab = false;
-    }
-
-    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
-	if (ch == 't') {
-	    *print_level_tab = true;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else if (ch == 's') {
-	    *print_level_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else {
-	    err(3, __func__, "syntax error for -L"); /*ooo*/
-	    not_reached();
-	}
-    } else if (!strcmp(optarg, "tab")) {
-	    *print_level_tab = true;
-	    *num_level_spaces = 1;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
-	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
-	not_reached();
-    } else {
-	*print_level_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    }
-}
 
 /*
  * jnamval_parse_value_option	- parse -t types list
@@ -1045,11 +791,11 @@ free_jnamval(struct jnamval **jnamval)
     }
 
     /* flush output file if open and then close it */
-    if ((*jnamval)->outfile != NULL && (*jnamval)->outfile != stdout) {
-	fflush((*jnamval)->outfile);
-	fclose((*jnamval)->outfile);
-	(*jnamval)->outfile = NULL;
-	(*jnamval)->outfile_path = NULL;
+    if ((*jnamval)->common.outfile != NULL && (*jnamval)->common.outfile != stdout) {
+	fflush((*jnamval)->common.outfile);
+	fclose((*jnamval)->common.outfile);
+	(*jnamval)->common.outfile = NULL;
+	(*jnamval)->common.outfile_path = NULL;
     }
 
     /* free the compare lists too */
@@ -1079,7 +825,7 @@ jnamval_print_count(struct jnamval *jnamval)
     }
 
     if (jnamval->count_only || jnamval->count_and_show_values) {
-	fpr(jnamval->outfile?jnamval->outfile:stdout, "jnamval", "%ju\n", jnamval->total_matches);
+	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%ju\n", jnamval->total_matches);
 	return true;
     }
 

--- a/jparse/jnamval_util.h
+++ b/jparse/jnamval_util.h
@@ -132,31 +132,16 @@ struct jnamval_number
  */
 struct jnamval
 {
-    /* JSON file related */
-    bool is_stdin;				/* reading from stdin */
-    FILE *json_file;				/* FILE * to json file */
-    char *file_contents;			/* file contents */
-
-    /* out file related to -o */
-    char *outfile_path;				/* -o file path */
-    FILE *outfile;				/* FILE * of -o ofile */
-    bool outfile_not_stdout;			/* -o used without stdout */
+    struct json_util common;			/* common data related to tools: jfmt, jval, jnamval */
 
     /* string related options */
     bool encode_strings;			/* -e used */
     bool quote_strings;				/* -Q used */
 
-    /* level constraints */
-    bool levels_constrained;			/* -l specified */
-    struct jnamval_number jnamval_levels;		/* -l level specified */
-
     /* printing related options */
     bool print_json_types_option;		/* -p explicitly used */
     uintmax_t print_json_types;			/* -p type specified */
     bool print_decoded;				/* -D used */
-    bool print_json_levels;			/* -L specified */
-    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
-    bool print_level_tab;			/* -L tab option */
     bool invert_matches;			/* -i used */
     bool count_only;				/* -c used, only show count */
     bool count_and_show_values;			/* -C used, show count and values */
@@ -177,8 +162,6 @@ struct jnamval
     struct jnamval_cmp_op *string_cmp;		/* for -S str */
     bool num_cmp_used;				/* for -n */
     struct jnamval_cmp_op *num_cmp;			/* for -n num */
-    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
-    struct json *json_tree;			/* json tree if valid merely as a convenience */
 };
 
 
@@ -210,15 +193,8 @@ bool jnamval_print_both(uintmax_t types);
 bool jnamval_print_json(uintmax_t types);
 
 
-/* for number range option -l */
-bool jnamval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jnamval_number *number);
-bool jnamval_number_in_range(intmax_t number, intmax_t total_matches, struct jnamval_number *range);
-
 /* for -S and -n */
 struct jnamval_cmp_op *jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg);
-
-/* for -L option */
-void jnamval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
 
 /* functions to print matches */
 bool jnamval_print_count(struct jnamval *jnamval);

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -65,7 +65,60 @@
 #define JSON_DBG_FORCED	    (-1)	    /* always print information, even if dbg_output_allowed == false */
 #define JSON_DBG_LEVEL	    (JSON_DBG_LOW)  /* default JSON debugging level json_verbosity_level */
 
+/* structures */
 
+/* number ranges for the options -l, -n and -n of jfmt, jval and jnamval */
+struct json_util_number_range
+{
+    intmax_t min;   /* min in range */
+    intmax_t max;   /* max in range */
+
+    bool less_than_equal;	/* true if number type must be <= min */
+    bool greater_than_equal;	/* true if number type must be >= max */
+    bool inclusive;		/* true if number type must be >= min && <= max */
+};
+struct json_util_number
+{
+    /* exact number if >= 0 */
+    intmax_t number;		/* exact number exact number (must be >= 0) */
+    bool exact;			/* true if an exact match (number) must be found */
+
+    /* for number ranges */
+    struct json_util_number_range range;	/* for ranges */
+};
+
+
+/*
+ * json_util - struct related to the json utils jfmt, jval and jnamval
+ */
+struct json_util
+{
+    /* JSON file related */
+    bool is_stdin;				/* reading from stdin */
+    FILE *json_file;				/* FILE * to json file */
+    char *file_contents;			/* file contents */
+
+    /* out file related to -o */
+    char *outfile_path;				/* -o file path */
+    FILE *outfile;				/* FILE * of -o ofile */
+    bool outfile_not_stdout;			/* -o used without stdout */
+
+    /* level constraints */
+    bool levels_constrained;			/* -l specified */
+    struct json_util_number json_util_levels;		/* -l level specified */
+
+    bool print_json_levels;			/* -L specified */
+    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
+    bool print_level_tab;			/* -L tab option */
+
+    bool indent_levels;				/* -I specified */
+    uintmax_t indent_spaces;			/* -I specified */
+    bool indent_tab;				/* -I <num>[{t|s}] specified */
+
+
+    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
+    struct json *json_tree;			/* json tree if valid merely as a convenience */
+};
 /*
  * global variables
  */
@@ -105,6 +158,17 @@ extern void json_tree_walk(struct json *node, unsigned int max_depth, unsigned i
 			   void (*vcallback)(struct json *, unsigned int, va_list), ...);
 extern void vjson_tree_walk(struct json *node, unsigned int max_depth, unsigned int depth, bool post_order,
 			    void (*vcallback)(struct json *, unsigned int, va_list), va_list ap);
+
+/* for number range option -l */
+bool json_util_parse_number_range(const char *option, char *optarg, bool allow_negative, struct json_util_number *number);
+bool json_util_number_in_range(intmax_t number, intmax_t total_matches, struct json_util_number *range);
+/* for -L option */
+void json_util_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
+/* for -I option */
+void json_util_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
+
+
+
 
 
 #endif /* INCLUDE_JSON_UTIL_H */

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.3 2023-07-24"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_test.c
+++ b/jparse/jval_test.c
@@ -31,13 +31,13 @@
 bool
 jval_run_tests(void)
 {
-    struct jval_number number;    /* number range */
+    struct json_util_number number;    /* number range */
     bool test = false;		    /* whether current test passes or fails */
     bool okay = true;	    /* if any test fails set to true, is return value */
     uintmax_t bits = 0;	    /* for bits tests */
 
     /* set up exact match of 5 */
-    jval_parse_number_range("-l", "5", false, &number);
+    json_util_parse_number_range("-l", "5", false, &number);
 
     /* make sure number matches exactly */
     test = jval_test_number_range_opts(true, 5, 10, __LINE__, &number);
@@ -52,7 +52,7 @@ jval_run_tests(void)
     }
 
     /* set up inclusive range of >= 5 && <= 10 */
-    jval_parse_number_range("-l", "5:10", false, &number);
+    json_util_parse_number_range("-l", "5:10", false, &number);
     /* make sure that number is in the range >= 5 && <= 10 */
     test = jval_test_number_range_opts(true, 6, 10, __LINE__, &number);
     if (!test) {
@@ -73,7 +73,7 @@ jval_run_tests(void)
      * set up inclusive range of >= 5 && <= max - 3 (i.e. up through the third to
      * last match)
      */
-    jval_parse_number_range("-n", "5:-3", true, &number);
+    json_util_parse_number_range("-n", "5:-3", true, &number);
     /* make sure that number is in the range >= 5 && <= 10 - 3 */
     test = jval_test_number_range_opts(true, 7, 10, __LINE__, &number);
     if (!test) {
@@ -103,7 +103,7 @@ jval_run_tests(void)
 
 
     /* set up minimum number */
-    jval_parse_number_range("-l", "10:", false, &number);
+    json_util_parse_number_range("-l", "10:", false, &number);
     /* make sure that number 10 is in the range >= 10 */
     test = jval_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -122,7 +122,7 @@ jval_run_tests(void)
     }
 
     /* set up maximum number */
-    jval_parse_number_range("-l", ":10", false, &number);
+    json_util_parse_number_range("-l", ":10", false, &number);
     /* make sure that number 10 is in the range <= 10 */
     test = jval_test_number_range_opts(true, 10, 42, __LINE__, &number);
     if (!test) {
@@ -292,7 +292,7 @@ jval_run_tests(void)
  * NOTE: this will not return on NULL pointers.
  */
 bool
-jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct jval_number *range)
+jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches, intmax_t line, struct json_util_number *range)
 {
     bool test = false;	    /* result of test */
 
@@ -301,7 +301,7 @@ jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_match
 	not_reached();
     }
 
-    test = jval_number_in_range(number, total_matches, range);
+    test = json_util_number_in_range(number, total_matches, range);
     print("in function %s from line %jd: expects %s: ", __func__, line, expected?"success":"failure");
     if (range->exact) {
 	print("expect exact match for number %jd: ", number);

--- a/jparse/jval_test.h
+++ b/jparse/jval_test.h
@@ -62,7 +62,7 @@
 
 bool jval_run_tests(void);
 bool jval_test_number_range_opts(bool expected, intmax_t number, intmax_t total_matches,
-	intmax_t line, struct jval_number *range);
+	intmax_t line, struct json_util_number *range);
 bool jval_test_bits(bool expected, uintmax_t set_bits, intmax_t line, bool (*check_func)(uintmax_t), const char *name);
 
 #endif /* !defined INCLUDE_JVAL_TEST_H */

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -45,13 +45,13 @@ alloc_jval(void)
     /* explicitly clear everything out and set defaults */
 
     /* JSON file member variables */
-    jval->is_stdin = false;			/* true if it's stdin */
-    jval->file_contents = NULL;			/* file.json contents */
-    jval->json_file = NULL;			/* JSON file * */
+    jval->common.is_stdin = false;			/* true if it's stdin */
+    jval->common.file_contents = NULL;			/* file.json contents */
+    jval->common.json_file = NULL;			/* JSON file * */
 
-    jval->outfile_path = NULL;			/* assume no -o used */
-    jval->outfile = stdout;			/* default stdout */
-    jval->outfile_not_stdout = false;		/* by default we write to stdout */
+    jval->common.outfile_path = NULL;			/* assume no -o used */
+    jval->common.outfile = stdout;			/* default stdout */
+    jval->common.outfile_not_stdout = false;		/* by default we write to stdout */
 
     /* string related options */
     jval->encode_strings = false;		/* -e used */
@@ -61,20 +61,20 @@ alloc_jval(void)
     /* number range options, see struct jval_number_range in jval_util.h for details */
 
     /* -l - levels number range */
-    jval->jval_levels.number = 0;
-    jval->jval_levels.exact = false;
-    jval->jval_levels.range.min = 0;
-    jval->jval_levels.range.max = 0;
-    jval->jval_levels.range.less_than_equal = false;
-    jval->jval_levels.range.greater_than_equal = false;
-    jval->jval_levels.range.inclusive = false;
-    jval->levels_constrained = false;
+    jval->common.json_util_levels.number = 0;
+    jval->common.json_util_levels.exact = false;
+    jval->common.json_util_levels.range.min = 0;
+    jval->common.json_util_levels.range.max = 0;
+    jval->common.json_util_levels.range.less_than_equal = false;
+    jval->common.json_util_levels.range.greater_than_equal = false;
+    jval->common.json_util_levels.range.inclusive = false;
+    jval->common.levels_constrained = false;
 
     /* print related options */
     jval->print_decoded = false;			/* -D not used if false */
-    jval->print_json_levels = false;			/* -L specified */
-    jval->num_level_spaces = 0;				/* number of spaces or tab for -L */
-    jval->print_level_tab = false;			/* -L tab option */
+    jval->common.print_json_levels = false;			/* -L specified */
+    jval->common.num_level_spaces = 0;				/* number of spaces or tab for -L */
+    jval->common.print_level_tab = false;			/* -L tab option */
     jval->invert_matches = false;			/* -i used */
     jval->count_only = false;				/* -c used, only show count */
     jval->count_and_show_values = false;		/* -C used, count and show values */
@@ -99,8 +99,8 @@ alloc_jval(void)
     jval->num_cmp = NULL;
 
     /* parsing related */
-    jval->max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
-    jval->json_tree = NULL;
+    jval->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
+    jval->common.json_tree = NULL;
 
 
     /* matches for -c / -C - subject to change */
@@ -400,260 +400,6 @@ jval_parse_types_option(char *optarg)
     return type;
 }
 
-/* jval_parse_number_range	- parse a number range for options -l, -N, -n
- *
- * given:
- *
- *	option		- option string (e.g. "-l"). Used for error and debug messages.
- *	optarg		- the option argument
- *	allow_negative	- true if max can be < 0
- *	number		- pointer to struct number
- *
- * Returns true if successfully parsed.
- *
- * The following rules apply:
- *
- * (0) an exact number is a number optional arg by itself e.g. -l 5 or -l5.
- * (1) an inclusive range is <min>:<max> e.g. -l 5:10 where:
- *     (1a) the last number can be negative in which case it's up through the
- *	    count - max.
- * (2) a minimum number, that is num >= minimum, is <num>:
- * (3) a maximum number, that is num <= maximum, is :<num>
- * (4) if allow_negative is true then max can be < 0 otherwise it's an error.
- * (5) anything else is an error
- *
- * See also the structs jval_number_range and jval_number in jval_util.h
- * for more details.
- *
- * NOTE: this function does not return on syntax error or NULL number.
- */
-bool
-jval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jval_number *number)
-{
-    intmax_t max = 0;
-    intmax_t min = 0;
-
-    /* firewall */
-    if (option == NULL || *option == '\0') {
-	err(3, __func__, "NULL or empty option given"); /*ooo*/
-	not_reached();
-    }
-    if (number == NULL) {
-	err(3, __func__, "NULL number struct for option %s", option); /*ooo*/
-	not_reached();
-    } else {
-	memset(number, 0, sizeof(struct jval_number));
-
-	/* don't assume everything is 0 */
-	number->exact = false;
-	number->range.min = 0;
-	number->range.max = 0;
-	number->range.inclusive = false;
-	number->range.less_than_equal = false;
-	number->range.greater_than_equal = false;
-    }
-
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg for %s", option); /*ooo*/
-	return false;
-    }
-
-    if (!strchr(optarg, ':')) {
-	if (string_to_intmax(optarg, &number->number)) {
-	    number->exact = true;
-	    number->range.min = 0;
-	    number->range.max = 0;
-	    number->range.inclusive = false;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    dbg(DBG_LOW, "exact number required for option %s: %jd", option, number->number);
-	} else {
-	    err(3, __func__, "invalid number for option %s: <%s>", option, optarg); /*ooo*/
-	    not_reached();
-	}
-    } else if (sscanf(optarg, "%jd:%jd", &min, &max) == 2) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    /*
-	     * NOTE: we can't check that min >= max because a negative number in the
-	     * maximum means that the range is up through the count - max matches
-	     */
-	    number->range.min = min;
-	    number->range.max = max;
-	    number->range.inclusive = true;
-	    number->range.less_than_equal = false;
-	    number->range.greater_than_equal = false;
-	    /* XXX - this debug message is problematic wrt the negative number
-	     * option
-	     */
-	    dbg(DBG_LOW, "number range inclusive required for option %s: >= %jd && <= %jd", option, number->range.min,
-		    number->range.max);
-	}
-    } else if (sscanf(optarg, "%jd:", &min) == 1) {
-	number->number = 0;
-	number->exact = false;
-	number->range.min = min;
-	number->range.max = number->range.min;
-	number->range.greater_than_equal = true;
-	number->range.less_than_equal = false;
-	number->range.inclusive = false;
-	dbg(DBG_LOW, "minimum number required for option %s: must be >= %jd", option, number->range.min);
-    } else if (sscanf(optarg, ":%jd", &max) == 1) {
-	/* if allow_negative is false we won't allow negative max in range. */
-	if (!allow_negative && max < 0) {
-	    err(3, __func__, "invalid number for option %s: <%s>: max cannot be < 0", option, optarg); /*ooo*/
-	    not_reached();
-	} else {
-	    number->range.max = max;
-	    number->range.min = number->range.max;
-	    number->number = 0;
-	    number->exact = false;
-	    number->range.less_than_equal = true;
-	    number->range.greater_than_equal = false;
-	    number->range.inclusive = false;
-	    dbg(DBG_LOW, "maximum number required for option %s: must be <= %jd", option, number->range.max);
-	}
-    } else {
-	err(3, __func__, "number range syntax error for option %s: <%s>", option, optarg);/*ooo*/
-	not_reached();
-    }
-
-    return true;
-}
-
-/* jval_number_in_range   - check if number is in required range
- *
- * given:
- *
- *	number		- number to check
- *	total_matches	- total number of matches found
- *	range		- pointer to struct jval_number with range
- *
- * Returns true if the number is in range.
- *
- * NOTE: if range is NULL it will return false.
- */
-bool
-jval_number_in_range(intmax_t number, intmax_t total_matches, struct jval_number *range)
-{
-    /* firewall check */
-    if (range == NULL) {
-	return false;
-    }
-
-    /* if exact is set and range->number == number then return true. */
-    if (range->exact && range->number == number) {
-	return true;
-    } else if (range->range.inclusive) {
-	/* if the number must be inclusive in range then we have to make sure
-	 * that number >= min and <= max.
-	 *
-	 * NOTE: we have to make a special check for negative numbers because a
-	 * negative number is up through the count of matches - the negative max
-	 * number (rather if there are 10 matches and the string -l 5:-3 is
-	 * specified then the items 5, 6, 7, 8 are to be printed).
-	 */
-	if (number >= range->range.min) {
-	    if (range->range.max < 0 && number <= total_matches + range->range.max) {
-		return true;
-	    } else if (number <= range->range.max) {
-		return true;
-	    } else {
-		return false;
-	    }
-	} else {
-	    return false;
-	}
-    } else if (range->range.less_than_equal) {
-	/* if number has to be less than equal we check number <= the maximum
-	 * number (range->range.max).
-	 */
-	if (number <= range->range.max) {
-	    return true;
-	} else {
-	    return false;
-	}
-    } else if (range->range.greater_than_equal) {
-	/* if number has to be greater than or equal to the number then we check
-	 * that number >= minimum number (range->range.min).
-	 */
-	if (number >= range->range.min) {
-	    return true;
-	} else {
-	    return false;
-	}
-    }
-
-    return false; /* no match */
-}
-
-
-/* jval_parse_st_level_option    - parse -L [num]{s,t}/-b level option
- *
- * This function parses the -L option.
- *
- * given:
- *
- *	optarg		    - option argument to -L option (can be faked)
- *	num_level_spaces    - pointer to number of spaces or tabs to print after levels
- *	print_level_tab	    - pointer to boolean indicating if tab or spaces are to be used
- *
- * Function returns void.
- *
- * NOTE: syntax errors are an error just like it was when it was in main().
- *
- * NOTE: this function does not return on NULL pointers.
- */
-void
-jval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab)
-{
-    char ch = '\0';	/* whether spaces or tabs are to be used, 's' or 't' */
-
-    /* firewall checks */
-    if (optarg == NULL || *optarg == '\0') {
-	err(3, __func__, "NULL or empty optarg"); /*ooo*/
-	not_reached();
-    } else if (num_level_spaces == NULL) {
-	err(3, __func__, "NULL num_level_spaces"); /*ooo*/
-	not_reached();
-    } else if (print_level_tab == NULL) {
-	err(3, __func__, "NULL print_token_tab"); /*ooo*/
-	not_reached();
-    } else {
-	/* ensure that the variables are empty */
-
-	/* make *num_level_spaces == 0 */
-	*num_level_spaces = 0;
-	/* make *print_level_tab == false */
-	*print_level_tab = false;
-    }
-
-    if (sscanf(optarg, "%ju%c", num_level_spaces, &ch) == 2) {
-	if (ch == 't') {
-	    *print_level_tab = true;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else if (ch == 's') {
-	    *print_level_tab = false; /* ensure it's false in case specified previously */
-	    dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-	} else {
-	    err(3, __func__, "syntax error for -L"); /*ooo*/
-	    not_reached();
-	}
-    } else if (!strcmp(optarg, "tab")) {
-	    *print_level_tab = true;
-	    *num_level_spaces = 1;
-	    dbg(DBG_LOW, "will print %ju tab%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    } else if (!string_to_uintmax(optarg, num_level_spaces)) {
-	err(3, __func__, "couldn't parse -L spaces"); /*ooo*/
-	not_reached();
-    } else {
-	*print_level_tab = false; /* ensure it's false in case specified previously */
-	dbg(DBG_LOW, "will print %jd space%s after levels", *num_level_spaces, *num_level_spaces==1?"":"s");
-    }
-}
 
 /*
  * jval_parse_value_option	- parse -t types list
@@ -730,11 +476,11 @@ free_jval(struct jval **jval)
     }
 
     /* flush output file if open and then close it */
-    if ((*jval)->outfile != NULL && (*jval)->outfile != stdout) {
-	fflush((*jval)->outfile);
-	fclose((*jval)->outfile);
-	(*jval)->outfile = NULL;
-	(*jval)->outfile_path = NULL;
+    if ((*jval)->common.outfile != NULL && (*jval)->common.outfile != stdout) {
+	fflush((*jval)->common.outfile);
+	fclose((*jval)->common.outfile);
+	(*jval)->common.outfile = NULL;
+	(*jval)->common.outfile_path = NULL;
     }
 
     /* free the compare lists too */
@@ -764,7 +510,7 @@ jval_print_count(struct jval *jval)
     }
 
     if (jval->count_only || jval->count_and_show_values) {
-	fpr(jval->outfile?jval->outfile:stdout, "jval", "%ju\n", jval->total_matches);
+	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%ju\n", jval->total_matches);
 	return true;
     }
 

--- a/jparse/jval_util.h
+++ b/jparse/jval_util.h
@@ -94,59 +94,22 @@ struct jval_cmp_op
     struct jval_cmp_op *next;	/* next in the list */
 };
 
-/* number ranges for the options -l, -n and -n */
-struct jval_number_range
-{
-    intmax_t min;   /* min in range */
-    intmax_t max;   /* max in range */
-
-    bool less_than_equal;	/* true if number type must be <= min */
-    bool greater_than_equal;	/* true if number type must be >= max */
-    bool inclusive;		/* true if number type must be >= min && <= max */
-};
-struct jval_number
-{
-    /* exact number if >= 0 */
-    intmax_t number;		/* exact number exact number (must be >= 0) */
-    bool exact;			/* true if an exact match (number) must be found */
-
-    /* for number ranges */
-    struct jval_number_range range;	/* for ranges */
-};
-
 /*
  * jval - struct that holds most of the options, other settings and other data
  */
 struct jval
 {
-    /* JSON file related */
-    bool is_stdin;				/* reading from stdin */
-    FILE *json_file;				/* FILE * to json file */
-    char *file_contents;			/* file contents */
-
-    /* out file related to -o */
-    char *outfile_path;				/* -o file path */
-    FILE *outfile;				/* FILE * of -o ofile */
-    bool outfile_not_stdout;			/* -o used without stdout */
+    struct json_util common;			/* data common to all three tools: jfmt, jval and jnamval */
 
     /* string related options */
     bool encode_strings;			/* -e used */
     bool quote_strings;				/* -Q used */
 
-    /* level constraints */
-    bool levels_constrained;			/* -l specified */
-    struct jval_number jval_levels;		/* -l level specified */
-
     /* printing related options */
     bool print_decoded;				/* -D used */
-    bool print_json_levels;			/* -L specified */
-    uintmax_t num_level_spaces;			/* number of spaces or tab for -L */
-    bool print_level_tab;			/* -L tab option */
-    bool invert_matches;			/* -i used */
-    bool count_only;				/* -c used, only show count */
-    bool count_and_show_values;			/* -C used, show count and values */
 
     /* search / matching related */
+    bool invert_matches;			/* -i used */
     bool json_types_specified;			/* -t used */
     uintmax_t json_types;			/* -t type */
     bool ignore_case;				/* true if -f, case-insensitive */
@@ -156,12 +119,13 @@ struct jval
     bool use_regexps;				/* -g used, allow grep-like regexps */
     uintmax_t total_matches;			/* for -c */
 
+    bool count_only;				/* -c used, only show count */
+    bool count_and_show_values;			/* -C used, show count and values */
+
     bool string_cmp_used;			/* for -S */
     struct jval_cmp_op *string_cmp;		/* for -S str */
     bool num_cmp_used;				/* for -n */
-    struct jval_cmp_op *num_cmp;			/* for -n num */
-    uintmax_t max_depth;			/* max depth to traverse set by -m depth */
-    struct json *json_tree;			/* json tree if valid merely as a convenience */
+    struct jval_cmp_op *num_cmp;		/* for -n num */
 };
 
 
@@ -181,15 +145,8 @@ bool jval_match_string(uintmax_t types);
 bool jval_match_null(uintmax_t types);
 bool jval_match_simple(uintmax_t types);
 
-/* for number range option -l */
-bool jval_parse_number_range(const char *option, char *optarg, bool allow_negative, struct jval_number *number);
-bool jval_number_in_range(intmax_t number, intmax_t total_matches, struct jval_number *range);
-
 /* for -S and -n */
 struct jval_cmp_op *jval_parse_cmp_op(struct jval *jval, const char *option, char *optarg);
-
-/* for -L option */
-void jval_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
 
 /* functions to print matches */
 bool jval_print_count(struct jval *jval);


### PR DESCRIPTION
The struct jfmt, struct jval and struct jnamval now have a single 'struct json_util common' which has the variables that are common to all three tools in json_util.h. Code moved to json_util.c.

The structs (jfmt|jval|jnamval)_number are now json_util_number in json_util.h and the associated code has been moved to json_util.c.

The code for the common -L option to the three tools has also been moved to the json_util.c file.

Any other common (to all three tools) options not mentioned here have also been moved to json_util unless some were missed by accident. I don't believe that is the case but if there are any they will be found and moved accordingly.

The options common to just jval and jnamval have NOT been moved to common structs just yet. That will happen in another commit.

Now why json_util.[ch] instead of some new file? Because they are json utilities and the document that describes them is json_util_README.md not something like jutil_README.md.

New version for these tools: 0.0.4 2023-07-25.