### PR TITLE
Update jparse/README.md and json_util_README.md

### DIFF
--- a/jparse/README.md
+++ b/jparse/README.md
@@ -30,6 +30,7 @@ We recommend that you read the [json_README.md](json_README.md) document
 to better understand the JSON terms used in this repo.
 
 
+
 ## Compiling
 
 We determine if you have a recent enough `flex(1)` and `bison(1)`. If you do not
@@ -213,3 +214,18 @@ man ./man/man1/jstrdecode.1
 ```
 
 NOTE: After doing a `make all`, this tool may be found as: `./jstrdecode`.
+
+
+## Other `jparse` tools:
+
+We also provide a number of tools that are, at least in what they will do when
+completed, in [json_util_README.md](json_util_README.md). But please note the
+warning there that says:
+
+<hr>
+Please be advised that the tools `jfmt`, `jval` and `jnamval` are **VERY
+INCOMPLETE** and **WILL BE HEAVILY MODIFIED**. It is also highly likely that
+they will be almost **entirely rewritten** as things changed as they were first
+worked on. Almost everything will be redone at this point. When this is done
+this notice will be removed.
+<hr>

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -1,5 +1,15 @@
 # Command line utilities that read and process JSON in different ways
 
+## WARNING: status of the tools
+
+### XXX - remove this WARNING once the tools are complete - XXX
+
+Please be advised that the tools `jfmt`, `jval` and `jnamval` are **VERY
+INCOMPLETE** and **WILL BE HEAVILY MODIFIED**. It is also highly likely that
+they will be almost **entirely rewritten** as things changed as they were first
+worked on. Almost everything will be redone at this point. When this is done
+this notice will be removed.
+
 ## Introduction to this document
 
 NOTE: Please see [json_README.md](./json_README.md) for some important **JSON


### PR DESCRIPTION
These files now state that the tools jfmt, jval and jnamval are VERY INCOMPLETE and will be HEAVILY MODIFIED and will be almost entirely rewritten. This is much quicker than updating the code and header files to note this fact but it feels useful as they still exist.

When the tools are rewritten the notice will be removed from both files and jparse/README.md will refer to them again, briefly giving an overview (or at least referring to the other document) and how to render the man pages.

This is partly done as I have updated the README.md in the jparse repo itself to refer to the README.md here to give people a better idea, noting that although one can certainly use the parser/library if they wish, it is still tied to the mkiocccentry repo.