### PR TITLE
fprintf() -> fpr() in jval and jnamval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ All "print function call"s are now followed by a call to
 `chk_stdio_printf_err()` to properly detect if there was a
 failure in the "print function call".
 
+Add `print_test` execution to `make test` in `jparse/test_jparse/Makefile`.
+
 New versions of `jfmt`, `jval` and `jnamval` with some minor bug fixes and
 enhancements: `"0.0.6 2023-07-28"`, `"0.0.7 2023-07-28"` and `"0.0.6
 2023-07-28"`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,10 +51,8 @@ implementation details until we have discussed output, how `jfmt` should format
 code, search routines are added and numerous other things. This was just an
 aside, one might say.
 
-For `jval` and `jnamval` use of `-c` or `-C` without an arg is considered an
-error and this is in the sanity check function of each tool. Added `XXX` comment
-to the print count function of each tool that points out that currently the
-count is not correct. This will be removed in time.
+Added `XXX` comment to the print count function of each tool that points out
+that currently the count is not correct. This will be removed in time.
 
 Update `jval(1)` man page - add exit code 8 to list of exit codes.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,5 @@
 # Major changes to the IOCCC entry toolkit
 
-
 ## Release 1.0.42 2023-07-29
 
 Add `jparse/test_jparse/print_test` test tool to test if various
@@ -26,8 +25,13 @@ failure in the "print function call".
 Add `print_test` execution to `make test` in `jparse/test_jparse/Makefile`.
 
 New versions of `jfmt`, `jval` and `jnamval` with some minor bug fixes and
-enhancements: `"0.0.6 2023-07-28"`, `"0.0.7 2023-07-28"` and `"0.0.6
-2023-07-28"`.
+enhancements: `"0.0.8 2023-07-29"`, `"0.0.8 2023-07-29"` and `"0.0.8
+2023-07-29"`. The version change synchronises the version number to keep track
+of the versions since the date was the same. This does mean that the version for
+both `jfmt` and `jnamval` jumped from 0.0.6 to 0.0.8 but this seems like a
+worthy compromise to keep things together especially as the documented change
+for the version update that technically took place on 28 July 2023 was or if it
+was is no longer documented.
 
 For `jval` and `jnamval` the functions `parse_jval_args()` and
 `parse_jnamval_args()` have been updated to take the proper struct, a pointer to
@@ -46,6 +50,11 @@ args specified means that there are no matches and that indicates exiting 8
 implementation details until we have discussed output, how `jfmt` should format
 code, search routines are added and numerous other things. This was just an
 aside, one might say.
+
+For `jval` and `jnamval` use of `-c` or `-C` without an arg is considered an
+error and this is in the sanity check function of each tool. Added `XXX` comment
+to the print count function of each tool that points out that currently the
+count is not correct. This will be removed in time.
 
 Update `jval(1)` man page - add exit code 8 to list of exit codes.
 

--- a/jparse/jfmt.c
+++ b/jparse/jfmt.c
@@ -308,7 +308,7 @@ main(int argc, char **argv)
     }
 
     /* XXX - change this to format the file - XXX */
-    fprintf(jfmt->common.outfile?jfmt->common.outfile:stdout, "%s", jfmt->common.file_contents);
+    fpr(jfmt->common.outfile?jfmt->common.outfile:stdout, "jfmt", "%s", jfmt->common.file_contents);
 
     /* free tree */
     json_tree_free(jfmt->common.json_tree, jfmt->common.max_depth);

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.6 2023-07-28"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -591,17 +591,6 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
      * parse args first */
     parse_jnamval_args(jnamval, argc, argv);
 
-    /*
-     * final checks that rely on argc and argv being shifted in
-     * parse_jnamval_args()
-     */
-
-    /* use of -c or -C without an arg is an error */
-    if ((jnamval->json_name_val.count_only || jnamval->json_name_val.count_and_show_values) && (*argv)[0] == NULL) {
-	err(3, __func__, "use of -c or -C without an arg is an error");/*ooo*/
-	not_reached();
-    }
-
 
     /* all good: return the (presumably) json FILE * */
     return jnamval->common.json_file;

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -395,9 +395,9 @@ main(int argc, char **argv)
 	 * this moment and at least we can test the option - XXX
 	 */
 	jnamval_print_count(jnamval);
-	fprintf(jnamval->common.outfile?jnamval->common.outfile:stdout, "%s", jnamval->common.file_contents);
+	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%s", jnamval->common.file_contents);
     } else {
-	fprintf(jnamval->common.outfile?jnamval->common.outfile:stdout, "%s", jnamval->common.file_contents);
+	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%s", jnamval->common.file_contents);
     }
 
     /* free tree */
