### PR TITLE
Improve location tool - make more generally useful

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,65 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.47 2023-08-03
+
+New version of `location` tool: `"1.0.1 2023-08-03"`.
+
+Improved tool to allow for `-a` (show all) and `-s` (substring search). Uses new
+re-entrant versions of the functions `lookup_location_name()` and
+`lookup_location_code()`. These new functions take a `size_t *idx` which is set
+to the _next_ element in the table (if != NULL) so that the next call can skip
+continue _after_ the previous element. They also take a `struct location **`
+which stores the _found_ location. This is useful for `-v 1` as one can then see
+something like:
+
+
+```sh
+./location -a -s -N -v 1 'united'
+United Arab Emirates ==> AE
+United Kingdom of Great Britain and Northern Ireland (the) ==> GB
+United States Miscellaneous Pacific Islands ==> PU
+Tanzania, United Republic of ==> TZ
+United Kingdom ==> UK
+United States Minor Outlying Islands ==> UM
+United Nations ==> UN
+United States of America ==> US
+```
+
+Without the `-v 1` it will only show:
+
+```sh
+$ ./location -a -s -N 'united'
+AE
+GB
+PU
+TZ
+UK
+UM
+UN
+US
+```
+
+If one does not use the `-N` option the `-a` is less useful as that function
+checks explicitly that the length is two characters so it has to be an exact
+match. Nevertheless there is a re-entrant version of the function that works
+much the same way as the other and the `-a` is processed without `-N`. Use of
+`-s` requires an arg much like `-N` but it does NOT require `-N` itself.
+
+The rationale behind these changes is they will make it easier for people to
+find their country code, if they do not know what it is (or they want say
+anonymous and don't know that it's `XX`). Search is done case-insensitively.
+Another example use:
+
+```sh
+$ ./location -asNv 1 germ
+German Democratic Republic ==> DD
+Germany ==> DE
+```
+
+I, that is Cody/@xexyl, observe that Germany is a country full of 'germ ridden
+people' (this is not really true of course but it's a fun pun of mine :-) )
+
+
 ## Release 1.0.46 2023-08-02
 
 Move `parse_verbosity(3)` to dbg/dbg.c as it is the dbg code that uses the

--- a/soup/location.h
+++ b/soup/location.h
@@ -66,6 +66,8 @@ extern size_t SIZEOF_LOCATION_TABLE;
 extern void check_location_table(void);
 extern char const *lookup_location_name(char const *code);
 extern char const *lookup_location_code(char const *location_name);
+extern char const *lookup_location_name_r(char const *code, size_t *idx, struct location **location, bool substrings);
+extern char const *lookup_location_code_r(char const *location_name, size_t *idx, struct location **location, bool substrings);
 extern bool location_code_name_match(char const *code, char const *location_name);
 
 #endif				/* INCLUDE_LOCATION_H */

--- a/soup/location_tbl.c
+++ b/soup/location_tbl.c
@@ -146,7 +146,7 @@ struct location loc[] = {
     {"CN", "China"},
     {"CO", "Colombia"},
     {"CP", "Clipperton Island"},	/* Exceptionally reserved code */
-    {"CQ", "island of Sark"},	/* Exceptionally reserved code */
+    {"CQ", "Island of Sark"},	/* Exceptionally reserved code */
     {"CR", "Costa Rica"},
     {"CS", "Serbia and Montenegro"},	/* Transitionally reserved code */
     {"CT", "Canton and Enderbury Island"},	/* Formerly assigned code */

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -8,7 +8,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH location 1 "04 June 2023" "location" "IOCCC tools"
+.TH location 1 "03 August 2023" "location" "IOCCC tools"
 .SH NAME
 .B location
 \- lookup ISO 3166 codes, location names or print the table
@@ -19,6 +19,8 @@
 .IR level \|]
 .RB [\| \-V \|]
 .RB [\| \-N \|]
+.RB [\| \-s \|]
+.RB [\| \-a \|]
 .RI [\| location
 .IR ... \|]
 .SH DESCRIPTION
@@ -40,6 +42,27 @@ are assumed to be the formal location name(s).
 The
 .B location
 tool will print their corresponding ISO 3166 code(s).
