### PR TITLE
Minor fixes and enhancements to jfmt/jval/jnamval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,39 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.42 2023-07-28
+
+New versions of `jfmt`, `jval` and `jnamval` with some minor bug fixes and
+enhancements: `"0.0.6 2023-07-28"`, `"0.0.7 2023-07-28"` and `"0.0.6
+2023-07-28"`.
+
+Fixed bug where redirecting stdout to `/dev/null` resulted in an error:
+
+```
+Warning: vfpr: called from jfmt: vfprintf returned: 56 <= 0: errno[25]: Inappropriate ioctl for device
+```
+
+For `jval` and `jnamval` the functions `parse_jval_args()` and
+`parse_jnamval_args()` have been updated to take the proper struct, a pointer to
+`argc` from `main()` and a pointer to `argv` from `main()`. That is a `int *`
+and a `char ***`. The functions increment `argc`/`argv` past the file name so
+that `main()` can check if there are any args without having to worry about
+`argv[0]`. The function (not `main()` - the parsing ones) now show debug
+information about the args shown. Currently the debug level is 0 so that it's
+always printed but this will change later on. As there is no implementation yet
+(but see below) there is no list or array or searching of any kind with the
+args.
+
+Since the ability to check if any args is now easy and since `-i` flag with no
+args specified means that there are no matches and that indicates exiting 8
+`jval` and `jnamval` now have this check. That is the extent of any
+implementation details until we have discussed output, how `jfmt` should format
+code, search routines are added and numerous other things. This was just an
+aside, one might say.
+
+Update `jval(1)` man page - add exit code 8 to list of exit codes.
+
+
 ## Release 1.0.41 2023-07-27
 
 Update `json_util_README.md` document.

--- a/jparse/jfmt.c
+++ b/jparse/jfmt.c
@@ -308,7 +308,7 @@ main(int argc, char **argv)
     }
 
     /* XXX - change this to format the file - XXX */
-    fpr(jfmt->common.outfile?jfmt->common.outfile:stdout, "jfmt", "%s", jfmt->common.file_contents);
+    fprintf(jfmt->common.outfile?jfmt->common.outfile:stdout, "%s", jfmt->common.file_contents);
 
     /* free tree */
     json_tree_free(jfmt->common.json_tree, jfmt->common.max_depth);
@@ -448,6 +448,8 @@ jfmt_sanity_chks(struct jfmt *jfmt, char const *program, int *argc, char ***argv
     dbg(DBG_LOW, "maximum depth to traverse: %ju%s", jfmt->common.max_depth, (jfmt->common.max_depth == 0?" (no limit)":
 		jfmt->common.max_depth==JSON_DEFAULT_MAX_DEPTH?" (default)":""));
 
+
+    /* XXX - should it be an error if any more args are specified ? - XXX */
 
     /* all good: return the (presumably) json FILE * */
     return jfmt->common.json_file;

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.6 2023-07-28"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -395,13 +395,21 @@ main(int argc, char **argv)
 	 * this moment and at least we can test the option - XXX
 	 */
 	jnamval_print_count(jnamval);
-	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%s", jnamval->common.file_contents);
+	fprintf(jnamval->common.outfile?jnamval->common.outfile:stdout, "%s", jnamval->common.file_contents);
     } else {
-	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%s", jnamval->common.file_contents);
+	fprintf(jnamval->common.outfile?jnamval->common.outfile:stdout, "%s", jnamval->common.file_contents);
     }
 
     /* free tree */
     json_tree_free(jnamval->common.json_tree, jnamval->common.max_depth);
+
+    /*
+     * if no match was requested and inversion was requested we exit with no
+     * matches found
+     */
+    if (argv[0] == NULL && jnamval->json_name_val.invert_matches) {
+	exit_code = 8;
+    }
 
     if (jnamval != NULL) {
 	free_jnamval(&jnamval);	/* free jnamval struct */
@@ -580,11 +588,8 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
 	}
     }
     /*
-     * parse args first
-     *
-     * XXX - implement this function if necessary
-     */
-    parse_jnamval_args(jnamval, *argv);
+     * parse args first */
+    parse_jnamval_args(jnamval, argc, argv);
 
     /* all good: return the (presumably) json FILE * */
     return jnamval->common.json_file;

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.5 2023-07-26"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.6 2023-07-28"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -839,13 +839,14 @@ jnamval_print_count(struct jnamval *jnamval)
  * given:
  *
  *	jnamval	    - pointer to our struct jnamval
- *	argv	    - argv from main()
+ *	argc	    - pointer to argc from main() (int *)
+ *	argv	    - pointer to argv from main() (char ***)
  *
  * This function will not return on NULL pointers.
  *
  */
 void
