### PR TITLE
Update .gitignore and test GitHub PR issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.[ao]
 *.dSYM/
 *~
-.*.sw[a-zA-Z0-9]
 .sw[a-zA-Z0-9]
+.*.sw[a-zA-Z0-9]
 .DS_Store
 ._.DS_Store
 /.build.log.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.dSYM/
 *~
 .*.sw[a-zA-Z0-9]
+.sw[a-zA-Z0-9]
 .DS_Store
 ._.DS_Store
 /.build.log.*


### PR DESCRIPTION

There is a problem with GitHub where if one pull request is closed then
accepting ones that come later will merge the closed pull requests. It
is my belief that this only happens if the maintainer closes it; if the
submitter closes it it does not seem to be a problem.

This pull request is the same as a pull request I just closed except the
line order has been swapped. This is not a perfect test and it entirely
depends on the order GitHub does merging (one might think that it would
be the order merged but perhaps it's not that - we do not know as it
should not be happening in the first place).

The diff of THIS commit is:

    -.*.sw[a-zA-Z0-9]
     .sw[a-zA-Z0-9]
    +.*.sw[a-zA-Z0-9]

which means that if all is okay (after this is merged), the glob:

    .sw[a-zA-Z0-9]

should come before the glob:

    .*.sw[a-zA-Z0-9]

In other words the .gitignore file should have the lines in this order:

    .sw[a-zA-Z0-9]
    .*.sw[a-zA-Z0-9]

and if I described it wrong above it is because it is an off day. I
believe, however, that the order will be as described, whereas it MIGHT
have been different if the other pull request had been closed by Landon
instead of me.

If it is not clear, the glob that was added is:

    .sw[a-zA-Z0-9]

These globs might (unsure) be better to have a '*' at the end but this
can be done later (it is extremely unlikely that anyone would have that
many vi(m) swap files and I have never bothered to check the vim - let
alone even the vi - code to determine its - or their - algorithm in
generating swap file names).
