### PR TITLE
Add to -V option json parser version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.9 2024-09-04
+
+Add to `-V` option of compiled tools that use the jparse library in some form or
+another (i.e. links it in) to print out the current json parser version. The
+json parser and jparse versions were also updated (from the jparse repo).
+
+
 ## Release 1.5.8 2024-09-01
 
 Add to Makefiles the `PREFIX` variable to allow for installing to a different
@@ -23,7 +30,7 @@ Updated the `MKIOCCCENTRY_REPO_VERSION` to `"1.5.7 2024-09-01"`.
 Synced `jparse` subdirectory from the [jparse
 repo](https://github.com/xexyl/jparse/). There was no code change and the only
 functionality changes are that the install rule installs more header files (now
-in a subdirectory - `/usr/local/include/jparse) and an uninstall rule is added
+in a subdirectory - `/usr/local/include/jparse`) and an uninstall rule is added
 (for those who wish to deobfuscate their system :-) ).
 
 Updated the `MKIOCCCENTRY_REPO_VERSION` to `"1.5.6 2024-08-31"`.

--- a/chkentry.c
+++ b/chkentry.c
@@ -198,6 +198,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s\n", CHKENTRY_VERSION);
+	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
 	    exit(2);		/*ooo*/
 	    not_reached();
 	    break;

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,7 +56,7 @@
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.4 2023-08-02"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.5 2024-09-04"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions
@@ -81,7 +81,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.1.4 2023-08-02"		/* library version format: major.minor YYYY-MM-DD */
+#define JSON_PARSER_VERSION "1.1.5 2024-09-04"		/* library version format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -261,6 +261,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s\n", MKIOCCCENTRY_VERSION);
+	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;

--- a/test_ioccc/fnamchk.c
+++ b/test_ioccc/fnamchk.c
@@ -139,6 +139,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s\n", FNAMCHK_VERSION);
+	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;

--- a/txzchk.c
+++ b/txzchk.c
@@ -154,6 +154,7 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s\n", TXZCHK_VERSION);
+	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;


### PR DESCRIPTION
As the json parser is now in its own repo
(https://github.com/xexyl/jparse) it seems like a good idea for the tools here to tell us what version is linked in in the case that there is a divergence (which can happen though it is not necessarily likely).

At the same time, because the parser is now in its own repo, the version of both the tool jparse (which is not in -V as it's not needed) and the library have been updated.