### PR TITLE
Fix read from stdin in jfmt, jval and jnamval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,34 @@
 
 ## Release 1.0.41 2023-07-26
 
-New version of `jnamval`: "0.0.5 2023-07-26". Moved code in `jnamval` common to
-both `jval` and `jnamval` to `json_util.c` like what was done yesterday for
-`jval`.
+New version of `jfmt`, `jval` and `jnamval`: "0.0.5 2023-07-26".
+
+Moved code in `jnamval` common to both `jval` and `jnamval` to `json_util.c`
+like what was done yesterday for `jval`.
+
+Fixed bug where one could not do:
+
+```sh
+echo '"test"' | ./jfmt -
+```
+
+and the same thing with `jval` and `jnamval`. This also fixes the bug where one
+could not do:
+
+```sh
+./jfmt -
+"test"
+^D
+```
+
+and the same thing with the other too tools. The above two fixes changes the use
+of `parse_json_stream()` to `parse_json()`. Note that the `FILE *` is still
+needed.
+
+Add to `struct json_util` the file path of the JSON file as `json_file_path`.
+
+Check that the path is not an empty file name and exit with error code 3 if it
+is in all three tools.
 
 
 ## Release 1.0.40 2023-07-25

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.41 2023-07-26
+
+New version of `jnamval`: "0.0.5 2023-07-26". Moved code in `jnamval` common to
+both `jval` and `jnamval` to `json_util.c` like what was done yesterday for
+`jval`.
+
+
 ## Release 1.0.40 2023-07-25
 
 New version for `jfmt`, `jval` and `jnamval`:  "0.0.4 2023-07-25". Moved common

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jfmt_util.c
+++ b/jparse/jfmt_util.c
@@ -47,6 +47,7 @@ alloc_jfmt(void)
     jfmt->common.is_stdin = false;			/* true if it's stdin */
     jfmt->common.file_contents = NULL;			/* file.json contents */
     jfmt->common.json_file = NULL;			/* JSON file * */
+    jfmt->common.json_file_path = NULL;			/* path to JSON file to read */
 
     jfmt->common.outfile_path = NULL;			/* assume no -o used */
     jfmt->common.outfile = stdout;			/* default stdout */

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -214,60 +214,60 @@ main(int argc, char **argv)
 	    json_util_parse_st_level_option(optarg, &jnamval->common.num_level_spaces, &jnamval->common.print_level_tab);
 	    break;
 	case 't':
-	    jnamval->json_types_specified = true;
-	    jnamval->json_types = jnamval_parse_types_option(optarg);
+	    jnamval->json_name_val.json_types_specified = true;
+	    jnamval->json_name_val.json_types = jnamval_parse_types_option(optarg);
 	    break;
 	case 'l':
 	    jnamval->common.levels_constrained = true;
 	    json_util_parse_number_range("-l", optarg, false, &jnamval->common.json_util_levels);
 	    break;
 	case 'Q':
-	    jnamval->quote_strings = true;
+	    jnamval->json_name_val.quote_strings = true;
 	    dbg(DBG_LOW, "-Q specified, will quote strings");
 	    break;
 	case 'D': /* -D - print decoded strings */
-	    jnamval->print_decoded = true;
+	    jnamval->json_name_val.print_decoded = true;
 	    break;
 	case 'd': /* -d - match decoded */
-	    jnamval->match_decoded = true;
+	    jnamval->json_name_val.match_decoded = true;
 	    break;
 	case 'i':
-	    jnamval->invert_matches = true; /* show non-matches */
+	    jnamval->json_name_val.invert_matches = true; /* show non-matches */
 	    break;
 	case 's':
-	    jnamval->match_substrings = true;
+	    jnamval->json_name_val.match_substrings = true;
 	    dbg(DBG_LOW, "-s specified, will match substrings");
 	    break;
 	case 'f':
-	    jnamval->ignore_case = true; /* make case cruel :-) */
+	    jnamval->json_name_val.ignore_case = true; /* make case cruel :-) */
 	    dbg(DBG_LOW, "-i specified, making matches case-insensitive");
 	    break;
 	case 'c':
-	    jnamval->count_only = true;
+	    jnamval->json_name_val.count_only = true;
 	    dbg(DBG_LOW, "-c specified, will only show count of matches");
 	    break;
 	case 'C':