-parse_jnamval_args(struct jnamval *jnamval, char **argv)
+parse_jnamval_args(struct jnamval *jnamval, int *argc, char ***argv)
 {
     int i;  /* to iterate through argv */
 
@@ -854,14 +855,30 @@ parse_jnamval_args(struct jnamval *jnamval, char **argv)
 	err(26, __func__, "jnamval is NULL");
 	not_reached();
     }
+    if (argc == NULL) {
+	err(27, __func__, "argc is NULL");
+	not_reached();
+    }
     if (argv == NULL) {
-	err(27, __func__, "argv is NULL");
+	err(28, __func__, "argv is NULL");
 	not_reached();
     }
 
-    for (i = 1; argv[i] != NULL; ++i) {
-	/* XXX - go through argv and add args to a list - XXX */
+    /* skip past file name */
+    (*argc)++;
+    (*argv)++;
+
+    for (i = 0; (*argv)[i] != NULL; ++i) {
+	json_dbg(JSON_DBG_NONE, __func__, "arg[%d]: %s", i, (*argv)[i]);
+	/* XXX - do we increment argc and argv? On the one hand this might seem
+	 * logical but on the other if we keep argc and argv as it is (past the
+	 * file name) then main() can check if any args are present. Now it
+	 * might be that later on we will have a list or array of some kind but
+	 * currently this is not the case so we don't update argc or argv past
+	 * the file name.
+	 */
     }
+
 }
 
 /* free_jnamval_cmp_op_lists - free the compare lists
@@ -881,7 +898,7 @@ free_jnamval_cmp_op_lists(struct jnamval *jnamval)
 
     /* firewall */
     if (jnamval == NULL) {
-	err(28, __func__, "jnamval is NULL");
+	err(29, __func__, "jnamval is NULL");
 	not_reached();
     }
 

--- a/jparse/jnamval_util.h
+++ b/jparse/jnamval_util.h
@@ -144,11 +144,8 @@ bool jnamval_print_json(uintmax_t types);
 /* functions to print matches */
 bool jnamval_print_count(struct jnamval *jnamval);
 
