### PR TITLE
Add clone/install of independ to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
       run: git clone https://github.com/lcn2/seqcexit
     - name: install seqcexit
       run: cd seqcexit && sudo make install
+    - name: clone independ
+      run: git clone https://github.com/lcn2/independ
+    - name: install independ
+      run: cd independ && sudo make install
     - name: clone picky
       run: git clone https://github.com/xexyl/picky
     - name: clone checknr


### PR DESCRIPTION
This is needed for the make slow_release. It is not an error if it is not installed but since it's used it might be good to have it work.