### PR TITLE
Fix Makefile.example for gcc specifics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a bug
 title: "[Bug] <title>"
+labels: ["bug"]
 body:
 - type: checkboxes
   attributes:

--- a/Makefile.example
+++ b/Makefile.example
@@ -113,9 +113,9 @@ endif
 #
 ifeq "$(findstring $(GCC),${CC})" "$(GCC)"
 #
-#CSILENCE+=
+CSILENCE+=
 #
-#CWARN+=
+CWARN+=
 #
 endif
 


### PR DESCRIPTION
The CSILENCE+= and CWARN+= were commented out.
