### PR TITLE
Update json_util_README.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.41 2023-07-27
+
+Update `json_util_README.md` document.
+
+Added missing exit code to `jval` tool. Updated version string to: "0.0.6
+2023-07-27".
+
+Sequenced exit codes.
+
+
 ## Release 1.0.41 2023-07-26
 
 New version of `jfmt`, `jval` and `jnamval`: "0.0.5 2023-07-26".

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -881,7 +881,7 @@ free_jnamval_cmp_op_lists(struct jnamval *jnamval)
 
     /* firewall */
     if (jnamval == NULL) {
-	err(42, __func__, "jnamval is NULL");
+	err(28, __func__, "jnamval is NULL");
 	not_reached();
     }
 

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -121,6 +121,7 @@ static const char * const usage_msg0 =
     "    5\tfile contents is not valid JSON\n"
     "    6\ttest mode failed\n"
     "    7\tunable to represent a number\n"
+    "    8\tno matches found\n"
     " >=10\tinternal error\n"
     "\n"
     "JSON parser version: %s\n"

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.6 2023-07-27"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -565,7 +565,7 @@ free_jval_cmp_op_lists(struct jval *jval)
 
     /* firewall */
     if (jval == NULL) {
-	err(41, __func__, "jval is NULL");
+	err(27, __func__, "jval is NULL");
 	not_reached();
     }
 

--- a/jparse/man/man1/jfmt.1
+++ b/jparse/man/man1/jfmt.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jfmt 1 "19 July 2023" "jfmt" "IOCCC tools"
+.TH jfmt 1 "27 July 2023" "jfmt" "IOCCC tools"
 .SH NAME
 .B jfmt
 \- IOCCC JSON printer
@@ -83,7 +83,7 @@ Suppress some of the output (def: show more information).
 Print the JSON levels followed by the number of spaces or tabs, depending on the letter specified,
 .BR T
 for tabs and
-.BR S 
+.BR S
 for spaces.
 Not specifying either defaults to spaces.
 As a convenience, specifying
@@ -96,7 +96,7 @@ is an alias for
 Indent the JSON levels by the number of spaces or tabs, depending on the letter specified,
 .BR T
 for tabs and
-.BR S 
+.BR S
 for spaces.
 Not specifying either defaults to spaces.
 As a convenience, specifying
@@ -189,8 +189,9 @@ We don't recommend you check the GitHub issue page! :\-)
 This is because it's incredibly long with a lot of OT things and would take even the fastest readers a very long time to read. :\-(
 .PP
 .SH BUGS
-.PP
 It is currently incomplete and listing the missing features and things that are not correct is not worth the time or effort.
+.PP
+It's important to note that one should not rely on the exact output of this tool and that future versions might change the way JSON is formatted.
 .SH EXAMPLES
 .PP
 Pretty print a JSON file

--- a/jparse/test_jparse/test_JSON/good/top_level_array2.json
+++ b/jparse/test_jparse/test_JSON/good/top_level_array2.json
@@ -1,0 +1,1 @@
+["string",42,3.1415,6.02214076e23,{"member_name":"member_value"},["str",31,2.718,2.99792458e8,{"mname":21701},[0,1,2,3,false,true,null,{"hair":"red"}],false,true,null]]

--- a/jparse/todo.md
+++ b/jparse/todo.md
@@ -1,0 +1,9 @@
+We have this todo list for the JSON tools `jfmt`, `jval` and `jnamval` as a way
+to make it easier for everyone to update the list. Once everything is done this
+file can be removed. We will try and not duplicate entries but it's entirely
+possible that there will be duplicates.
+
+Last updated: *Thu Jul 27 10:58:02 UTC 2023*
+
+* Add to `jval(1)` the **IMPORTANT NOTE** about JSON levels discussed in the
+[json_util_README.md](./json_util_README.md) document.


### PR DESCRIPTION
Fix header formatting for the three tools.

Some typos were fixed.

Add to common exit codes codes that are in all tools.

Add to common options options that are in all tools.

Added missing exit code to jval.c: no matches was missing.

Added a json file that is mentioned in the json_util_README.md document for jfmt but with a minor change which was also updated in the json_util_README.md document as well. The change was changing 'one_tooth' with a value of 'ree' to 'hair' with the value of 'red'. This is because 'ree' is not a word and I have a weakness for redheads and besides that it sounds better than "one_tooth":"red" :-)

Sequenced exit codes.

I have not finished the json_util_README.md document for jval and I've not finished it for jnamval either. That might come later today or might not be until tomorrow and possibly the next day but at the latest it should be finished by the end of the week (where Sunday is the last day of the week: real weeks start with Monday :-) ).