### PR TITLE
Move parse_verbosity(3) to dbg facility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.46 2023-08-02
+
+Move `parse_verbosity(3)` to dbg/dbg.c as it is the dbg code that uses the
+`verbosity_level` variable. Ran `make test` to verify that this works okay.
+
+Updated `dbg.3` man page to add this function to the man page. Also improved the
+man page in some clarification of other functions (call semantics for example).
+
+New version of `dbg` facility and the `jparse` and json parser: respectively
+they are `"2.11 2023-08-02"` and for both `jparse` and the json parser `"1.1.4
+2023-08-02"`.
+
+Remove `parse_verbosity(3)` from `dyn_array(3)` facility as it is in the
+`dbg(3)` facility and the `dyn_array(3)` facility uses the `dbg(3)` facility.
+
+
 ## Release 1.0.45 2023-08-01
 
 New version of `jfmt`, `jval` and `jnamval`: `"0.0.10 2023-08-01"`.

--- a/dbg/dbg.c
+++ b/dbg/dbg.c
@@ -43,13 +43,13 @@
  * IMPORTANT WARNING: This code is widely used by a number of applications. A
  *		      great deal of care has gone in to making these debugging
  *		      facilities easy to code with, and much less likely to be
- *		      the source (pun intended) of bugs.
+ *		      the source (pun intended, obviously :-) ) of bugs.
  *
  *		      We apologize in advance for any problems this code may
  *		      introduce. We would be happy to fix a general bug by
  *		      considering a pull request to the dbg repo.
  *
- * DBG repo: https://github.com/lcn2/dbg
+ * dbg repo: https://github.com/lcn2/dbg
  *
  *		      You may also report a bug in the form of an issue using
  *		      the above URL.
@@ -6261,6 +6261,39 @@ vfprintf_usage(int exitcode, FILE *stream, char const *fmt, va_list ap)
 	errno = saved_errno;
     }
     return;
