### PR TITLE
Fix hostchk.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.5.3 2024-08-28
+
+Fix `hostchk.sh` that was broken with the recent change of `MKIOCCCENTRY_SRC`.
+New version for hostchk.sh: `"1.0.2 2024-08-28"`.
+
+
 ## Release 1.5.2 2024-08-28
 
 Remove dependence of `jparse/jsemtblgen.h` on `../iocccsize.h`.

--- a/test_ioccc/hostchk.sh
+++ b/test_ioccc/hostchk.sh
@@ -63,7 +63,7 @@ CC="$(type -P cc 2>/dev/null)"
 if [[ -z $CC ]]; then
     CC="/usr/bin/cc"
 fi
-export HOSTCHK_VERSION="1.0.1 2023-02-22"
+export HOSTCHK_VERSION="1.0.2 2024-08-28"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w work_dir] [-f] [-Z topdir]
 
     -h			    Print help and exit
@@ -237,7 +237,7 @@ if [[ -n $F_FLAG ]]; then
     #
     printf "%s\\n%s\\n" "$(grep '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] \
 	"$TOPDIR"/dyn_array/*.[hc] "$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hcly] \
-	"$TOPDIR"/jparse/test_jparse/*.[hc] |cut -f 2- -d:|sort -u)" "int main(void) { return 0; }" |
+	"$TOPDIR"/jparse/test_jparse/*.[hc]|grep -vE '<dbg.h>|<dyn_array.h>' |cut -f 2- -d:|sort -u)" "int main(void) { return 0; }" |
 	    "${CC}" -x c - -o "$PROG_FILE"
     status="$?"
     if [[ $status -ne 0 ]]; then


### PR DESCRIPTION
With the recent updates to the inclusion of the different repos and the MKIOCCCENTRY_SRC a problem in linux for hostchk.sh had to be resolved. This might also be a problem in macOS but since the libraries were already installed this is not detected (it seems that in linux if the other libraries were installed this also was not a problem).

There still exists an issue with building, however, as the make dependencies have system paths (cc -MM will solve this so it might be the way independ works but this is not clear to me at this time). Nonetheless the hostchk.sh should at least now work.

New version of hostchk.sh is 1.0.2 2024-08-28.