### PR TITLE
Add -F format to jfmt, jval and jnamval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.44 2023-07-31
+
+Add `-F format` option to to `jfmt`, `jval` and `jnamval`. New version for tools
+`"0.0.9 2023-07-31"`. `color` is aliased to `colour`. Other options are
+`default` and `pedantic`. Debug output (with `DBG_NONE` which has to change -
+later on) is added based on the optarg. This option has NOT been added to the
+man pages. That will come later either later today or another day.
+
+Add missing setting of variables in `alloc_jnamval()`.
+
+
 ## Release 1.0.43 2023-07-30
 
 Improve, typo fix and bug fix `jparse/test_jparse/print_test.c`. Now checks the

--- a/jparse/jfmt.c
+++ b/jparse/jfmt.c
@@ -41,7 +41,7 @@ static bool quiet = false;				/* true ==> quiet mode */
  */
 static const char * const usage_msg0 =
     "usage:\t%s [-h] [-V] [-v level] [-J level] [-q] [-L <num>{[t|s]}] [-I <num>{[t|s]}]\n"
-    "\t[-l lvl] [-m depth] [-K] [-o ofile] file.json\n"
+    "\t[-l lvl] [-m depth] [-K] [-o ofile] [-F fmt] file.json\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
@@ -75,6 +75,12 @@ static const char * const usage_msg0 =
     "\t-K\t\tRun test mode\n"
     "\n"
     "\t-o ofile\tOutput formatted JSON to ofile (def: stdout, same as '-')\n"
+    "\n"
+    "\t-F format\tChange the JSON format style (def: use default)\n\n"
+    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
+    "\t\t\tpedantic\tOne level per lines style\n"
+    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour\n"
     "\n"
     "\tfile.json\tJSON file to parse (- ==> read from stdin)\n"
     "\n"
@@ -166,7 +172,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:qL:I:l:m:Ko:")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:qL:I:l:m:Ko:F:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jfmt(&jfmt);
@@ -229,6 +235,14 @@ main(int argc, char **argv)
 		jfmt->common.outfile_not_stdout = true;
 	    }
 	    jfmt->common.outfile_path = optarg;
+	    break;
+	case 'F':
+	    /*
+	     * setting the common.format and common.format_output_changed is redundant
+	     * but we do it anyway
+	     */
+	    jfmt->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jfmt->common.format = parse_json_util_format(&jfmt->common, "jfmt", optarg);
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.9 2023-07-31"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jfmt_util.c
+++ b/jparse/jfmt_util.c
@@ -73,6 +73,10 @@ alloc_jfmt(void)
     jfmt->common.indent_spaces = 4;				/* -I number of tabs or spaces */
     jfmt->common.indent_tab = false;				/* -I <num>[{t|s}] specified */
 
+    /* for -F format output option */
+    jfmt->common.format_output_changed = false;			/* -F format used */
+    jfmt->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
+
     /* parsing related */
     jfmt->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
 

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -42,7 +42,7 @@ static bool quiet = false;				/* true ==> quiet mode */
 static const char * const usage_msg0 =
     "usage:\t%s [-h] [-V] [-v level] [-J level] [-q] [-L <num>{[t|s]}] [-t type] [-l lvl]\n"
     "\t[-Q] [-D] [-d] [-i] [-s] [-f] [-c] [-C] [-g] [-e] [-n op=num] [-S op=str] [-o ofile]\n"
-    "\t[-p parts] [-N] [-H] [-m max_depth] [-K] file.json [arg ...]\n"
+    "\t[-p parts] [-N] [-H] [-m max_depth] [-K] [-F fmt] file.json [arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
@@ -130,6 +130,12 @@ static const char * const usage_msg1 =
     "\n"
     "\t-K\t\tRun tests on jnamval constraints\n"
     "\n"
+    "\t-F format\tChange the JSON format style (def: use default)\n\n"
+    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
+    "\t\t\tpedantic\tOne level per lines style\n"
+    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour\n"
+    "\n"
     "\tfile.json\tJSON file to parse (- ==> read from stdin)\n"
     "\targ\t\tmatch arg(s)\n"
     "\n"
@@ -180,7 +186,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:qL:t:l:QDdisfcCgen:S:o:m:Kp:NH")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:qL:t:l:QDdisfcCgen:S:o:m:Kp:NHF:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jnamval(&jnamval);
@@ -306,6 +312,14 @@ main(int argc, char **argv)
 	case 'H':
 	    jnamval->match_hierarchies = true;
 	    jnamval->match_json_member_names = true; /* -H implies -N */