+}
+
+/*
+ * parse_verbosity - parse -v option for our tools
+ *
+ * given:
+ *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
+ *	arg		- the optarg in the calling tool
+ *
+ * Returns the parsed verbosity.
+ *
+ * Returns DBG_NONE if passed NULL args or empty string.
+ */
+int
+parse_verbosity(char const *program, char const *arg)
+{
+    int verbosity;
+
+    if (program == NULL || arg == NULL || !strlen(arg)) {
+	return DBG_NONE;
+    }
+
+    /*
+     * parse verbosity
+     */
+    errno = 0;		/* pre-clear errno for errp() */
+    verbosity = (int)strtol(arg, NULL, 0);
+    if (errno != 0) {
+	errp(3, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
+	not_reached();
+    }
+
+    return verbosity;
 }
 
 

--- a/dbg/dbg.h
+++ b/dbg/dbg.h
@@ -41,7 +41,7 @@
 /*
  * definitions
  */
-#define DBG_VERSION "2.10 2023-08-01"		/* format: major.minor YYYY-MM-DD */
+#define DBG_VERSION "2.11 2023-08-02"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -258,5 +258,6 @@ extern void fprintf_usage(int exitcode, FILE *stream, const char *fmt, ...) \
 	__attribute__((format(printf, 3, 4)));		/* 3=format 4=params */
 extern void vfprintf_usage(int exitcode, FILE *stream, char const *fmt, va_list ap);
 
+extern int parse_verbosity(char const *program, char const *arg);
 
 #endif				/* INCLUDE_DBG_H */

--- a/dbg/dbg_example.c
+++ b/dbg/dbg_example.c
@@ -1,7 +1,7 @@
 /*
  * dbg_example.c - trivial demo
  *
- * This is just a trivial demo for the dbg api.  See the main function in dbg.c
+ * This is just a trivial demo for the dbg API.  See the main function in dbg.c
  * for a more complete example.
  *
  * Written in 2022 by:
@@ -35,8 +35,10 @@ main(void)
 {
 
     /*
-     * We suggest you use getopt(3) and strtol(3) (cast to an int)
-     * to convert -v verbosity_level on the command line.
+     * We suggest you use getopt(3) and the parse_verbosity(3) function to
+     * convert -v verbosity_level on the command line like:
+     *
+     *	    verbosity_level = parse_verbosity(argv[0], optarg);
      */
     msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */

--- a/dbg/man/man3/dbg.3
+++ b/dbg/man/man3/dbg.3
@@ -12,14 +12,15 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dbg 3  "05 February 2023" "dbg"
+.TH dbg 3  "02 August 2023" "dbg"
 .SH NAME
 .BR dbg() \|,
 .BR vdbg() \|,
 .BR fdbg() \|,
 .BR vfdbg() \|,
 .BR sndbg() \|,
-.BR vsndbg()
+.BR vsndbg() \|,
+.BR parse_verbosity()
 \- debug message facility
 .SH SYNOPSIS
 \fB#include "dbg.h"\fP
@@ -31,6 +32,8 @@
 .B "extern int verbosity_level;		/* maximum debug level for debug messages */"
 .br
 .B "extern bool dbg_output_allowed;		/* false ==> disable debug messages */"
+.br
+.B "int parse_verbosity(char const *program, char const *arg);"
 .sp
 .B "void dbg(int level, const char *fmt, ...);"
 .br
@@ -49,6 +52,33 @@ These functions provide a way to write debug messages to a stream such as
 or to a
 .B char *
 of a fixed size.
+The messages will not be written unless the boolean
+.B dbg_output_allowed
+is true and the verbosity (debug) level is high enough.
+To parse the verbosity level you can use the function
+.BR parse_verbosity (3).
+.PP
+The general call semantics of the
+.BR dbg (3)
+functions is passing in a debug level, a format string and any format args.
+The other versions are similar except that they take additional args as well, depending on the family.
+See below subsections for details.
+.SS Parsing verbosity level
+We provide a function
+.BR parse_verbosity (3)
+to let you easily parse the verbosity level in your programs.
+The function returns an
+.BR int ,
+which you can assign to the variable
+.BR verbosity_level ,
+and takes the parameters
+.BR program ,
+the name of the program, and
+.BR arg ,
+the option argument to the option you choose for verbosity.
+We choose
+.B \-v
+but you can choose whichever you wish.
 .SS Alternative output \fBFILE *\fP stream
 The functions that do not take a
 .B FILE *
@@ -194,8 +224,10 @@ main(void)
 {
 
     /*
-     * We suggest you use getopt(3) and strtol(3) (cast to an int)
-     * to convert \-v verbosity_level on the command line.
+     * We suggest you use getopt(3) and the parse_verbosity(3) function to
+     * convert \-v verbosity_level on the command line like:
+     *
+     *	    verbosity_level = parse_verbosity(argv[0], optarg);
      */
     msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -353,10 +353,10 @@ dyn_array.a: ${LIB_OBJS}
 	${RANLIB} $@
 
 dyn_test.o: dyn_test.c dyn_array.h
-	${CC} ${CFLAGS} dyn_test.c -c
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
 dyn_test: dyn_test.o dyn_array.a ../dbg/dbg.a
-	${CC} ${CFLAGS} dyn_test.o dyn_array.a ../dbg/dbg.a -o dyn_test
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o dyn_array.a ../dbg/dbg.a -o dyn_test
 
 
 #########################################################

--- a/dyn_array/dyn_test.c
+++ b/dyn_array/dyn_test.c
@@ -76,6 +76,9 @@ static const char * const usage_msg =
 /*
  * forward declarations
  */
+#if !defined(DBG_USE)
+static int parse_verbosity(char const *program, char const *arg);
+#endif
 static void usage(int exitcode, char const *str, char const *prog) __attribute__((noreturn));
 
 int
@@ -210,7 +213,40 @@ main(int argc, char *argv[])
     exit(0); /*ooo*/
 }
 
+#if !defined(DBG_USE)
+/*
+ * parse_verbosity - parse -v option for our tools
+ *
+ * given:
+ *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
+ *	arg		- the optarg in the calling tool
+ *
+ * Returns the parsed verbosity.
+ *
+ * Returns DBG_NONE if passed NULL args or empty string.
+ */
+static int
+parse_verbosity(char const *program, char const *arg)
+{
+    int verbosity;
 
+    if (program == NULL || arg == NULL || !strlen(arg)) {
+	return DBG_NONE;
+    }
+
+    /*
+     * parse verbosity
+     */
+    errno = 0;		/* pre-clear errno for errp() */
+    verbosity = (int)strtol(arg, NULL, 0);
+    if (errno != 0) {
+	errp(3, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
+	not_reached();
+    }
+
+    return verbosity;
+}
+#endif /* !defined(DBG_USE) */
 
 /*
  * usage - print usage to stderr

--- a/dyn_array/dyn_test.c
+++ b/dyn_array/dyn_test.c
@@ -76,7 +76,6 @@ static const char * const usage_msg =
 /*
  * forward declarations
  */
-static int parse_verbosity(char const *program, char const *arg);
 static void usage(int exitcode, char const *str, char const *prog) __attribute__((noreturn));
 
 int
@@ -211,39 +210,6 @@ main(int argc, char *argv[])
     exit(0); /*ooo*/
 }
 
-
-/*
- * parse_verbosity - parse -v option for our tools
- *
- * given:
- *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
- *	arg		- the optarg in the calling tool
- *
- * Returns the parsed verbosity.
- *
- * Returns DBG_NONE if passed NULL args or empty string.
- */
-static int
-parse_verbosity(char const *program, char const *arg)
-{
-    int verbosity;
-
-    if (program == NULL || arg == NULL || !strlen(arg)) {
-	return DBG_NONE;
-    }
-
-    /*
-     * parse verbosity
-     */
-    errno = 0;		/* pre-clear errno for errp() */
-    verbosity = (int)strtol(arg, NULL, 0);
-    if (errno != 0) {
-	errp(3, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
-	not_reached();
-    }
-
-    return verbosity;
-}
 
 
 /*

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -52,7 +52,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.3 2023-07-26"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.4 2023-08-02"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -77,7 +77,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.1.3 2023-07-26"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.4 2023-08-02"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -2501,39 +2501,6 @@ string_to_uintmax(char const *str, uintmax_t *ret)
 }
 
 
-/*
- * parse_verbosity - parse -v option for our tools
- *
- * given:
- *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
- *	arg		- the optarg in the calling tool
- *
- * Returns the parsed verbosity.
- *
- * Returns DBG_NONE if passed NULL args or empty string.
- */
-int
-parse_verbosity(char const *program, char const *arg)
-{
-    int verbosity;
-
-    if (program == NULL || arg == NULL || !strlen(arg)) {
-	return DBG_NONE;
-    }
-
-    /*
-     * parse verbosity
-     */
-    errno = 0;		/* pre-clear errno for errp() */
-    verbosity = (int)strtol(arg, NULL, 0);
-    if (errno != 0) {
-	errp(3, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
-	not_reached();
-    }
-
-    return verbosity;
-}
-
 
 /*
  * is_decimal - if the buffer is a base 10 integer in ASCII

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -208,7 +208,6 @@ extern bool is_string(char const * const ptr, size_t len);
 extern char const *strnull(char const * const str);
 extern bool string_to_intmax(char const *str, intmax_t *ret);
 extern bool string_to_uintmax(char const *str, uintmax_t *ret);
-extern int parse_verbosity(char const *program, char const *arg);
 extern bool is_decimal(char const *ptr, size_t len);
 extern bool is_decimal_str(char const *str, size_t *retlen);
 extern bool is_floating_notation(char const *ptr, size_t len);


### PR DESCRIPTION
Since the debug facility is the one that uses a verbosity_level that I added here I have moved the function from jparse/util.c to dbg/dbg.c.

The dbg.3 man page has been updated with this and also some other improvements. There is a recursive reference to the man page for parse_verbosity(3) in the man page just for fun.

The dbg related changes have already been added to the dbg(3) repo as a pull request.

The dbg_example.c file that I wrote for this repo and the dbg(3) repo has also been updated with a comment change, referring to not strtol(3) but rather the parse_verbosity(3) function.

The dyn_array/dyn_test.c no longer has the parse_verbosity() function as this is in the dbg(3) facility which the dyn_array facility uses.