### PR TITLE
Fix make rule jparse.clone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.51 2023-08-07
+
+Fix link in make rule `jparse.clone` to use
+`https://github.com/xexyl/jparse.git` as the link used,
+`https://github.com/lcn2/jparse.git`, is actually a clone of the repo I set up
+(empty for now) which will be populated with `jparse` later on when the parser
+is tested more fully.
+
 
 ## Release 1.0.50 2023-08-06
 

--- a/Makefile
+++ b/Makefile
@@ -1255,9 +1255,9 @@ jparse.clone:
 	else \
 	    echo "If git clone fails because you do not have the ssh key, try:"; \
 	    echo; \
-	    echo "	${GIT} clone https://github.com/lcn2/jparse.git jparse.clone"; \
+	    echo "	${GIT} clone https://github.com/xexyl/jparse.git jparse.clone"; \
 	    echo; \
-	    ${GIT} clone git@github.com:lcn2/jparse.git jparse.clone; \
+	    ${GIT} clone git@github.com:xexyl/jparse.git jparse.clone; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"


### PR DESCRIPTION
The link that was used, https://github.com/lcn2/jparse.git, is actually a fork of the repo that I set up, which will be populated with jparse/ after it is more thoroughly tested in this repo. That is located at https://github.com/xexyl/jparse.git.