+	    break;
+	case 'F':
+	    /*
+	     * setting the common.format and common.format_output_changed is redundant
+	     * but we do it anyway
+	     */
+	    jnamval->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jnamval->common.format = parse_json_util_format(&jnamval->common, "jnamval", optarg);
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.9 2023-07-31"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -72,12 +72,16 @@ alloc_jnamval(void)
     jnamval->common.levels_constrained = false;
 
     /* print related options */
+    jnamval->common.print_json_levels = false;			/* -L specified */
+    jnamval->common.num_level_spaces = 4;			/* number of spaces or tab for -L */
+    jnamval->common.print_level_tab = false;			/* -L tab option */
+    jnamval->common.indent_levels = false;			/* -I used */
+    jnamval->common.indent_spaces = 4;				/* -I number of tabs or spaces */
+    jnamval->common.indent_tab = false;				/* -I <num>[{t|s}] specified */
     jnamval->print_json_types_option = false;		/* -p explicitly used */
     jnamval->print_json_types = JNAMVAL_PRINT_VALUE;	/* -p type specified */
     jnamval->json_name_val.print_decoded = false;			/* -D not used if false */
-    jnamval->common.print_json_levels = false;			/* -L specified */
-    jnamval->common.num_level_spaces = 0;				/* number of spaces or tab for -L */
-    jnamval->common.print_level_tab = false;			/* -L tab option */
+
     jnamval->json_name_val.invert_matches = false;			/* -i used */
     jnamval->json_name_val.count_only = false;				/* -c used, only show count */
     jnamval->json_name_val.count_and_show_values = false;		/* -C used, count and show values */
@@ -95,6 +99,7 @@ alloc_jnamval(void)
     jnamval->match_hierarchies = false;			/* -H used, match any JSON member name */
 
 
+
     /* comparison options -S and -n */
 
     /* -S op=string */
@@ -110,6 +115,10 @@ alloc_jnamval(void)
 
     /* matches for -c / -C - subject to change */
     jnamval->json_name_val.total_matches = 0;
+
+    /* for -F format output option */
+    jnamval->common.format_output_changed = false;			/* -F format used */
+    jnamval->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
 
     return jnamval;
 }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -2844,4 +2844,58 @@ json_util_parse_cmp_op(struct json_util_name_val *json_name_val, const char *opt
     return cmp;
 }
 
+/* parse_json_util_format - parse -F format option of jfmt, jval and jnamval
+ *
+ * given:
+ *
+ *	json_util	- pointer to struct json_util in the struct jfmt, jval
+ *			  and jnamval
+ *	name		- name of tool
+ *	optarg		- option arg to parse
+ *
+ * This function will not return on NULL pointer.
+ *
+ * This function returns an enum output_format which is also given in the struct
+ * json_util json_util in the struct of the tool used.
+ */
+enum output_format
+parse_json_util_format(struct json_util *json_util, char const *name, char const *optarg)
+{
+    enum output_format format = JSON_FMT_DEFAULT;
+
+    /* firewall */
+
+    /* name MUST be checked first! */
+    if (name == NULL) {
+	err(3, __func__, "name is NULL");
+	not_reached();
+    }
+    if (json_util == NULL) {
+	err(3, name?name:__func__, "json_util is NULL");
+	not_reached();
+    }
+
+    if (optarg == NULL || *optarg == '\0') {
+	err(3, name?name:__func__, "optarg is NULL or empty");/*ooo*/
+	not_reached();
+    }
+
+    json_util->format_output_changed = true;	    /* set the boolean to true */
+
+    if (!strcmp(optarg, "default")) {
+	format = json_util->format = JSON_FMT_DEFAULT;
+	dbg(DBG_NONE, "%s output format", optarg);
+    } else if (!strcmp(optarg, "pedantic")) {
+	format = json_util->format = JSON_FMT_PEDANTIC;
+	dbg(DBG_NONE, "%s output format", optarg);
+    } else if (!strcmp(optarg, "colour") || !strcmp(optarg, "color")) {
+	format = json_util->format = JSON_FMT_COLOUR;
+	dbg(DBG_NONE, "%sed output format", optarg);
+    } else {
+	err(3, name?name:__func__, "invalid format type used for -F: %s", optarg); /*ooo*/
+	not_reached();
+    }
+
+    return format;
+}
 

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -73,6 +73,15 @@
 #define JSON_UTIL_CMP_GT	    (4)
 #define JSON_UTIL_CMP_GE	    (5)
 
