### PR TITLE
Fix mkiocccentry -y message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Updated Makefile rule `rebuild_jparse_err_files` to not show the command being
 run for each file to make the output clean (and to show what it looks like in
 the README.md file - which has been updated due to slight changes).
 
+Fix warning message of `mkiocccentry -y` and move it to happen before the option
+to ignore all warnings as that one says no more warnings will be displayed so it
+should come last.
 
 ## Release 1.0.48 2023-08-04
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -389,6 +389,18 @@ main(int argc, char *argv[])
     info.mkiocccentry_ver = MKIOCCCENTRY_VERSION;
     dbg(DBG_HIGH, "info.mkiocccentry_ver: %s", info.mkiocccentry_ver);
 
+
+    /* warn about -y option */
+    if (answer_yes) {
+	para("",
+	     "WARNING: you've chosen to answer yes to almost all prompts. If this was",
+	     "unintentional, run the program again without specifying -y. We cannot",
+	     "stress the importance of this enough! Well OK, we can over-stress most things",
+	     "but you get the point. Do not use the -y option without EXTREME caution!",
+	     "",
+	     NULL);
+    }
+
     /* if the user requested to ignore warnings, ignore this once and warn them :) */
     if (ignore_warnings) {
 	para("",
@@ -401,16 +413,6 @@ main(int argc, char *argv[])
 	     "",
 	     NULL);
     }
-    if (answer_yes) {
-	para("",
-	     "WARNING: you've chosen to answer yes to almost all prompts. If this was",
-	     "unintentional, run the program again without specifying -y. We cannot"
-	     "stress the importance of this enough! Well OK, we can over-stress most things"
-	     "but you get the point. Do not use the -y option without EXTREME caution!",
-	     "",
-	     NULL);
-    }
-
     /*
      * environment sanity checks
      */


### PR DESCRIPTION
Missing ',' at end of lines in para() made for long lines and merged words.

Moved the call above the warning about ignoring warnings as that warning says no more warnings will be shown so the -y warning should be shown first.