### PR TITLE
Fixes to jval and jnamval -S and -n options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,26 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.52 2023-08-09
+
+New version of `jval` and `jnamval`, `"0.0.14 2023-08-09"`.
+
+Fixed the lists of `-S` and `-n` option parsing. For now it should just be a
+string that's strdup()d. The operators are in the list in the order specified,
+one list for strings and one list for numbers. This can be changed to a single
+list later on if necessary (as I suspect it might need to be but the way it is
+now is set up as two which is what I'm operating under).
+
+The function that frees the `-S` and `-n` lists in `jval` and `jnamval` is now
+in `json_util.c` as they are actually in a struct common to both `jval` and
+`jnamval`. The functions that free them in `jval_util.c` and `jnamval_util.c`
+simply check that `jval` or `jnamval` is not NULL and then calls the new
+`free_json_util_cmp_list()` function.
+
+Made the json util operator macros an enum.
+
+Rename the enum `output_format` to `JSON_UTIL_OUTPUT_FMT`.
+
+
 ## Release 1.0.51 2023-08-07
 
 Fix link in make rule `jparse.clone` to use

--- a/jparse/jnamval.c
+++ b/jparse/jnamval.c
@@ -300,7 +300,7 @@ main(int argc, char **argv)
 	    dbg(DBG_LOW, "-e specified, will encode strings");
 	    break;
 	case 'n': /* -n op=num */
-	    jnamval->json_name_val.num_cmp_used = true;
+	    jnamval->json_name_val.numcmp_used = true;
 	    if (json_util_parse_cmp_op(&jnamval->json_name_val, "n", optarg) == NULL) {
 		free_jnamval(&jnamval);
 		err(24, "jnamval", "couldn't parse -n option");
@@ -308,7 +308,7 @@ main(int argc, char **argv)
 	    }
 	    break;
 	case 'S': /* -S op=str */
-	    jnamval->json_name_val.string_cmp_used = true;
+	    jnamval->json_name_val.strcmp_used = true;
 	    if (json_util_parse_cmp_op(&jnamval->json_name_val, "S", optarg) == NULL) {
 		free_jnamval(&jnamval);
 		err(25, "jnamval", "couldn't parse -S option");

--- a/jparse/jnamval.h
+++ b/jparse/jnamval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jnamval version string */
-#define JNAMVAL_VERSION "0.0.13 2023-08-07"		/* format: major.minor YYYY-MM-DD */
+#define JNAMVAL_VERSION "0.0.14 2023-08-09"		/* format: major.minor YYYY-MM-DD */
 
 /* jnamval functions - see jnamval_util.h for most */
 

--- a/jparse/jnamval_util.c
+++ b/jparse/jnamval_util.c
@@ -105,11 +105,11 @@ alloc_jnamval(void)
     /* comparison options -S and -n */
 
     /* -S op=string */
-    jnamval->json_name_val.string_cmp_used = false;
-    jnamval->json_name_val.string_cmp = NULL;
+    jnamval->json_name_val.strcmp_used = false;
+    jnamval->json_name_val.strcmp = NULL;
     /* -n op=number */
-    jnamval->json_name_val.num_cmp_used = false;
-    jnamval->json_name_val.num_cmp = NULL;
+    jnamval->json_name_val.numcmp_used = false;
+    jnamval->json_name_val.numcmp = NULL;
 
     /* parsing related */
     jnamval->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
@@ -913,31 +913,11 @@ parse_jnamval_args(struct jnamval *jnamval, int *argc, char ***argv)
 void
 free_jnamval_cmp_op_lists(struct jnamval *jnamval)
 {
-    struct json_util_cmp_op *op, *next_op;
-
     /* firewall */
     if (jnamval == NULL) {
 	err(29, __func__, "jnamval is NULL");
 	not_reached();
     }
 
-    /* first the string compare list */
-    for (op = jnamval->json_name_val.string_cmp; op != NULL; op = next_op) {
-	next_op = op->next;
-
-	/* XXX - free json node - XXX */
-
-	free(op);
-	op = NULL;
-    }
-
-    /* now the number compare list */
-    for (op = jnamval->json_name_val.num_cmp; op != NULL; op = next_op) {
-	next_op = op->next;
-
-	/* XXX - free json node - XXX */
-
-	free(op);
-	op = NULL;
-    }
+    free_json_util_cmp_list(&jnamval->json_name_val);
 }

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -65,16 +65,22 @@
 #define JSON_DBG_FORCED	    (-1)	    /* always print information, even if dbg_output_allowed == false */
 #define JSON_DBG_LEVEL	    (JSON_DBG_LOW)  /* default JSON debugging level json_verbosity_level */
 
-/* for json tools jval and jnamval */
-#define JSON_UTIL_CMP_OP_NONE	    (0)
-#define JSON_UTIL_CMP_EQ	    (1)
-#define JSON_UTIL_CMP_LT	    (2)
-#define JSON_UTIL_CMP_LE	    (3)
-#define JSON_UTIL_CMP_GT	    (4)
-#define JSON_UTIL_CMP_GE	    (5)
+/* for json tools jval and jnamval -S and -n options */
+enum JSON_UTIL_CMP_OP
+{
+    JSON_CMP_OP_NONE = 0,	/* must be first */
+    JSON_CMP_OP_EQ = 1,		/* equality check */
+    JSON_CMP_OP_LT = 2,		/* less than check */
+    JSON_CMP_OP_LE = 3,		/* less than or equal check */
+    JSON_CMP_OP_GT = 4,		/* greater than check */
+    JSON_CMP_OP_GE = 5,		/* greater than or equal check */
+    JSON_CMP_OP_NE = 6,		/* not equal */
+};
+
 
 /* for -F with jfmt, jval and jnamval */
-enum output_format {
+enum JSON_UTIL_OUTPUT_FMT
+{
     JSON_FMT_TTY = 0,		    /* tty (default): when output is to a TTY, use colour, otherwise use simple */
     JSON_FMT_SIMPLE = 1,	    /* simple: each line has one JSON level determined by '[]'s and '{}'s */
     JSON_FMT_COLOUR = 2,	    /* coloured format: syntax highlighting */
@@ -103,8 +109,7 @@ enum output_format {
 /* for comparison of numbers / strings - options -n and -S */
 struct json_util_cmp_op
 {
-    struct json_number *number;	    /* for -n as signed number */
-    struct json_string *string;	    /* for -S str */
+    char *string;
 
     bool is_string;	    /* true if -S */
     bool is_number;	    /* true if -n */
@@ -127,10 +132,10 @@ struct json_util_name_val
     bool count_only;				/* -c used, only show count */
     bool count_and_show_values;			/* -C used, show count and values */
 
-    bool string_cmp_used;			/* for -S */
-    struct json_util_cmp_op *string_cmp;		/* for -S str */
-    bool num_cmp_used;				/* for -n */
-    struct json_util_cmp_op *num_cmp;		/* for -n num */
+    bool strcmp_used;			/* for -S */
+    struct json_util_cmp_op *strcmp;		/* for -S str */
+    bool numcmp_used;				/* for -n */
+    struct json_util_cmp_op *numcmp;		/* for -n num */
 
     /* search / matching related */
     bool invert_matches;			/* -i used */
@@ -198,8 +203,8 @@ struct json_util
     uintmax_t indent_spaces;			/* -I specified */
     bool indent_tab;				/* -I <num>[{t|s}] specified */
 
-    bool format_output_changed;			/* -F output_format used */
-    enum output_format format;			/* for -F output_format */
+    bool format_output_changed;			/* -F JSON_UTIL_OUTPUT_FMT used */
+    enum JSON_UTIL_OUTPUT_FMT format;			/* for -F JSON_UTIL_OUTPUT_FMT */
 
     uintmax_t max_depth;			/* max depth to traverse set by -m depth */
     struct json *json_tree;			/* json tree if valid merely as a convenience */
@@ -253,8 +258,9 @@ void json_util_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, 
 void json_util_parse_st_indent_option(char *optarg, uintmax_t *indent_level, bool *indent_tab);
 /* for -S and -n */
 struct json_util_cmp_op *json_util_parse_cmp_op(struct json_util_name_val *json_util_name_val, const char *option, char *optarg);
+void free_json_util_cmp_list(struct json_util_name_val *json_name_val);
 /* for -F option */
-enum output_format parse_json_util_format(struct json_util *json_util, char const *name, char const *optarg);
+enum JSON_UTIL_OUTPUT_FMT parse_json_util_format(struct json_util *json_util, char const *name, char const *optarg);
 /* JSON types - -t option*/
 uintmax_t json_util_parse_match_types(char *optarg);
 bool json_util_match_none(uintmax_t types);

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -254,7 +254,7 @@ main(int argc, char **argv)
 	    dbg(DBG_LOW, "-e specified, will encode strings");
 	    break;
 	case 'n': /* -n op=num */
-	    jval->json_name_val.num_cmp_used = true;
+	    jval->json_name_val.numcmp_used = true;
 	    if (json_util_parse_cmp_op(&jval->json_name_val, "n", optarg) == NULL) {
 		free_jval(&jval);
 		err(24, "jval", "failed to parse -n option");
@@ -262,7 +262,7 @@ main(int argc, char **argv)
 	    }
 	    break;
 	case 'S': /* -S op=str */
-	    jval->json_name_val.string_cmp_used = true;
+	    jval->json_name_val.strcmp_used = true;
 	    if (json_util_parse_cmp_op(&jval->json_name_val, "S", optarg) == NULL) {
 		free_jval(&jval);
 		err(25, "jval", "failed to parse -S option");

--- a/jparse/jval.h
+++ b/jparse/jval.h
@@ -63,7 +63,7 @@
 #include "jparse.h"
 
 /* jval version string */
-#define JVAL_VERSION "0.0.12 2023-08-06"		/* format: major.minor YYYY-MM-DD */
+#define JVAL_VERSION "0.0.14 2023-08-09"		/* format: major.minor YYYY-MM-DD */
 
 /* jval functions - see jval_util.h for most */
 

--- a/jparse/jval_util.c
+++ b/jparse/jval_util.c
@@ -97,12 +97,12 @@ alloc_jval(void)
     jval->json_name_val.use_regexps = false;				/* -g used, allow grep-like regexps */
 
     /* for -S */
-    jval->json_name_val.string_cmp_used = false;
-    jval->json_name_val.string_cmp = NULL;
+    jval->json_name_val.strcmp_used = false;
+    jval->json_name_val.strcmp = NULL;
 
     /* for -n */
-    jval->json_name_val.num_cmp_used = false;
-    jval->json_name_val.num_cmp = NULL;
+    jval->json_name_val.numcmp_used = false;
+    jval->json_name_val.numcmp = NULL;
 
     /* parsing related */
     jval->common.max_depth = JSON_DEFAULT_MAX_DEPTH;		/* max depth to traverse set by -m depth */
@@ -244,31 +244,11 @@ parse_jval_args(struct jval *jval, int *argc, char ***argv)
 void
 free_jval_cmp_op_lists(struct jval *jval)
 {
-    struct json_util_cmp_op *op, *next_op;
-
     /* firewall */
     if (jval == NULL) {
 	err(27, __func__, "jval is NULL");
 	not_reached();
     }
 
-    /* first the string compare list */
-    for (op = jval->json_name_val.string_cmp; op != NULL; op = next_op) {
-	next_op = op->next;
-
-	/* XXX - free json node - XXX */
-
-	free(op);
-	op = NULL;
-    }
-
-    /* now the number compare list */
-    for (op = jval->json_name_val.num_cmp; op != NULL; op = next_op) {
-	next_op = op->next;
-
-	/* XXX - free json node - XXX */
-
-	free(op);
-	op = NULL;
-    }
+    free_json_util_cmp_list(&jval->json_name_val);
 }


### PR DESCRIPTION
New version of both tools is 0.0.14 2023-08-09.

Fixed the lists of -S and -n option parsing. For now it should just be a string that's strdup()d. The operators are in the list in the order specified, one list for strings and one list for numbers. This can be changed to a single list later on if necessary (as I suspect it might need to be but the way it is now is set up as two which is what I'm operating under).

The -S and -n lists are by default ORed but an option that is to make them AND is to be added. This will require some discussion first so that is not yet added.

The function that frees the -S and -n lists in jval and jnamval is now in json_util.c as they are actually in a struct common to both jval and jnamval. The functions that free them in jval_util.c and jnamval_util.c simply check that jval or jnamval is not NULL and then calls the new free_json_util_cmp_list() function.

Made the json util operator macros an enum.

Rename the enum output_format to JSON_UTIL_OUTPUT_FMT.