### PR TITLE
Fix comments and strings about author_handle regex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.0.61 2024-03-07
+
+Remove from comments the `winner_handle`. Fixed the regexp of an allowed handle
+(in comments and in strings). It is regrettable but due to the use of
+`posix_plus_safe()` additional characters are allowed that might be better left
+out (these have been allowed for a long time but the comments and strings said
+otherwise). The regexp that is allowed for `author_handle`s is:
+
+```re
+^[0-9A-Za-z][0-9A-Za-z._+-]*$
+```
+
+The difference is that it allows upper case characters too. In particular the
+old regexp was `^[0-9a-z][0-9a-z._+-]*$`.
+
+Typo fix in txzchk.h: referred to `posix_safe_plus()` instead of
+`posix_plus_safe()`.
+
+
 ## Release 1.0.59 2024-03-04
 
 Added a distinction between a "common name" and "name" for locations.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3029,7 +3029,7 @@ check_extra_data_files(struct info *infop, char const *submission_dir, char cons
 	if (posix_plus_safe(base, false, false, true) == false) {
 	    fpara(stderr,
 		  "",
-		  "The basename of an extra file must match the following regexp:",
+		  "The basename of an extra file must match the following regular expression:",
 		  "",
 		  "    ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
 		  "",
@@ -4427,9 +4427,9 @@ get_author_info(struct author **author_set_p)
 		 */
 		fpara(stderr,
 		      "",
-		      "The IOCCC author handle must match the following regexp:",
+		      "The IOCCC author handle must match the following regular expression:",
 		      "",
-		      "    ^[0-9a-z][0-9a-z_]*$",
+		      "     ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
 		      "",
 		      NULL);
 		errno = 0;		/* pre-clear errno for warnp() */

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -2309,11 +2309,11 @@ test_author_handle(char const *str)
 		 "invalid: author_handle: <%s> is invalid", str);
 	return false;
     }
-    /* IOCCC author handle must use only lower case POSIX portable filename and + chars */
+    /* IOCCC author_handle must use POSIX portable filename and + chars */
     test = posix_plus_safe(str, false, false, true);
     if (test == false) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: author_handle does not match regexp: ^[0-9a-z][0-9a-z._+-]*$");
+		 "invalid: author_handle does not match regexp: ^[0-9A-Za-z][0-9A-Za-z._+-]*$");
 	json_dbg(JSON_DBG_HIGH, __func__,
 		 "invalid: author_handle: <%s> contains invalid characters", str);
 	return false;

--- a/soup/utf8_posix_map.c
+++ b/soup/utf8_posix_map.c
@@ -3,17 +3,17 @@
  *
  * "Because even POSIX needs an extra plus." :-)
  *
- * An author_handle, for an IOCCC winner, will be used to form
- * a winner_handle.  These winner handles will become part of a
- * JSON filename on the www.ioccc.org website.  For this reason,
- * (and other reasons), we must restrict an author_handle to
- * only lower case POSIX portable filenames, with the addition of the +,
- * and restrictions on leading characters.
+ * An author_handle, if the submission is selected by the
+ * IOCCC judges to win the IOCCC, will be used to form a
+ * JSON filename under the author directory on the IOCCC
+ * website.  For this and other reasons, we must restrict an
+ * author_handle to use only POSIX portable filenames, and we
+ * must restrict the leading character to be ASCII alphabetic,
+ * in addition to other character restrictions.
  *
- * The author_handle (and winner_handle) must fit the following
- * regular expression:
+ * The author_handle must fit the following regular expression:
  *
- *	^[0-9a-z][0-9a-z_]*$
+ *	^[0-9A-Za-z][0-9A-Za-z._+-]*$
  *
  * Copyright (c) 2022,2023 by Landon Curt Noll.  All Rights Reserved.
  *

--- a/soup/utf8_posix_map.h
+++ b/soup/utf8_posix_map.h
@@ -3,17 +3,17 @@
  *
  * "Because even POSIX needs an extra plus." :-)
  *
- * An author_handle, for an IOCCC winning author, will be used to form
- * a winner_handle.  These winner handles will become part of a
- * JSON filename on the www.ioccc.org website.  For this reason,
- * (and other reasons), we must restrict an author_handle to
- * only lower case POSIX portable filenames, with the addition of the +,
- * and restrictions on leading characters.
+ * An author_handle, if the submission is selected by the
+ * IOCCC judges to win the IOCCC, will be used to form a
+ * JSON filename under the author directory on the IOCCC
+ * website.  For this and other reasons, we must restrict an
+ * author_handle to use only POSIX portable filenames, and we
+ * must restrict the leading character to be ASCII alphabetic,
+ * in addition to other character restrictions.
  *
- * The author_handle (and winner_handle) must fit the following
- * regular expression:
+ * The author_handle must fit the following regular expression:
  *
- *	^[0-9a-z][0-9a-z._+-]*$
+ *	^[0-9A-Za-z][0-9A-Za-z._+-]*$
  *
  * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
  *

--- a/test_ioccc/utf8_test.c
+++ b/test_ioccc/utf8_test.c
@@ -3,17 +3,17 @@
  *
  * "Because even POSIX needs an extra plus." :-)
  *
- * An author_handle, for an IOCCC winner, will be used to form
- * a winner_handle.  These winner handles will become part of a
- * JSON filename on the www.ioccc.org website.  For this reason,
- * (and other reasons), we must restrict an author_handle to
- * only lower case POSIX portable filenames, with the addition of the +,
- * and restrictions on leading characters.
+ * An author_handle, if the submission is selected by the
+ * IOCCC judges to win the IOCCC, will be used to form a
+ * JSON filename under the author directory on the IOCCC
+ * website.  For this and other reasons, we must restrict an
+ * author_handle to use only POSIX portable filenames, and we
+ * must restrict the leading character to be ASCII alphabetic,
+ * in addition to other character restrictions.
  *
- * The author_handle (and winner_handle) must fit the following
- * regular expression:
+ * The author_handle must fit the following regular expression:
  *
- *	^[0-9a-z][0-9a-z._+-]*$
+ *	^[0-9A-Za-z][0-9A-Za-z._+-]*$*
  *
  * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
  *

--- a/txzchk.h
+++ b/txzchk.h
@@ -97,7 +97,7 @@ struct tarball
     bool has_Makefile;			    /* true ==> has a Makefile */
     bool empty_Makefile;		    /* true ==> Makefile size == 0 */
     off_t Makefile_size;		    /* Makefile file size */
-    uintmax_t unsafe_chars;		    /* > 0 ==> unsafe characters found in this number of filenames (posix_safe_plus()) */
+    uintmax_t unsafe_chars;		    /* > 0 ==> unsafe characters found in this number of filenames (posix_plus_safe()) */
     off_t size;				    /* size of the tarball itself */
     off_t files_size;			    /* total size of all the files combined */
     off_t previous_files_size;		    /* the previous total size of all files combined */


### PR DESCRIPTION
There was also a typo fix in txzchk.h: the words plus and safe in the function posix_plus_safe() were swapped.

No versions needed to be changed because no code functionality was changed as the regexp was allowed already.