### PR TITLE
Add print_test to make test in jparse/test_jparse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ All "print function call"s are now followed by a call to
 `chk_stdio_printf_err()` to properly detect if there was a
 failure in the "print function call".
 
+Add `print_test` execution to `make test` in `jparse/test_jparse/Makefile`.
+
 New versions of `jfmt`, `jval` and `jnamval` with some minor bug fixes and
 enhancements: `"0.0.6 2023-07-28"`, `"0.0.7 2023-07-28"` and `"0.0.6
 2023-07-28"`.

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -406,6 +406,22 @@ test:
 	    fi; \
 	fi
 	${S} echo
+	${Q} if [[ ! -x ./print_test ]]; then \
+	    echo "${OUR_NAME}: ERROR: executable not found: ./print_test" 1>&2; \
+	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
+	    exit 1; \
+	else \
+	    echo "./print_test"; \
+	    ./print_test; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: print_test failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo ${OUR_NAME}: "PASSED: print_test"; \
+	    fi; \
+	fi
+	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes


### PR DESCRIPTION
With this commit the test_jparse/Makefile now runs test_jparse/print_test as per the suggestion on GitHub. It does NOT redirect stdout or stderr to /dev/null so extra output will now be shown in make release/make prep/make test.