### PR TITLE
Fix git clone picky

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: install checknr
       run: cd checknr && sudo make install
     - name: clone picky
-      run: git clone https://github.com/lcn2/picky
+      run: git clone https://github.com/xexyl/picky
     - name: install picky
       run: cd picky && sudo make install
     - name: make


### PR DESCRIPTION
The repo it was changed to was actually a fork of my repo so it seems better to have it as my repo.