### PR TITLE
Improve Makefiles (install, uninstall rules)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.8 2024-09-01
+
+Add to Makefiles the `PREFIX` variable to allow for installing to a different
+location than the default `/usr/local`.
+
+Added some uninstall rules to the Makefile in a number of subdirectories. The
+external repos that are synced to this repo have not had any direct changes as
+those repos first need those rules (which will be done soon). This is also why
+the top level Makefile does not run `make uninstall` in those subdirectories.
+Once these are all done the top level Makefile can have a simpler uninstall
+rule.
+
+Along the lines of silencing (non-verbose) `install` in the `install` rule one
+may now do the same with the uninstall (instead of `INSTALL_V` it is `RM_V`).
+This is only done to be congruent with the `install` rule.
+
+Updated the `MKIOCCCENTRY_REPO_VERSION` to `"1.5.7 2024-09-01"`.
+
 ## Release 1.5.7 2024-08-31
 
 Synced `jparse` subdirectory from the [jparse

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions about the `mkiocccentry` repo
 
-This is FAQ version **28.0.0 2024-07-31**.
+This is FAQ version **28.0.1 2024-09-01**.
 
 <div id="toc"></div>
 
@@ -10,7 +10,7 @@ This is FAQ version **28.0.0 2024-07-31**.
 
 1. [How do I compile the mkiocccentry tools?](#compiling)
 
-2. [Do I need to install this code to use it?](#install)
+2. [How may I install the tools if I wish to and is it required?](#install)
 
 3. [What can I do if my system's tar(1) does not support the correct options?](#tar)
 
@@ -23,6 +23,8 @@ This is FAQ version **28.0.0 2024-07-31**.
 7. [Why do these tools sometimes use the incorrect IOCCC terms?](#terms)
 
 8. [How do I participate in the IOCCC?](#ioccc)
+
+9. [How do I uninstall the toolkit?](#uninstalling)
 
 
 <div id="download"></div>
@@ -70,7 +72,33 @@ local directory.  If something went wrong, see
 <div id="install"></div>
 <div id="installing"></div>
 
-## 2. Do I need to install this code to use it?
+
+## 2.  How may I install the tools if I wish to and is it required?
+
+You do not need to install the code (see below) but it can be helpful to do so
+as you can then run the tools from any directory including your submission
+directory, so you do not have to specify paths.
+
+If you do wish to install the toolkit, you can do:
+
+```sh
+    make install
+```
+
+as either root or via sudo. By default this will install with the `PREFIX` of
+`/usr/local` so the programs will be installed to `/usr/local/bin`, libraries in
+`/usr/local/lib`, man pages in `/usr/local/share/man/man[138]` etc. If you wish
+to have them elsewhere, for instance `/usr` or some other location, you can
+override the default location with the `PREFIX` variable. For instance, to
+install with the `PREFIX` of `/usr`:
+
+
+```sh
+    make PREFIX=/usr install
+```
+
+
+### Is installing required?
 
 No, installing the code in this repo is not necessary to use it. These tools
 were designed to be used from the top level directory of the source, or after
@@ -278,3 +306,30 @@ the [Rules](https://ioccc-src.github.io/temp-test-ioccc/next/rules.html) and the
 
 Pay especial care to [Rule
 17](https://ioccc-src.github.io/temp-test-ioccc/next/rules.html#rule17)!
+
+
+<div id="uninstalling">
+## 9. How do I uninstall the toolkit?
+</div>
+
+If you have installed the tools and you wish to uninstall them, you can do so
+from the top level repo directory by typing:
+
+```sh
+    make uninstall
+```
+
+as either root or via sudo.
+
+Remember that if you installed with a different `PREFIX` you will have to use
+that same `PREFIX` to successfully uninstall the programs, library and man
+pages. For instance if you installed with the `PREFIX` of `/usr` you would type
+instead:
+
+```sh
+    make PREFIX=/usr uninstall
+```
+
+After this all the files installed should be removed. If this is not the case by
+some chance it is likely a bug and you may report it as a bug
+[here](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,36 @@ else
 Q_V_OPTION="1"
 endif
 
+# installing variables
+#
+
 # INSTALL_V=				install w/o -v flag (quiet mode)
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# where to install
+#
+# Default PREFIX is /usr/local so binaries would be installed in /usr/local/bin,
+# libraries in /usr/local/lib etc. If one wishes to override this, say
+# installing to /usr, they can do so like:
+#
+#	make PREFIX=/usr install
+#
+PREFIX= /usr/local
+
+# uninstalling variables
+#
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
+# Additional controls
+#
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -266,12 +291,12 @@ ALL_MAN_BUILT= ${MAN1_BUILT} ${MAN3_BUILT} ${MAN8_BUILT}
 
 # where to install
 #
-MAN1_DIR= /usr/local/share/man/man1
-MAN3_DIR= /usr/local/share/man/man3
-MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
-DEST_LIB= /usr/local/lib
-DEST_DIR= /usr/local/bin
+MAN1_DIR= ${PREFIX}/share/man/man1
+MAN3_DIR= ${PREFIX}/share/man/man3
+MAN8_DIR= ${PREFIX}/share/man/man8
+DEST_INCLUDE= ${PREFIX}/include
+DEST_LIB= ${PREFIX}/lib
+DEST_DIR= ${PREFIX}/bin
 
 
 #################################
@@ -428,7 +453,7 @@ hostchk_warning:
 	check_man clean clean_generated_obj clean_mkchk_sem clobber configure depend hostchk \
 	install uninstall test_ioccc legacy_clobber mkchk_sem parser parser-o picky prep soup \
         pull release seqcexit shellcheck tags local_dir_tags all_tags test test-chkentry use_json_ref \
-	eat eating eat eating_soup kitchen soup_kitchen \
+	eat eating eat eating_soup kitchen soup_kitchen bug_report-txl \
 	build release pull reset_min_timestamp load_json_ref build_man bug_report-tx \
 	all_dbg all_dyn_array all_jparse all_jparse_test all_man all_soup all_test_ioccc depend
 
@@ -1553,154 +1578,156 @@ install: all dbg/Makefile dyn_array/Makefile jparse/Makefile \
 # No directories are removed by this rule, however.
 #
 uninstall:
-	${RM} -f -v ${DEST_DIR}/all_sem_ref.sh
-	${RM} -f -v ${DEST_DIR}/chkentry
-	${RM} -f -v ${DEST_DIR}/dbg_example
-	${RM} -f -v ${DEST_DIR}/dbg_test
-	${RM} -f -v ${DEST_DIR}/dyn_test
-	${RM} -f -v ${DEST_DIR}/fnamchk
-	${RM} -f -v ${DEST_DIR}/hostchk.sh
-	${RM} -f -v ${DEST_DIR}/iocccsize
-	${RM} -f -v ${DEST_DIR}/jfmt
-	${RM} -f -v ${DEST_DIR}/jnamval
-	${RM} -f -v ${DEST_DIR}/jnum_chk
-	${RM} -f -v ${DEST_DIR}/jnum_gen
-	${RM} -f -v ${DEST_DIR}/jparse
-	${RM} -f -v ${DEST_DIR}/jsemtblgen
-	${RM} -f -v ${DEST_DIR}/jstrdecode
-	${RM} -f -v ${DEST_DIR}/jstrencode
-	${RM} -f -v ${DEST_DIR}/jval
-	${RM} -f -v ${DEST_DIR}/location
-	${RM} -f -v ${DEST_DIR}/mkiocccentry
-	${RM} -f -v ${DEST_DIR}/pr_jparse_test
-	${RM} -f -v ${DEST_DIR}/prep.sh
-	${RM} -f -v ${DEST_DIR}/reset_tstamp.sh
-	${RM} -f -v ${DEST_DIR}/run_usage.sh
-	${RM} -f -v ${DEST_DIR}/txzchk
-	${RM} -f -v ${DEST_DIR}/utf8_test
-	${RM} -f -v ${DEST_DIR}/verge
-	${RM} -f -v ${DEST_DIR}/vermod.sh
-	${RM} -f -v ${DEST_INCLUDE}/dbg.h
-	${RM} -f -v ${DEST_INCLUDE}/dyn_array.h
-	${RM} -f -v ${DEST_INCLUDE}/jparse.h
-	${RM} -f -v ${DEST_LIB}/libdbg.a
-	${RM} -f -v ${DEST_LIB}/libdyn_array.a
-	${RM} -f -v ${DEST_LIB}/libjparse.a
-	${RM} -f -v ${DEST_LIB}/soup.a
-	${RM} -f -v ${MAN1_DIR}/bug_report.1
-	${RM} -f -v ${MAN1_DIR}/bug_report.sh.1
-	${RM} -f -v ${MAN1_DIR}/chkentry.1
-	${RM} -f -v ${MAN1_DIR}/fnamchk.1
-	${RM} -f -v ${MAN1_DIR}/iocccsize.1
-	${RM} -f -v ${MAN1_DIR}/jfmt.1
-	${RM} -f -v ${MAN1_DIR}/jnamval.1
-	${RM} -f -v ${MAN1_DIR}/jparse.1
-	${RM} -f -v ${MAN1_DIR}/jstrdecode.1
-	${RM} -f -v ${MAN1_DIR}/jstrencode.1
-	${RM} -f -v ${MAN1_DIR}/jval.1
-	${RM} -f -v ${MAN1_DIR}/location.1
-	${RM} -f -v ${MAN1_DIR}/mkiocccentry.1
-	${RM} -f -v ${MAN1_DIR}/txzchk.1
-	${RM} -f -v ${MAN3_DIR}/dbg.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_addr.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_alloced.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_append_set.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_append_value.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_avail.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_beyond.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_clear.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_concat_array.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_create.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_free.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_rewind.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_seek.3
-	${RM} -f -v ${MAN3_DIR}/dyn_array_tell.3
-	${RM} -f -v ${MAN3_DIR}/err.3
-	${RM} -f -v ${MAN3_DIR}/errp.3
-	${RM} -f -v ${MAN3_DIR}/fdbg.3
-	${RM} -f -v ${MAN3_DIR}/ferr.3
-	${RM} -f -v ${MAN3_DIR}/ferrp.3
-	${RM} -f -v ${MAN3_DIR}/fmsg.3
-	${RM} -f -v ${MAN3_DIR}/fprintf_usage.3
-	${RM} -f -v ${MAN3_DIR}/fwarn.3
-	${RM} -f -v ${MAN3_DIR}/fwarn_or_err.3
-	${RM} -f -v ${MAN3_DIR}/fwarnp.3
-	${RM} -f -v ${MAN3_DIR}/fwerr.3
-	${RM} -f -v ${MAN3_DIR}/fwerrp.3
-	${RM} -f -v ${MAN3_DIR}/jparse.3
-	${RM} -f -v ${MAN3_DIR}/json_dbg.3
-	${RM} -f -v ${MAN3_DIR}/json_dbg_allowed.3
-	${RM} -f -v ${MAN3_DIR}/json_err_allowed.3
-	${RM} -f -v ${MAN3_DIR}/json_warn_allowed.3
-	${RM} -f -v ${MAN3_DIR}/msg.3
-	${RM} -f -v ${MAN3_DIR}/parse_json.3
-	${RM} -f -v ${MAN3_DIR}/parse_json_file.3
-	${RM} -f -v ${MAN3_DIR}/parse_json_stream.3
-	${RM} -f -v ${MAN3_DIR}/printf_usage.3
-	${RM} -f -v ${MAN3_DIR}/sndbg.3
-	${RM} -f -v ${MAN3_DIR}/snmsg.3
-	${RM} -f -v ${MAN3_DIR}/snwarn.3
-	${RM} -f -v ${MAN3_DIR}/snwarnp.3
-	${RM} -f -v ${MAN3_DIR}/snwerr.3
-	${RM} -f -v ${MAN3_DIR}/snwerrp.3
-	${RM} -f -v ${MAN3_DIR}/vdbg.3
-	${RM} -f -v ${MAN3_DIR}/verr.3
-	${RM} -f -v ${MAN3_DIR}/verrp.3
-	${RM} -f -v ${MAN3_DIR}/vfdbg.3
-	${RM} -f -v ${MAN3_DIR}/vferr.3
-	${RM} -f -v ${MAN3_DIR}/vferrp.3
-	${RM} -f -v ${MAN3_DIR}/vfmsg.3
-	${RM} -f -v ${MAN3_DIR}/vfprintf_usage.3
-	${RM} -f -v ${MAN3_DIR}/vfwarn.3
-	${RM} -f -v ${MAN3_DIR}/vfwarn_or_err.3
-	${RM} -f -v ${MAN3_DIR}/vfwarnp.3
-	${RM} -f -v ${MAN3_DIR}/vfwerr.3
-	${RM} -f -v ${MAN3_DIR}/vfwerrp.3
-	${RM} -f -v ${MAN3_DIR}/vmsg.3
-	${RM} -f -v ${MAN3_DIR}/vprintf_usage.3
-	${RM} -f -v ${MAN3_DIR}/vsndbg.3
-	${RM} -f -v ${MAN3_DIR}/vsnmsg.3
-	${RM} -f -v ${MAN3_DIR}/vsnwarn.3
-	${RM} -f -v ${MAN3_DIR}/vsnwarnp.3
-	${RM} -f -v ${MAN3_DIR}/vsnwerr.3
-	${RM} -f -v ${MAN3_DIR}/vsnwerrp.3
-	${RM} -f -v ${MAN3_DIR}/vwarn.3
-	${RM} -f -v ${MAN3_DIR}/vwarn_or_err.3
-	${RM} -f -v ${MAN3_DIR}/vwarnp.3
-	${RM} -f -v ${MAN3_DIR}/vwerr.3
-	${RM} -f -v ${MAN3_DIR}/vwerrp.3
-	${RM} -f -v ${MAN3_DIR}/warn.3
-	${RM} -f -v ${MAN3_DIR}/warn_or_err.3
-	${RM} -f -v ${MAN3_DIR}/warnp.3
-	${RM} -f -v ${MAN3_DIR}/werr.3
-	${RM} -f -v ${MAN3_DIR}/werrp.3
-	${RM} -f -v ${MAN8_DIR}/all_sem_ref.8
-	${RM} -f -v ${MAN8_DIR}/chkentry_test.8
-	${RM} -f -v ${MAN8_DIR}/hostchk.8
-	${RM} -f -v ${MAN8_DIR}/ioccc_test.8
-	${RM} -f -v ${MAN8_DIR}/ioccc_test.sh.8
-	${RM} -f -v ${MAN8_DIR}/iocccsize_test.8
-	${RM} -f -v ${MAN8_DIR}/jnum_chk.8
-	${RM} -f -v ${MAN8_DIR}/jnum_gen.8
-	${RM} -f -v ${MAN8_DIR}/jparse_test.8
-	${RM} -f -v ${MAN8_DIR}/jsemcgen.8
-	${RM} -f -v ${MAN8_DIR}/jsemcgen.sh.8
-	${RM} -f -v ${MAN8_DIR}/jsemtblgen.8
-	${RM} -f -v ${MAN8_DIR}/jstr_test.8
-	${RM} -f -v ${MAN8_DIR}/mkiocccentry_test.8
-	${RM} -f -v ${MAN8_DIR}/prep.8
-	${RM} -f -v ${MAN8_DIR}/prep.sh.8
-	${RM} -f -v ${MAN8_DIR}/reset_tstamp.8
-	${RM} -f -v ${MAN8_DIR}/run_bison.8
-	${RM} -f -v ${MAN8_DIR}/run_bison.sh.8
-	${RM} -f -v ${MAN8_DIR}/run_flex.8
-	${RM} -f -v ${MAN8_DIR}/run_flex.sh.8
-	${RM} -f -v ${MAN8_DIR}/run_usage.8
-	${RM} -f -v ${MAN8_DIR}/txzchk_test.8
-	${RM} -f -v ${MAN8_DIR}/utf8_test.8
-	${RM} -f -v ${MAN8_DIR}/verge.8
-	${RM} -f -v ${MAN8_DIR}/vermod.8
+	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL=${C_SPECIAL}
+	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL=${C_SPECIAL}
+	${RM} -f ${RM_V} ${DEST_DIR}/all_sem_ref.sh
+	${RM} -f ${RM_V} ${DEST_DIR}/chkentry
+	${RM} -f ${RM_V} ${DEST_DIR}/dbg_example
+	${RM} -f ${RM_V} ${DEST_DIR}/dbg_test
+	${RM} -f ${RM_V} ${DEST_DIR}/dyn_test
+	${RM} -f ${RM_V} ${DEST_DIR}/fnamchk
+	${RM} -f ${RM_V} ${DEST_DIR}/hostchk.sh
+	${RM} -f ${RM_V} ${DEST_DIR}/iocccsize
+	${RM} -f ${RM_V} ${DEST_DIR}/jfmt
+	${RM} -f ${RM_V} ${DEST_DIR}/jnamval
+	${RM} -f ${RM_V} ${DEST_DIR}/jnum_chk
+	${RM} -f ${RM_V} ${DEST_DIR}/jnum_gen
+	${RM} -f ${RM_V} ${DEST_DIR}/jparse
+	${RM} -f ${RM_V} ${DEST_DIR}/jsemtblgen
+	${RM} -f ${RM_V} ${DEST_DIR}/jstrdecode
+	${RM} -f ${RM_V} ${DEST_DIR}/jstrencode
+	${RM} -f ${RM_V} ${DEST_DIR}/jval
+	${RM} -f ${RM_V} ${DEST_DIR}/location
+	${RM} -f ${RM_V} ${DEST_DIR}/mkiocccentry
+	${RM} -f ${RM_V} ${DEST_DIR}/pr_jparse_test
+	${RM} -f ${RM_V} ${DEST_DIR}/prep.sh
+	${RM} -f ${RM_V} ${DEST_DIR}/reset_tstamp.sh
+	${RM} -f ${RM_V} ${DEST_DIR}/run_usage.sh
+	${RM} -f ${RM_V} ${DEST_DIR}/txzchk
+	${RM} -f ${RM_V} ${DEST_DIR}/utf8_test
+	${RM} -f ${RM_V} ${DEST_DIR}/verge
+	${RM} -f ${RM_V} ${DEST_DIR}/vermod.sh
+	${RM} -f ${RM_V} ${DEST_INCLUDE}/dbg.h
+	${RM} -f ${RM_V} ${DEST_INCLUDE}/dyn_array.h
+	${RM} -f ${RM_V} ${DEST_INCLUDE}/jparse.h
+	${RM} -f ${RM_V} ${DEST_LIB}/libdbg.a
+	${RM} -f ${RM_V} ${DEST_LIB}/libdyn_array.a
+	${RM} -f ${RM_V} ${DEST_LIB}/libjparse.a
+	${RM} -f ${RM_V} ${DEST_LIB}/soup.a
+	${RM} -f ${RM_V} ${MAN1_DIR}/bug_report.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/bug_report.sh.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/chkentry.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/fnamchk.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/iocccsize.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jfmt.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jnamval.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jparse.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jstrdecode.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jstrencode.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/jval.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/location.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/mkiocccentry.1
+	${RM} -f ${RM_V} ${MAN1_DIR}/txzchk.1
+	${RM} -f ${RM_V} ${MAN3_DIR}/dbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_addr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_alloced.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_set.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_value.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_avail.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_beyond.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_clear.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_concat_array.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_create.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_free.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_rewind.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_seek.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_tell.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/err.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/errp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fdbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/ferr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/ferrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fmsg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fprintf_usage.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fwarn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fwarn_or_err.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fwarnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fwerr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/fwerrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/jparse.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/json_dbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/json_dbg_allowed.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/json_err_allowed.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/json_warn_allowed.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/msg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/parse_json.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/parse_json_file.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/parse_json_stream.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/printf_usage.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/sndbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/snmsg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/snwarn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/snwarnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/snwerr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/snwerrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vdbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/verr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/verrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfdbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vferr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vferrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfmsg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfprintf_usage.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn_or_err.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfwarnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfwerr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vfwerrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vmsg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vprintf_usage.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsndbg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsnmsg.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vwarn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vwarn_or_err.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vwarnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vwerr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/vwerrp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/warn.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/warn_or_err.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/warnp.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/werr.3
+	${RM} -f ${RM_V} ${MAN3_DIR}/werrp.3
+	${RM} -f ${RM_V} ${MAN8_DIR}/all_sem_ref.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/chkentry_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/hostchk.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/ioccc_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/ioccc_test.sh.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/iocccsize_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jnum_chk.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jnum_gen.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jparse_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jsemcgen.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jsemcgen.sh.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jsemtblgen.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/jstr_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/mkiocccentry_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/prep.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/prep.sh.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/reset_tstamp.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/run_bison.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/run_bison.sh.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/run_flex.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/run_flex.sh.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/run_usage.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/txzchk_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/utf8_test.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/verge.8
+	${RM} -f ${RM_V} ${MAN8_DIR}/vermod.8
 
 ###############
 # make depend #
@@ -1721,6 +1748,18 @@ depend: ${ALL_CSRC}
 	    echo 'See the following GitHub repo for ${INDEPEND}:'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/independ'; 1>&2; \
+	elif ! type -P ${SED} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${SED} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${SED} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${GREP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${GREP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${GREP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${CMP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${CMP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${CMP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
 	else \
 	    if ! ${GREP} -q '^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$' Makefile; then \
 	        echo "${OUR_NAME}: make $@ aborting, Makefile missing: ### DO NOT CHANGE MANUALLY BEYOND THIS LINE" 1>&2; \

--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ Finally we thank you once again in helping to make the IOCCC toolkit even better
 in order to improve the IOCCC itself!
 
 
-## Getting help
+## Getting help / reporting issues
 
-If you have a problem with anything in this repo, please see the
-[FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) for
-answers to a number of possible problems as well as to see how to report issues.
+If you have a problem with anything in this repo, including with compiling
+and/or installing (which is not required), please see the
+[FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) for answers
+to a number of possible problems as well as to see how to report issues.
 
 
 ## The mkiocccentry toolkit

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -115,11 +115,37 @@ else
 Q_V_OPTION="1"
 endif
 
+# installing variables
+#
+
 # INSTALL_V=				install w/o -v flag (quiet mode)
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# where to install
+#
+# Default PREFIX is /usr/local so binaries would be installed in /usr/local/bin,
+# libraries in /usr/local/lib etc. If one wishes to override this, say
+# installing to /usr, they can do so like:
+#
+#	make PREFIX=/usr install
+#
+PREFIX= /usr/local
+
+# uninstalling variables
+#
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
+# Additional controls
+#
+
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -258,12 +284,12 @@ ALL_MAN_BUILT= ${MAN1_BUILT} ${MAN3_BUILT} ${MAN8_BUILT}
 
 # where to install
 #
-MAN1_DIR= /usr/local/share/man/man1
-MAN3_DIR= /usr/local/share/man/man3
-MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
-DEST_LIB= /usr/local/lib
-DEST_DIR= /usr/local/bin
+MAN1_DIR= ${PREFIX}/share/man/man1
+MAN3_DIR= ${PREFIX}/share/man/man3
+MAN8_DIR= ${PREFIX}/share/man/man8
+DEST_INCLUDE= ${PREFIX}/include
+DEST_LIB= ${PREFIX}/lib
+DEST_DIR= ${PREFIX}/bin
 
 
 #################################
@@ -843,6 +869,29 @@ install: all install_man
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+uninstall:
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo
+	${RM} -r -f ${RM_V} ${DEST_LIB}/soup.a
+	${RM} -r -f ${RM_V} ${DEST_DIR}/vermod.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/reset_tstamp.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/all_sem_ref.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/location
+	${RM} -r -f ${RM_V} ${DEST_DIR}/run_usage.sh
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/bug_report.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/bug_report.sh.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/chkentry.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/iocccsize.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/mkiocccentry.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/txzchk.1
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/location.1
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/all_sem_ref.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/reset_tstamp.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_usage.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/vermod.8
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ###############
 # make depend #
@@ -858,6 +907,18 @@ depend: ${ALL_CSRC}
 	    echo 'See the following GitHub repo for ${INDEPEND}:'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/independ'; 1>&2; \
+	elif ! type -P ${SED} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${SED} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${SED} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${GREP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${GREP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${GREP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${CMP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${CMP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${CMP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
 	else \
 	    if ! ${GREP} -q '^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$' Makefile; then \
 	        echo "${OUR_NAME}: make $@ aborting, Makefile missing: ### DO NOT CHANGE MANUALLY BEYOND THIS LINE" 1>&2; \

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.5 2024-08-30"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.7 2024-09-01"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -110,11 +110,37 @@ else
 Q_V_OPTION="1"
 endif
 
+# installing variables
+#
+
 # INSTALL_V=				install w/o -v flag (quiet mode)
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# where to install
+#
+# Default PREFIX is /usr/local so binaries would be installed in /usr/local/bin,
+# libraries in /usr/local/lib etc. If one wishes to override this, say
+# installing to /usr, they can do so like:
+#
+#	make PREFIX=/usr install
+#
+PREFIX= /usr/local
+
+# uninstalling variables
+#
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
+# Additional controls
+#
+
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -255,12 +281,12 @@ TXZCHK_LOG= txzchk_test.log
 
 # where to install
 #
-MAN1_DIR= /usr/local/share/man/man1
-MAN3_DIR= /usr/local/share/man/man3
-MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
-DEST_LIB= /usr/local/lib
-DEST_DIR= /usr/local/bin
+MAN1_DIR= ${PREFIX}/share/man/man1
+MAN3_DIR= ${PREFIX}/share/man/man3
+MAN8_DIR= ${PREFIX}/share/man/man8
+DEST_INCLUDE= ${PREFIX}/include
+DEST_LIB= ${PREFIX}/lib
+DEST_DIR= ${PREFIX}/bin
 
 
 #################################
@@ -340,7 +366,7 @@ all: ${TARGETS} ${EXTERN_PROG}
 .PHONY: all \
 	test legacy_clean legacy_clobber install_man hostchk.sh \
 	tags local_dir_tags all_tags \
-	configure clean clobber install depend
+	configure clean clobber install depend uninstall
 
 
 ####################################
@@ -649,6 +675,26 @@ install: all install_man
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+uninstall:
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo
+	${RM} -r -f ${RM_V} ${DEST_DIR}/utf8_test
+	${RM} -r -f ${RM_V} ${DEST_DIR}/fnamchk
+	${RM} -r -f ${RM_V} ${DEST_DIR}/prep.sh
+	${RM} -r -f ${RM_V} ${DEST_DIR}/hostchk.sh
+	${RM} -r -f ${RM_V} ${MAN1_DIR}/fnamchk.1
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/chkentry_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/ioccc_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/iocccsize_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/mkiocccentry_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/txzchk_test.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/hostchk.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/ioccc_test.sh.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/prep.8
+	${RM} -r -f ${RM_V} ${MAN8_DIR}/utf8_test.8
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ###############
 # make depend #
@@ -664,6 +710,18 @@ depend: ${ALL_CSRC}
 	    echo 'See the following GitHub repo for ${INDEPEND}:'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/independ'; 1>&2; \
+	elif ! type -P ${SED} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${SED} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${SED} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${GREP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${GREP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${GREP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
+	elif ! type -P ${CMP} >/dev/null 2>&1; then \
+	    echo '${OUR_NAME}: The ${CMP} command could not be found.' 1>&2; \
+	    echo '${OUR_NAME}: The ${CMP} command is required to run the $@ rule'; 1>&2; \
+	    echo ''; 1>&2; \
 	else \
 	    if ! ${GREP} -q '^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$' Makefile; then \
 	        echo "${OUR_NAME}: make $@ aborting, Makefile missing: ### DO NOT CHANGE MANUALLY BEYOND THIS LINE" 1>&2; \


### PR DESCRIPTION
Add to Makefiles the 'PREFIX' variable to allow for installing to a different location than the default /usr/local.

Added some uninstall rules to the Makefile in a number of subdirectories. The external repos that are synced to this repo have not had any direct changes as those repos first need those rules (which will be done soon). This is also why the top level Makefile does not run 'make uninstall' in those subdirectories. Once these are all done the top level Makefile can have a simpler uninstall rule.

Along the lines of silencing (non-verbose) install in the install rule one may now do the same with the uninstall (instead of 'INSTALL_V' it is 'RM_V'). This is only done to be congruent with the install rule.

Updated the MKIOCCCENTRY_REPO_VERSION to "1.5.7 2024-09-01".