-/*
- * XXX - currently does nothing functionally - might or might not be needed to
- * process argv - XXX
- */
-void parse_jnamval_args(struct jnamval *jnamval, char **argv);
+/* process argv */
+void parse_jnamval_args(struct jnamval *jnamval, int *argc, char ***argv);
 
 /* free compare lists */
 void free_jnamval_cmp_op_lists(struct jnamval *jnamval);

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -509,10 +509,10 @@ The `jval` command, without any "`args`" on the command line, will cause the
 printing of any [JSON values](./json_README.md#json-value) that are not
 otherwise restricted by a `-t type` or `-l lvl` option.
 
-The presence of "`args`" creates match conditions that may further restrict
-which [JSON values](./json_README.md#json-value) are printed.  When using the
-`jval` command with "`args`", match criteria is setup to further select which
-[JSON values](./json_README.md#json-value) are printed.
+The presence of "`args`" creates match conditions that can restrict which [JSON
+values](./json_README.md#json-value) are printed.  When using the `jval` command
+with "`args`", a match criteria is setup to further select which [JSON
+values](./json_README.md#json-value) are printed.
 
 
 #### jval command line options
@@ -571,7 +571,7 @@ JSON document.
 Because of the complexity of trying to describe a complex JSON value on
 the command line, let alone the problem of describing complex value ranges,
 the `-t type` does **NOT** include complex JSON types. For that see the
-`jnamval(1)` utility, discussed later in this document.
+`jnamval` utility, discussed later in this document.
 
 If no "`arg`" is given on the command line then any value can be considered
 unless `-i` inverts the match in which case no value is to be considered.

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -363,13 +363,21 @@ main(int argc, char **argv)
 	 * this moment and at least we can test the option - XXX
 	 */
 	jval_print_count(jval);
-	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%s", jval->common.file_contents);
+	fprintf(jval->common.outfile?jval->common.outfile:stdout, "%s", jval->common.file_contents);
     } else {
-	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%s", jval->common.file_contents);
+	fprintf(jval->common.outfile?jval->common.outfile:stdout, "%s", jval->common.file_contents);
     }
 
     /* free tree */
     json_tree_free(jval->common.json_tree, jval->common.max_depth);
+
+    /*
+     * if no match was requested and inversion was requested we exit with no
+     * matches found
+     */
+    if (argv[0] == NULL && jval->json_name_val.invert_matches) {
+	exit_code = 8;
+    }
 
     if (jval != NULL) {
 	free_jval(&jval);	/* free jval struct */
@@ -544,10 +552,8 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
     }
     /*
      * parse args first
-     *
-     * XXX - implement this function if necessary
      */
-    parse_jval_args(jval, *argv);
+    parse_jval_args(jval, argc, argv);
 
     /* all good: return the (presumably) json FILE * */
     return jval->common.json_file;

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.6 2023-07-27"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.7 2023-07-28"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -523,13 +523,14 @@ jval_print_count(struct jval *jval)
  * given:
  *
  *	jval	    - pointer to our struct jval
- *	argv	    - argv from main()
+ *	argc	    - pointer to argc from main() (int *)
+ *	argv	    - pointer to argv from main() (char ***)
  *
  * This function will not return on NULL pointers.
  *
  */
 void
-parse_jval_args(struct jval *jval, char **argv)
+parse_jval_args(struct jval *jval, int *argc, char ***argv)
 {
     int i;  /* to iterate through argv */
 
@@ -538,13 +539,28 @@ parse_jval_args(struct jval *jval, char **argv)
 	err(25, __func__, "jval is NULL");
 	not_reached();
     }
+    if (argc == NULL) {
+	err(26, __func__, "argc is NULL");
+	not_reached();
+    }
     if (argv == NULL) {
-	err(26, __func__, "argv is NULL");
+	err(27, __func__, "argv is NULL");
 	not_reached();
     }
 
-    for (i = 1; argv[i] != NULL; ++i) {
-	/* XXX - go through argv and add args to a list - XXX */
+    /* skip past file name */
+    (*argc)++;
+    (*argv)++;
+
+    for (i = 0; (*argv)[i] != NULL; ++i) {
+	json_dbg(JSON_DBG_NONE, __func__, "arg[%d]: %s", i, (*argv)[i]);
+	/* XXX - do we increment argc and argv? On the one hand this might seem
+	 * logical but on the other if we keep argc and argv as it is (past the
+	 * file name) then main() can check if any args are present. Now it
+	 * might be that later on we will have a list or array of some kind but
+	 * currently this is not the case so we don't update argc or argv past
+	 * the file name.
+	 */
     }
 }
 
@@ -565,7 +581,7 @@ free_jval_cmp_op_lists(struct jval *jval)
 
     /* firewall */
     if (jval == NULL) {
-	err(27, __func__, "jval is NULL");
+	err(28, __func__, "jval is NULL");
 	not_reached();
     }
 

--- a/jparse/jval_util.h
+++ b/jparse/jval_util.h
@@ -116,7 +116,7 @@ bool jval_print_count(struct jval *jval);
  * XXX - currently does nothing functionally - might or might not be needed to
  * process argv - XXX
  */
-void parse_jval_args(struct jval *jnamval, char **argv);
+void parse_jval_args(struct jval *jnamval, int *argc, char ***argv);
 
 void free_jval_cmp_op_lists(struct jval *jval);
 /* to free the entire struct jval */

--- a/jparse/man/man1/jval.1
+++ b/jparse/man/man1/jval.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jval 1 "21 July 2023" "jval" "IOCCC tools"
+.TH jval 1 "28 July 2023" "jval" "IOCCC tools"
 .SH NAME
 .B jval
 \- IOCCC JSON printer
@@ -326,6 +326,9 @@ test mode failed
 .TQ
 7
 unable to represent a number
+.TQ
+8
+no matches found
 .TQ
 >=10
 internal error


### PR DESCRIPTION
New versions of jfmt, jval and jnamval with some minor bug fixes and enhancements: 0.0.6 2023-07-28, 0.0.7 2023-07-28 and 0.0.6 2023-07-28.

Fixed bug where redirecting stdout to /dev/null resulted in an error:

    Warning: vfpr: called from jfmt: vfprintf returned: 56 <= 0: errno[25]: Inappropriate ioctl for device

For jval and jnamval the functions parse_jval_args() and parse_jnamval_args() have been updated to take the proper struct, a pointer to argc from main() and a pointer to argv from main(). That is a int * and a char ***. The functions increment argc/argv past the file name so that main() can check if there are any args without having to worry about argv[0]. The function (not main() - the parsing ones) now show debug information about the args shown. Currently the debug level is 0 so that it's always printed but this will change later on. As there is no implementation yet (but see below) there is no list or array or searching of any kind with the args.

Since the ability to check if any args is now easy and since -i flag with no args specified means that there are no matches and that indicates exiting 8 jval and jnamval now have this check. That is the extent of any implementation details until we have discussed output, how jfmt should format code, search routines are added and numerous other things. This was just an aside, one might say.

Update jval(1) man page - add exit code 8 to list of exit codes.