### PR TITLE
Fix (hopefully) workflow of make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,6 +632,26 @@ release: test_ioccc/prep.sh
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
 
+# a slower version of release that does not write to a log file so one can see the
+# full details.
+#
+slow_release: test_ioccc/prep.sh
+	${Q} ${RM} -f ${TMP_BUILD_LOG}
+	${Q} ./test_ioccc/prep.sh -m${MAKE} -e -o; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo; \
+	        echo "make $@: ERROR: ./test_ioccc/prep.sh exit code: $$EXIT_CODE"; \
+	    fi; \
+	    echo; \
+	    echo "make $@: see ${BUILD_LOG} for details"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		exit "$$EXIT_CODE"; \
+	    else \
+	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
+	    fi
+
+
 # force test_ioccc/txzchk_test.sh results into test suite *.err files
 #
 # If test_ioccc/txzchk_test.sh reports some *.err files under ./test_ioccc/test_txzchk


### PR DESCRIPTION
The problem, it would appear, is that in trying to be done for the day, I forgot to commit the Makefile, which would mean the rule could not be run since it was not there.