### PR TITLE
Add test case for forbidden tarball files

### DIFF
--- a/test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt
+++ b/test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt
@@ -1,0 +1,14 @@
+drwxr-xr-x  0 501    20          0 Feb  6 02:28 test-9/
+-rw-r--r--  0 501    20          0 Feb  6 02:28 test-9/Makefile
+-rw-r--r--  0 501    20          4 Feb  6 02:28 test-9/extra2
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/prog.c
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/prog
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/prog.orig
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/prog.orig.c
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/README.md
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/index.html
+-rw-r--r--  0 501    20         29 Feb  6 02:30 test-9/inventory.html
+-rw-r--r--  0 501    20          0 Feb  6 02:28 test-9/.auth.json
+-rw-r--r--  0 501    20          0 Feb  6 02:28 test-9/remarks.md
+-rw-r--r--  0 501    20          0 Feb  6 02:28 test-9/.info.json
+-rw-r--r--  0 501    20          4 Feb  6 02:28 test-9/extra1

--- a/test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt.err
+++ b/test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt.err
@@ -1,0 +1,11 @@
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: found empty .info.json file
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: found empty remarks.md
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: found empty .auth.json file
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: inventory.html
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: index.html
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: README.md
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: prog.orig.c
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: prog.orig
+Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: filename not allowed: prog
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: found empty Makefile
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/entry.test-9.9876543211.txt: found 10 feathers stuck in the tarball


### PR DESCRIPTION
The new fake tarball has files with each new forbidden file:

- README.md
- index.html
- inventory.html
- prog
- prog.orig
- prog.orig.c