### PR TITLE
Sync jparse subdirectory from jparse repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.5.6 2024-08-31
+
+Add to `dyn_array/Makefile` or `dyn_test` the flag `-L../dbg` in hopes to solve
+the workflow failure. If this works then the `dyn_array` repo will also have to
+have this added to its Makefile.
+
+
 ## Release 1.5.5 2024-08-30
 
 We updated `dbg/` from the dbg repo.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Add to `dyn_array/Makefile` or `dyn_test` the flag `-L../dbg` in hopes to solve
 the workflow failure. If this works then the `dyn_array` repo will also have to
 have this added to its Makefile.
 
+Add to `jparse/Makefile` `-L../dbg -L../dyn_array` for the same reasons as
+above. If this works then the `jparse` repo Makefile will also have to be
+updated for this (along with some other pending changes).
+
 
 ## Release 1.5.5 2024-08-30
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.7 2024-08-31
+
+Synced `jparse` subdirectory from the [jparse
+repo](https://github.com/xexyl/jparse/). There was no code change and the only
+functionality changes are that the install rule installs more header files (now
+in a subdirectory - `/usr/local/include/jparse) and an uninstall rule is added
+(for those who wish to deobfuscate their system :-) ).
+
+Updated the `MKIOCCCENTRY_REPO_VERSION` to `"1.5.6 2024-08-31"`.
+
 
 ## Release 1.5.6 2024-08-31
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Add to `jparse/Makefile` `-L../dbg -L../dyn_array` for the same reasons as
 above. If this works then the `jparse` repo Makefile will also have to be
 updated for this (along with some other pending changes).
 
+Add to `jparse/test_jparse/Makefile` `-L../dbg -L../dyn_array` for the above
+reasons as well.
+
+
 
 ## Release 1.5.5 2024-08-30
 

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -357,7 +357,7 @@ dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
 dyn_test: dyn_test.o
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array -ldbg -o dyn_test
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -L../dbg -ldyn_array -ldbg -o dyn_test
 
 
 #########################################################

--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -1,7 +1,8 @@
 *.[ao]
 *.dSYM/
 *~
-.*.swp
+.*.sw[a-zA-Z0-9]*
+.sw[a-zA-Z0-9]*
 .DS_Store
 /.jsemcgen.*.out
 /.local.dir.tags
@@ -15,6 +16,7 @@
 /jparse.lex.h
 /jparse.tab.c
 /jparse.tab.h
+/jprint
 /jsemtblgen
 /jstrdecode
 /jstrencode

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -101,10 +101,18 @@ Q_V_OPTION="1"
 endif
 
 # INSTALL_V=				install w/o -v flag (quiet mode)
-# INSTALL_V= -v				install with -v (debug / verbose mode
+# INSTALL_V= -v				install with -v (debug / verbose mode)
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
+
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -315,7 +323,7 @@ ALL_SRC= ${ALL_CSRC} ${ALL_HSRC} ${SH_FILES}
 MAN1_DIR= /usr/local/share/man/man1
 MAN3_DIR= /usr/local/share/man/man3
 MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
+DEST_INCLUDE= /usr/local/include/jparse
 DEST_LIB= /usr/local/lib
 DEST_DIR= /usr/local/bin
 
@@ -362,7 +370,8 @@ PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode
 
 # include files NOT to removed by clobber
 #
-H_SRC_TARGETS= jparse.h
+H_SRC_TARGETS= jparse.h jparse.lex.h jparse.lex.ref.h jparse.tab.h jparse.tab.ref.h \
+	       jparse_main.h json_parse.h json_sem.h json_util.h sorry.tm.ca.h util.h
 
 # what to make by all but NOT to removed by clobber
 #
@@ -402,11 +411,11 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS} Makefile
 # .PHONY list of rules that do not create files #
 #################################################
 
-.PHONY: all \
-	extern_include extern_objs extern_liba extern_man extern_prog extern_everything man/man1/jparse.1 man/man8/jparse_test.8 \
-	parser parser-o use_json_ref rebuild_jnum_test bison flex test tags local_dir_tags all_tags check_man \
-	legacy_clean legacy_clobber load_json_ref install_man \
-	configure clean clobber install depend
+.PHONY: all extern_include extern_objs extern_liba extern_man extern_prog \
+	extern_everything man/man1/jparse.1 man/man8/jparse_test.8 \
+	parser parser-o use_json_ref rebuild_jnum_test bison flex test \
+	tags local_dir_tags all_tags check_man legacy_clean legacy_clobber \
+	load_json_ref install_man configure clean clobber install depend
 
 
 ####################################
@@ -426,19 +435,19 @@ jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
 jstrencode: jstrencode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
 jstrdecode: jstrdecode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
 	${CC} ${CFLAGS} json_parse.c -c
@@ -447,7 +456,7 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
 jsemtblgen: jsemtblgen.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -486,7 +495,7 @@ verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o util.o
-	${CC} ${CFLAGS} $^ -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}
 	${RM} -f $@
@@ -888,6 +897,47 @@ install: all test_jparse/Makefile install_man
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending"
+
+# uninstall: we provide this in case someone wants to deobfuscate their system. :-)
+uninstall:
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo
+	${I} ${RM} -r -f ${RM_V} ${DEST_LIB}/libjparse.a
+	${I} ${RM} -r -f ${RM_V} ${DEST_INCLUDE}
+	${RM} -r -f ${RM_V} ${DEST_DIR}/jparse
+	${RM} -r -f ${RM_V} ${DEST_DIR}/verge
+	${RM} -r -f ${RM_V} ${DEST_DIR}/jsemtblgen
+	${RM} -r -f ${RM_V} ${DEST_DIR}/jstrdecode
+	${RM} -r -f ${RM_V} ${DEST_DIR}/jstrencode
+	${RM} -r -f ${RM_V} ${DEST_DIR}/jsemcgen.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/run_bison.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/run_flex.sh
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/jparse.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/jstrdecode.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/jstrencode.1
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/jparse.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/json_dbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/json_dbg_allowed.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/json_err_allowed.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/json_warn_allowed.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/parse_json.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/parse_json_file.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/parse_json_stream.3
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jnum_chk.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jnum_gen.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jparse_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jsemcgen.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jsemtblgen.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jstr_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/verge.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_bison.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_bison.sh.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_flex.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_flex.sh.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/jsemcgen.sh.8
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -435,19 +435,19 @@ jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
 jstrencode: jstrencode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
 jstrdecode: jstrdecode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
 	${CC} ${CFLAGS} json_parse.c -c
@@ -456,7 +456,7 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
 jsemtblgen: jsemtblgen.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -495,7 +495,7 @@ verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o util.o
-	${CC} ${CFLAGS} $^ -o $@ -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}
 	${RM} -f $@
@@ -978,28 +978,22 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-jparse.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.c jparse.h \
-    jparse.tab.h json_parse.h json_sem.h json_util.h util.h
-jparse.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.ref.c \
-    jparse.tab.h json_parse.h json_sem.h json_util.h util.h
-jparse.tab.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.lex.h \
-    jparse.tab.c jparse.tab.h json_parse.h json_sem.h json_util.h util.h
-jparse.tab.ref.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h \
-    jparse.lex.h jparse.tab.h jparse.tab.ref.c json_parse.h json_sem.h \
+jparse.o: jparse.c jparse.h jparse.tab.h json_parse.h json_sem.h \
     json_util.h util.h
-jparse_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
-    jparse_main.c jparse_main.h json_parse.h json_sem.h json_util.h util.h
-jsemtblgen.o: ../dbg/dbg.h ../dyn_array/dyn_array.h jparse.h jparse.tab.h \
-    jsemtblgen.c jsemtblgen.h json_parse.h json_sem.h json_util.h util.h
-json_parse.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.c \
-    json_parse.h json_util.h util.h
-json_sem.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h json_sem.c \
+jparse.ref.o: jparse.h jparse.ref.c jparse.tab.h json_parse.h json_sem.h \
+    json_util.h util.h
+jparse.tab.o: jparse.h jparse.lex.h jparse.tab.c jparse.tab.h json_parse.h \
     json_sem.h json_util.h util.h
-json_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h json_util.c \
-    json_util.h util.h
-jstrdecode.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h \
-    jstrdecode.c jstrdecode.h util.h
-jstrencode.o: ../dbg/dbg.h ../dyn_array/dyn_array.h json_parse.h \
-    jstrencode.c jstrencode.h util.h
-util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h util.c util.h
-verge.o: ../dbg/dbg.h ../dyn_array/dyn_array.h util.h verge.c verge.h
+jparse.tab.ref.o: jparse.h jparse.lex.h jparse.tab.h jparse.tab.ref.c \
+    json_parse.h json_sem.h json_util.h util.h
+jparse_main.o: jparse.h jparse.tab.h jparse_main.c jparse_main.h \
+    json_parse.h json_sem.h json_util.h util.h
+jsemtblgen.o: jparse.h jparse.tab.h jsemtblgen.c jsemtblgen.h json_parse.h \
+    json_sem.h json_util.h util.h
+json_parse.o: json_parse.c json_parse.h json_util.h util.h
+json_sem.o: json_parse.h json_sem.c json_sem.h json_util.h util.h
+json_util.o: json_parse.h json_util.c json_util.h util.h
+jstrdecode.o: json_parse.h jstrdecode.c jstrdecode.h util.h
+jstrencode.o: json_parse.h jstrencode.c jstrencode.h util.h
+util.o: util.c util.h
+verge.o: util.h verge.c verge.h

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -426,19 +426,19 @@ jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
 jstrencode: jstrencode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
 jstrdecode: jstrdecode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
 	${CC} ${CFLAGS} json_parse.c -c
@@ -447,7 +447,7 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
 jsemtblgen: jsemtblgen.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -486,7 +486,7 @@ verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o util.o
-	${CC} ${CFLAGS} $^ -o $@ -L. -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ -L. -L../dbg -L../dyn_array -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}
 	${RM} -f $@

--- a/jparse/README.md
+++ b/jparse/README.md
@@ -2,7 +2,8 @@
 
 
 `jparse` is a JSON parser (a stand-alone tool and a library) written in C with
-the help of `flex(1)` and `bison(1)`. It was co-developed in 2022 by:
+the help of `flex(1)` and `bison(1)`. The library, and the additional tools,
+were co-developed in 2022 by:
 
 *@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
 [https://ioccc.xexyl.net](https://ioccc.xexyl.net))
@@ -30,7 +31,7 @@ We recommend that you read the [json_README.md](json_README.md) document
 to better understand the JSON terms used in this repo.
 
 
-## Dependencies
+# Dependencies
 
 In order to compile and use `jparse` (the applications and the library) you will
 need to download, compile and install the [dbg
@@ -40,23 +41,23 @@ repo](https://github.com/lcn2/dyn_array).
 To do this you might try:
 
 ```sh
-    git clone https://github.com/lcn2/dbg
-    cd dbg && make all
-    # then as root or via sudo:
-    make install
+git clone https://github.com/lcn2/dbg
+cd dbg && make all
+# then as root or via sudo:
+make install
 
-    git clone https://github.com/lcn2/dyn_array
-    cd dyn_array
-    make all
-    # then as root or via sudo:
-    make install
+git clone https://github.com/lcn2/dyn_array
+cd dyn_array
+make all
+# then as root or via sudo:
+make install
 ```
 
 If there are any issues with this then please open an issue in the respective
 repo.
 
 
-## Compiling
+# Compiling
 
 We determine if you have a recent enough `flex(1)` and `bison(1)`. If you do not
 we use backup files. Either way, to compile you need only run:
@@ -67,37 +68,27 @@ make all
 ```
 
 
-### Running the test-suite:
-
-We provide a test-suite, should you wish to test a variety of json files and
-other things. To run it:
-
-```sh
-make clobber all test
-```
-
-
-## Installing
+# Installing
 
 If you wish to install this, which is recommended, especially if you want to use
 the library, you can do as root or via sudo:
 
 ```sh
-    make install
+make install
 ```
 
 
-## Stand-alone tool
+# `jparse`: a stand-alone tool to validate JSON
 
 As a tool by itself `jparse` takes a block of memory from either a file (stdin
 or a text file) or a string (via `-s` option) and parses it as JSON, reporting
 if it is validly formed JSON or not.
 
-### Synopsis
+## Synopsis
 
 
 ```sh
-./jparse [-h] [-v level] [-J level] [-q] [-V] [-s] -- arg
+jparse [-h] [-v level] [-J level] [-q] [-V] [-s] -- arg
 ```
 
 The `-v` option increases the overall verbosity level whereas the `-J` option
@@ -111,38 +102,289 @@ The options `-V` and `-h` show the version of the parser and the help or usage
 string, respectively.
 
 
-### Exit status
+## Exit status
 
 If the JSON is valid the exit status of `jparse` is 0. Different non-zero values
 are for different error conditions, or help or version string printed.
 
+## Examples
 
-## The jparse library
+Parse the JSON string `{ "test_mode" : false }`:
+
+```sh
+jparse -s '{ "test_mode" : false }'
+```
+
+Parse input from stdin (send EOF, usually ctrl-d or ^D, to parse):
+
+```sh
+jparse -
+[]
+^D
+```
+
+Parse just a negative number:
+
+```sh
+jparse -s -- -5
+```
+
+Parse .info.json file:
+
+```sh
+jparse .info.json
+```
+
+
+## `jstrencode`
+
+This tool can converts data into JSON encoded strings according to the so-called
+[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
+
+
+## Synopsis
+
+
+```sh
+jstrencode [-h] [-v level] [-q] [-V] [-t] [-n] [-Q] [string ...]
+```
+
+The `-v` option increases the overall verbosity level. Unlike the `jparse`
+utility, no JSON parsing functions are called, so there is no `-J level` option.
+The `-q` option suppresses some of the output.
+
+The options `-V` and `-h` show the version of the parser and the help or usage
+string, respectively.
+
+If no string is given on the command line it expects you to type something on
+`stdin`, ending it with EOF.
+
+
+## Exit status
+
+If the encoding is successful the exit status of `jstrencode` is 0, otherwise 1.
+Different non-zero values are for different error conditions, or help or version
+string printed.
+
+
+## Examples
+
+Encode an empty string (`""`):
+
+
+```sh
+jstrencode '""'
+```
+
+This will show:
+
+```
+\"\"
+```
+
+Encode a negative number:
+
+```sh
+jstrencode -- -5
+```
+
+This will show:
+
+```
+-5
+```
+
+For more information and examples, see the man page:
+
+```sh
+man ./man/man1/jstrencode.1
+```
+
+from the repo directory, or if installed:
+
+```sh
+man jstrencode
+```
+
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./jstrencode`.
+If you run `make install` (as root or via sudo) you can just do: `jstrencode`.
+
+
+### `jstrdecode`
+
+This tool converts JSON encoded strings to their original data according to the so-called
+[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
+
+
+## Synopsis
+
+
+```sh
+jstrdecode [-h] [-v level] [-q] [-V] [-t] [-n] [-Q] [string ...]
+```
+
+
+The `-v` option increases the overall verbosity level. Unlike the `jparse`
+utility, no JSON parsing functions are called, so there is no `-J level` option.
+The `-q` option suppresses some of the output.
+
+The options `-V` and `-h` show the version of the parser and the help or usage
+string, respectively.
+
+If no string is given on the command line it expects you to type something on
+`stdin`, ending it with EOF.
+
+
+## Exit status
+
+If the decoding is successful the exit status of `jstrdecode` is 0, otherwise 1.
+Different non-zero values are for different error conditions, or help or version
+string printed.
+
+
+## Examples
+
+Decode `\"\"`:
+
+
+```sh
+jstrdecode '\"\"'
+```
+
+This will show:
+
+```
+""
+```
+
+Decode a negative number:
+
+```sh
+jstrdecode -- -5
+```
+
+This will show:
+
+```
+-5
+```
+
+For more information and examples, see the man page:
+
+```sh
+man ./man/man1/jstrdecode.1
+```
+
+from the repo directory, or if installed:
+
+```sh
+man jstrdecode
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./jstrdecode`.
+If you run `make install` (as root or via sudo) you can just do: `jstrdecode`.
+
+
+# The jparse library
 
 As a library, `jparse` is much more useful as it allows one to parse JSON in
 their application and then interact with the parsed tree.
 
+In order to use the library, you will need to `#include` the necessary header
+files and then link in the libraries, the dependencies and the `jparse` library
+itself.
 
-### Linking the library into your own code
+## Example
 
-To use you need to include `jparse.h` and then link in the `libjparse.a` static
-library. This will be documented at a later date.
+For a relatively simple example program that uses the library, take a look at
+[jparse_main.c](https://github.com/xexyl/jparse/blob/master/jparse_main.c). As we already gave details on how to use it, we
+will not do that here. It is,  however, a nice example program to give you a
+basic idea of how to use the library, especially as it is commented nicely.
+
+As you will see, in the case of this tool, we include
+[jparse_main.h](https://github.com/xexyl/jparse/blob/master/jparse_main.h), which includes the two most useful header files,
+[jparse.h](https://github.com/xexyl/jparse/blob/master/jparse.h) and
+[util.h](https://github.com/xexyl/jparse/blob/master/util.h), the former of
+which is required (in actuality, `jparse.h` includes it, but it does not hurt to
+include it anyway due to inclusion guards).
+
+We must also link in the libraries.
+
+We explain these details next.
 
 
-### Example use of the library
+### Header files
 
-We currently do not have a short and simple example to go through. This will
-come at a later date when I (Cody) make this into a separate GitHub repo.
-Nevertheless one may check the library man page by:
+As far as using them, there are two ways to go about it. If you install the
+library, which again we recommend, you can include them like:
 
+```c
+#include <jparse/jparse.h>
+#include <jparse/util.h>
+```
+
+or you can instead do:
+
+```c
+#include <jparse.h>
+#include <util.h>
+```
+
+and add to your Makefile or compiler line the option
+`-I/usr/local/include/jparse`. Naturally the easiest way is the first but the
+code in this repo uses the repo's copy, for obvious reasons.
+
+
+### Linking in the library
+
+In order to use the library you will have to link the static libraries (the
+`jparse(3)` library as well as the `dbg` and `dyn_array` libraries) into your
+program.
+
+To do this you should pass to the compiler `-ljparse -ldbg -ldyn_array`. For
+instance to compile [json_main.c](https://github.com/xexyl/jparse/blob/master/jparse_main.c), with the `#include` lines
+changed to:
+
+```c
+#include <jparse/jparse.h>
+#include <jparse/util.h>
+```
+
+we can compile it like:
+
+```sh
+cc jparse_main.c -o jparse -ljparse -ldbg -ldyn_array
+```
+
+and expect to find `jparse` in the current working directory.
+
+If you need an example for a Makefile, take a look at the
+[Makefile](https://github.com/xexyl/jparse/blob/master/Makefile)'s
+`jparse_main.o` and `jparse` rules, to give you an idea.
+
+
+Once your code has been compiled and linked into an executable, you should be
+good to go!
+
+## API overview
+
+To get an overview of the API, try from the repo directory:
 
 ```sh
 man ./man/man3/jparse.3
 ```
 
+or if installed:
+
+```sh
+man 3 jparse
+```
+
 which gives more information about the most important functions.
 
-### Re-entrancy
+
+## Re-entrancy
 
 Although the scanner and parser are both re-entrant, only one parse at one time
 in a process has been tested. The testing of more than one parse at the same
@@ -152,42 +394,6 @@ it.
 If it's not clear this means that having more than one parse active in the same
 process at the same time is not tested so even though it should be okay there
 might be some issues that have yet to be discovered.
-
-
-# Examples
-
-Parse the JSON string `{ "test_mode" : false }`:
-
-```sh
-./jparse -s '{ "test_mode" : false }'
-```
-
-Parse input from stdin (send EOF, usually ctrl-d or ^D, to parse):
-
-```sh
-./jparse -
-[]
-^D
-```
-
-Parse just a negative number:
-
-```sh
-./jparse -s -- -5
-```
-
-Parse .info.json file:
-
-```sh
-./jparse .info.json
-```
-
-Run the `jparse_test.sh` script using the default `json_teststr.txt` file with verbosity set at 5:
-
-```sh
-./jparse_test.sh -v 5
-```
-
 
 
 # See also
@@ -201,53 +407,9 @@ man ./man/man1/jstrencode.1
 man ./man/man1/jstrdecode.1
 ```
 
-NOTE: the library man page currently has no example and this will not happen
-until later, possibly not until it's an actual repo.
-
-### `jstrencode`
-
-Encode data.  This tool can converts data into JSON encoded strings according to the so-called
-[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./man/man1/jstrencode.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./jstrencode`.
-
-
-### `jstrdecode`
-
-Decode JSON encoded strings.  This tool converts JSON encoded strings to their original data according to the so-called
-[JSON data interchange syntax - ECMA-404](https://www.ecma-international.org/publications-and-standards/standards/ecma-404/).
-
-This tool was co-developed in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-```sh
-man ./man/man1/jstrdecode.1
-```
-
-NOTE: After doing a `make all`, this tool may be found as: `./jstrdecode`.
+**NOTE**: the library man page currently has no example but you can always look
+at [jparse_main.c](jparse_main.c) for a relatively simple example (as described
+earlier).
 
 # Our testing suite:
 
@@ -263,7 +425,28 @@ interest between Landon and Cody :-) ) as well as from the
 GRATITUDE** to the maintainers: **THANK YOU**!) and all is good. If for some
 reason the parser were to be modified, in error or otherwise, and the test fails
 then we know there is a problem. As the GitHub repo has workflows to make sure
-that this does not happen it should never be added to the repo.
+that this does not happen it should never be added to the repo (unless of course
+we happen to push a commit that does :-) but if that happens we'll end up fixing
+it).
+
+If you wish to run this test-suite, try from the repo directory:
+
+```sh
+make clobber all test
+```
+
+
+# Uninstalling
+
+If you wish to deobfuscate your system a bit :-) you can uninstall the programs,
+library and header files by running:
+
+```sh
+make uninstall
+```
+
+as root or via sudo.
+
 
 <hr>
 

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -34,7 +34,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/jparse_main.h
+++ b/jparse/jparse_main.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/jsemtblgen.h
+++ b/jparse/jsemtblgen.h
@@ -38,7 +38,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -41,7 +41,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -21,7 +21,7 @@
 
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/json_sem.h
+++ b/jparse/json_sem.h
@@ -27,7 +27,7 @@
 
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -1,9 +1,21 @@
 # Command line utilities that read and process JSON in different ways
 
 
+## XXX - this document is for tools that have not yet been written - XXX
+
+This document was prior to setting up this repo and it describes tools to be
+written (that were being worked on until one of us got sick). As such these
+tools have **NOT** been written yet. Additionally there might be some changes
+in how they work, when it is time to write them. As well, another utility is
+going to be created as well. All of these will happen at a later time as there
+are other things that are of higher priority. When the tools exist then this
+note will be either removed (if the tools are complete) or modified (if the
+tools are still being worked on but do exist).
+
+
 ## Introduction to this document
 
-NOTE: Please see [json_README.md](./json_README.md) for some important **JSON
+**NOTE**: Please see [json_README.md](./json_README.md) for some important **JSON
 terms** used in this document.
 
 There is a general lack of JSON aware command line tools that allow someone to

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/json_dbg.3
+++ b/jparse/man/man3/json_dbg.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/json_dbg_allowed.3
+++ b/jparse/man/man3/json_dbg_allowed.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/json_err_allowed.3
+++ b/jparse/man/man3/json_err_allowed.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>"\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/json_warn_allowed.3
+++ b/jparse/man/man3/json_warn_allowed.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/parse_json.3
+++ b/jparse/man/man3/parse_json.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/parse_json_file.3
+++ b/jparse/man/man3/parse_json_file.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/man/man3/parse_json_stream.3
+++ b/jparse/man/man3/parse_json_stream.3
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "19 October 2023" "jparse"
+.TH jparse 3  "31 August 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
 .BR parse_json_stream() \|,
@@ -20,7 +20,7 @@
 .BR json_dbg()
 \- JSON parsing library
 .SH SYNOPSIS
-\fB#include "jparse.h"\fP
+\fB#include <jparse/jparse.h>\fP
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -ldyn_array -ldbg
 
 
 

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
 
 
 

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -L../dyn_array -L../dbg -ldyn_array -ldbg
 
 
 
@@ -638,13 +638,10 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-jnum_chk.o: ../../dbg/dbg.h ../../dyn_array/dyn_array.h ../json_parse.h \
-    ../json_util.h ../util.h jnum_chk.c jnum_chk.h
-jnum_gen.o: ../../dbg/dbg.h ../../dyn_array/dyn_array.h ../json_parse.h \
-    ../json_util.h ../util.h jnum_gen.c jnum_gen.h
-jnum_header.o: ../../dbg/dbg.h ../../dyn_array/dyn_array.h ../json_parse.h \
-    ../json_util.h ../util.h jnum_chk.h jnum_header.c
-jnum_test.o: ../../dbg/dbg.h ../../dyn_array/dyn_array.h ../json_parse.h \
-    ../json_util.h ../util.h jnum_chk.h jnum_test.c
-pr_jparse_test.o: ../../dbg/dbg.h ../../dyn_array/dyn_array.h ../util.h \
-    pr_jparse_test.c
+jnum_chk.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.c jnum_chk.h
+jnum_gen.o: ../json_parse.h ../json_util.h ../util.h jnum_gen.c jnum_gen.h
+jnum_header.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.h \
+    jnum_header.c
+jnum_test.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.h \
+    jnum_test.c
+pr_jparse_test.o: ../util.h pr_jparse_test.c

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -L. -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -L. -L../../dbg -L../../dyn_array -ldyn_array -ldbg
 
 
 

--- a/jparse/test_jparse/jnum_chk.h
+++ b/jparse/test_jparse/jnum_chk.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "../util.h"
 

--- a/jparse/test_jparse/jnum_gen.h
+++ b/jparse/test_jparse/jnum_gen.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "../util.h"
 

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1,5 +1,5 @@
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  *
  * "Because even printf has a return value worth paying attention to." :-)
  *
@@ -56,7 +56,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -1,5 +1,5 @@
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  *
  * Copyright (c) 1989,1997,2018-2022 by Landon Curt Noll.  All Rights Reserved.
  *

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -32,7 +32,7 @@
 #endif
 
 /*
- * util - common utility functions for the IOCCC toolkit
+ * util - common utility functions for the JSON parser
  */
 #include "util.h"
 


### PR DESCRIPTION

With recent updates to the jparse repo
(https://github.com/xexyl/jparse) there was a need to sync that repo to
the jparse/ subdirectory. No code changes were made and the only
functionality changes made are that a few more header files are
installed (and now into a subdirectory - /usr/local/include/jparse) and
an uninstall rule was added (for those who wish to deobfuscate their
system a bit :-) ). The uninstall rule in the top level Makefile (this
repo) does not run make uninstall in other directories but perhaps it
should.

Did the following steps to make sure things are okay:

    # to be sure the tree is clean
    git status
    # to see if things can still build and test
    make release
    # to be sure the tree is clean
    make clobber

    make jparse.help
    make jparse.recreate_clone
    make jparse.update_from_clone

    # to see if anything changed
    git status
    # to see if things can still build and test
    make release

.. and all is good.

Updated the repo release version to "1.5.6 2024-08-31".