### PR TITLE
Rename library filenames for external repos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.4 2024-08-29
+
+Rename libraries for easier linking in other applications. In particular the
+[jparse repo](https://github.com/xexyl/jparse/) (which currently requires some
+changes in order to work on its own but this release is part of that) needs the
+`dbg` and `dyn_array` libraries but in order to link these in properly one must
+name them `libdbg.a` and `libdyn_array.a` (i.e. add the `lib`) so that one can
+then do `-ldbg` and `-ldyn_array`. Along the same lines `jparse.a` has been
+renamed to `libjparse.a` for linking in (this is something that has not yet been
+done in the jparse repo but in order to link it in it will have to be done).
+
+Updated the `MKIOCCCENTRY_REPO_VERSION` to `"1.5.4 2024-08-29"`.
+
 
 ## Release 1.5.3 2024-08-28
 

--- a/Makefile
+++ b/Makefile
@@ -441,25 +441,25 @@ hostchk_warning:
 mkiocccentry.o: mkiocccentry.c
 	${CC} ${CFLAGS} mkiocccentry.c -c
 
-mkiocccentry: mkiocccentry.o soup/soup.a jparse/jparse.a dyn_array/dyn_array.a dbg/dbg.a
+mkiocccentry: mkiocccentry.o soup/soup.a jparse/libjparse.a dyn_array/libdyn_array.a dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 iocccsize.o: iocccsize.c
 	${CC} ${CFLAGS} -DMKIOCCCENTRY_USE iocccsize.c -c
 
-iocccsize: iocccsize.o soup/soup.a dbg/dbg.a
+iocccsize: iocccsize.o soup/soup.a dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 txzchk.o: txzchk.c
 	${CC} ${CFLAGS} txzchk.c -c
 
-txzchk: txzchk.o soup/soup.a jparse/jparse.a dyn_array/dyn_array.a dbg/dbg.a
+txzchk: txzchk.o soup/soup.a jparse/libjparse.a dyn_array/libdyn_array.a dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 chkentry.o: chkentry.c
 	${CC} ${CFLAGS} chkentry.c -c
 
-chkentry: chkentry.o soup/soup.a jparse/jparse.a dyn_array/dyn_array.a dbg/dbg.a
+chkentry: chkentry.o soup/soup.a jparse/libjparse.a dyn_array/libdyn_array.a dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 
@@ -497,7 +497,7 @@ all_test_ioccc: test_ioccc/Makefile
 dbg/dbg.h: dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg extern_include C_SPECIAL=${C_SPECIAL}
 
-dbg/dbg.a: dbg/Makefile
+dbg/libdbg.a: dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg extern_liba C_SPECIAL=${C_SPECIAL}
 
 dbg/dbg_test: dbg/Makefile
@@ -506,13 +506,13 @@ dbg/dbg_test: dbg/Makefile
 dyn_array/dyn_array.h: dyn_array/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array extern_include C_SPECIAL=${C_SPECIAL}
 
-dyn_array/dyn_array.a: dyn_array/Makefile
+dyn_array/libdyn_array.a: dyn_array/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array extern_liba C_SPECIAL=${C_SPECIAL}
 
 jparse/jparse.h: jparse/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C jparse extern_include C_SPECIAL=${C_SPECIAL}
 
-jparse/jparse.a: jparse/Makefile
+jparse/libjparse.a: jparse/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C jparse extern_liba C_SPECIAL=${C_SPECIAL}
 
 jparse/jparse: jparse/Makefile
@@ -1583,9 +1583,9 @@ uninstall:
 	${RM} -f -v ${DEST_INCLUDE}/dbg.h
 	${RM} -f -v ${DEST_INCLUDE}/dyn_array.h
 	${RM} -f -v ${DEST_INCLUDE}/jparse.h
-	${RM} -f -v ${DEST_LIB}/dbg.a
-	${RM} -f -v ${DEST_LIB}/dyn_array.a
-	${RM} -f -v ${DEST_LIB}/jparse.a
+	${RM} -f -v ${DEST_LIB}/libdbg.a
+	${RM} -f -v ${DEST_LIB}/libdyn_array.a
+	${RM} -f -v ${DEST_LIB}/libjparse.a
 	${RM} -f -v ${DEST_LIB}/soup.a
 	${RM} -f -v ${MAN1_DIR}/bug_report.1
 	${RM} -f -v ${MAN1_DIR}/bug_report.sh.1

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -265,7 +265,7 @@ DEST_DIR= /usr/local/bin
 EXTERN_H= dbg.h
 EXTERN_O= dbg.o
 EXTERN_MAN= ${ALL_MAN_TARGETS}