+/* for -F with jfmt, jval and jnamval */
+enum output_format {
+    JSON_FMT_DEFAULT = 0,
+    JSON_FMT_PEDANTIC = 1,
+    JSON_FMT_COLOUR = 2
+};
+#define JSON_UTIL_FMT_DEFAULT	    (0)
+#define	JSON_UTIL_FMT_PEDANTIC	    (1)
+#define JSON_UTIL_FMT_COLOUR	    (2)
 
 /* structures */
 
@@ -174,6 +183,8 @@ struct json_util
     uintmax_t indent_spaces;			/* -I specified */
     bool indent_tab;				/* -I <num>[{t|s}] specified */
 
+    bool format_output_changed;			/* -F output_format used */
+    enum output_format format;			/* for -F output_format */
 
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     struct json *json_tree;			/* json tree if valid merely as a convenience */
@@ -227,5 +238,7 @@ void json_util_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, 
 void json_util_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
 /* for -S and -n */
 struct json_util_cmp_op *json_util_parse_cmp_op(struct json_util_name_val *json_util_name_val, const char *option, char *optarg);
+/* for -F option */
+enum output_format parse_json_util_format(struct json_util *json_util, char const *name, char const *optarg);
 
 #endif /* INCLUDE_JSON_UTIL_H */

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -42,7 +42,7 @@ static bool quiet = false;				/* true ==> quiet mode */
 static const char * const usage_msg0 =
     "usage:\t%s [-h] [-V] [-v level] [-J level] [-q] [-L <num>{[t|s]}] [-t type] [-l lvl]\n"
     "\t[-Q] [-D] [-d] [-i] [-s] [-f] [-c] [-C] [-g] [-e] [-n op=num] [-S op=str] [-o ofile]\n"
-    "\t[-m common.max_depth] [-K] file.json [arg ...]\n"
+    "\t[-m common.max_depth] [-K] [-F fmt] file.json [arg ...]\n"
     "\n"
     "\t-h\t\tPrint help and exit\n"
     "\t-V\t\tPrint version and exit\n"
@@ -103,9 +103,16 @@ static const char * const usage_msg0 =
     "\t\t\top may be one of: eq, lt, le, gt, ge\n"
     "\n"
     "\t-o ofile\tWrite to ofile (def: stdout)\n"
-    "\t-m common.max_depth\tSet the maximum JSON level depth to common.max_depth (0 == infinite depth, def: %d)\n"
     "\n"
-    "\t\t\tA 0 common.max_depth implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n"
+    "\t-F format\tChange the JSON format style (def: use default)\n\n"
+    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
+    "\t\t\tpedantic\tOne level per lines style\n"
+    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour\n"
+    "\n"
+    "\t-m max_depth\tSet the maximum JSON level depth to max_depth (0 == infinite depth, def: %d)\n"
+    "\n"
+    "\t\t\tA 0 max_depth implies JSON_INFINITE_DEPTH: only safe with infinite variable size and RAM :-)\n"
     "\n"
     "\t-K\t\tRun tests on jval constraints\n"
     "\n"
@@ -159,7 +166,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hVv:J:qL:t:l:QDdisfcCgen:S:o:m:K")) != -1) {
+    while ((i = getopt(argc, argv, ":hVv:J:qL:t:l:QDdisfcCgen:S:o:m:KF:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 0 */
 	    free_jval(&jval);
@@ -274,6 +281,14 @@ main(int argc, char **argv)
 		free_jval(&jval);
 		exit(0); /*ooo*/
 	    }
+	    break;
+	case 'F':
+	    /*
+	     * setting the common.format and common.format_output_changed is redundant
+	     * but we do it anyway
+	     */
+	    jval->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jval->common.format = parse_json_util_format(&jval->common, "jval", optarg);
 	    break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.8 2023-07-29"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.9 2023-07-31"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -71,6 +71,11 @@ alloc_jval(void)
     jval->common.json_util_levels.range.inclusive = false;
     jval->common.levels_constrained = false;
 
+    /* for -F format output option */
+    jval->common.format_output_changed = false;			/* -F format used */
+    jval->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
+
+
     /* print related options */
     jval->json_name_val.print_decoded = false;			/* -D not used if false */
     jval->common.print_json_levels = false;			/* -L specified */


### PR DESCRIPTION
New version for all tools 0.0.9 2023-07-31.

The optarg 'color' is aliased to 'colour'. Other options are 'default' and 'pedantic'. Debug output (with DBG_NONE' which has to change - later on) is added based on the optarg.

The option has NOT been added to the man pages. This will come later either later today or another day. Most likely another day.

Add missing setting of variables in alloc_jnamval().