### PR TITLE
Move open_json_dir_file to open_dir_file (util.c)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 Move `open_json_dir_file()` from `chkentry.c` to `open_dir_file()` in
 `jparse/util.c`.
 
+Updated `MKIOCCCENTRY_REPO_VERSION` version to "1.5.1 2024-08-28".
+
 
 ## Release 1.5 2024-08-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.5.1 2024-08-28
+
+Move `open_json_dir_file()` from `chkentry.c` to `open_dir_file()` in
+`jparse/util.c`.
+
+
 ## Release 1.5 2024-08-27
 
 Prep for "**Release 1.5 2024-08-27**".

--- a/chkentry.h
+++ b/chkentry.h
@@ -3,11 +3,14 @@
  *
  * "Because grammar and syntax alone do not make a complete language." :-)
  *
- * This tool was improved by:
+ * This tool and the JSON parser were co-developed in 2022-2024 by Cody Boone
+ * Ferguson and Landon Curt Noll:
  *
  *	@xexyl
  *	https://xexyl.net		Cody Boone Ferguson
  *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * "Because sometimes even the IOCCC Judges need some help." :-)
  *
@@ -15,30 +18,6 @@
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
- *
- * Copyright (c) 2022-2024 by Landon Curt Noll.  All Rights Reserved.
- *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
- *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
- *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * Share and enjoy! :-)
  */
 
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -221,6 +221,7 @@ extern void clearerr_or_fclose(FILE *stream);
 extern ssize_t fprint_line_buf(FILE *stream, const void *buf, size_t len, int start, int end);
 extern ssize_t fprint_line_str(FILE *stream, char *str, size_t *retlen, int start, int end);
 extern char *calloc_path(char const *dirname, char const *filename);
+extern FILE *open_dir_file(char const *dir, char const *file);
 
 extern size_t count_char(char const *str, int ch);
 

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5 2024-08-27"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.1 2024-08-28"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
As this function is useful for more than just chkentry.c and more than just JSON (though this is all it's used for currently) it has been renamed and moved to jparse/util.c.

This commit is, although useful, not critical at this time. No versions have changed because it is not clear yet what version strings should be changed and because this might not (yet) warrant a new release.