-EXTERN_LIBA= dbg.a
+EXTERN_LIBA= libdbg.a
 EXTERN_PROG= dbg_example dbg_test
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
@@ -286,7 +286,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and removed by clobber
 #
-LIBA_TARGETS= dbg.a
+LIBA_TARGETS= libdbg.a
 
 # shell targets to make by all and removed by clobber
 #
@@ -352,7 +352,7 @@ all: ${TARGETS}
 dbg.o: dbg.c
 	${CC} ${CFLAGS} dbg.c -c
 
-dbg.a: ${LIB_OBJS}
+libdbg.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
@@ -364,14 +364,14 @@ dbg_test.c: dbg.c
 dbg_test.o: dbg_test.c
 	${CC} ${CFLAGS} -DDBG_TEST dbg_test.c -c
 
-dbg_test: dbg_test.o dbg.a
-	${CC} ${CFLAGS} dbg_test.o dbg.a -o $@
+dbg_test: dbg_test.o libdbg.a
+	${CC} ${CFLAGS} dbg_test.o libdbg.a -o $@
 
 dbg_example.o: dbg_example.c
 	${CC} ${CFLAGS} dbg_example.c -c
 
-dbg_example: dbg_example.o dbg.a
-	${CC} ${CFLAGS} dbg_example.o dbg.a -o $@
+dbg_example: dbg_example.o libdbg.a
+	${CC} ${CFLAGS} dbg_example.o libdbg.a -o $@
 
 
 #########################################################

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -262,7 +262,7 @@ DEST_DIR= /usr/local/bin
 EXTERN_H= dyn_array.h
 EXTERN_O= dyn_array.o
 EXTERN_MAN= ${ALL_MAN_TARGETS}
-EXTERN_LIBA= dyn_array.a
+EXTERN_LIBA= libdyn_array.a
 EXTERN_PROG= dyn_test
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
@@ -283,7 +283,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and removed by clobber
 #
-LIBA_TARGETS= dyn_array.a
+LIBA_TARGETS= libdyn_array.a
 
 # shell targets to make by all and removed by clobber
 #
@@ -347,7 +347,7 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS}
 dyn_array.o: dyn_array.c dyn_array.h
 	${CC} ${CFLAGS} dyn_array.c -c
 
-dyn_array.a: ${LIB_OBJS}
+libdyn_array.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
@@ -355,15 +355,15 @@ dyn_array.a: ${LIB_OBJS}
 dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
-dyn_test: dyn_test.o dyn_array.a ../dbg/dbg.a
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o dyn_array.a ../dbg/dbg.a -o dyn_test
+dyn_test: dyn_test.o libdyn_array.a ../dbg/libdbg.a
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o libdyn_array.a ../dbg/libdbg.a -o dyn_test
 
 
 #########################################################
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../dbg/dbg.a: ../dbg/Makefile
+../dbg/libdbg.a: ../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dbg extern_liba C_SPECIAL=${C_SPECIAL}
 
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -329,7 +329,7 @@ DEST_DIR= /usr/local/bin
 EXTERN_H= jparse.h
 EXTERN_O=
 EXTERN_MAN= ${ALL_MAN_TARGETS}
-EXTERN_LIBA= jparse.a
+EXTERN_LIBA= libjparse.a
 EXTERN_PROG= jparse jsemtblgen jsemcgen.sh jstrdecode jstrencode
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
@@ -350,7 +350,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and removed by clobber
 #
-LIBA_TARGETS= jparse.a
+LIBA_TARGETS= libjparse.a
 
 # shell targets to make by all and removed by clobber
 #
@@ -425,19 +425,19 @@ jparse_main.o: jparse_main.c
 jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
-jparse: jparse_main.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jparse: jparse_main.o libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
-jstrencode: jstrencode.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jstrencode: jstrencode.o libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
-jstrdecode: jstrdecode.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jstrdecode: jstrdecode.o libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 json_parse.o: json_parse.c
@@ -446,7 +446,7 @@ json_parse.o: json_parse.c
 jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
-jsemtblgen: jsemtblgen.o jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+jsemtblgen: jsemtblgen.o libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 json_sem.o: json_sem.c
@@ -485,10 +485,10 @@ util.o: util.c util.h
 verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
-verge: verge.o util.o ../dbg/dbg.a ../dyn_array/dyn_array.a
+verge: verge.o util.o ../dbg/libdbg.a ../dyn_array/libdyn_array.a
 	${CC} ${CFLAGS} $^ -o $@
 
-jparse.a: ${LIB_OBJS}
+libjparse.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
@@ -504,10 +504,10 @@ run_flex-v7: verge sorry.tm.ca.h
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../dbg/dbg.a: ../dbg/Makefile
+../dbg/libdbg.a: ../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dbg extern_liba C_SPECIAL=${C_SPECIAL}
 
