### PR TITLE
Add make release to GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: install ctags
       run: sudo apt-get install -y universal-ctags
+    - name: install flex
+      run: sudo apt-get install -y flex
+    - name: install bison
+      run: sudo apt-get install -y bison
     - name: install shellcheck
       run: sudo apt-get install -y shellcheck
     - name: clone seqcexit
@@ -31,8 +35,8 @@ jobs:
       run: cd picky && make && sudo cp -p picky /usr/local/bin
     - name: make
       run: make
-    - name: make slow_prep
-      run: make slow_prep
+    - name: make slow_release
+      run: make slow_release
     - name: make clobber all test
       run: make clobber all test
     - name: make clobber


### PR DESCRIPTION
... or actually the new make slow_release. This is a test to see if it can install flex and bison and generate the jparse backup files in case the .l/.y files are modified and by accident make release or make parser is not run.