### PR TITLE
Remove duplicate option in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ root = true
 # Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
-insert_final_newline = true
 # remove trailing whitespace
 trim_trailing_whitespace = true
 # ensure file ends with a newline when saving


### PR DESCRIPTION
According to @SirWumpus this causes a problem in TextPad. Since the key is indeed duplicate and in the same section it should not be a problem to remove it. I removed it where there was no comment about it.