### PR TITLE
Improve rebuilding txzchk test error files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,14 +632,6 @@ release: test_ioccc/prep.sh
 #
 rebuild_txzchk_test_errors force_expectations_for_txzchk_test:
 	@./test_ioccc/txzchk_test.sh -B || exit 1
-	@echo
-	@echo "Now run ./test_ioccc/txzchk_test.sh and verify it works!" 1>&2
-	@echo
-	@echo "Assuming all tests pass you must then do:" 1>&2
-	@echo
-	@echo "    git add test_ioccc/test_txzchk/bad/*.txt test_ioccc/test_txzchk/bad/*.err" 1>&2
-	@echo
-	@echo "and then commit them (and if necessary open a pull request)." 1>&2
 
 # make parser
 #

--- a/Makefile
+++ b/Makefile
@@ -630,11 +630,16 @@ release: test_ioccc/prep.sh
 #	     out of date and that the difference between what is in the *.err
 #	     files and what is being generated is correct.
 #
-force_expectations_for_txzchk_test:
-	for i in ./test_ioccc/test_txzchk/bad/*.txt; do \
-	    echo "./txzchk -q -v 0 -w -T -E txt -F ./test_ioccc/fnamchk $$i 2>$$i.err"; \
-	    ./txzchk -q -v 0 -w -T -E txt -F ./test_ioccc/fnamchk "$$i" 2>"$$i.err"; \
-	done
+rebuild_txzchk_test_errors force_expectations_for_txzchk_test:
+	@./test_ioccc/txzchk_test.sh -B || exit 1
+	@echo
+	@echo "Now run ./test_ioccc/txzchk_test.sh and verify it works!" 1>&2
+	@echo
+	@echo "Assuming all tests pass you must then do:" 1>&2
+	@echo
+	@echo "    git add test_ioccc/test_txzchk/bad/*.txt test_ioccc/test_txzchk/bad/*.err" 1>&2
+	@echo
+	@echo "and then commit them (and if necessary open a pull request)." 1>&2
 
 # make parser
 #

--- a/test_ioccc/test_txzchk/README.md
+++ b/test_ioccc/test_txzchk/README.md
@@ -55,12 +55,14 @@ Whenever a new bad test file is added one must generate the proper err file. To
 simplify it you can from the top level directory where the mkiocccentry.c source
 file is located:
 
-    for i in ./test_ioccc/test_txzchk/bad/*.txt; do ./txzchk -q -v 0 -w -T -E txt -F ./test_ioccc/fnamchk "$i" 2>"$i.err" ; done
+```sh
+make rebuild_txzchk_test_errors
+git add test_ioccc/test_txzchk/bad/*.txt test_ioccc/test_txzchk/bad/*.err
+```
 
-then do:
+BUT MAKE SURE THAT ALL FILES ARE CORRECT! The make rule will run the `-B` option
+on the test script which will first prompt you to make sure if you wish to do
+it. Again one must make sure that the files are correct!
 
-    git add ./test_txzchk/bad/*.txt ./test_txzchk/bad/*.err
-
-(assuming that there aren't any other files with those extensions that should
-not be there). We could have the `txzchk_test.sh` script do this but the problem
-is we need to manually inspect that the errors are correct.
+This, of course, is assuming that there aren't any other files with those
+extensions that should not be there.

--- a/test_ioccc/txzchk_test.sh
+++ b/test_ioccc/txzchk_test.sh
@@ -316,6 +316,19 @@ if [[ -n "$B_FLAG" ]]; then
 	echo "$0: debug[1]: rebuilt test error files" 1>&2
     fi
 
+    echo 1>&2
+    echo "You should now run, from the top level directory:" 1>&2
+    echo 1>&2
+    echo "    ./test_ioccc/txzchk_test.sh -v $V_FLAG" 1>&2
+    echo 1>&2
+    echo "to verify that everything is in order. If it is and there are any file changes," 1>&2
+    echo "you will need to then run:" 1>&2
+    echo 1>&2
+    echo "    git add test_ioccc/test_txzchk/bad/*.txt test_ioccc/test_txzchk/bad/*.err" 1>&2
+    echo 1>&2
+    echo "and then commit (and if necessary open a pull request)." 1>&2
+    echo "Otherwise, if there is a problem you will have to fix any other issues first." 1>&2
+
     exit 0
 fi
 

--- a/test_ioccc/txzchk_test.sh
+++ b/test_ioccc/txzchk_test.sh
@@ -34,7 +34,7 @@
 
 # setup
 
-# attempt to fetch system specific path to the tools we need
+# attempt to fetch system specific path to the tool (tar) we need
 #
 # get tar path
 TAR="$(type -P tar 2>/dev/null)"
@@ -51,15 +51,13 @@ TAR="$(type -P tar 2>/dev/null)"
 #   ${TAR:=/usr/bin/tar} 2>/dev/null
 #
 # but due to the reasons cited above we must rely on the more complicated form:
-if [[ -z "$TAR" ]]; then
-    TAR="/usr/bin/tar"
-fi
+[[ -z "$TAR" ]] && TAR="/usr/bin/tar"
 
-export TXZCHK_TEST_VERSION="1.0.1 2023-02-05"
+export TXZCHK_TEST_VERSION="1.0.2 2024-03-05"
 export FNAMCHK="./test_ioccc/fnamchk"
 export TXZCHK="./txzchk"
 export TXZCHK_TREE="./test_ioccc/test_txzchk"
-export USAGE="usage: $0 [-h] [-V] [-v level] [-t tar] [-T txzchk] [-F fnamchk] [-d txzchk_tree] [-Z topdir] [-k]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-t tar] [-T txzchk] [-F fnamchk] [-d txzchk_tree] [-Z topdir] [-k] [-B]
 
     -h			    print help and exit
     -V			    print version and exit
@@ -77,6 +75,7 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-t tar] [-T txzchk] [-F fnamchk] [
 				    txzchk and the error file is done as an exact match
     -Z topdir		    top level build directory (def: try . or ..)
     -k			    keep temporary files on exit (def: remove temporary files before exiting)
+    -B			    rebuild error files
 
 Exit codes:
      0   all OK
@@ -95,7 +94,8 @@ export TOPDIR=
 #
 export V_FLAG="0"
 export K_FLAG=""
-while getopts :hVv:t:d:T:F:Z:k flag; do
+export B_FLAG=""
+while getopts :hVv:t:d:T:F:Z:kB flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -117,6 +117,8 @@ while getopts :hVv:t:d:T:F:Z:k flag; do
         ;;
     k)  K_FLAG="true";
         ;;
+    B)	B_FLAG="true";
+	;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
 	echo 1>&2
 	echo "$USAGE" 1>&2
@@ -291,6 +293,30 @@ fi
 if [[ ! -w "${LOGFILE}" ]]; then
     echo "$0: ERROR: log file not writable" 1>&2
     exit 29
+fi
+
+# if -B used we will just rebuild the test error files
+#
+if [[ -n "$B_FLAG" ]]; then
+    echo "Are you POSITIVE that the *.err files are simply out of date and" 1>&2
+    echo "that the difference between what is in the *.err files and" 1>&2
+    read -r -p "what is being generated is correct (YES/NO)? "
+
+    if [[ "$REPLY" != "YES" ]]; then
+	echo "$0: did not get YES as a reply, not regenerating files." 1>&2
+	exit 3
+    fi
+
+    for i in "$TXZCHK_BAD_TREE"/*.txt; do \
+	echo "$TXZCHK -q -v 0 -w -T -E txt -F $FNAMCHK $i 2>$i.err"; \
+	"$TXZCHK" -q -v 0 -w -T -E txt -F "$FNAMCHK" "$i" 2>"$i.err"; \
+    done
+
+    if [[ $V_FLAG -ge 1 ]]; then
+	echo "$0: debug[1]: rebuilt test error files" 1>&2
+    fi
+
+    exit 0
 fi
 
 # set up for the different tests


### PR DESCRIPTION
The script test_ioccc/test_txzchk.sh now has a new option: -B. This rebuilds the test error files. The script prompts the user to verify that everything is correct. If it does not get a YES (case sensitive!) it will exit 3 (invalid command line). If this is the case the rest of the rule is not run so no notice about adding and committing the new or updated files.

The rule in the Makefile now is called (the previous one still exists though): rebuild_txzchk_test_errors.

The test_ioccc/test_txzchk/README.md file has been updated for this (there was also an error in it but that text has been removed as the make rule tells the user what to do which is what the incorrect text was only of course the text is now corrected).