### PR TITLE
Add bad manifest filenames tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.55 2023-11-07
+
+Add another forbidden file name in submissions: `prog.alt` (prog.alt.c is
+allowed).
+
+Modularise the checks for invalid filenames in entries. For instance in
+`check_extra_file()` there's no need to check each extra filename and then give
+the same error message changing the macro of the filename that's disallowed when
+we can just print the string being tested against. The only difference is that
+there's one if (with multiple checks) and instead of duplicating the same error
+message we just print it once with the string being tested against. Note that
+there are two sets of checks: one for extra files being required filenames and
+another for disallowed filenames.
+
+Make sure to use the macros for the filenames, not the literal strings (e.g. use
+`PROG_FILENAME` not `"prog"`).
+
+Check filenames in alphabetical order (I think :-) .. very tired so maybe missed
+one or two).
+
+Note that the function `check_extra_file()` CANNOT be used in every case so it's
+not used except in chkentry!
+
+
 ## Release 1.0.54 2023-11-06
 
 The following filenames are no longer allowed in an entry's extra files list:

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3038,8 +3038,10 @@ check_extra_data_files(struct info *infop, char const *entry_dir, char const *cp
 	    not_reached();
 	}
 
-	if (!strcasecmp(args[i], "README.md") || !strcasecmp(args[i], "index.html") || !strcasecmp(args[i], "inventory.html") ||
-	    !strcasecmp(args[i], "prog.orig.c") || !strcasecmp(args[i], "prog.orig") || !strcasecmp(args[i], "prog")) {
+	if (!strcasecmp(args[i], README_MD_FILENAME) || !strcasecmp(args[i], INDEX_HTML_FILENAME) ||
+	    !strcasecmp(args[i], INVENTORY_HTML_FILENAME) || !strcasecmp(args[i], PROG_FILENAME) ||
+	    !strcasecmp(args[i], PROG_ALT_FILENAME) || !strcasecmp(args[i], PROG_ORIG_FILENAME) ||
+	    !strcasecmp(args[i], PROG_ORIG_C_FILENAME)) {
 	    fpara(stderr,
 		"",
 		"An extra file cannot be named any of:",

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -2879,52 +2879,21 @@ test_extra_file(char const *str)
     }
 
     /* verify that extra_file does not match a mandatory filename */
-    if (strcasecmp(str, INFO_JSON_FILENAME) == 0) {
+    if (!strcasecmp(str, AUTH_JSON_FILENAME) || !strcasecmp(str, INFO_JSON_FILENAME) ||
+	!strcasecmp(str, MAKEFILE_FILENAME) || !strcasecmp(str, PROG_C_FILENAME) ||
+	!strcasecmp(str, REMARKS_FILENAME)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file %s", INFO_JSON_FILENAME);
-	return false;
-    } else if (strcasecmp(str, AUTH_JSON_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file %s", AUTH_JSON_FILENAME);
-	return false;
-    } else if (strcasecmp(str, PROG_C_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file %s", PROG_C_FILENAME);
-	return false;
-    } else if (strcasecmp(str, MAKEFILE_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file %s", MAKEFILE_FILENAME);
-	return false;
-    } else if (strcasecmp(str, REMARKS_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: extra_file matches a mandatory file %s", REMARKS_FILENAME);
+		 "invalid: extra_file matches a mandatory file: <%s>", str);
 	return false;
     }
     /* also verify it does not match a disallowed filename */
-    else if (strcasecmp(str, README_MD_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", README_MD_FILENAME);
-	return false;
-    } else if (strcasecmp(str, PROG_ORIG_C_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", PROG_ORIG_C_FILENAME);
-	return false;
-    } else if (strcasecmp(str, PROG_ORIG_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", PROG_ORIG_FILENAME);
-	return false;
-    } else if (strcasecmp(str, INDEX_HTML_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", INDEX_HTML_FILENAME);
-	return false;
-    } else if (strcasecmp(str, INVENTORY_HTML_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", INVENTORY_HTML_FILENAME);
-	return false;
-    } else if (strcasecmp(str, PROG_FILENAME) == 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		"invalid: extra_file matches invalid filename %s", PROG_FILENAME);
-	return false;
+    else if (!strcasecmp(str, INDEX_HTML_FILENAME) || !strcasecmp(str, INVENTORY_HTML_FILENAME) ||
+	     !strcasecmp(str, PROG_FILENAME) || !strcasecmp(str, PROG_ALT_FILENAME) ||
+	     !strcasecmp(str, PROG_ORIG_FILENAME) || !strcasecmp(str, PROG_ORIG_C_FILENAME) ||
+	     !strcasecmp(str, README_MD_FILENAME)) {
+		json_dbg(JSON_DBG_MED, __func__,
+			"invalid: extra_file matches disallowed filename: <%s>", str);
+		return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "extra_file is valid");
     return true;

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -40,13 +40,13 @@
 #define PROG_C_FILENAME "prog.c"
 #define REMARKS_FILENAME "remarks.md"
 #define MAKEFILE_FILENAME "Makefile"
-#define README_MD_FILENAME "README.md"
-#define PROG_ORIG_C_FILENAME "prog.orig.c"
-#define PROG_FILENAME "prog"
-#define PROG_ORIG_FILENAME "prog.orig"
 #define INDEX_HTML_FILENAME "index.html"
 #define INVENTORY_HTML_FILENAME "inventory.html"
-
+#define PROG_FILENAME "prog"
+#define PROG_ALT_FILENAME "prog.alt"
+#define PROG_ORIG_FILENAME "prog.orig"
+#define PROG_ORIG_C_FILENAME "prog.orig.c"
+#define README_MD_FILENAME "README.md"
 
 /*
  * IOCCC author information

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-README-md.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-README-md.json
@@ -37,13 +37,7 @@
 		{"c_src" : "prog.c"},
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
-		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "README.md"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-index-html.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-index-html.json
@@ -37,13 +37,7 @@
 		{"c_src" : "prog.c"},
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
-		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "index.html"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-inventory-html.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-inventory-html.json
@@ -37,12 +37,6 @@
 		{"c_src" : "prog.c"},
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
-		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
 		{"extra_file" : "inventory.html"}
 	],
 	"formed_timestamp" : 1675547786,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-alt.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-alt.json
@@ -37,13 +37,7 @@
 		{"c_src" : "prog.c"},
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
-		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "prog.alt"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-orig-c.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-orig-c.json
@@ -38,12 +38,7 @@
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
 		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "prog.orig.c"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-orig.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-prog-orig.json
@@ -38,12 +38,7 @@
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
 		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "prog.orig"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/test_ioccc/test_JSON/info.json/bad/info.manifest-prog.json
+++ b/test_ioccc/test_JSON/info.json/bad/info.manifest-prog.json
@@ -37,13 +37,7 @@
 		{"c_src" : "prog.c"},
 		{"Makefile" : "Makefile"},
 		{"remarks" : "remarks.md"},
-		{"extra_file" : "README.md"},
-		{"extra_file" : "prog.orig.c"},
-		{"extra_file" : "prog.alt"},
-		{"extra_file" : "prog.orig"},
-		{"extra_file" : "prog"},
-		{"extra_file" : "index.html"},
-		{"extra_file" : "inventory.html"}
+		{"extra_file" : "prog"}
 	],
 	"formed_timestamp" : 1675547786,
 	"formed_timestamp_usec" : 13685,

--- a/txzchk.c
+++ b/txzchk.c
@@ -652,9 +652,10 @@ check_txz_file(char const *tarball_path, char const *dir_name, struct txz_file *
 	    ++tarball.unsafe_chars;
 	    warn(__func__, "%s: file basename does not match regexp ^[0-9A-Za-z][0-9A-Za-z._+-]*$: %s",
 			   tarball_path, file->basename);
-	} else if (!strcasecmp(file->basename, README_MD_FILENAME) || !strcasecmp(file->basename, PROG_ORIG_C_FILENAME) ||
-		   !strcasecmp(file->basename, PROG_FILENAME) || !strcasecmp(file->basename, PROG_ORIG_FILENAME) ||
-		   !strcasecmp(file->basename, INDEX_HTML_FILENAME) || !strcasecmp(file->basename, INVENTORY_HTML_FILENAME)) {
+	} else if (!strcasecmp(file->basename, INDEX_HTML_FILENAME) || !strcasecmp(file->basename, INVENTORY_HTML_FILENAME) ||
+	    !strcasecmp(file->basename, PROG_FILENAME) || !strcasecmp(file->basename, PROG_ALT_FILENAME) ||
+	    !strcasecmp(file->basename, PROG_ORIG_FILENAME) || !strcasecmp(file->basename, PROG_ORIG_C_FILENAME) ||
+		   !strcasecmp(file->basename, README_MD_FILENAME)) {
 	    ++tarball.total_feathers;
 	    ++tarball.invalid_filenames;
 	    warn(__func__, "%s: filename not allowed: %s", tarball_path, file->basename);


### PR DESCRIPTION

Each forbidden filename in the manifest now has a separate file to check
it including prog.alt. The -34.json file was also updated to have 
prog.alt as an extra filename though it might be better to also check 
this for other files too if this is not done (been too long and too many
other changes in the other repo to recall if this is done or not).

That means that under test_ioccc/test_JSON/info.json/bad individual 
files that have an extra file with the names of:

- README.md
- index.html
- inventory.html
- prog
- prog.alt
- prog.orig
- prog.orig.c

have been added. Unless other files have to be added later to the list 
of disallowed filenames or there needs to be a more specific check in 
mkiocccentry for filenames of the required files this should complete 
the disallowed and required filenames checks.
