### PR TITLE
Add to dyn_array/Makefile -L../dbg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.5.6 2024-08-31
+
+Add to `dyn_array/Makefile` or `dyn_test` the flag `-L../dbg` in hopes to solve
+the workflow failure. If this works then the `dyn_array` repo will also have to
+have this added to its Makefile.
+
+
 ## Release 1.5.5 2024-08-30
 
 We updated `dbg/` from the dbg repo.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Add to `dyn_array/Makefile` or `dyn_test` the flag `-L../dbg` in hopes to solve
 the workflow failure. If this works then the `dyn_array` repo will also have to
 have this added to its Makefile.
 
+Add to `jparse/Makefile` `-L../dbg -L../dyn_array` for the same reasons as
+above. If this works then the `jparse` repo Makefile will also have to be
+updated for this (along with some other pending changes).
+
 
 ## Release 1.5.5 2024-08-30
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Add to `jparse/Makefile` `-L../dbg -L../dyn_array` for the same reasons as
 above. If this works then the `jparse` repo Makefile will also have to be
 updated for this (along with some other pending changes).
 
+Add to `jparse/test_jparse/Makefile` `-L../dbg -L../dyn_array` for the above
+reasons as well.
+
+
 
 ## Release 1.5.5 2024-08-30
 

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -357,7 +357,7 @@ dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
 dyn_test: dyn_test.o
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array -ldbg -o dyn_test
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -L../dbg -ldyn_array -ldbg -o dyn_test
 
 
 #########################################################

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -426,19 +426,19 @@ jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
 jstrencode: jstrencode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
 jstrdecode: jstrdecode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
 	${CC} ${CFLAGS} json_parse.c -c
@@ -447,7 +447,7 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
 jsemtblgen: jsemtblgen.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -486,7 +486,7 @@ verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o util.o
-	${CC} ${CFLAGS} $^ -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}
 	${RM} -f $@

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 
 


### PR DESCRIPTION
The way the dyn_array repo Makefile now work (required for dbg for jparse repo) is that it links in the dbg api by -ldbg (hence renaming it to libdbg.a). But since GitHub does not have it installed this fails. This suggests that compiling this repo might also fail if a person does not have it installed. Thus I added -L../dbg. If this works then the dyn_array repo's Makefile will have to have this added too.