+.PP
+To search by substring use the
+.B \-s
+option.
+To show all matches use the
+.B \-a
+option.
+Showing all matches is less useful without the
+.B \-N
+option because country codes are two characters and are exact matches.
+The use of
+.B \-s
+requires an arg to the program much like
+.B \-N
+but it does not require the
+.B \-N
+option itself.
+.PP
+If verbosity is > level 0 and
+.B \-a
+is used it will show a string that shows name and code to more easily identify each match.
 .SH OPTIONS
 .TP
 .B \-h
@@ -63,6 +86,25 @@ and their corresponding formal location name(s) are printed.
 The use of
 .B \-N
 requires at least one argument.
+.TP
+.B \-s
+Search by substring instead of by an exact match.
+.sp
+Use of
+.B \-s
+requires at least one arg.
+.TP
+.B \-a
+Show all matches.
+.sp
+Use of
+.B \-a
+is less useful without the
+.B \-N
+option but nonetheless it is possible to use
+.B \-s
+without
+.BR \-N .
 .SH EXIT STATUS
 .TP
 0
@@ -101,7 +143,6 @@ The table is printed as a two character ISO 3166 code
 (in UPPER CASE), followed by a tab, followed by
 the corresponding formal location name.
 .PP
-.PP
 Print the formal location name given ISO 3166 codes:
 .sp
 .RS
@@ -120,6 +161,25 @@ Print the ISO 3166 codes given a formal location name:
 .RS
 .B ./location 'Equatorial Guinea'
 .RE
+.PP
+Show all matches with the substring
+.I united
+in the name:
+.sp
+.RS
+.B ./location \-a \-s \-N united
+.RE
+.sp
+.PP
+Show all matches with the substring
+.I germ
+in the name, showing both name and code to more easily identify each match:
+.sp
+.RS
+.B ./location \-a \-s \-N \-v 1 germ
+.RE
+.sp
+We note that, as the above example shows, Germany is a country full of 'germ ridden people' but we do not mean offence by this: it's just a fun pun of one of the author's.
 .SH EDITORIAL NOTES
 .sp
 The primary source of the location table is:


### PR DESCRIPTION
New version of location is 1.0.1 2023-08-03.

New option -s searches by substring rather than exact match.

New option -a shows all matches. Only useful with -s as otherwise it's an exact match.

To implement -a we have two new re-entrant functions:

    char const *lookup_location_name_r(char const *code, size_t *idx, struct location **location, bool substrings);
    char const *lookup_location_code_r(char const *location_name, size_t *idx, struct location **location, bool substrings);

These are the same as lookup_location_name() and lookup_location_code() except that they allow for calling them additional times to get the next match. If idx != NULL set *idx to the position + 1 for the next call. If location != NULL then set *location to the matching location. Then in location's main() (see location_main.c) it prints (if code/name != NULL) both the return value and then the name/code, depending on whether -N is used. When *idx >= the sizeof the table or no more matches are found then the functions will return NULL, signalling to location's main() that there are no more matches. This also means that instead of calling err() on NULL return value it just exits 1 if -a is used and no matches are found.

Note that without -N -s and -a are not very useful as the function that does country code checks explicitly checks for two characters so there's no real substring match that can be done. However the function was added to have matching functions.

Use of -s requires at least one arg.

Use of -a with an exact country name (if -N) is not very useful as it will only find an exact match (obviously). Nevertheless the only error condition is if -s is used without an arg.

With -a if -v 1 show text in the form of:

    XX ==> Anonymous location
    DE ==> Germany

or more generally:

    foo ==> bar

and

    Anonymous location ==> XX
    DE ==> Germany
    ...

Example command and output:

    ./soup/location -a -s -N -v 1 germ
    German Democratic Republic ==> DD
    Germany ==> DE

The joke here, of course, is that 'Germ'any is a country full of 'germ ridden people' (obviously not but it's a fun pun of mine :-) ).

Note that chkentry does NOT use these new features as the checks must be exact in that tool. The rationale of these changes is to help users of mkiocccentry find the right country code, even if they know their own (as they can also find country codes / names for other countries).