@@ -590,6 +590,18 @@ jnamval_sanity_chks(struct jnamval *jnamval, char const *program, int *argc, cha
     /*
      * parse args first */
     parse_jnamval_args(jnamval, argc, argv);
+
+    /*
+     * final checks that rely on argc and argv being shifted in
+     * parse_jnamval_args()
+     */
+
+    /* use of -c or -C without an arg is an error */
+    if ((jnamval->json_name_val.count_only || jnamval->json_name_val.count_and_show_values) && (*argv)[0] == NULL) {
+	err(3, __func__, "use of -c or -C without an arg is an error");/*ooo*/
+	not_reached();
+    }
+
 
     /* all good: return the (presumably) json FILE * */
     return jnamval->common.json_file;

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.6 2023-07-28"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -827,6 +827,8 @@ jnamval_print_count(struct jnamval *jnamval)
     }
 
     if (jnamval->json_name_val.count_only || jnamval->json_name_val.count_and_show_values) {
+	/* XXX - the next line will be removed when -c and -C are done - XXX */
+	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "XXX - the count is currently incorrect - XXX\n");
 	fpr(jnamval->common.outfile?jnamval->common.outfile:stdout, "jnamval", "%ju\n", jnamval->json_name_val.total_matches);
 	return true;
     }

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -363,9 +363,9 @@ main(int argc, char **argv)
 	 * this moment and at least we can test the option - XXX
 	 */
 	jval_print_count(jval);
-	fprintf(jval->common.outfile?jval->common.outfile:stdout, "%s", jval->common.file_contents);
+	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%s", jval->common.file_contents);
     } else {
-	fprintf(jval->common.outfile?jval->common.outfile:stdout, "%s", jval->common.file_contents);
+	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%s", jval->common.file_contents);
     }
 
     /* free tree */
@@ -554,6 +554,17 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
      * parse args first
      */
     parse_jval_args(jval, argc, argv);
+
+    /*
+     * final checks that rely on argc and argv being shifted in
+     * parse_jval_args()
+     */
+
+    /* use of -c or -C without an arg is an error */
+    if ((jval->json_name_val.count_only || jval->json_name_val.count_and_show_values) && (*argv)[0] == NULL) {
+	err(3, __func__, "use of -c or -C without an arg is an error");/*ooo*/
+	not_reached();
+    }
 
     /* all good: return the (presumably) json FILE * */
     return jval->common.json_file;

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -555,17 +555,6 @@ jval_sanity_chks(struct jval *jval, char const *program, int *argc, char ***argv
      */
     parse_jval_args(jval, argc, argv);
 
-    /*
-     * final checks that rely on argc and argv being shifted in
-     * parse_jval_args()
-     */
-
-    /* use of -c or -C without an arg is an error */
-    if ((jval->json_name_val.count_only || jval->json_name_val.count_and_show_values) && (*argv)[0] == NULL) {
-	err(3, __func__, "use of -c or -C without an arg is an error");/*ooo*/
-	not_reached();
-    }
-
     /* all good: return the (presumably) json FILE * */
     return jval->common.json_file;
 }

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.7 2023-07-28"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -511,6 +511,8 @@ jval_print_count(struct jval *jval)
     }
 
     if (jval->json_name_val.count_only || jval->json_name_val.count_and_show_values) {
+	/* XXX - the next line will be removed when -c and -C are done - XXX */
+	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "XXX - the count is currently incorrect - XXX\n");
 	fpr(jval->common.outfile?jval->common.outfile:stdout, "jval", "%ju\n", jval->json_name_val.total_matches);
 	return true;
     }

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -406,6 +406,22 @@ test:
 	    fi; \
 	fi
 	${S} echo
+	${Q} if [[ ! -x ./print_test ]]; then \
+	    echo "${OUR_NAME}: ERROR: executable not found: ./print_test" 1>&2; \
+	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
+	    exit 1; \
+	else \
+	    echo "./print_test"; \
+	    ./print_test; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: print_test failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo ${OUR_NAME}: "PASSED: print_test"; \
+	    fi; \
+	fi
+	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes


### PR DESCRIPTION

In jfmt, jval and jnamval when printing the file contents (which is done
in temporary way) use fpr() not fprintf() now that the tty issue is
resolved.

If jval -c/-C or jnamval -c/-C is used without an arg is a command line
error.  This is done in the sanity check function of each tool.
