### PR TITLE
Add some credits to location code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -427,7 +427,7 @@ German Democratic Republic ==> DD
 Germany ==> DE
 ```
 
-I, that is Cody/@xexyl, observe that Germany is a country full of 'germ ridden
+I, that is Cody, observe that Germany is a country full of 'germ ridden
 people' (this is not really true of course but it's a fun pun of mine :-) )
 
 Add `tmp/TODO.md` file with todo items not specific to any open issue.

--- a/soup/location.h
+++ b/soup/location.h
@@ -3,6 +3,15 @@
  *
  * "Because there is an I in IOCCC." :-)
  *
+ * This tool was improved (show all codes, substring search via re-entrant
+ * functions) by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * Copyright (c) 2022 by Landon Curt Noll.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -3,6 +3,15 @@
  *
  * "Because there is an I in IOCCC." :-)
  *
+ * This tool was improved (show all codes, substring search via re-entrant
+ * functions) by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * Copyright (c) 2023,2024 by Landon Curt Noll.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and

--- a/soup/location_tbl.c
+++ b/soup/location_tbl.c
@@ -3,6 +3,15 @@
  *
  * "Because there is an I in IOCCC." :-)
  *
+ * This tool was improved (show all codes, substring search via re-entrant
+ * functions) by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * Copyright (c) 2022,2023 by Landon Curt Noll.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and

--- a/soup/location_util.c
+++ b/soup/location_util.c
@@ -3,6 +3,15 @@
  *
  * "Because there is an I in IOCCC." :-)
  *
+ * This tool was improved (show all codes, substring search via re-entrant
+ * functions) by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
  * Copyright (c) 2022,2023 by Landon Curt Noll.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and


### PR DESCRIPTION
To match what was done in chkentry I have also done it in the location tool code in the same way that was done in the chkentry code and header files.

Also in CHANGES.md I removed a reference to '@xexyl' (a fun pun is attributed to me still, however). This is because otherwise every time a release is made GitHub would tell me I was mentioned which is both confusing (as it's buried deeply) and unnecessary (plus if ever I am mentioned I might otherwise miss it). This problem is actually how I discovered the missing credits mentioned in this commit.