### PR TITLE
Documentation fixes/additions for location(1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.1.1 2024-05-22
+
+Changed `LOCATION_VERSION` to `"1.0.4 2024-05-22"`.
+
+Fixed usage string in `location_main.c`: it did not suggest that one can specify
+more than one location but it can.
+
+Added to the README.md brief documentation of the `location(1)` tool (it was not
+there at all) and fixed some typos and added some clarity in the `location.1`
+man page.
+
+
 ## Release 1.1 2024-05-19
 
 Release version 1.1 of the mkiocccentry tool set.
@@ -399,7 +411,7 @@ United States of America ==> US
 Without the `-v 1` it will only show:
 
 ```sh
-$ ./location -a -s -N 'united'
+$ ./location -a -s -n 'united'
 AE
 GB
 PU
@@ -410,11 +422,11 @@ UN
 US
 ```
 
-If one does not use the `-N` option the `-a` is less useful as that function
+If one does not use the `-n` option the `-a` is less useful as that function
 checks explicitly that the length is two characters so it has to be an exact
 match. Nevertheless there is a re-entrant version of the function that works
-much the same way as the other and the `-a` is processed without `-N`. Use of
-`-s` requires an arg much like `-N` but it does NOT require `-N` itself.
+much the same way as the other and the `-a` is processed without `-n`. Use of
+`-s` requires an arg much like `-n` but it does NOT require `-n` itself.
 
 The rationale behind these changes is they will make it easier for people to
 find their country code, if they do not know what it is (or they want say
@@ -422,7 +434,7 @@ anonymous and don't know that it's `XX`). Search is done case-insensitively.
 Another example use:
 
 ```sh
-$ ./location -asNv 1 germ
+$ ./location -asnv 1 germ
 German Democratic Republic ==> DD
 Germany ==> DE
 ```

--- a/README.md
+++ b/README.md
@@ -217,6 +217,33 @@ man ./soup/man/man1/bug_report.1
 NOTE: This tool may be found as: `./bug_report.sh`.
 
 
+###  `location`
+
+The official **IOCCC** tool to look up ISO 3166 codes and location names to help
+aid users in finding country codes. With the `-s` option one can search by
+substring and with the `-a` option one can list all codes that match, though the `-a`
+option is less useful without `-n` and is only checked for with at least one arg
+specified.
+
+This tool was developed in 2023 by:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+with improvements (`-a` and `-s` options via new re-entrant functions) by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+
+For more information and examples, try:
+
+```sh
+man ./soup/man/man1/location.1
+```
+
+NOTE: After doing a `make all`, this tool may be found as: `./soup/location`.
+
+
 
 ## How do I submit my submission to the IOCCC?
 

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -58,14 +58,14 @@
 /*
  * official location version
  */
-#define LOCATION_VERSION "1.0.3 2024-03-03"		/* format: major.minor YYYY-MM-DD */
+#define LOCATION_VERSION "1.0.4 2024-05-22"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
  * usage message
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-V] [-n] [-s] [-a] [location]\n"
+    "usage: %s [-h] [-v level] [-V] [-n] [-s] [-a] [location...]\n"
     "\n"
     "\t-h\t\tprint help message and exit\n"
     "\t-v level\tset verbosity level (def level: %d)\n"

--- a/soup/man/man1/location.1
+++ b/soup/man/man1/location.1
@@ -8,10 +8,10 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH location 1 "03 March 2024" "location" "IOCCC tools"
+.TH location 1 "22 May 2024" "location" "IOCCC tools"
 .SH NAME
 .B location
-\- lookup ISO 3166 codes, location names or print the table
+\- look up ISO 3166 codes, location names by name (substring, full) or print the entire table
 .SH SYNOPSIS
 .B location
 .RB [\| \-h \|]
@@ -52,7 +52,7 @@ To show all matches use the
 option.
 Showing all matches is less useful without the
 .B \-n
-option because country codes are two characters and are exact matches.
+option because country codes are two characters and are exact matches and the option is only relevant if an arg is specified.
 The use of
 .B \-s
 requires an arg to the program much like
@@ -105,8 +105,8 @@ Use of
 .B \-a
 is less useful without the
 .B \-n
-option but nonetheless it is possible to use
-.B \-s
+option and only checked for if at least one arg is specified but nonetheless it is possible to use
+.B \-a
 without
 .BR \-n .
 .SH EXIT STATUS


### PR DESCRIPTION
Updated LOCATION_VERSION to "1.0.4 2024-05-22" from "1.0.3 2024-03-03".

Fixed usage string in location_main.c so that it shows that one can specify more than one location.

The location(1) tool was missing from the README.md and this seems like a good tool to have there. There might be other tools missing too but that can be determined and if necessary fixed another time.

The man page had a typo as well: in SYNOPSIS it had lookup when it would probably be more correct to say 'look up': the former is the facility and the retrieval of information but one would 'look up information' or in this case 'look up location information' or to be more specific 'look up ISO 3166 codes, location names by name (substring, full) or print the entire table' (this was expanded as well as it was missing some useful information). Also added some clarity to the -s and -a options in the DESCRIPTION section.