### PR TITLE
Update jfmt, jval and jnamval -F option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,34 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.0.50 2023-08-06
+
+New version of `jfmt`, `jval` and `jnamval`: `"0.0.12 2023-08-06"`. `jfmt` and
+`jval` jumped from 0.0.10 to make them match. Later on after version 1.0.0 this
+will no longer happen.
+
+Updated the `-F` option list. It now is:
+
+```
+-f fmt		change the json format style (def: use default)
+
+		tty		when output is to a tty, use colour, otherwise use simple
+		simple		each line has one json level determined by '[]'s and '{}'s
+		colour		simple plus ansi colour syntax highlighting
+		color		alias for colour (colour excluding you :-) )
+		1line		one line output
+		nows		One line output, no extra whitespace
+```
+
+Updated man pages for the three tools for this change as well as a typo fix in
+`jnamval.1` for the `-p` option (wrongly listed as `-P` which is something
+else).
+
+Updated `tmp/TODO.md`: the options for the three tools should be in the same
+order, particularly the common options, both in usage string and man pages. But
+since the specs are not finalised this needn't be done yet.
+
+
 ## Release 1.0.49 2023-08-05
 
 New version of `jnamval`: `"0.0.11 2023-08-05"`. Add `-I` option with same

--- a/jparse/jfmt.c
+++ b/jparse/jfmt.c
@@ -77,10 +77,10 @@ static const char * const usage_msg0 =
     "\t-o ofile\tOutput formatted JSON to ofile (def: stdout, same as '-')\n"
     "\n"
     "\t-F fmt\t\tChange the JSON format style (def: use default)\n\n"
-    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
-    "\t\t\tpedantic\tOne level per line style\n"
-    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
-    "\t\t\tcolor\t\tAlias for colour\n"
+    "\t\t\ttty\t\tWhen output is to a TTY, use colour, otherwise use simple\n"
+    "\t\t\tsimple\t\tEach line has one JSON level determined by '[]'s and '{}'s\n"
+    "\t\t\tcolour\t\tSimple plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour (colour excluding you :-) )\n"
     "\t\t\t1line\t\tOne line output\n"
     "\t\t\tnows\t\tOne line output, no extra whitespace\n"
     "\n"
@@ -251,7 +251,7 @@ main(int argc, char **argv)
 	     * setting the common.format and common.format_output_changed is redundant
 	     * but we do it anyway
 	     */
-	    jfmt->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jfmt->common.format = JSON_FMT_TTY; /* assume default */
 	    jfmt->common.format = parse_json_util_format(&jfmt->common, "jfmt", optarg);
 	    break;
 	case ':':   /* option requires an argument */

--- a/jparse/jfmt.h
+++ b/jparse/jfmt.h
@@ -68,7 +68,7 @@
 #include "jparse.h"
 
 /* jfmt version string */
-#define JFMT_VERSION "0.0.10 2023-08-01"		/* format: major.minor YYYY-MM-DD */
+#define JFMT_VERSION "0.0.12 2023-08-06"		/* format: major.minor YYYY-MM-DD */
 
 /* jfmt functions - see jfmt_util.h for most */
 

--- a/jparse/jfmt_util.c
+++ b/jparse/jfmt_util.c
@@ -75,7 +75,7 @@ alloc_jfmt(void)
 
     /* for -F format output option */
     jfmt->common.format_output_changed = false;			/* -F format used */
-    jfmt->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
+    jfmt->common.format = JSON_FMT_TTY;		/* default format for -F */
 
     /* parsing related */
     jfmt->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -149,10 +149,10 @@ static const char * const usage_msg1 =
     "\t-K\t\tRun tests on jnamval constraints\n"
     "\n"
     "\t-F fmt\t\tChange the JSON format style (def: use default)\n\n"
-    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
-    "\t\t\tpedantic\tOne level per line style\n"
-    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
-    "\t\t\tcolor\t\tAlias for colour\n"
+    "\t\t\ttty\t\tWhen output is to a TTY, use colour, otherwise use simple\n"
+    "\t\t\tsimple\t\tEach line has one JSON level determined by '[]'s and '{}'s\n"
+    "\t\t\tcolour\t\tSimple plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour (colour excluding you :-) )\n"
     "\t\t\t1line\t\tOne line output\n"
     "\t\t\tnows\t\tOne line output, no extra whitespace\n"
     "\n"