-../dyn_array/dyn_array.a: ../dyn_array/Makefile
+../dyn_array/libdyn_array.a: ../dyn_array/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dyn_array extern_liba C_SPECIAL=${C_SPECIAL}
 
 test_jparse/test_JSON/info.json/good/info.reference.json: test_jparse/Makefile

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -316,19 +316,19 @@ jnum_test.o: jnum_test.c
 jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
-jnum_chk: jnum_chk.o jnum_test.o ../jparse.a ../../dyn_array/dyn_array.a ../../dbg/dbg.a
+jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a ../../dyn_array/libdyn_array.a ../../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
-jnum_gen: jnum_gen.o ../jparse.a ../../dyn_array/dyn_array.a ../../dbg/dbg.a
+jnum_gen: jnum_gen.o ../libjparse.a ../../dyn_array/libdyn_array.a ../../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -lm -o $@
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
-pr_jparse_test: pr_jparse_test.o ../jparse.a ../../dyn_array/dyn_array.a ../../dbg/dbg.a
+pr_jparse_test: pr_jparse_test.o ../libjparse.a ../../dyn_array/libdyn_array.a ../../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 
@@ -337,13 +337,13 @@ pr_jparse_test: pr_jparse_test.o ../jparse.a ../../dyn_array/dyn_array.a ../../d
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../../dbg/dbg.a: ../../dbg/Makefile
+../../dbg/libdbg.a: ../../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../../dbg extern_liba C_SPECIAL=${C_SPECIAL}
 
-../../dyn_array/dyn_array.a: ../../dyn_array/Makefile
+../../dyn_array/libdyn_array.a: ../../dyn_array/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../../dyn_array extern_liba C_SPECIAL=${C_SPECIAL}
 
-../jparse.a: ../Makefile
+../libjparse.a: ../Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C .. extern_liba C_SPECIAL=${C_SPECIAL}
 
 

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -386,7 +386,7 @@ location_util.o: location_util.c
 location_main.o: location_main.c
 	${CC} ${CFLAGS} location_main.c -c
 
-location: location_main.o location_tbl.o location_util.o ../dbg/dbg.a
+location: location_main.o location_tbl.o location_util.o ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 foo.o: foo.c

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.2 2024-08-28"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.4 2024-08-29"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -350,7 +350,7 @@ all: ${TARGETS} ${EXTERN_PROG}
 utf8_test.o: utf8_test.c
 	${CC} ${CFLAGS} utf8_test.c -c
 
-utf8_test: utf8_test.o ../soup/soup.a ../jparse/jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+utf8_test: utf8_test.o ../soup/soup.a ../jparse/libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 ioccc_test.sh: ../dbg/dbg_test ../dyn_array/dyn_test
@@ -359,7 +359,7 @@ ioccc_test.sh: ../dbg/dbg_test ../dyn_array/dyn_test
 fnamchk.o: fnamchk.c fnamchk.h
 	${CC} ${CFLAGS} fnamchk.c -c
 
-fnamchk: fnamchk.o ../jparse/jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
+fnamchk: fnamchk.o ../jparse/libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 
@@ -367,13 +367,13 @@ fnamchk: fnamchk.o ../jparse/jparse.a ../dyn_array/dyn_array.a ../dbg/dbg.a
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../dbg/dbg.a: ../dbg/Makefile
+../dbg/libdbg.a: ../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dbg extern_liba
 
 ../dbg/dbg_test: ../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dbg extern_prog
 
-../dyn_array/dyn_array.a: ../dyn_array/Makefile
+../dyn_array/libdyn_array.a: ../dyn_array/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dyn_array extern_liba
 
 ../dyn_array/dyn_test: ../dyn_array/Makefile


### PR DESCRIPTION
Rename dbg.a, dyn_array.a and jparse.a to libdbg.a, libdyn_array.a and libjparse.a, respectively. These respective repos have had the respective change done as well (well the jparse one has not been committed yet as it needs the other libraries in order to work).

This is important for the jparse repo (not the jparse/ subdirectory here though this has also been updated) to be usable outside this repo without having to have ../dbg and ../dyn_array directories containing the correct respective libraries. The jparse repo
(https://github.com/xexyl/jparse) still has to be updated (and there might be some additional changes here as well) but that cannot happen until the dbg and dyn_array repos have also had this done (or rather merged).

The Makefile does NOT use -ldbg, -ldyn_array or -ljparse (yet?). Obviously if it does it'll use the -I option.

Updated MKIOCCCENTRY_REPO_VERSION to match this release version (this means it jumped from 1.5.2 to 1.5.4 as it was not updated when 1.5.2 2024-08-28 was updated to 1.5.3 2024-08-29).

Ran make prep to test these changes.