### PR TITLE
Fix a few error messages in jparse/json_sem.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 Add constants for `test_formed_timestamp_usec()` in `entry_util.c`.
 
+Fix error messages in a number of `sem_member_value_*` functions in
+`jparse/json_sem.c`, where the `*` is some of the number checks. In particular
+a number of non-boolean checks reported incorrectly that the type was not a bool
+when it actually expects something else.
+
 
 ## Release 1.2.3 2024-07-12
 

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -1259,7 +1259,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(66, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(66, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;
@@ -1336,7 +1336,7 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(69, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(69, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;
@@ -1414,7 +1414,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(72, node, depth, sem, name, "node value type %s != JTYPE_BOOL",
+	    *val_err = werr_sem_val(72, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;


### PR DESCRIPTION
In some of the functions sem_member_value_*() (those that validate JSON parse node types) the error message (if the type was wrong) reported incorrectly the type expected and in particular all of them suggested the type should be JTYPE_BOOL but none of the functions were for booleans (though all were for numbers I think).