### PR TITLE
Fix limit_ioccc.sh not being generated at times

### DIFF
--- a/soup/Makefile
+++ b/soup/Makefile
@@ -390,6 +390,7 @@ soup.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
+	${MAKE} limit_ioccc.sh
 
 chk_sem_info.c: ../jparse/jsemtblgen ../jparse/jsemcgen.sh ../test_ioccc/test_JSON/info.json/good/info.reference.json \
 		chk.info.head.c chk.info.ptch.c chk.info.tail.c
@@ -450,8 +451,7 @@ kitchen soup_kitchen: kitchen.sh
 # rules for use by other Makefiles #
 ####################################
 
-limit_ioccc.sh: limit_ioccc.h version.h ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h ../jparse/run_bison.sh \
-		../jparse/run_flex.sh ../jparse/verge.c
+limit_ioccc.sh:
 	${Q} ${RM} -f $@
 	${Q} echo '#!/usr/bin/env bash' > $@
 	${Q} echo '#' >> $@


### PR DESCRIPTION
If one were to do make clobber iocccsize it would not build soup/limit_ioccc.sh. It would, however, build the soup.a library, and since it's a useful file to be built, and since tools rely on soup.a, the soup.a rule now makes limit_ioccc.sh.

Doing it this way prevents having to add something like:

		${MAKE} -C soup limit_ioccc.sh

to all the rules in the Makefile and now one can do:

		make clobber iocccsize
		./test_ioccc/iocccsize_test.sh

and have it run okay. Without something like this (that can probably be improved upon / cleaned up) one would have to build everything in order for the file to be built (which maybe indicates a better procedure could be devised).