### PR TITLE
Add constants for test_formed_timestamp_usec()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.2.4 2024-07-14
+
+Add constants for `test_formed_timestamp_usec()` in `entry_util.c`.
+
 
 ## Release 1.2.3 2024-07-12
 

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -488,7 +488,7 @@ picky: ${ALL_SRC}
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -448,7 +448,7 @@ picky: ${ALL_SRC}
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -718,7 +718,7 @@ picky: ${ALL_SRC} test_jparse/Makefile
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -444,7 +444,7 @@ picky: ${ALL_SRC}
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -628,7 +628,7 @@ picky: ${ALL_SRC}
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -2992,13 +2992,14 @@ test_formed_timestamp_usec(int formed_timestamp_usec)
     /*
      * validate count
      */
-    if (formed_timestamp_usec < 0) {
+    if (formed_timestamp_usec < MIN_FORMED_TIMESTAMP_USEC) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: formed_timestamp_usec: %d < 0", formed_timestamp_usec);
+		 "invalid: formed_timestamp_usec: %d < %d", formed_timestamp_usec, MIN_FORMED_TIMESTAMP_USEC);
 	return false;
-    } else if (formed_timestamp_usec > 999999) {
+    } else if (formed_timestamp_usec > MAX_FORMED_TIMESTAMP_USEC) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: formed_timestamp_usec: %d > 999999", formed_timestamp_usec);
+		 "invalid: formed_timestamp_usec: %d > MAX_FORMED_TIMESTAMP_USEC %d", formed_timestamp_usec,
+                 MAX_FORMED_TIMESTAMP_USEC);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "formed_timestamp_usec is valid");

--- a/soup/limit_ioccc.h
+++ b/soup/limit_ioccc.h
@@ -71,6 +71,9 @@
 #define MAX_TIMESTAMP_LEN (48)		/* 28 + 20 more padding for locate */
 #define MAX_CLOCK_ERROR ((42*60)-1)	/* maximum seconds allowed for a clock to be in error */
 
+#define MIN_FORMED_TIMESTAMP_USEC (1)       /* minimum formed_timestamp_usec value */
+#define MAX_FORMED_TIMESTAMP_USEC (999999)  /* maximum formed_timestamp_usec value */
+
 /*
  * Be careful not to change this value as it will invalidate all IOCCC timestamps < this value
  */

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -442,7 +442,7 @@ picky: ${ALL_SRC}
 	    echo 1>&2; \
 	    echo 'See the following GitHub repo for ${PICKY}:'; 1>&2; \
 	    echo 1>&2; \
-	    echo '    https://github.com/xexyl/picky' 1>&2; \
+	    echo '    https://github.com/lcn2/picky' 1>&2; \
 	    echo 1>&2; \
 	    exit 1; \
 	else \


### PR DESCRIPTION

This is part of chkentry(1) - see soup/entry_util.c for details on this
function.
