### PR TITLE
Change C standard to c17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,23 +145,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#	in late 2021 that do not have compilers that (yet) support gnu17.
-#	While there may be even more out of date systems that do not
-#	support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
 #	--------------------------------------------------
 #
 #	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -125,23 +125,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#       in late 2021 that do not have compilers that (yet) support gnu17.
-#       While there may be even more out of date systems that do not
-#       support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
-#       --------------------------------------------------
+#	--------------------------------------------------
 #
-#       ^^ the line is above :-)
+#	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -129,23 +129,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#       in late 2021 that do not have compilers that (yet) support gnu17.
-#       While there may be even more out of date systems that do not
-#       support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
-#       --------------------------------------------------
+#	--------------------------------------------------
 #
-#       ^^ the line is above :-)
+#	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -119,23 +119,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#       in late 2021 that do not have compilers that (yet) support gnu17.
-#       While there may be even more out of date systems that do not
-#       support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
-#       --------------------------------------------------
+#	--------------------------------------------------
 #
-#       ^^ the line is above :-)
+#	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -120,23 +120,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#	in late 2021 that do not have compilers that (yet) support gnu17.
-#	While there may be even more out of date systems that do not
-#	support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
 #	--------------------------------------------------
 #
 #	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -134,23 +134,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#       in late 2021 that do not have compilers that (yet) support gnu17.
-#       While there may be even more out of date systems that do not
-#       support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
-#       --------------------------------------------------
+#	--------------------------------------------------
 #
-#       ^^ the line is above :-)
+#	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -129,23 +129,21 @@ MAKE_CD_Q= --no-print-directory
 
 # C source standards being used
 #
-# This repo supports c11 and later.
+# This repo supports c17 and later.
 #
-# NOTE: The use of -std=gnu11 is because there are a few older systems
-#	in late 2021 that do not have compilers that (yet) support gnu17.
-#	While there may be even more out of date systems that do not
-#	support gnu11, we have to draw the line somewhere.
+# NOTE: at one point we used -std=gnu11 because there were a few older systems
+#       in late 2021 that did not have compilers that (yet) supported gnu17.
+#       While there may be even more out of date systems that do not support
+#       gnu11, we have to draw the line somewhere. Besides, one of those systems
+#       reaches its EOL on 30 June 2024 and that's three days away at this
+#       point.
 #
 #	--------------------------------------------------
 #
 #	^^ the line is above :-)
 #
-# TODO - ############################################################################### - TODO #
-# TODO - Sometime in 2023 we will will support only c17 so C_STD will become -std=gnu17  - TODO #
-# TODO - ############################################################################### - TODO #
-#
-C_STD= -std=gnu11
-#C_STD= -std=gnu17
+#C_STD= -std=gnu11
+C_STD= -std=gnu17
 
 # optimization and debug level
 #


### PR DESCRIPTION
It was stated that this would happen sometime in 2023 and we're almost at July in 2024. One of the problem systems that required c11 will be reaching EOL (thanks to Red Hat) on 30 June 2024 so it seems to not be a problem. Rocky linux appears to work with c17 (although I only tested the top level Makefile for that but it should work fine).