### PR TITLE
GH-873 Fix potential keyword buffer overflow off by 1 byte causing stack corruption.

### DIFF
--- a/iocccsize.h
+++ b/iocccsize.h
@@ -41,7 +41,7 @@ typedef unsigned char bool;
 #endif
 
 #ifndef WORD_BUFFER_SIZE
-#define WORD_BUFFER_SIZE	256
+#define WORD_BUFFER_SIZE	16
 #endif
 
 /*

--- a/soup/rule_count.c
+++ b/soup/rule_count.c
@@ -243,7 +243,7 @@ RuleCount
 rule_count(FILE *fp_in)
 {
 	size_t wordi = 0;
-	char word[WORD_BUFFER_SIZE+1];
+	char word[WORD_BUFFER_SIZE];
 	RuleCount counts = { 0, 0, 0, false, false, false, false, false };
 	int ch, next_ch, quote = NO_STRING, escape = 0, is_comment = NO_COMMENT;
 
@@ -431,11 +431,20 @@ rule_count(FILE *fp_in)
 
 		/* Collect next word not in a string or comment. */
 		if (IS_CODE && (isalnum(ch) || ch == '_' || ch == '#')) {
+			word[wordi++] = (char) ch;
 			if (sizeof (word) <= wordi) {
+				/* ISO C11 section 5.2.4.1 Translation limits, identifiers
+				 * can have 63 significant initial characters, which can be
+				 * multibyte.  The C keywords are all ASCII, longest is 14
+				 * bytes.
+				 *
+				 * We only care about the C keywords and not the identifiers,
+				 * so the buffer can overflow regularly as long words or
+				 * identifiers are ignored.
+				 */
 				counts.wordbuf_warning = true;
 				wordi = 0;
 			}
-			word[wordi++] = (char) ch;
 			word[wordi] = '\0';
 		}
 

--- a/test_ioccc/iocccsize_test.sh
+++ b/test_ioccc/iocccsize_test.sh
@@ -7,6 +7,10 @@
 # Public Domain 1992, 2015, 2019 by Anthony Howe.  All rights released.
 #
 # IOCCC mods in 2019,2021,2022 by chongo (Landon Curt Noll) ^oo^
+#
+# ***
+# *** NOTE when editing this file it contains UTF8 multibyte characters.
+# ***
 
 # setup
 #
@@ -327,8 +331,9 @@ test_size crlf.c "2 8 1"
 
 #######################################################################
 
-printf 'char str[] = "\xe8\xe9\xf8";\r\n' >"$WORK_DIR/utf8.c"
-test_size utf8.c "12 21 1"
+# String literal with multibyte characters (mb2).
+printf 'char str[] = "èéø";\r\n' >"${WORK_DIR}/utf8.c"
+test_size utf8.c "15 24 1"
 
 #######################################################################
 
@@ -654,6 +659,57 @@ main(int argc, char **argv)
 }
 EOF
 test_size semicolon2.c "67 127 8"
+
+#######################################################################
+
+# String literal with multibyte charaters (mb3).
+cat <<EOF >"${WORK_DIR}/hello-jp.c"
+#include <stdio.h>
+
+int
+main(int argc, char **argv)
+{
+	(void) printf("こんにちは世界！\n");
+	return 0;
+}
+EOF
+test_size hello-jp.c "71 113 6"
+
+#######################################################################
+
+# Unicode identifier using hiragana and kanji.
+cat <<EOF >"${WORK_DIR}/hello-jp2.c"
+#include <stdio.h>
+
+int
+main(int argc, char **argv)
+{
+	char str_こんにちは世界！[] = "Kon'nichiwa sekai!\n";
+	(void) printf(str_こんにちは世界！);
+	return 0;
+}
+EOF
+test_size hello-jp2.c "124 176 7"
+
+#######################################################################
+
+# Long Unicode identifier
+cat <<EOF >"${WORK_DIR}/hello-jp3.c"
+#include <stdio.h>
+
+int
+main(int argc, char **argv)
+{
+	/* Identifier with 4 ASCII + 20 hiragana, katakana, and kanji.
+	 * There is nothing wrong with this source code.
+	 */
+	char str_このソースコードには何も問題はありません[] = "Kono sōsukōdo ni wa nani mo mondai wa arimasen.\n";
+	(void) printf(str_このソースコードには何も問題はありません);
+	return 0;
+}
+EOF
+test_size hello-jp3.c "313 398 7"
+
 
 # All Done!!! -- Jessica Noll, Age 2
 #


### PR DESCRIPTION
My initial attempt to address this issue.  I'm not yet able to duplicate the failure.  This change still makes sense regardless so worth merging and testing on those platforms with compiler options that failed.