### PR TITLE
Fix .gitignore wrt vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 *.[ao]
 *.dSYM/
 *~
-.sw[a-zA-Z0-9]
-.*.sw[a-zA-Z0-9]
+.sw[a-zA-Z0-9]*
+.*.sw[a-zA-Z0-9]*
 .DS_Store
 ._.DS_Store
 /.build.log.*


### PR DESCRIPTION
The globs are now:

    .sw[a-zA-Z0-9]*
    .*.sw[a-zA-Z0-9]*

It is unclear if the file I have in my directory, '.swox', is actually a vim swap file (it happens to be empty which suggests it is NOT a vim swap file) but the format of vim swap files (no longer sure on vi(1) but certainly vim(1)) is .sw[a-z] and .*.sw[a-z] at the very least but it might end up with more than one letter after the third letter (the upper case and digits in the range is in case it also goes that far - I do not know as I never checked the source code but this change seems like a good idea anyway).