-	    jnamval->count_and_show_values = true;
+	    jnamval->json_name_val.count_and_show_values = true;
 	    break;
 	case 'g':   /* allow grep-like ERE */
-	    jnamval->use_regexps = true;
+	    jnamval->json_name_val.use_regexps = true;
 	    dbg(DBG_LOW, "-g specified, name_args will be regexps");
 	    break;
 	case 'e':
-	    jnamval->encode_strings = true;
+	    jnamval->json_name_val.encode_strings = true;
 	    dbg(DBG_LOW, "-e specified, will encode strings");
 	    break;
 	case 'n': /* -n op=num */
-	    jnamval->num_cmp_used = true;
-	    if (jnamval_parse_cmp_op(jnamval, "n", optarg) == NULL) {
+	    jnamval->json_name_val.num_cmp_used = true;
+	    if (json_util_parse_cmp_op(&jnamval->json_name_val, "n", optarg) == NULL) {
 		free_jnamval(&jnamval);
 		err(24, "jnamval", "couldn't parse -n option");
 		not_reached();
 	    }
 	    break;
 	case 'S': /* -S op=str */
-	    jnamval->string_cmp_used = true;
-	    if (jnamval_parse_cmp_op(jnamval, "S", optarg) == NULL) {
+	    jnamval->json_name_val.string_cmp_used = true;
+	    if (json_util_parse_cmp_op(&jnamval->json_name_val, "S", optarg) == NULL) {
 		free_jnamval(&jnamval);
 		err(25, "jnamval", "couldn't parse -S option");
 		not_reached();
@@ -389,10 +389,10 @@ main(int argc, char **argv)
 
     /* XXX - implement core of the tool, for now just print count (if requested)
      * and file to out file or stdout - XXX */
-    if (jnamval->count_only) {
+    if (jnamval->json_name_val.count_only) {
 	/* XXX - the count will currently be 0 but we can at least test this option */
 	jnamval_print_count(jnamval);
-    } else if (jnamval->count_and_show_values) {
+    } else if (jnamval->json_name_val.count_and_show_values) {
 	/* XXX - the count will be wrong, the format will be wrong and it might
 	 * be that not the full document is requested but this is all we have at
 	 * this moment and at least we can test the option - XXX
@@ -464,7 +464,7 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
      */
 
     /* use of -g conflicts with -s and is an error. */
-    if (jnamval->use_regexps && jnamval->match_substrings) {
+    if (jnamval->json_name_val.use_regexps && jnamval->json_name_val.match_substrings) {
 	free_jnamval(&jnamval);
 	err(3, __func__, "cannot use both -g and -s"); /*ooo*/
 	not_reached();
@@ -474,16 +474,16 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
      * use of -c with -C or -L is an error and use of -C with -c or -L is an
      * error
      */
-    if (jnamval->count_only || jnamval->common.print_json_levels || jnamval->count_and_show_values) {
-	if (jnamval->count_and_show_values && jnamval->count_only) {
+    if (jnamval->json_name_val.count_only || jnamval->common.print_json_levels || jnamval->json_name_val.count_and_show_values) {
+	if (jnamval->json_name_val.count_and_show_values && jnamval->json_name_val.count_only) {
 	    err(3, __func__, "cannot use -c and -C together"); /*ooo*/
 	    not_reached();
 	}
-	if (jnamval->common.print_json_levels && jnamval->count_only) {
+	if (jnamval->common.print_json_levels && jnamval->json_name_val.count_only) {
 	    err(3, __func__, "cannot use -L and -c together"); /*ooo*/
 	    not_reached();
 	}
-	if (jnamval->common.print_json_levels && jnamval->count_and_show_values) {
+	if (jnamval->common.print_json_levels && jnamval->json_name_val.count_and_show_values) {
 	    err(3, __func__, "cannot use -L and -C together"); /*ooo*/
 	    not_reached();
 	}

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -48,6 +48,7 @@ alloc_jnamval(void)
     jnamval->common.is_stdin = false;			/* true if it's stdin */
     jnamval->common.file_contents = NULL;			/* file.json contents */
     jnamval->common.json_file = NULL;			/* JSON file * */
+    jnamval->common.json_file_path = NULL;			/* path to read */
 
     jnamval->common.outfile_path = NULL;			/* assume no -o used */
     jnamval->common.outfile = stdout;			/* default stdout */

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -54,11 +54,11 @@ alloc_jnamval(void)
     jnamval->common.outfile_not_stdout = false;		/* by default we write to stdout */
 
     /* string related options */
-    jnamval->encode_strings = false;		/* -e used */
-    jnamval->quote_strings = false;		/* -Q used */
+    jnamval->json_name_val.encode_strings = false;		/* -e used */
+    jnamval->json_name_val.quote_strings = false;		/* -Q used */
 
 
-    /* number range options, see struct jnamval_number_range in jnamval_util.h for details */
+    /* number range options, see struct json_util_number_range in jnamval_util.h for details */
 
     /* -l - levels number range */
     jnamval->common.json_util_levels.number = 0;
@@ -73,41 +73,42 @@ alloc_jnamval(void)
     /* print related options */
     jnamval->print_json_types_option = false;		/* -p explicitly used */
     jnamval->print_json_types = JNAMVAL_PRINT_VALUE;	/* -p type specified */
-    jnamval->print_decoded = false;			/* -D not used if false */
+    jnamval->json_name_val.print_decoded = false;			/* -D not used if false */
     jnamval->common.print_json_levels = false;			/* -L specified */
     jnamval->common.num_level_spaces = 0;				/* number of spaces or tab for -L */
     jnamval->common.print_level_tab = false;			/* -L tab option */
-    jnamval->invert_matches = false;			/* -i used */
-    jnamval->count_only = false;				/* -c used, only show count */
-    jnamval->count_and_show_values = false;		/* -C used, count and show values */
+    jnamval->json_name_val.invert_matches = false;			/* -i used */
+    jnamval->json_name_val.count_only = false;				/* -c used, only show count */
+    jnamval->json_name_val.count_and_show_values = false;		/* -C used, count and show values */
 
     /* search / matching related */
     /* json types to look for */
-    jnamval->json_types_specified = false;			/* -t used */
-    jnamval->json_types = JNAMVAL_TYPE_SIMPLE;		/* -t type specified, default simple */
-    jnamval->ignore_case = false;				/* true if -f, case-insensitive */
-    jnamval->match_decoded = false;			/* if -d used match decoded */
-    jnamval->arg_specified = false;			/* true if an arg was specified */
-    jnamval->match_substrings = false;			/* -s used, matching substrings okay */
-    jnamval->use_regexps = false;				/* -g used, allow grep-like regexps */
+    jnamval->json_name_val.json_types_specified = false;			/* -t used */
+    jnamval->json_name_val.json_types = JNAMVAL_TYPE_SIMPLE;		/* -t type specified, default simple */
+    jnamval->json_name_val.ignore_case = false;				/* true if -f, case-insensitive */
+    jnamval->json_name_val.match_decoded = false;			/* if -d used match decoded */
+    jnamval->json_name_val.arg_specified = false;			/* true if an arg was specified */
+    jnamval->json_name_val.match_substrings = false;			/* -s used, matching substrings okay */
+    jnamval->json_name_val.use_regexps = false;				/* -g used, allow grep-like regexps */
     jnamval->match_json_member_names = false;		/* -N used, match based on member names */
     jnamval->match_hierarchies = false;			/* -H used, match any JSON member name */
 
-    /* for -S */
-    jnamval->string_cmp_used = false;
-    jnamval->string_cmp = NULL;
 
-    /* for -n */
-    jnamval->num_cmp_used = false;
-    jnamval->num_cmp = NULL;
+    /* comparison options -S and -n */
+
+    /* -S op=string */
+    jnamval->json_name_val.string_cmp_used = false;
+    jnamval->json_name_val.string_cmp = NULL;
+    /* -n op=number */
+    jnamval->json_name_val.num_cmp_used = false;
+    jnamval->json_name_val.num_cmp = NULL;
 
     /* parsing related */
     jnamval->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
     jnamval->common.json_tree = NULL;
 
-
     /* matches for -c / -C - subject to change */
-    jnamval->total_matches = 0;
+    jnamval->json_name_val.total_matches = 0;
 
     return jnamval;
 }
@@ -824,8 +825,8 @@ jnamval_print_count(struct jnamval *jnamval)
 	not_reached();
     }
 
-    if (jnamval->count_only || jnamval->count_and_show_values) {
-	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%ju\n", jnamval->total_matches);
+    if (jnamval->json_name_val.count_only || jnamval->json_name_val.count_and_show_values) {
+	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%ju\n", jnamval->json_name_val.total_matches);
 	return true;
     }
 
@@ -862,150 +863,6 @@ parse_jnamval_args(struct jnamval *jnamval, char **argv)
     }
 }
 
-/*
- * jnamval_parse_cmp_op	- parse -S / -n compare options
- *
- * given:
- *
- *	jnamval	    - pointer to our jnamval struct
- *	option	    - the option letter (without the '-') that triggered this
- *		      function
- *	optarg	    - option arg to the option
- *
- *
- *  This function fills out either the jnamval->string_cmp or jnamval->num_cmp if the
- *  syntax is correct. Or more correctly it adds to the list as more than one
- *  can be specified.
- *
- *  This function will not return on error in conversion or syntax error or NULL
- *  pointers.
- *
- *  This function returns void.
- */
-struct jnamval_cmp_op *
-jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
-{
-    char *p = NULL;		    /* to find the = separator */
-    char *mode = NULL;		    /* if -S then "str" else "num" */
-    struct json *item = NULL;	    /* to get the converted value */
-    struct jnamval_cmp_op *cmp = NULL;	/* compare operation struct */
-    int op = JNAMVAL_CMP_OP_NONE;	/* assume invalid op */
-
-    /* firewall */
-    if (jnamval == NULL) {
-	err(28, __func__, "NULL jnamval");
-	not_reached();
-    }
-    if (option == NULL) {
-	err(29, __func__, "NULL option");
-	not_reached();
-    }
-    if (optarg == NULL) {
-	err(30, __func__, "NULL optarg");
-	not_reached();
-    }
-
-    if (!strcmp(option, "S")) {
-	mode = "str";
-    } else if (!strcmp(option, "n")) {
-	mode = "num";
-    } else {
-	err(31, __func__, "invalid option used for function: -%s", option);
-	not_reached();
-    }
-
-    p = strchr(optarg, '=');
-    if (p == NULL) {
-	err(32, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
-	not_reached();
-    } else if (p == optarg) {
-	err(33, __func__, "syntax error in -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
-	not_reached();
-    } else if (p[1] == '\0') {
-	err(34, __func__, "nothing found after =: use -%s {eq,lt,le,gt,ge}=%s", option, mode);
-	not_reached();
-    }
-
-    if (!strncmp(optarg, "eq=", 3)) {
-	op = JNAMVAL_CMP_EQ;
-    } else if (!strncmp(optarg, "lt=", 3)) {
-	op = JNAMVAL_CMP_LT;
-    } else if (!strncmp(optarg, "le=", 3)) {
-	op = JNAMVAL_CMP_LE;
-    } else if (!strncmp(optarg, "gt=", 3)){
-	op = JNAMVAL_CMP_GT;
-    } else if (!strncmp(optarg, "ge=", 3)) {
-	op = JNAMVAL_CMP_GE;
-    } else {
-	err(35, __func__, "invalid op found for -%s: use -%s {eq,lt,le,gt,ge}=%s", option, option, mode);
-	not_reached();
-    }
-
-    if (!strcmp(option, "S")) { /* -S */
-	errno = 0;
-	item = json_conv_string(optarg + 3, strlen(optarg + 3), *(optarg +3) == '"' ? true : false);
-	if (item == NULL) {
-	    err(36, __func__, "failed to convert string <%s> for -%s", optarg + 3, option);
-	    not_reached();
-	} else {
-	    cmp = calloc(1, sizeof *cmp);
-	    if (cmp == NULL) {
-		err(37, __func__, "failed to allocate struct jval_cmp_op *");
-		not_reached();
-	    }
-	    cmp->string = &(item->item.string);
-	    if (cmp->string == NULL) {
-		err(38, __func__, "failed to convert string: <%s> for -%s: cmp->string is NULL", optarg + 3, option);
-		not_reached();
-	    } else if (!CONVERTED_PARSED_JSON_NODE(cmp->string)) {
-		err(39, __func__, "failed to convert or parse string: <%s> for option -%s but string pointer not NULL!",
-			optarg + 3, option);
-		not_reached();
-	    }
-
-	    cmp->op = op;
-
-	    cmp->next = jnamval->string_cmp;
-	    jnamval->string_cmp = cmp;
-
-	    /* XXX - add function that prints out what compare operation - XXX */
-	    json_dbg(JSON_DBG_NONE, __func__, "string to compare: <%s>", cmp->string->str);
-
-	}
-    } else if (!strcmp(option, "n")) { /* -n */
-	item = json_conv_number(optarg + 3, strlen(optarg + 3));
-	if (item == NULL) {
-	    err(40, __func__, "syntax error in -%s: no number found: <%s>", option, optarg + 3);
-	    not_reached();
-	} else {
-	    cmp = calloc(1, sizeof *cmp);
-	    if (cmp == NULL) {
-		err(41, __func__, "failed to allocate struct jval_cmp_op *");
-		not_reached();
-	    }
-	    cmp->number = &(item->item.number);
-	    if (!CONVERTED_PARSED_JSON_NODE(cmp->number)) {
-		err(7, __func__, "failed to convert or parse number: <%s> for option -%s but number pointer not NULL!",/*ooo*/
-			optarg + 3, option);
-		not_reached();
-	    } else if (PARSED_JSON_NODE(cmp->number) && !CONVERTED_JSON_NODE(cmp->number)) {
-		err(7, __func__, "failed to convert number: <%s> for option -%s", optarg +3 , option); /*ooo*/
-		not_reached();
-	    }
-
-	    cmp->op = op;
-
-	    cmp->next = jnamval->num_cmp;
-	    jnamval->num_cmp = cmp;
-
-	    /* XXX - add function that prints out what compare operation - XXX */
-	    json_dbg(JSON_DBG_NONE, __func__, "number to compare: <%s>", cmp->number->as_str);
-	}
-    }
-
-    return cmp;
-}
-
 /* free_jnamval_cmp_op_lists - free the compare lists
  *
  * given:
@@ -1019,7 +876,7 @@ jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg)
 void
 free_jnamval_cmp_op_lists(struct jnamval *jnamval)
 {
-    struct jnamval_cmp_op *op, *next_op;
+    struct json_util_cmp_op *op, *next_op;
 
     /* firewall */
     if (jnamval == NULL) {
@@ -1028,7 +885,7 @@ free_jnamval_cmp_op_lists(struct jnamval *jnamval)
     }
 
     /* first the string compare list */
-    for (op = jnamval->string_cmp; op != NULL; op = next_op) {
+    for (op = jnamval->json_name_val.string_cmp; op != NULL; op = next_op) {
 	next_op = op->next;
 
 	/* XXX - free json node - XXX */
@@ -1038,7 +895,7 @@ free_jnamval_cmp_op_lists(struct jnamval *jnamval)
     }
 
     /* now the number compare list */
-    for (op = jnamval->num_cmp; op != NULL; op = next_op) {
+    for (op = jnamval->json_name_val.num_cmp; op != NULL; op = next_op) {
 	next_op = op->next;
 
 	/* XXX - free json node - XXX */

--- a/jparse/jnamval_util.h
+++ b/jparse/jnamval_util.h
@@ -82,50 +82,15 @@
 #define JNAMVAL_PRINT_JSON   (4)
 #define JNAMVAL_PRINT_BOTH   (JNAMVAL_PRINT_NAME | JNAMVAL_PRINT_VALUE)
 
-
-#define JNAMVAL_CMP_OP_NONE (0)
-#define JNAMVAL_CMP_EQ	    (1)
-#define JNAMVAL_CMP_LT	    (2)
-#define JNAMVAL_CMP_LE	    (3)
-#define JNAMVAL_CMP_GT	    (4)
-#define JNAMVAL_CMP_GE	    (5)
+/* -S and -n */
+#define JNAMVAL_CMP_OP_NONE JSON_UTIL_CMP_OP_NONE
+#define JNAMVAL_CMP_EQ	    JSON_UTIL_CMP_OP_EQ
+#define JNAMVAL_CMP_LT	    JSON_UTIL_CMP_OP_LT
+#define JNAMVAL_CMP_LE	    JSON_UTIL_CMP_OP_LE
+#define JNAMVAL_CMP_GT	    JSON_UTIL_CMP_OP_GT
+#define JNAMVAL_CMP_GE	    JSON_UTIL_CMP_OP_GE
 
 /* structs */
-
-/* structs for various options */
-
-/* for comparison of numbers / strings - options -n and -S */
-struct jnamval_cmp_op
-{
-    struct json_number *number;	    /* for -n as signed number */
-    struct json_string *string;	    /* for -S str */
-
-    bool is_string;	    /* true if -S */
-    bool is_number;	    /* true if -n */
-    uintmax_t op;	    /* the operation - see JNAMVAL_CMP macros above */
-
-    struct jnamval_cmp_op *next;    /* next in the list */
-};
-
-/* number ranges for the options -l, -n and -n */
-struct jnamval_number_range
-{
-    intmax_t min;   /* min in range */
-    intmax_t max;   /* max in range */
-
-    bool less_than_equal;	/* true if number type must be <= min */
-    bool greater_than_equal;	/* true if number type must be >= max */
-    bool inclusive;		/* true if number type must be >= min && <= max */
-};
-struct jnamval_number
-{
-    /* exact number if >= 0 */
-    intmax_t number;		/* exact number exact number (must be >= 0) */
-    bool exact;			/* true if an exact match (number) must be found */
-
-    /* for number ranges */
-    struct jnamval_number_range range;	/* for ranges */
-};
 
 /*
  * jnamval - struct that holds most of the options, other settings and other data
@@ -134,34 +99,17 @@ struct jnamval
 {
     struct json_util common;			/* common data related to tools: jfmt, jval, jnamval */
 
-    /* string related options */
-    bool encode_strings;			/* -e used */
-    bool quote_strings;				/* -Q used */
+    struct json_util_name_val json_name_val; /* common to jval and jnamval */
+
+    /* below are those not common to any other tools */
 
     /* printing related options */
     bool print_json_types_option;		/* -p explicitly used */
     uintmax_t print_json_types;			/* -p type specified */
-    bool print_decoded;				/* -D used */
-    bool invert_matches;			/* -i used */
-    bool count_only;				/* -c used, only show count */
-    bool count_and_show_values;			/* -C used, show count and values */
 
     /* search / matching related */
-    bool json_types_specified;			/* -t used */
-    uintmax_t json_types;			/* -t type */
-    bool ignore_case;				/* true if -f, case-insensitive */
-    bool match_decoded;				/* -d used - match decoded */
-    bool arg_specified;				/* true if an arg was specified */
-    bool match_substrings;			/* -s used, match substrings */
-    bool use_regexps;				/* -g used, allow grep-like regexps */
     bool match_json_member_names;		/* -N used, match based on member names */
     bool match_hierarchies;			/* -H used, name hierarchies */
-    uintmax_t total_matches;			/* for -c */
-
-    bool string_cmp_used;			/* for -S */
-    struct jnamval_cmp_op *string_cmp;		/* for -S str */
-    bool num_cmp_used;				/* for -n */
-    struct jnamval_cmp_op *num_cmp;			/* for -n num */
 };
 
 
@@ -192,9 +140,6 @@ bool jnamval_print_value(uintmax_t types);
 bool jnamval_print_both(uintmax_t types);
 bool jnamval_print_json(uintmax_t types);
 
-
-/* for -S and -n */
-struct jnamval_cmp_op *jnamval_parse_cmp_op(struct jnamval *jnamval, const char *option, char *optarg);
 
 /* functions to print matches */
 bool jnamval_print_count(struct jnamval *jnamval);

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -155,6 +155,7 @@ struct json_util
     bool is_stdin;				/* reading from stdin */
     FILE *json_file;				/* FILE * to json file */
     char *file_contents;			/* file contents */
+    char *json_file_path;			/* path to JSON file to read */
 
     /* out file related to -o */
     char *outfile_path;				/* -o file path */

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -7,7 +7,7 @@ terms** used in this document!
 
 There is a general lack of JSON aware command line tools that allows someone to
 obtain information from within a JSON document.  By "obtaining information" we
-refer to the ability to extract data, either as a whole, or in part, that
+refer to the ability to extract data, either as a whole, or in part, that is
 contained within a [JSON document](./json_README.md#json-document).
 
 There exists a multiple JSON APIs (Application Program Interfaces) for various
@@ -17,7 +17,8 @@ contains a rich JSON parser API C programs can use, as well as a semantic JSON
 check interface for C.  However all those APIs require the user to "program" in
 a specific language in order to do something as simple as obtain a selective
 [JSON values](./json_README.md#json-value) from a [JSON
-document](./json_README.md#json-document).
+document](./json_README.md#json-document). With these tools we attempt to
+address some of these missing capabilities.
 
 
 
@@ -35,7 +36,7 @@ considering utilities that either create or modify JSON.
 
 If a command line utility is given an **invalid JSON document**, the utility
 shall exit non-zero with an error message indicating that the [JSON
-document](./json_README.md#json-document) was not valid JSON.  Therefore we're
+document](./json_README.md#json-document) is not valid JSON.  Therefore we're
 only concerned with reading various information from an existing [JSON
 document](./json_README.md#json-document) that contains [Valid
 JSON](./json_README.md#valid-json).

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -310,8 +310,7 @@ main(int argc, char **argv)
     }
 
     /*
-     * Read in entire file BEFORE trying to parse it as json as the parser
-     * function will close the file if not stdin.
+     * Read in contents of file.
      *
      * NOTE: why doesn't the jval_sanity_chks() function do this? Because this
      * is not so much about a sane environment as much as being unable to
@@ -322,11 +321,9 @@ main(int argc, char **argv)
 	err(4, "jval", "could not read in file: %s", argv[0]); /*ooo*/
 	not_reached();
     }
-    /* clear EOF status and rewind for parse_json_stream() */
-    clearerr(jval->common.json_file);
-    rewind(jval->common.json_file);
 
-    jval->common.json_tree = parse_json_stream(jval->common.json_file, argv[0], &is_valid);
+    jval->common.json_tree = parse_json(jval->common.file_contents, strlen(jval->common.file_contents),
+	    jval->common.json_file_path, &is_valid);
     if (!is_valid || jval->common.json_tree == NULL) {
 	if (jval->common.json_file != stdin) {
 	    fclose(jval->common.json_file);  /* close file prior to exiting */
@@ -468,6 +465,12 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
 	not_reached();
     }
 
+    /* check that file path is not an empty string */
+    if (*(*argv)[0] == '\0') {
+	usage(3, program, "empty file path");/*ooo*/
+	not_reached();
+    }
+
     /* if argv[0] != "-" we will attempt to open a regular readable file */
     if (strcmp((*argv)[0], "-") != 0) {
 	/*
@@ -502,13 +505,15 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
 	}
 
 	errno = 0; /* pre-clear errno for errp() */
-	jval->common.json_file = fopen((*argv)[0], "r");
+	jval->common.json_file_path = (*argv)[0];
+	jval->common.json_file = fopen(jval->common.json_file_path, "r");
 	if (jval->common.json_file == NULL) {
 	    free_jval(&jval);
 	    errp(4, __func__, "%s: could not open for reading", (*argv)[0]); /*ooo*/
 	    not_reached();
 	}
     } else { /* argv[0] is "-": will read from stdin */
+	jval->common.json_file_path = "-";
 	jval->common.is_stdin = true;
 	jval->common.json_file = stdin;
     }

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.4 2023-07-25"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -48,6 +48,7 @@ alloc_jval(void)
     jval->common.is_stdin = false;			/* true if it's stdin */
     jval->common.file_contents = NULL;			/* file.json contents */
     jval->common.json_file = NULL;			/* JSON file * */
+    jval->common.json_file_path = NULL;			/* JSON file path */
 
     jval->common.outfile_path = NULL;			/* assume no -o used */
     jval->common.outfile = stdout;			/* default stdout */
@@ -58,7 +59,7 @@ alloc_jval(void)
     jval->json_name_val.quote_strings = false;		/* -Q used */
 
 
-    /* number range options, see struct jval_number_range in jval_util.h for details */
+    /* number range options, see struct json_util_number_range in json_util.h for details */
 
     /* -l - levels number range */
     jval->common.json_util_levels.number = 0;


### PR DESCRIPTION

New version of all three tools: 0.0.5 2023-07-26.

The tools can now work with:

    echo '"test"' | ./jfmt
    echo '"test"' | ./jval
    echo '"test"' | ./jnamval

and also:

    ./jfmt -
    ./jval -
    ./jnamval -

This uses parse_json() instead of parse_json_stream(). We already have
the contents of the stream so this is okay.

Add to json_util struct a char *, json_file_path, which is the file path
specified at the command line.

Check that file path is not empty.
