### PR TITLE
Fix picky rule in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,7 +766,7 @@ picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \


### PR DESCRIPTION
As the GitHub repo was changed in the workflow it should also refer to it in the Makefiles.