@@ -354,7 +354,7 @@ main(int argc, char **argv)
 	     * setting the common.format and common.format_output_changed is redundant
 	     * but we do it anyway
 	     */
-	    jnamval->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jnamval->common.format = JSON_FMT_TTY; /* assume default */
 	    jnamval->common.format = parse_json_util_format(&jnamval->common, "jnamval", optarg);
 	    break;
 	case ':':   /* option requires an argument */

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.11 2023-08-05"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.12 2023-08-06"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -119,8 +119,8 @@ alloc_jnamval(void)
     jnamval->json_name_val.total_matches = 0;
 
     /* for -F format output option */
-    jnamval->common.format_output_changed = false;			/* -F format used */
-    jnamval->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
+    jnamval->common.format_output_changed = false;		/* -F format used */
+    jnamval->common.format = JSON_FMT_TTY;			/* default format for -F */
 
     return jnamval;
 }

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -2861,7 +2861,7 @@ json_util_parse_cmp_op(struct json_util_name_val *json_name_val, const char *opt
 enum output_format
 parse_json_util_format(struct json_util *json_util, char const *name, char const *optarg)
 {
-    enum output_format format = JSON_FMT_DEFAULT;
+    enum output_format format = JSON_FMT_TTY;
 
     /* firewall */
 
@@ -2882,15 +2882,18 @@ parse_json_util_format(struct json_util *json_util, char const *name, char const
 
     json_util->format_output_changed = true;	    /* set the boolean to true */
 
-    if (!strcmp(optarg, "default")) {
-	format = json_util->format = JSON_FMT_DEFAULT;
+    if (!strcmp(optarg, "tty") || !strcmp(optarg, "default")) {
+	format = json_util->format = JSON_FMT_TTY;
 	dbg(DBG_NONE, "%s output format", optarg);
-    } else if (!strcmp(optarg, "pedantic")) {
-	format = json_util->format = JSON_FMT_PEDANTIC;
+    } else if (!strcmp(optarg, "simple")) {
+	format = json_util->format = JSON_FMT_SIMPLE;
 	dbg(DBG_NONE, "%s output format", optarg);
     } else if (!strcmp(optarg, "colour") || !strcmp(optarg, "color")) {
 	format = json_util->format = JSON_FMT_COLOUR;
 	dbg(DBG_NONE, "%sed output format", optarg);
+    } else if (!strcmp(optarg, "1line")) {
+	format = json_util->format = JSON_FMT_1LINE;
+	dbg(DBG_NONE, "%s output format", optarg);
     } else if (!strcmp(optarg, "nows") || !strcmp(optarg, "news")) {
 	bool news = !strcmp(optarg, "news");
 	format = json_util->format = JSON_FMT_NOWS;

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -75,15 +75,12 @@
 
 /* for -F with jfmt, jval and jnamval */
 enum output_format {
-    JSON_FMT_DEFAULT = 0,	    /* default format */
-    JSON_FMT_PEDANTIC = 1,	    /* pedantic format: one level per line style */
+    JSON_FMT_TTY = 0,		    /* tty (default): when output is to a TTY, use colour, otherwise use simple */
+    JSON_FMT_SIMPLE = 1,	    /* simple: each line has one JSON level determined by '[]'s and '{}'s */
     JSON_FMT_COLOUR = 2,	    /* coloured format: syntax highlighting */
     JSON_FMT_1LINE = 3,		    /* one line output: one line for all output */
     JSON_FMT_NOWS = 4,		    /* nows (no whitespace) output: one line for all output with no extra whitespace */
 };
-#define JSON_UTIL_FMT_DEFAULT	    (0)
-#define	JSON_UTIL_FMT_PEDANTIC	    (1)
-#define JSON_UTIL_FMT_COLOUR	    (2)
 
 /* jval and jnamval -t types */
 #define JSON_UTIL_MATCH_TYPE_NONE	    (0)

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -105,10 +105,10 @@ static const char * const usage_msg0 =
     "\t-o ofile\tWrite to ofile (def: stdout)\n"
     "\n"
     "\t-F fmt\t\tChange the JSON format style (def: use default)\n\n"
-    "\t\t\tdefault\t\tDefault JSON style, 1 or 2 levels per line\n"
-    "\t\t\tpedantic\tOne level per line style\n"
-    "\t\t\tcolour\t\tDefault plus ANSI colour syntax highlighting\n"
-    "\t\t\tcolor\t\tAlias for colour\n"
+    "\t\t\ttty\t\tWhen output is to a TTY, use colour, otherwise use simple\n"
+    "\t\t\tsimple\t\tEach line has one JSON level determined by '[]'s and '{}'s\n"
+    "\t\t\tcolour\t\tSimple plus ANSI colour syntax highlighting\n"
+    "\t\t\tcolor\t\tAlias for colour (colour excluding you :-) )\n"
     "\t\t\t1line\t\tOne line output\n"
     "\t\t\tnows\t\tOne line output, no extra whitespace\n"
     "\n"
@@ -297,7 +297,7 @@ main(int argc, char **argv)
 	     * setting the common.format and common.format_output_changed is redundant
 	     * but we do it anyway
 	     */
-	    jval->common.format = JSON_FMT_DEFAULT; /* assume default */
+	    jval->common.format = JSON_FMT_TTY; /* assume default */
 	    jval->common.format = parse_json_util_format(&jval->common, "jval", optarg);
 	    break;
 	case ':':   /* option requires an argument */

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.10 2023-08-01"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.12 2023-08-06"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -73,7 +73,7 @@ alloc_jval(void)
 
     /* for -F format output option */
     jval->common.format_output_changed = false;			/* -F format used */
-    jval->common.format = JSON_FMT_DEFAULT;		/* default format for -F */
+    jval->common.format = JSON_FMT_TTY;				/* default format for -F */
 
 
     /* print related options */

--- a/jparse/man/man1/jfmt.1
+++ b/jparse/man/man1/jfmt.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jfmt 1 "05 August 2023" "jfmt" "IOCCC tools"
+.TH jfmt 1 "06 August 2023" "jfmt" "IOCCC tools"
 .SH NAME
 .B jfmt
 \- IOCCC JSON printer
@@ -156,23 +156,32 @@ Default is stdout which is the same as if you specified
 Change the JSON output format of the tool.
 .RS
 .TQ
-.B default
-Default JSON style, 1 or 2 levels per line
+.B tty
+When output is to a TTY, use
+.BR colour ,
+otherwise use
+.BR simple .
 .RE
 .RS
 .TQ
-.B pedantic
-One level per line style
+.B simple
+Each line has one JSON level determined by '[]'s and '{}'s
 .RE
 .RS
 .TQ
 .B colour
-Default plus ANSI colour syntax highlighting
+.B simple
+plus ANSI colour syntax highlighting
 .RE
 .RS
 .TQ
 .B color
-Alias for colour, see below subsection
+Alias for
+.B colour
+.RB (  colour
+excluding yo(\c
+.BR u )
+:\-) ), see below subsection
 .RS
 .RE
 .RE
@@ -187,8 +196,16 @@ One line output
 One line output, no extra whitespace
 .RE
 .SS Coloured output
-Although we do allow for 'color' instead of 'colour' it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
-As such we recommend that you only use 'color' if you wish to be exclusive.
+Although we do allow for
+.B color
+instead of
+.B colour
+it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
+In particular it excludes yo(\c
+.BR u )
+so we recommend that you only use
+.B color
+if you want to exclude yourself. :\-)
 .SH EXIT STATUS
 .TP
 0

--- a/jparse/man/man1/jnamval.1
+++ b/jparse/man/man1/jnamval.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jnamval 1 "05 August 2023" "jnamval" "IOCCC tools"
+.TH jnamval 1 "06 August 2023" "jnamval" "IOCCC tools"
 .SH NAME
 .B jnamval
 \- IOCCC JSON printer
@@ -340,7 +340,7 @@ Implies the
 .B \-N
 option.
 .TP
-.BI \-P\  parts
+.BI \-p\  parts
 Instead of printing matching member values, print the specified parts:
 .RS
 .TQ
@@ -443,13 +443,16 @@ Default is stdout which is the same as if you specified
 Change the JSON output format of the tool.
 .RS
 .TQ
-.B default
-Default JSON style, 1 or 2 levels per line
+.B tty
+When output is to a TTY, use
+.BR colour ,
+otherwise use
+.BR simple .
 .RE
 .RS
 .TQ
-.B pedantic
-One level per line style
+.B simple
+Each line has one JSON level determined by '[]'s and '{}'s
 .RE
 .RS
 .TQ
@@ -459,7 +462,12 @@ Default plus ANSI colour syntax highlighting
 .RS
 .TQ
 .B color
-Alias for colour, see below subsection
+Alias for
+.B colour
+.RB (  colour
+excluding yo(\c
+.BR u )
+:\-) ), see below subsection
 .RS
 .RE
 .RE
@@ -474,8 +482,16 @@ One line output
 One line output, no extra whitespace
 .RE
 .SS Coloured output
-Although we do allow for 'color' instead of 'colour' it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
-As such we recommend that you only use 'color' if you wish to be exclusive.
+Although we do allow for
+.B color
+instead of
+.B colour
+it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
+In particular it excludes yo(\c
+.BR u )
+so we recommend that you only use
+.B color
+if you want to exclude yourself. :\-)
 .SH EXIT STATUS
 .TP
 0

--- a/jparse/man/man1/jval.1
+++ b/jparse/man/man1/jval.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jval 1 "05 August 2023" "jval" "IOCCC tools"
+.TH jval 1 "06 August 2023" "jval" "IOCCC tools"
 .SH NAME
 .B jval
 \- IOCCC JSON printer
@@ -288,23 +288,32 @@ Write to ofile (def: stdout)
 Change the JSON output format of the tool.
 .RS
 .TQ
-.B default
-Default JSON style, 1 or 2 levels per line
+.B tty
+When output is to a TTY, use
+.BR colour ,
+otherwise use
+.BR simple .
 .RE
 .RS
 .TQ
-.B pedantic
-One level per line style
+.B simple
+Each line has one JSON level determined by '[]'s and '{}'s
 .RE
 .RS
 .TQ
 .B colour
-Default plus ANSI colour syntax highlighting
+.B simple
+plus ANSI colour syntax highlighting
 .RE
 .RS
 .TQ
 .B color
-Alias for colour, see below subsection
+Alias for
+.B colour
+.RB (  colour
+excluding yo(\c
+.BR u )
+:\-) ), see below subsection
 .RS
 .RE
 .RE
@@ -340,8 +349,16 @@ Default is stdout which is the same as if you specified
 .BR \- .
 .RE
 .SS Coloured output
-Although we do allow for 'color' instead of 'colour' it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
-As such we recommend that you only use 'color' if you wish to be exclusive.
+Although we do allow for
+.B color
+instead of
+.B colour
+it should be noted that this is not only strictly incorrect but it also prevents it from being used by both you and me.
+In particular it excludes yo(\c
+.BR u )
+so we recommend that you only use
+.B color
+if you want to exclude yourself. :\-)
 .SH EXIT STATUS
 .TP
 0

--- a/tmp/TODO.md
+++ b/tmp/TODO.md
@@ -1,8 +1,13 @@
 # A temporary todo list of known things to check and/or do
-*Last updated: Thu Aug  3 12:08:51 UTC 2023*
+*Last updated: Sun Aug  6 17:17:53 UTC 2023*
 
 This document is a list of things to do that are not specific to any particular
 issue that is open.
 
 - Add to the FAQ how to find country codes for submitting entries and more
 generally as the `location` tool is rather useful.
+
+- Make options list for `jfmt`, `jval` and `jnamval` the same order in both
+tools and the usage strings. It might be better to do this after the specs are
+finalised as new options have been introduced or have been changed as discussion
+is had which is part of the problem here.


### PR DESCRIPTION
The option now looks like:

    -F fmt	Change the JSON format style (def: use default)

		tty	    When output is to a TTY, use colour, otherwise use simple
		simple	    Each line has one JSON level determined by '[]'s and '{}'s
		colour	    Simple plus ANSI colour syntax highlighting
		color	    Alias for colour (colour excluding you :-) )
		1line	    One line output
		nows	    One line output, no extra whitespace

Updated man pages for this option as well as a typo fix in jnamval.1 (an option letter was incorrect making it so that the example had no explanation).

Updated tmp/TODO.md - something that has to be done after the specs of these tools are finalised is to make sure common options are in the same order ahead of the other options both in usage strings and man pages.

The -F option is not yet added to the json_util_README.md file or if it is it's not updated. That will happen another time.