### PR TITLE
Add timestamps to some Makefile rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,51 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.10 2024-09-05
+
+Synced `jparse` subdirectory from the [jparse
+repo](https://github.com/xexyl/jparse/) with some useful updates and fixes. See
+the git log of that repo for more detailed information. Changes that these
+updates required here (and some that are in the jparse subdirectory):
+
+- The `test_ioccc/ioccc_test.sh` script no longer runs the `jstr_test.sh`,
+`jnum_chk` tests and it does not run `jparse_test.sh` except
+on the `test_ioccc/test_JSON` directory as the `jparse/Makefile` runs the
+appropriate tests in `test_jparse/` (in this repo under `jparse/test_jparse`) -
+obviously the jparse repo knows nothing about `test_ioccc/test_JSON` so it has
+to be done this way. It's likely that with the `-Z topdir` option (that was
+recently added to `jparse_test.sh`) or some other workaround the script could
+run from `test_ioccc/ioccc_test.sh` but it is redundant and not useful so it no
+longer does.
+- Due to `jparse_test.sh` path updates (one of the changes is to fix it to work
+on its own but this required some changes in test error files) the error files
+under `jparse/test_jparse/test_JSON/bad_loc` have been updated here (this is
+another reason that we cannot as easily run `jparse_test.sh` from `ioccc_test/`
+without the `-Z topdir` hack or some other workaround).
+
+A useful update (besides the addition of the `-Z topdir` hack) to
+`jparse_test.sh` that was synced here is the new `-f` option for the files that
+hold JSON blobs, one per line: it inverts the check, saying that the JSON blobs
+must be invalid. This required a new file here,
+`jparse/test_jparse/json_teststr_fail.txt`. As `jparse_test.sh` always runs on
+at least `json_teststr.txt` (if no files specified) it might be good to not have
+the option and always run a fail test on the new file but this can be worried
+about another time. As the `jparse/test_jparse/Makefile` runs it with this
+option it doesn't matter much anyway.
+
+The `jparse/test_jparse/jparse_test.sh` version is now `1.0.5 2024-09-04` (fixed
+from the <del>more natural</del> :-) international way `1.0.5 04-09-2024` that
+was added by habit, to match the format of the other versions); the old version
+was `1.0.3 2023-08-01`.
+
+`make release` should be fine now, after the updates to `ioccc_test.sh`. The
+version of that script is now `"1.0.2 2024-09-05"`.
+
+Repo release version is now `1.5.10 2024-09-05` (a recent update did not update
+the version string so it jumped more than one). Except for some last minute
+fixes that might be required it might be the last release until after IOCCC28
+(let's all hope it is!).
+
+
 ## Release 1.5.9 2024-09-04
 
 Add to `-V` option of compiled tools that use the jparse library in some form or

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ on its own but this required some changes in test error files) the error files
 under `jparse/test_jparse/test_JSON/bad_loc` have been updated here (this is
 another reason that we cannot as easily run `jparse_test.sh` from `ioccc_test/`
 without the `-Z topdir` hack or some other workaround).
+- The `bad_loc` error files are now always tested as if there is not a matching
+error in the file it indicates a problem with the parser.
 
 A useful update (besides the addition of the `-Z topdir` hack) to
 `jparse_test.sh` that was synced here is the new `-f` option for the files that
@@ -39,6 +41,10 @@ was `1.0.3 2023-08-01`.
 
 `make release` should be fine now, after the updates to `ioccc_test.sh`. The
 version of that script is now `"1.0.2 2024-09-05"`.
+
+In the Makefile rules that have echo lines that end with `starting"` and those
+that end with `ending"` it now shows the timestamp (except or the `dyn_array`
+and `dbg` Makefiles as those are from other repos also).
 
 Repo release version is now `1.5.10 2024-09-05` (a recent update did not update
 the version string so it jumped more than one). Except for some last minute

--- a/Makefile
+++ b/Makefile
@@ -664,6 +664,7 @@ slow_prep: test_ioccc/prep.sh
 build: release
 pull: release
 release: test_ioccc/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE} -e -o -l "${TMP_BUILD_LOG}"; \
 	    EXIT_CODE="$$?"; \
@@ -679,11 +680,13 @@ release: test_ioccc/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
 
 # a slower version of release that does not write to a log file so one can see the
 # full details.
 #
 slow_release: test_ioccc/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE} -e -o; \
 	    EXIT_CODE="$$?"; \
@@ -698,6 +701,7 @@ slow_release: test_ioccc/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
 
 
 # force test_ioccc/txzchk_test.sh results into test suite *.err files
@@ -780,7 +784,7 @@ rebuild_jparse_err_files: jparse/test_jparse/Makefile
 seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -802,12 +806,12 @@ seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -841,14 +845,14 @@ picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -876,14 +880,14 @@ shellcheck: ${SH_FILES} .shellcheckrc dbg/Makefile dyn_array/Makefile jparse/Mak
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify man pages
 #
 check_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -892,14 +896,14 @@ check_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # build a user convenience man directory
 #
 build_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${V} echo
-	${V} echo "${OUR_NAME}: make $@ starting"
+	${V} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${V} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg install_man \
 		     MAN1_DIR=../man/man1 MAN3_DIR=../man/man3 MAN8_DIR=../man/man8 I=@ \
@@ -918,14 +922,14 @@ build_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 		     MAN1_DIR=../man/man1 MAN3_DIR=../man/man3 MAN8_DIR=../man/man8 I=@ \
 		     INSTALL_V= C_SPECIAL="${C_SPECIAL}"
 	${V} echo
-	${V} echo "${OUR_NAME}: make $@ ending"
+	${V} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # vi/vim tags
 #
 tags: ${ALL_CSRC} ${ALL_HSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -949,13 +953,13 @@ tags: ${ALL_CSRC} ${ALL_HSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -971,13 +975,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${E} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -999,7 +1003,7 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # perform all of the mkiocccentry repo required tests
 #
@@ -1044,7 +1048,7 @@ mkchk_sem: soup/Makefile
 legacy_clean: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1054,14 +1058,14 @@ legacy_clean: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # clobber legacy code and files - files that are no longer needed
 #
 legacy_clobber: legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	jparse/test_jparse/Makefile soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1073,7 +1077,7 @@ legacy_clobber: legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ########################################################################
@@ -1132,7 +1136,7 @@ dbg.help:
 
 dbg.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-@if [[ -d dbg.clone ]]; then \
 	    ${MAKE} dbg.update_clone; \
@@ -1140,11 +1144,11 @@ dbg.setup:
 	    ${MAKE} dbg.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if [[ -d dbg.clone ]]; then \
 	    echo "ERROR: dbg.clone exists"; \
@@ -1157,53 +1161,53 @@ dbg.clone:
 	    ${GIT} clone git@github.com:lcn2/dbg.git dbg.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.clone_status: dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${GIT} status dbg.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.update_clone: dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} cd dbg.clone && ${GIT} fetch
 	${E} cd dbg.clone && ${GIT} fetch --prune --tags
 	${E} cd dbg.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} dbg.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RM} -rf dbg.clone
 	${E} ${MAKE} dbg.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.update_from_clone: dbg.clone/ dbg/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dbg.clone/ dbg
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg depend C_SPECIAL=-DINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.update_into_clone: dbg/ dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dbg/ dbg.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg.clone depend C_SPECIAL=-UINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dbg.diff_dbg_clone: dbg.clone/ dbg/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude dbg.clone dbg
@@ -1235,7 +1239,7 @@ dyn_array.help:
 
 dyn_array.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-@if [[ -d dyn_array.clone ]]; then \
 	    ${MAKE} dyn_array.update_clone; \
@@ -1243,11 +1247,11 @@ dyn_array.setup:
 	    ${MAKE} dyn_array.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if [[ -d dyn_array.clone ]]; then \
 	    echo "ERROR: dyn_array.clone exists"; \
@@ -1260,53 +1264,53 @@ dyn_array.clone:
 	    ${GIT} clone git@github.com:lcn2/dyn_array.git dyn_array.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.clone_status: dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${GIT} status dyn_array.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.update_clone: dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} cd dyn_array.clone && ${GIT} fetch
 	${E} cd dyn_array.clone && ${GIT} fetch --prune --tags
 	${E} cd dyn_array.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} dyn_array.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RM} -rf dyn_array.clone
 	${E} ${MAKE} dyn_array.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.update_from_clone: dyn_array.clone/ dyn_array/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dyn_array.clone/ dyn_array
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array depend C_SPECIAL=-DINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.update_into_clone: dyn_array/ dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dyn_array/ dyn_array.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array.clone depend C_SPECIAL=-UINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 dyn_array.diff_dyn_array_clone: dyn_array.clone/ dyn_array/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude dyn_array.clone dyn_array
@@ -1338,7 +1342,7 @@ jparse.help:
 
 jparse.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-@if [[ -d jparse.clone ]]; then \
 	    ${MAKE} jparse.update_clone; \
@@ -1346,11 +1350,11 @@ jparse.setup:
 	    ${MAKE} jparse.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if [[ -d jparse.clone ]]; then \
 	    echo "ERROR: jparse.clone exists"; \
@@ -1363,55 +1367,55 @@ jparse.clone:
 	    ${GIT} clone git@github.com:xexyl/jparse.git jparse.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.clone_status: jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${GIT} status jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.update_clone: jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} cd jparse.clone && ${GIT} fetch
 	${E} cd jparse.clone && ${GIT} fetch --prune --tags
 	${E} cd jparse.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} jparse.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RM} -rf jparse.clone
 	${E} ${MAKE} jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.update_from_clone: jparse.clone/ jparse/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v jparse.clone/ jparse
 	${E} ${MAKE} ${MAKE_CD_Q} -C jparse depend C_SPECIAL=-DINTERNAL_INCLUDE \
 		     LD_DIR="${LD_DIR}" LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.update_into_clone: jparse/ jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v jparse/ jparse.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C jparse.clone depend C_SPECIAL=-UINTERNAL_INCLUDE \
 		     LD_DIR="${LD_DIR}" LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 jparse.diff_jparse_clone: jparse.clone/ jparse/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude jparse.clone jparse
@@ -1443,77 +1447,77 @@ all.help:
 
 all.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.setup
 	${E} ${MAKE} dyn_array.setup
 	${E} ${MAKE} jparse.setup
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.clone
 	${E} ${MAKE} dyn_array.clone
 	${E} ${MAKE} jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.clone_status:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.clone_status
 	${E} ${MAKE} dyn_array.clone_status
 	${E} ${MAKE} jparse.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.update_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.update_clone
 	${E} ${MAKE} dyn_array.update_clone
 	${E} ${MAKE} jparse.update_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.recreate_clone
 	${E} ${MAKE} dyn_array.recreate_clone
 	${E} ${MAKE} jparse.recreate_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.update_from_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.update_from_clone
 	${E} ${MAKE} dyn_array.update_from_clone
 	${E} ${MAKE} jparse.update_from_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.update_into_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.update_into_clone
 	${E} ${MAKE} dyn_array.update_into_clone
 	${E} ${MAKE} jparse.update_into_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.diff_dir_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.diff_dbg_clone
 	${E} echo
@@ -1521,11 +1525,11 @@ all.diff_dir_clone:
 	${E} echo
 	${E} ${MAKE} jparse.diff_jparse_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.diff_clone_dir:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.diff_clone_dbg
 	${E} echo
@@ -1533,11 +1537,11 @@ all.diff_clone_dir:
 	${E} echo
 	${E} ${MAKE} jparse.diff_clone_jparse
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 all.diff_summary:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} dbg.diff_summary
 	${E} echo
@@ -1545,7 +1549,7 @@ all.diff_summary:
 	${E} echo
 	${E} ${MAKE} jparse.diff_summary
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ###################################
@@ -1558,7 +1562,7 @@ configure:
 clean: clean_generated_obj legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1570,12 +1574,12 @@ clean: clean_generated_obj legacy_clean dbg/Makefile dyn_array/Makefile jparse/M
 	${RM} -f ${OTHER_OBJS} ${LESS_PICKY_OBJS}
 	${RM} -rf ${DSYMDIRS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	jparse/test_jparse/Makefile soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1596,7 +1600,7 @@ clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${RM} -f jparse_test.log chkentry_test.log txzchk_test.log ${BUILD_LOG}
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # NOTE: We do NOT install dbg nor do we install dyn_array, nor jparse.
 #       This repo do not use installed dbg, nor dyn_array, nor jparse code.
@@ -1604,7 +1608,7 @@ clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 install: all dbg/Makefile dyn_array/Makefile jparse/Makefile \
         soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
@@ -1612,7 +1616,7 @@ install: all dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # uninstall - uninstall all files installed and directories created via this repo
 #
@@ -1669,7 +1673,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
@@ -1717,7 +1721,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 chkentry.o: chkentry.c chkentry.h dbg/dbg.h dyn_array/dyn_array.h \

--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -3,6 +3,7 @@
 *~
 .*.sw[a-zA-Z0-9]*
 .sw[a-zA-Z0-9]*
+.build.log.*
 .DS_Store
 /bug-report*
 /.jsemcgen.*.out

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -32,6 +32,7 @@ CTAGS= ctags
 GREP= grep
 INDEPEND= independ
 INSTALL= install
+MV= mv
 PICKY= picky
 RANLIB= ranlib
 RM= rm
@@ -266,7 +267,7 @@ OTHER_OBJS= verge.o jsemtblgen.o jstrdecode.o jstrencode.o jparse_main.o
 #
 ALL_OBJS= ${LIB_OBJS} ${OTHER_OBJS}
 
-# rule used by prep.sh and make clean via make clean_generated_obj
+# built object files created by make parser
 #
 BUILT_OBJS= jparse.o jparse.tab.o
 
@@ -300,6 +301,7 @@ BISON_DIRS= \
 	-B /opt/local/bin \
 	-B /usr/local/opt \
 	-B /usr/local/bin \
+	-B /usr/bin \
 	-B .
 
 # Additional flags to pass to bison
@@ -330,6 +332,7 @@ FLEX_DIRS= \
 	-F /opt/local/bin \
 	-F /usr/local/opt \
 	-F /usr/local/bin \
+	-F /usr/bin \
 	-F .
 
 # flags to pass to flex
@@ -385,7 +388,7 @@ MAN3_TARGETS= ${MAN3_PAGES} ${MAN3_BUILT}
 MAN8_TARGETS= ${MAN8_PAGES} ${MAN8_BUILT}
 ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
-# libraries to make by all, what to install, and removed by clobber
+# libraries to make by all, what to install, and remove by clobber
 #
 LIBA_TARGETS= libjparse.a
 
@@ -409,6 +412,11 @@ ALL_OTHER_TARGETS= ${SH_TARGETS} extern_everything ${ALL_MAN_PAGES}
 # what to make by all, what to install, and removed by clobber (and thus not ${ALL_OTHER_TARGETS})
 #
 TARGETS= ${LIBA_TARGETS} ${PROG_TARGETS} ${ALL_MAN_BUILT}
+
+# logs for testing
+#
+TMP_BUILD_LOG= ".build.log.$$$$"
+BUILD_LOG= build.log
 
 
 ############################################################
@@ -631,6 +639,118 @@ parser: jparse.y jparse.l
 parser-o: jparse.y jparse.l
 	${E} ${MAKE} parser RUN_O_FLAG='-o' C_SPECIAL=${C_SPECIAL}
 
+# make prep
+#
+# Things to do before a release, forming a pull request and/or updating the
+# GitHub repo.
+#
+# This runs through all of the prep steps.  If some step failed along the way,
+# exit non-zero at the end.
+#
+# NOTE: This rule is useful if for example you're not working on the parser and
+# you're on a system without the proper versions of flex and/or bison but you
+# still want to work on the repo. Another example use is if you don't have
+# shellcheck and/or picky and you want to work on the repo.
+#
+# The point is: if you're working on this repo and make build fails, try this
+# rule instead.
+#
+prep: test_jparse/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${Q} ${RM} -f ${TMP_BUILD_LOG}
+	${Q} ./test_jparse/prep.sh -m${MAKE} -l "${TMP_BUILD_LOG}"; \
+	    EXIT_CODE="$$?"; \
+	    ${MV} -f ${TMP_BUILD_LOG} ${BUILD_LOG}; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo; \
+	        echo "make $@: ERROR: ./test_jparse/prep.sh exit code: $$EXIT_CODE"; \
+	    fi; \
+	    echo; \
+	    echo "make $@: see ${BUILD_LOG} for details"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		exit "$$EXIT_CODE"; \
+	    else \
+	        echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
+	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+
+# a slower version of prep that does not write to a log file so one can see the
+# full details.
+#
+slow_prep: test_jparse/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${Q} ${RM} -f ${TMP_BUILD_LOG}
+	${Q} ./test_jparse/prep.sh -m${MAKE}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo; \
+	        echo "make $@: ERROR: ./test_jparse/prep.sh exit code: $$EXIT_CODE"; \
+	    fi; \
+	    echo; \
+	    echo "make $@: see ${BUILD_LOG} for details"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		exit "$$EXIT_CODE"; \
+	    else \
+	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
+	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+
+
+# make build release pull
+#
+# Things to do before a release, forming a pull request and/or updating the
+# GitHub repo.
+#
+# This runs through all of the prep steps, exiting on the first failure.
+#
+# NOTE: The reference copies of the JSON parser C code will NOT be used
+# so if bison and/or flex is not found or too old THIS RULE WILL FAIL!
+#
+# NOTE: Please try this rule BEFORE make prep.
+#
+build: release
+pull: release
+release: test_jparse/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${Q} ${RM} -f ${TMP_BUILD_LOG}
+	${Q} ./test_jparse/prep.sh -m${MAKE} -e -o -l "${TMP_BUILD_LOG}"; \
+	    EXIT_CODE="$$?"; \
+	    ${MV} -f ${TMP_BUILD_LOG} ${BUILD_LOG}; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo; \
+	        echo "make $@: ERROR: ./test_jparse/prep.sh exit code: $$EXIT_CODE"; \
+	    fi; \
+	    echo; \
+	    echo "make $@: see ${BUILD_LOG} for details"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		exit "$$EXIT_CODE"; \
+	    else \
+	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
+	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+
+# a slower version of release that does not write to a log file so one can see the
+# full details.
+#
+slow_release: test_jparse/prep.sh
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${Q} ${RM} -f ${TMP_BUILD_LOG}
+	${Q} ./test_jparse/prep.sh -m${MAKE} -e -o; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo; \
+	        echo "make $@: ERROR: ./test_jparse/prep.sh exit code: $$EXIT_CODE"; \
+	    fi; \
+	    echo; \
+	    echo "make $@: see ${BUILD_LOG} for details"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		exit "$$EXIT_CODE"; \
+	    else \
+	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
+	    fi
+	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+
+
 # load reference code from the previous successful make parser
 #
 load_json_ref: jparse.tab.c jparse.tab.h jparse.c jparse.lex.h
@@ -667,12 +787,12 @@ use_json_ref: jparse.tab.ref.c jparse.tab.ref.h jparse.ref.c jparse.lex.ref.h
 #
 rebuild_jnum_test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 bison: jparse.tab.c jparse.tab.h
 	@:
@@ -680,14 +800,34 @@ bison: jparse.tab.c jparse.tab.h
 flex: jparse.c jparse.lex.h
 	@:
 
+# rebuild jparse error files for testing
+#
+# IMPORTANT: DO NOT run this rule unless you KNOW that the output produced by
+#	     jparse on each file is CORRECT!
+#
+rebuild_jparse_err_files: jparse
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo
+	${RM} -f test_jparse/test_JSON/bad_loc/*.err
+	-@for i in test_jparse/test_JSON/./bad_loc/*.json; do \
+	    ./jparse -- "$$i" 2> "$$i.err" ;  \
+	done
+	${S} echo
+	${S} echo "Make sure to run make test from the top level directory before doing a"
+	${S} echo "git add on all the *.json and *.json.err files in test_jparse/test_JSON/bad_loc!"
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+
+
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`";
 
 # rule used by prep.sh and make clean
 #
@@ -698,7 +838,7 @@ clean_generated_obj:
 #
 seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -718,11 +858,11 @@ seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 picky: ${ALL_SRC} test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -752,13 +892,13 @@ picky: ${ALL_SRC} test_jparse/Makefile
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -782,13 +922,13 @@ shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -804,7 +944,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 
@@ -822,7 +962,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -846,13 +986,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags C_SPECIAL=${C_SPECIAL}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -871,13 +1011,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -891,29 +1031,26 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clean: test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${V} echo
-	${S} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clobber: legacy_clean test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${V} echo
-	${S} echo "${OUR_NAME}: nothing to do"
-	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ###################################
@@ -923,17 +1060,17 @@ legacy_clobber: legacy_clean test_jparse/Makefile
 configure:
 	@echo nothing to $@
 
-clean:
+clean: clean_generated_obj
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -942,11 +1079,11 @@ clobber: legacy_clobber clean
 	${RM} -f jsemcgen.out.*
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 install: all test_jparse/Makefile install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -957,12 +1094,21 @@ install: all test_jparse/Makefile install_man
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
-uninstall:
+legacy_uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo
+	${RM} -f ${RM_V} ${DEST_INCLUDE}/jparse.h ${DEST_LIB}/jparse.a
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+
+# uninstall: we provide this in case someone wants to deobfuscate their system. :-)
+uninstall: legacy_uninstall
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	# uninstall files under test_jparse:
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
@@ -1002,7 +1148,7 @@ uninstall:
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_flex.sh.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/jsemcgen.sh.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ###############
@@ -1013,7 +1159,7 @@ depend: ${ALL_CSRC}
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -1051,7 +1197,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 jparse.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \

--- a/jparse/README.md
+++ b/jparse/README.md
@@ -480,7 +480,7 @@ invalid JSON files **DO** pass as valid then it is an error.
 We have used our own files (with some Easter eggs included due to a shared
 interest between Landon and Cody :-) ) as well as from the
 [JSONTestSuite](https://github.com/nst/JSONTestSuite) repo (with **MUCH
-GRATITUDE** to the maintainers: **THANK YOU**!) and all is good. If for some
+GRATITUDE** to the maintainers: **THANK YOU!**) and all is good. If for some
 reason the parser were to be modified, in error or otherwise, and the test fails
 then we know there is a problem. As the GitHub repo has workflows to make sure
 that this does not happen it should never be added to the repo (unless of course

--- a/jparse/jparse.lex.ref.h
+++ b/jparse/jparse.lex.ref.h
@@ -21,7 +21,7 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code is in support of the
+ * Now some might be tempted to point out this code was originally in support of the
  * International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -21,7 +21,7 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code is in support of the
+ * Now some might be tempted to point out this code was originally in support of the
  * International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -21,7 +21,7 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code is in support of the
+ * Now some might be tempted to point out this code was originally in support of the
  * International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of

--- a/jparse/jparse.tab.ref.h
+++ b/jparse/jparse.tab.ref.h
@@ -21,7 +21,7 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code is in support of the
+ * Now some might be tempted to point out this code was originally in support of the
  * International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of

--- a/jparse/man/man8/jparse_test.8
+++ b/jparse/man/man8/jparse_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse_test.sh 8 "14 June 2023" "jparse_test.sh" "jparse tools"
+.TH jparse_test.sh 8 "04 September 2024" "jparse_test.sh" "jparse tools"
 .SH NAME
 .B jparse_test.sh
 \- test jparse on one or more files with one or more one\-line JSON blobs
@@ -30,8 +30,10 @@
 .IR json_tree \|]
 .RB [\| \-s
 .IR subdir \|]
+.RB [\| \-Z
+.IR topdir \|]
 .RB [\| \-k \|]
-.RB [\| \-L \|]
+.RB [\| \-f \|]
 .RI [\| file
 .IR ... \|]
 .SH DESCRIPTION
@@ -41,25 +43,29 @@ The file name
 .I \-
 means read from stdin.
 At least one file is required.
-It also uses
+If the
+.I \-d
+option is used it also uses
 .BR find (1)
 to look under the JSON tree for good and bad files (two kinds, see below) that must pass or fail respectively.
 The normal files that must pass are in the subdirectory called
 .I good
 and the normal files that must fail are in the subdirectory called
 .IR bad .
-However, if
-.B \-L
-is specified, then there is another kind of file that must fail, located in the subdirectory called
-.IR bad_loc .
-These files have errors in syntax and the purpose is to make sure that error location reporting is valid.
-See the subsection
-.B Error locations
-under
-.B NOTES
-for details on this and what one
-.B MUST
-do whenever a file with a syntax error with a location is added to the test suite.
+.PP
+Another subdirectory must also exist under which are bad files that have corresponding error files.
+These error files have the location of failure and specific error messages that must match the output of
+.BR jparse (1)
+and if they do not it is an error.
+The purpose here is to make sure that error location reporting is valid.
+.PP
+If the
+.I \-f
+option is used then the strings in the file specified must be invalid JSON, and if any are not, it will fail.
+It is on the user to make sure that they use the right file in order to get valid results, but having this option allows one to verify that the input is either valid or invalid, depending on what is needed.
+If
+.I \-f
+is not given then the script will not run a fail test on any file.
 .PP
 The script keeps a log of all the tests in
 .I jparse_test.log
@@ -113,6 +119,16 @@ directories.
 To not specify a subdirectory specify
 .I .
 (dot) as the directory.
+.TP
+.BI \-Z\  topdir
+Set the top directory (where the jparse binary and the test_jparse subdirectory reside) in order for the tests to work right, in specific situations.
+If not specified, the script tries to determine the top level directory by first checking the current working directory for the file
+.B jparse.c
+and if this fails by checking for the file
+.B ../jparse.c
+and finally if that fails by checking for the file
+.BR ../../jparse.c .
+This allows the jparse test suite to properly run in the rare case where one has a copy of the jparse repo in a subdirectory of their project.
 .TP
 .BI \-k
 Keep temporary stderr files in the directory for investigation.
@@ -193,7 +209,7 @@ Assuming you're at the top level directory:
 .sp
 .RS
 .ft B
-cd jparse/test_jparse
+cd test_jparse
 .ft R
 .RE
 .PP
@@ -221,7 +237,7 @@ make test
 .RE
 .PP
 After that go back to the
-.I jparse/test_jparse
+.I test_jparse
 subdirectory and run
 .sp
 .RS
@@ -235,18 +251,46 @@ Assuming everything is OK you can then add the JSON files and the error files li
 .sp
 .RS
 .ft B
-git add ./jparse/test_jparse/test_JSON/bad_loc/*.json
+git add ./test_jparse/test_JSON/bad_loc/*.json
 .br
-git add ./jparse/test_jparse/test_JSON/bad_loc/*.err
+git add ./test_jparse/test_JSON/bad_loc/*.err
 .ft R
 .RE
 .PP
 Finally commit these files and make a pull request to have them added to the repo.
 .SH BUGS
+.PP
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
+.PP
+If one is in the test suite subdirectory then one must
+.B STILL
+specify the subdirectory name in paths under that directory and no directory for the 
+.B jparse
+binary itself.
+On the other hand, if the directory structure is not correct it might be that the script fails.
+In other words, the test suite is meant to be run from the jparse (or a clone of the jparse) repo itself.
+.SH EXAMPLES
+.PP
+Run test suite from top level (repo root) directory:
+.sp
+.RS
+.ft B
+ make test
+.ft R
+.RE
+.PP
+Run the test script from the top level (repo root) directory manually, without testing the files under the
+.B test_JSON
+subdirectory:
+.sp
+.RS
+.ft B
+ ./test_jparse/jparse_test.sh
+.ft R
+.RE
 .SH SEE ALSO
 .BR jparse (1),
 .BR jparse (3)

--- a/jparse/sorry.tm.ca.h
+++ b/jparse/sorry.tm.ca.h
@@ -21,7 +21,7 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code is in support of the
+ * Now some might be tempted to point out this code was originally in support of the
  * International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -405,52 +405,79 @@ rebuild_jnum_test: jnum_gen jnum.testset jnum_header.c
 	${CP} -f -v jnum_header.c jnum_test.c
 	./jnum_gen jnum.testset >> jnum_test.c
 
-# rebuild jparse error files for testing
-#
-# IMPORTANT: DO NOT run this tool unless you KNOW that
-#	     the tables produced by jparse are CORRECT!
-#
-rebuild_jparse_err_files: ../jparse
+rebuild_jparse_err_files:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUT_NAME}: make $@ starting at: `date`"
 	${S} echo
-	${RM} -f test_JSON/bad_loc/*.err
-	-@for i in test_JSON/./bad_loc/*.json; do \
-	    ../jparse -- "$$i" 2> "$$i.err" ;  \
-	done
+	${Q} cd .. ; \
+	    ${MAKE} $@
 	${S} echo
-	${S} echo "Make sure to run make test from the top level directory befor doing a"
-	${S} echo "git add on all the *.json and *.json.err files in test_json/bad_loc!"
-	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
-	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} if [[ ! -x ./jparse_test.sh ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./jparse_test.sh" 1>&2; \
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
 	    exit 1; \
+	elif [[ ! -x ./jstr_test.sh ]]; then \
+	    echo "${OUR_NAME}: ERROR: executable not found: ./jstr_test.sh" 1>&2; \
+	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
+	    exit 1; \
+	elif [[ ! -x ./jnum_chk ]]; then \
+	    echo "${OUR_NAME}: ERROR: executable not found: ./jnum_chk" 1>&2; \
+	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
+	    exit 1; \
 	else \
-	    echo "./jparse_test.sh -L -j ../jparse -p ./pr_jparse_test -d test_JSON -s . ./json_teststr.txt"; \
-	    ./jparse_test.sh -L -j ../jparse -p ./pr_jparse_test -d test_JSON -s . ./json_teststr.txt; \
+	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt"; \
+	    ./jparse_test.sh -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \
 		exit "$$EXIT_CODE"; \
 	    else \
-		echo ${OUR_NAME}: "PASSED: jparse_test.sh"; \
+		echo "${OUR_NAME}: PASSED: jparse_test.sh"; \
+	    fi; \
+	    echo; \
+	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -f -j ./jparse test_jparse/json_teststr_fail.txt"; \
+	    ./jparse_test.sh -f -j ./jparse test_jparse/json_teststr_fail.txt >/dev/null 2>&1; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo "${OUR_NAME}: PASSED: jparse_test.sh"; \
+	    fi; \
+	    echo; \
+	    echo "${OUR_NAME}: RUNNING: ./jstr_test.sh"; \
+	    ./jstr_test.sh 2>&1; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: jstr_test.sh failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo ${OUR_NAME}: "PASSED: jstr_test.sh"; \
+	    fi; \
+	    echo; \
+	    echo "${OUR_NAME}: RUNNING: ./jnum_chk"; \
+	    ./jnum_chk 2>&1; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: jnum_chk failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo ${OUR_NAME}: "PASSED: jnum_chk"; \
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # sequence exit codes
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -466,11 +493,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -498,13 +525,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -526,23 +553,23 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify man pages
 #
 check_man:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # vi/vim tags
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} for dir in ../../dbg ../../dyn_alloc ..; do \
 	    if [[ -f $$dir/Makefile && ! -f $$dir/${LOCAL_DIR_TAGS} ]]; then \
@@ -555,24 +582,24 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags C_SPECIAL=${C_SPECIAL}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . .. ../../dbg ../../dyn_alloc; do \
@@ -583,23 +610,23 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ###################################
@@ -611,41 +638,41 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f jparse_test.log chkentry_test.log txzchk_test.log
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 install: all
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_DIR}/jnum_chk
 	${RM} -r -f ${RM_V} ${DEST_DIR}/jnum_gen
 	${RM} -r -f ${RM_V} ${DEST_DIR}/pr_jparse_test
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ###############
 # make depend #
@@ -653,7 +680,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -692,7 +719,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 jnum_chk.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \

--- a/jparse/test_jparse/README.md
+++ b/jparse/test_jparse/README.md
@@ -1,11 +1,41 @@
-# Preparing the bad location tests
+# The jparse test suite
 
-If ever a file is added to the `test_JSON/bad_loc` directory then one **MUST**
-take the following steps.
+There are many files in this directory including a lot of JSON files, both good
+and bad, in subdirectories, that are tested with the `-d` option to the
+`jparse_test.sh` test-suite script, along with a text file of a number of valid
+JSON strings and another file with invalid JSON strings. The good/valid JSON
+must pass validation and the bad/invalid must fail validation.
+
+To see the options of the script:
+
+```sh
+./jparse_test.sh -h
+```
+
+If you need more information on this tool, check the man page `jparse_test.8`.
+To run the script it is better to use `make test` from the top level directory.
+
+If, on the other hand, you are reporting a bug, it is best to run `make
+bug_report` from the top level directory, and then open a bug report in the
+[jparse bug report
+page](https://github.com/xexyl/jparse/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=Bug%3A+%3Cbug+title%3E)
+or otherwise, if you're reporting something else, perhaps a feature request or
+enhancement, find the appropriate templates at the [jparse issues
+page](https://github.com/xexyl/jparse/issues/new/choose). **PLEASE** attach the
+bug report log file!
+
+
+## Preparing the bad location tests
+
+This task is only meant for the repo maintainers but for the curious if ever a
+file is added to the `test_JSON/bad_loc` directory then one **MUST** take the
+following steps.
 
 First make a visual inspection to be sure that the output of `jparse` is correct
-on the files. If they are then run from `jparse/test_jparse/` the following
-commands exactly:
+on the files. This is a **MUST!** If the output **IS CORRECT**, then run from
+the top level directory the following command (if run from the
+`jparse/test_jparse/` subdirectory it will first do a `cd ..`) these commands
+exactly:
 
 ```sh
 make rebuild_jparse_err_files
@@ -15,16 +45,15 @@ You should see something like:
 
 ```sh
 $ make rebuild_jparse_err_files
+jparse: make rebuild_jparse_err_files starting
 
-test_jparse: make rebuild_jparse_err_files starting
+rm -f test_jparse/test_JSON/bad_loc/*.err
+make: [Makefile:693: rebuild_jparse_err_files] Error 1 (ignored)
 
-rm -f test_JSON/bad_loc/*.err
-make: [Makefile:379: rebuild_jparse_err_files] Error 1 (ignored)
+Make sure to run make test from the top level directory before doing a
+git add on all the *.json and *.json.err files in test_jparse/test_JSON/bad_loc!
 
-Make sure to run make test from the top level directory befor doing a
-git add on all the *.json and *.json.err files in test_json/bad_loc!
-
-test_jparse: make rebuild_jparse_err_files ending
+jparse: make rebuild_jparse_err_files ending
 ```
 
 Assuming you see the above you **MUST** then run `make test` from the top level
@@ -37,6 +66,7 @@ git add test_JSON/bad_loc/*.json
 git add test_JSON/bad_loc/*.json.err
 ```
 
-Then commit and make a pull request to have it added to the repo.
+Then commit and push to the repo.
 
-If the error files are not added, `make test` **WILL FAIL!**
+If the error files are not added, or something else is wrong, `make test` **WILL
+FAIL!**

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -9,12 +9,17 @@
 #
 #	json_tree/tree/subdir/good
 #	json_tree/tree/subdir/bad
+#	json_tree/tree/subdir/bad_loc
+#
+# All files under json_tree/tree/subdir/bad must be invalid JSON.  If any file under
+# that directory tests as a valid JSON file, this script will exit non-zero.
+#
+# All files under json_tree/tree/subdir/bad_loc must be invalid JSON but the
+# error reported by jparse must match the file's corresponding .err file to make
+# sure error reporting is valid.
 #
 # All files under json_tree/tree/subdir/good must be valid JSON.  If any file under
 # that directory tests as an invalid JSON file, this script will exit non-zero.
-#
-# All files under json_tree/tree/subdir/bad must be valid JSON.  If any file under
-# that directory tests as a valid JSON file, this script will exit non-zero.
 #
 # Without "-d json_tree -s subdir" a list of files in the command line are
 # tested to see if they are valid JSON files.  With no arguments, or - the
@@ -38,13 +43,15 @@
 
 # setup
 #
-export JPARSE_TEST_VERSION="1.0.3 2023-08-01"
-export CHK_TEST_FILE="./jparse/test_jparse/json_teststr.txt"
-export JPARSE="./jparse/jparse"
-export PRINT_TEST="./jparse/test_jparse/print_test"
-export JSON_TREE="./jparse/test_jparse/test_JSON"
+export JPARSE_TEST_VERSION="1.0.5 2024-09-04"	    # version format: major.minor YYYY-MM-DD */
+export CHK_TEST_FILE="./test_jparse/json_teststr.txt"
+export JPARSE="./jparse"
+export PRINT_TEST="./test_jparse/print_test"
+export JSON_TREE="./test_jparse/test_JSON"
+export PASS_FAIL="pass"
 export SUBDIR="."
-export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jparse] [-p print_test] [-d json_tree] [-s subdir] [-k] [-L] [file ..]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j jparse]
+		[-p print_test] [-d json_tree] [-s subdir] [-Z topdir] [-k] [-f] [file ..]
 
     -h			print help and exit
     -V			print version and exit
@@ -57,12 +64,16 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j 
     -d json_tree	read files under json_tree/subdir/good and json_tree/subdir/bad (def: $JSON_TREE)
 			    These subdirectories are expected:
 				json_tree/tree/subdir/bad
+				json_tree/tree/subdir/bad_loc
 				json_tree/tree/subdir/good
     -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
+    -Z topdir		set path to top directory
     -k			keep temporary files on exit (def: remove temporary files before exiting)
-    -L			run error location reporting test
+    -f			files specified must fail check, not pass (def: must $PASS_FAIL)
+
     [file ...]		read JSON documents, one per line, from these files, - means stdin (def: $CHK_TEST_FILE)
-			NOTE: To use stdin, end the command line with: -- -
+			NOTE: to use stdin, end the command line with: -- -.
+			NOTE: without -f, do not check any strings for failure.
 
 Exit codes:
      0   all tests are OK
@@ -88,11 +99,12 @@ export STRING_FAILURE_SUMMARY=""
 export PRINT_TEST_FLAG_USED=""
 export PRINT_TEST_FAILURE=""
 export K_FLAG=""
-export L_FLAG=""
+export D_FLAG=""
+export TOPDIR=
 
 # parse args
 #
-while getopts :hVv:D:J:qj:p:d:s:kL flag; do
+while getopts :hVv:D:J:qj:p:d:s:Z:kf flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -114,13 +126,16 @@ while getopts :hVv:D:J:qj:p:d:s:kL flag; do
 	PRINT_TEST_FLAG_USED="1"
 	;;
     d)	JSON_TREE="$OPTARG"
+	D_FLAG="-d"
 	;;
     s)  SUBDIR="$OPTARG"
 	;;
+    Z)	TOPDIR="$OPTARG";
+	;;
     k)  K_FLAG="true";
         ;;
-    L)  L_FLAG="true";
-        ;;
+    f)	PASS_FAIL="fail"
+	;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
 	echo 1>&2
 	echo "$USAGE" 1>&2
@@ -158,6 +173,62 @@ export JSON_GOOD_TREE="$JSON_TREE/$SUBDIR/good"
 export JSON_BAD_TREE="$JSON_TREE/$SUBDIR/bad"
 export JSON_BAD_LOC_TREE="$JSON_TREE/$SUBDIR/bad_loc"
 
+# change to the top level directory as needed
+#
+if [[ -n $TOPDIR ]]; then
+    if [[ ! -d $TOPDIR ]]; then
+	echo "$0: ERROR: -Z $TOPDIR given: not a directory: $TOPDIR" 1>&2
+	exit 3
+    fi
+    if [[ $V_FLAG -ge 1 ]]; then
+	echo "$0: debug[1]: -Z $TOPDIR given, about to cd $TOPDIR" 1>&2
+    fi
+    # SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+    # https://www.shellcheck.net/wiki/SC2164
+    # shellcheck disable=SC2164
+    cd "$TOPDIR"
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: -Z $TOPDIR given: cd $TOPDIR exit code: $status" 1>&2
+	exit 3
+    fi
+elif [[ -f jparse.c ]]; then
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is .: $TOPDIR" 1>&2
+    fi
+elif [[ -f ../jparse.c ]]; then
+    cd ..
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: cd .. exit code: $status" 1>&2
+	exit 3
+    fi
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is ..: $TOPDIR" 1>&2
+    fi
+elif [[ -f ../../jparse.c ]]; then
+    cd ../..
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: cd .. exit code: $status" 1>&2
+	exit 3
+    fi
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is ..: $TOPDIR" 1>&2
+    fi
+
+else
+    echo "$0: ERROR: cannot determine TOPDIR, use -Z topdir" 1>&2
+    exit 3
+fi
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: TOPDIR is the current directory: $TOPDIR" 1>&2
+fi
+
+
 # firewall
 #
 if [[ ! -e $JPARSE ]]; then
@@ -165,7 +236,7 @@ if [[ ! -e $JPARSE ]]; then
     exit 4
 fi
 if [[ ! -f $JPARSE ]]; then
-    echo "$0: ERROR: jparse not a regular file: $JPARSE"
+    echo "$0: ERROR: jparse not a regular file: $JPARSE" 1>&2
     exit 4
 fi
 if [[ ! -x $JPARSE ]]; then
@@ -189,54 +260,55 @@ if [[ -n "$PRINT_TEST_FLAG_USED" ]]; then
     fi
 fi
 
-# check that json_tree is a readable directory
+# if -d used, check that json_tree and its subdirectories are readable
+# directories.
 #
-if [[ ! -e $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -d $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -r $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
-    exit 6
-fi
+if [[ -n "$D_FLAG" ]]; then
+    if [[ ! -e $JSON_TREE ]]; then
+	echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -d $JSON_TREE ]]; then
+	echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -r $JSON_TREE ]]; then
+	echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+	exit 6
+    fi
 
-# good tree
-#
-if [[ ! -e $JSON_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/good for jparse directory not found: $JSON_GOOD_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -d $JSON_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/good for jparse not a directory: $JSON_GOOD_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -r $JSON_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/good for jparse not readable directory: $JSON_GOOD_TREE" 1>&2
-    exit 6
-fi
+    # good tree
+    #
+    if [[ ! -e $JSON_GOOD_TREE ]]; then
+	echo "$0: ERROR: json_tree/good for jparse directory not found: $JSON_GOOD_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -d $JSON_GOOD_TREE ]]; then
+	echo "$0: ERROR: json_tree/good for jparse not a directory: $JSON_GOOD_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -r $JSON_GOOD_TREE ]]; then
+	echo "$0: ERROR: json_tree/good for jparse not readable directory: $JSON_GOOD_TREE" 1>&2
+	exit 6
+    fi
 
-# bad tree
-#
-if [[ ! -e $JSON_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/bad for jparse directory not found: $JSON_BAD_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -d $JSON_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/bad for jparse not a directory: $JSON_BAD_TREE" 1>&2
-    exit 6
-fi
-if [[ ! -r $JSON_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/bad for jparse not readable directory: $JSON_BAD_TREE" 1>&2
-    exit 6
-fi
+    # bad tree
+    #
+    if [[ ! -e $JSON_BAD_TREE ]]; then
+	echo "$0: ERROR: json_tree/bad for jparse directory not found: $JSON_BAD_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -d $JSON_BAD_TREE ]]; then
+	echo "$0: ERROR: json_tree/bad for jparse not a directory: $JSON_BAD_TREE" 1>&2
+	exit 6
+    fi
+    if [[ ! -r $JSON_BAD_TREE ]]; then
+	echo "$0: ERROR: json_tree/bad for jparse not readable directory: $JSON_BAD_TREE" 1>&2
+	exit 6
+    fi
 
-# bad location tree
-#
-if [[ -n "$L_FLAG" ]]; then
+    # bad location tree
+    #
     if [[ ! -e $JSON_BAD_LOC_TREE ]]; then
 	echo "$0: ERROR: json_tree/bad for jparse directory not found: $JSON_BAD_LOC_TREE" 1>&2
 	exit 6
@@ -249,25 +321,25 @@ if [[ -n "$L_FLAG" ]]; then
 	echo "$0: ERROR: json_tree/bad for jparse not readable directory: $JSON_BAD_LOC_TREE" 1>&2
 	exit 6
     fi
+fi
 
-    # We need a file to write the output of jparse to in order to compare it
-    # with any error file. This is needed for the files that are supposed to
-    # fail but it's possible that there could be a use for good files too.
-    TMP_STDERR_FILE=$(mktemp -u .jparse_test.stderr.XXXXXXXXXX)
-    # delete the temporary file in the off chance it already exists
-    rm -f "$TMP_STDERR_FILE"
-    # now let's make sure we can create it as well: if we can't or it's not
-    # writable there's an issue.
-    #
-    touch "$TMP_STDERR_FILE"
-    if [[ ! -e "$TMP_STDERR_FILE" ]]; then
-	echo "$0: could not create output file: $TMP_STDERR_FILE"
-	exit 35
-    fi
-    if [[ ! -w "$TMP_STDERR_FILE" ]]; then
-	echo "$0: output file not writable: $TMP_STDERR_FILE"
-	exit 36
-    fi
+# We need a file to write the output of jparse to in order to compare it
+# with any error file. This is needed for the files that are supposed to
+# fail but it's possible that there could be a use for good files too.
+TMP_STDERR_FILE=$(mktemp -u .jparse_test.stderr.XXXXXXXXXX)
+# delete the temporary file in the off chance it already exists
+rm -f "$TMP_STDERR_FILE"
+# now let's make sure we can create it as well: if we can't or it's not
+# writable there's an issue.
+#
+touch "$TMP_STDERR_FILE"
+if [[ ! -e "$TMP_STDERR_FILE" ]]; then
+    echo "$0: could not create output file: $TMP_STDERR_FILE"
+    exit 35
+fi
+if [[ ! -w "$TMP_STDERR_FILE" ]]; then
+    echo "$0: output file not writable: $TMP_STDERR_FILE"
+    exit 36
 fi
 
 # remove logfile so that each run starts out with an empty file
@@ -283,14 +355,12 @@ if [[ ! -w "${LOGFILE}" ]]; then
     exit 5
 fi
 
-if [[ -n "$L_FLAG" ]]; then
-    # remove or keep (some) temporary files
-    #
-    if [[ -z $K_FLAG ]]; then
-	trap "rm -f \$TMP_STDERR_FILE; exit" 0 1 2 3 15
-    else
-	trap "rm -f \$TMP_STDERR_FILE; exit" 1 2 3 15
-    fi
+# remove or keep (some) temporary files
+#
+if [[ -z $K_FLAG ]]; then
+    trap "rm -f \$TMP_STDERR_FILE; exit" 0 1 2 3 15
+else
+    trap "rm -f \$TMP_STDERR_FILE; exit" 1 2 3 15
 fi
 
 # run_location_err_test - run a single test
@@ -552,20 +622,21 @@ run_print_test()
 # run_string_test - run a single jparse test on a string
 #
 # usage:
-#	run_string_test jparse dbg_level json_dbg_level quiet_mode json_doc_string
+#	run_string_test jparse dbg_level json_dbg_level quiet_mode json_doc_string pass|fail
 #
 #	jparse			path to the jparse program
 #	dbg_level		internal test debugging level to use as in: jparse -v dbg_level
 #	json_dbg_level		JSON parser debug level to use in: jparse -J json_dbg_level
 #	quiet_mode		quiet mode to use in: jparse -q
 #	json_doc_string		JSON document as a string to give to jparse
+#	pass_fail		if "pass" then tests must pass, otherwise if "fail" they must fail
 #
 run_string_test()
 {
     # parse args
     #
-    if [[ $# -ne 5 ]]; then
-	echo "$0: ERROR: expected 5 args to run_string_test, found $#" 1>&2
+    if [[ $# -ne 6 ]]; then
+	echo "$0: ERROR: expected 6 args to run_string_test, found $#" 1>&2
 	exit 12
     fi
     declare jparse="$1"
@@ -573,6 +644,13 @@ run_string_test()
     declare json_dbg_level="$3"
     declare quiet_mode="$4"
     declare json_doc_string="$5"
+    declare pass_fail="$6"
+
+    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
+	echo "$0: ERROR: in run_string_test: pass_fail neither 'pass' nor 'fail'" 1>&2
+	EXIT_CODE=11
+	return
+    fi
 
     # debugging
     #
@@ -582,19 +660,18 @@ run_string_test()
 	echo "$0: debug[9]: in run_string_test: json_dbg_level: $json_dbg_level" 1>&2
 	echo "$0: debug[9]: in run_string_test: quiet_mode: $quiet_mode" 1>&2
 	echo "$0: debug[9]: in run_string_test: json_doc_string: $json_doc_string" 1>&2
+	echo "$0: debug[9]: in run_string_test: pass_fail: $pass_fail" 1>&2
     fi
 
     if [[ -z $quiet_mode ]]; then
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run: $jparse -v $dbg_level -J $json_dbg_level -s -- $json_doc_string >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jparse -v $dbg_level -J $json_dbg_level -s -- $json_doc_string >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: debug[3]: about to run: $jparse -v $dbg_level -J $json_dbg_level -s -- $json_doc_string >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
 	"$jparse" -v "$dbg_level" -J "$json_dbg_level" -s -- "$json_doc_string" >> "${LOGFILE}" 2>&1
     else
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run: $jparse -v $dbg_level -J $json_dbg_level -q -s -- $json_doc_string >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must $pass_fail: $jparse -v $dbg_level -J $json_dbg_level -q -s -- $json_doc_string >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: debug[3]: about to run: $jparse -v $dbg_level -J $json_dbg_level -q -s -- $json_doc_string >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
 	"$jparse" -v "$dbg_level" -J "$json_dbg_level" -q -s -- "$json_doc_string" >> "${LOGFILE}" 2>&1
     fi
     status="$?"
@@ -602,20 +679,42 @@ run_string_test()
     # examine test result
     #
     if [[ $status -eq 0 ]]; then
-	echo "$0: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
-	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: jparse OK, exit code 0" 1>&2
+	if [[ $pass_fail = pass ]]; then
+	    echo "$0: in test that must pass: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    if [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    fi
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    STRING_FAILURE_SUMMARY="$STRING_FAILURE_SUMMARY
+	    STRING: $json_doc_string"
+	    EXIT_CODE=1
 	fi
     else
-	if [[ $V_FLAG -ge 1 ]]; then
-	    echo "$0: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 3 ]]; then
-		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
+	if [[ $pass_fail = pass ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must pass: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
 	    fi
+	    STRING_FAILURE_SUMMARY="$STRING_FAILURE_SUMMARY
+	    STRING: $json_doc_string"
+	    EXIT_CODE=1
+	else
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: in test that must fail: jparse OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		if [[ $V_FLAG -ge 3 ]]; then
+		    echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
+		fi
+	    fi
+	    EXIT_CODE=0
 	fi
-	STRING_FAILURE_SUMMARY="$STRING_FAILURE_SUMMARY
-	STRING: $json_doc_string"
-	EXIT_CODE=1
     fi
     echo >> "${LOGFILE}"
 
@@ -624,7 +723,7 @@ run_string_test()
     return
 }
 
-# case: process stdin
+# case: process stdin or given file(s)
 #
 if [[ $# -gt 0 ]]; then
 
@@ -650,7 +749,7 @@ if [[ $# -gt 0 ]]; then
 	    # read JSON document lines from stdin
 	    #
 	    while read -r JSON_DOC; do
-		run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC"
+		run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC" "$PASS_FAIL"
 	    done
 	else
 	    if [[ ! -e $CHK_TEST_FILE ]]; then
@@ -668,11 +767,12 @@ if [[ $# -gt 0 ]]; then
 	    # process all lines in test file
 	    #
 	    while read -r JSON_DOC; do
-		run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC"
+		run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC" "$PASS_FAIL"
 	    done < "$CHK_TEST_FILE"
 	fi
     done
-elif [[ -n "$CHK_TEST_FILE" ]]; then
+# case: check the default file, unless -f
+elif [[ -z "$F_FLAG" && -n "$CHK_TEST_FILE" ]]; then
 	if [[ $V_FLAG -ge 1 ]]; then
 	    echo "$0: debug[1]: reading JSON documents from: $CHK_TEST_FILE" 1>&2 >> "${LOGFILE}"
 	fi
@@ -695,30 +795,33 @@ elif [[ -n "$CHK_TEST_FILE" ]]; then
 	# process all lines in test file
 	#
 	while read -r JSON_DOC; do
-	    run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC"
+	    run_string_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$JSON_DOC" "$PASS_FAIL"
 	done < "$CHK_TEST_FILE"
 fi
 
-# run tests that must pass
+# if -d used run tests in directories
 #
-if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run jparse tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
-fi
-while read -r file; do
-    run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
-done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
+if [[ -n "$D_FLAG" ]]; then
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: about to run jparse tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+    fi
+
+    # run tests that must pass
+    while read -r file; do
+	run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
+    done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
 
 
-# run tests that must fail
-#
-if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run jparse tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
-fi
-while read -r file; do
-    run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
-done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
+    # run tests that must fail
+    #
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: about to run jparse tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+    fi
+    while read -r file; do
+	run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
+    done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
 
-if [[ -n "$L_FLAG" ]]; then
+    # run tests that must fail with correct error locations
     while read -r file; do
 	run_location_err_test "$file"
     done < <(find "$JSON_BAD_LOC_TREE" -type f -name '*.json' -print)
@@ -742,25 +845,23 @@ if [[ -n "$STRING_FAILURE_SUMMARY" ]]; then
     echo "--" | tee -a -- "${LOGFILE}"
 fi
 if [[ -n "$PRINT_TEST_FAILURE" ]]; then
-    echo "NOTE: the print_test test failed. See the log for details."
+    echo "NOTE: the print_test test failed. See the ${LOGFILE} file for details."
 fi
 
-# explicitly delete the temporary files
-if [[ -n "$L_FLAG" ]]; then
-    if [[ -z $K_FLAG ]]; then
-	rm -f "$TMP_STDERR_FILE"
-    else
-	echo
-	echo "$0: keeping temporary files due to use of -k"
-	echo
-	echo "$0: to remove the temporary files:"
-	echo
-	echo -n "rm -f"
-	if [[ -e $TMP_STDERR_FILE ]]; then
-	    echo -n " $TMP_STDERR_FILE"
-	fi
-	echo
+# explicitly delete the temporary files if -k not used
+if [[ -z $K_FLAG ]]; then
+    rm -f "$TMP_STDERR_FILE"
+else
+    echo
+    echo "$0: keeping temporary files due to use of -k"
+    echo
+    echo "$0: to remove the temporary files:"
+    echo
+    echo -n "rm -f"
+    if [[ -e $TMP_STDERR_FILE ]]; then
+	echo -n " $TMP_STDERR_FILE"
     fi
+    echo
 fi
 
 # All Done!!! All Done!!! -- Jessica Noll, Age 2

--- a/jparse/test_jparse/json_teststr_fail.txt
+++ b/jparse/test_jparse/json_teststr_fail.txt
@@ -1,0 +1,3 @@
+true:
+:false
+foobar"

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -19,11 +19,11 @@
 
 # setup
 #
-export JSTRENCODE="./jparse/jstrencode"
-export JSTRDECODE="./jparse/jstrdecode"
-export TEST_FILE="./jparse/test_jparse/jstr_test.out"
-export TEST_FILE2="./jparse/test_jparse/jstr_test2.out"
-export JSTR_TEST_VERSION="1.0.1 2024-03-02"
+export JSTRENCODE="./jstrencode"
+export JSTRDECODE="./jstrdecode"
+export TEST_FILE="./test_jparse/jstr_test.out"
+export TEST_FILE2="./test_jparse/jstr_test2.out"
+export JSTR_TEST_VERSION="1.0.2 2024-09-04"
 export TOPDIR=
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode] [-Z topdir]
@@ -102,12 +102,23 @@ if [[ -n $TOPDIR ]]; then
 	echo "$0: ERROR: -Z $TOPDIR given: cd $TOPDIR exit code: $status" 1>&2
 	exit 3
     fi
-elif [[ -f mkiocccentry.c ]]; then
+elif [[ -f jparse.c ]]; then
     TOPDIR="$PWD"
     if [[ $V_FLAG -ge 3 ]]; then
 	echo "$0: debug[3]: assume TOPDIR is .: $TOPDIR" 1>&2
     fi
-elif [[ -f ../mkiocccentry.c ]]; then
+elif [[ -f ../jparse.c ]]; then
+    cd ..
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+	echo "$0: ERROR: cd .. exit code: $status" 1>&2
+	exit 3
+    fi
+    TOPDIR="$PWD"
+    if [[ $V_FLAG -ge 3 ]]; then
+	echo "$0: debug[3]: assume TOPDIR is ..: $TOPDIR" 1>&2
+    fi
+elif [[ -f ../../jparse.c ]]; then
     cd ..
     status="$?"
     if [[ $status -ne 0 ]]; then
@@ -201,9 +212,7 @@ fi
 # test some text holes in the encoding and decoding pipe
 #
 echo "$0: about to run test #3"
-export SRC_SET="$0 dbg/dbg.c dbg/dbg.h test_ioccc/fnamchk.c iocccsize.c"
-SRC_SET="$SRC_SET chkentry.c ./jparse/json_parse.c ./jparse/json_parse.h ./jparse/jstrdecode.c ./jparse/jstrencode.c"
-SRC_SET="$SRC_SET soup/limit_ioccc.h mkiocccentry.c txzchk.c jparse/util.c jparse/util.h"
+export SRC_SET="jparse.c json_parse.c json_parse.h jstrdecode.c jstrencode.c util.h util.c"
 echo "cat \$SRC_SET | $JSTRENCODE -v $V_FLAG -n | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
 # We cannot double-quote $SRC_SET because doing so would make the shell try
 # catting the list of files as a single file name which obviously would not work

--- a/jparse/test_jparse/prep.sh
+++ b/jparse/test_jparse/prep.sh
@@ -2,8 +2,7 @@
 #
 # prep.sh - prep for a release - actions for make prep and make release
 #
-# This script was co-developed in 2022 by:
-#
+# This script was co-developed in 2022-2024 by:
 #
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson
@@ -126,7 +125,7 @@ if [[ -n "$LOGFILE" ]]; then
     fi
 fi
 
-# Determine the name of the bug_report.sh log file
+# Determine the name of the jparse_bug_report.sh log file
 #
 # NOTE: this log file does not have an underscore in the name because we want to
 # distinguish it from this script which does have an underscore in it.
@@ -278,11 +277,11 @@ make_action() {
 # make bug report
 #
 # usage:
-#	make_bug_report code
+#	make_jparse_bug_report code
 #
 #	code - exit code if script fails
 #
-make_bug_report() {
+make_jparse_bug_report() {
 
     # parse args
     #
@@ -295,36 +294,36 @@ make_bug_report() {
     # announce pre-action
     #
     if [[ -z "$LOGFILE" ]]; then
-	write_echo "=-=-= START: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
+	write_echo "=-=-= START: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
     else
-	write_echo_n "make_action $CODE bug_report-txl -L $BUG_REPORT_LOGFILE "
+	write_echo_n "make_action $CODE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE "
     fi
 
     # perform action
     #
-    exec_command "./bug_report.sh" -t -x -l -L "$BUG_REPORT_LOGFILE"
+    exec_command "./jparse_bug_report.sh" -t -x -l -L "$BUG_REPORT_LOGFILE"
     status="$?"
 
-    # Finally we report on the exit status of the bug_report.sh
+    # Finally we report on the exit status of the jparse_bug_report.sh
     #
     if [[ $status -ne 0 ]]; then
 
-	# process a bug_report.sh failure (i.e. error or actual issue
-	# detected NOT ONLY a warning)
+	# process a jparse_bug_report.sh failure (i.e. error or actual issue
+	# detected, NOT ONLY a warning)
 	#
 	EXIT_CODE="$CODE"
 
 	FAILURE_SUMMARY="$FAILURE_SUMMARY
-	$MAKE bug_report-txl $EXIT_CODE: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE: non-zero exit code: $status"
+	$MAKE jparse_bug_report-txl $EXIT_CODE: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE: non-zero exit code: $status"
 	if [[ -z "$LOGFILE" ]]; then
 	    write_echo "$0: Warning: EXIT_CODE is now: $EXIT_CODE" 1>&2
 	fi
 	if [[ -n $E_FLAG ]]; then
 	    if [[ -z "$LOGFILE" ]]; then
 		write_echo
-		write_echo "$0: Warning: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE exit status: $status" 1>&2
+		write_echo "$0: Warning: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE exit status: $status" 1>&2
 		write_echo
-		write_echo "=-=-= FAIL: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
+		write_echo "=-=-= FAIL: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
 		write_echo
 	    else
 		write_echo "ERROR exit code $status"
@@ -333,7 +332,7 @@ make_bug_report() {
 	else
 	    if [[ -z "$LOGFILE" ]]; then
 		write_echo
-		write_echo "$0: Warning: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE exit status: $status" 1>&2
+		write_echo "$0: Warning: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE exit status: $status" 1>&2
 		write_echo
 		write_echo "=-=-= FAIL: $MAKE $RULE =-=-="
 		write_echo
@@ -346,7 +345,7 @@ make_bug_report() {
     else
 	if [[ -z "$LOGFILE" ]]; then
 	    write_echo
-	    write_echo "=-=-= PASS: $MAKE bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
+	    write_echo "=-=-= PASS: $MAKE jparse_bug_report-txl -L $BUG_REPORT_LOGFILE =-=-="
 	    write_echo
 	else
 	    write_echo "OK"
@@ -365,28 +364,25 @@ fi
 make_action 10 clobber
 make_action 11 all
 make_action 12 depend
-make_action 13 clean_mkchk_sem
-make_action 14 all_sem_ref
-make_action 15 mkchk_sem
-make_action 16 all
+make_action 13 all
 if [[ -n $O_FLAG ]]; then
-    make_action 17 parser-o
+    make_action 14 parser-o
 else
-    make_action 18 parser
+    make_action 15 parser
 fi
-make_action 19 all
-make_action 20 load_json_ref
-make_action 21 use_json_ref
-make_action 22 clean_generated_obj
-make_action 23 all
-make_bug_report 24
-make_action 25 shellcheck
-make_action 26 seqcexit
-make_action 27 picky
-make_action 28 tags
-make_action 29 check_man
-make_action 30 all
-make_action 31 test
+make_action 16 all
+make_action 17 load_json_ref
+make_action 18 use_json_ref
+make_action 19 clean_generated_obj
+make_action 20 all
+make_jparse_bug_report 21
+make_action 22 shellcheck
+make_action 23 seqcexit
+make_action 24 picky
+make_action 25 tags
+make_action 26 check_man
+make_action 27 all
+make_action 28 test
 
 # If we have a logfile, count the number of Notice: messages in the logfile
 #
@@ -413,15 +409,15 @@ if [[ -e "$BUG_REPORT_LOGFILE" ]]; then
 
     # Next we summarize Notices and Warnings directly the logfile
     #
-    write_logfile "=-=-= bug_report.sh generated $NOTICE_COUNT notices in $BUG_REPORT_LOGFILE"
+    write_logfile "=-=-= jparse_bug_report.sh generated $NOTICE_COUNT notices in $BUG_REPORT_LOGFILE"
     if [[ $NOTICE_COUNT -gt 0 ]]; then
 	write_logfile
-	write_logfile "=-=-= Summary of make_bug_report notices follow:"
+	write_logfile "=-=-= Summary of make_jparse_bug_report notices follow:"
 	write_logfile
 	NOTICE_SET=$(grep -E "[[:space:]]+Notice:[[:space:]]" "$BUG_REPORT_LOGFILE")
 	write_logfile "$NOTICE_SET"
 	write_logfile
-	write_logfile "=-=-= End of of make_bug_report notice summary"
+	write_logfile "=-=-= End of of make_jparse_bug_report notice summary"
     fi
 fi
 
@@ -435,15 +431,15 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 	write_echo
 	if [[ $NOTICE_COUNT -gt 0 ]]; then
 	    if [[ $NOTICE_COUNT -eq 1 ]]; then
-		write_echo "bug_report.sh issued $NOTICE_COUNT notice."
+		write_echo "jparse_bug_report.sh issued $NOTICE_COUNT notice."
 	    else
-		write_echo "bug_report.sh issued $NOTICE_COUNT notices."
+		write_echo "jparse_bug_report.sh issued $NOTICE_COUNT notices."
 	    fi
 	fi
     else
 	if [[ $NOTICE_COUNT -gt 0 ]]; then
 	    if [[ $NOTICE_COUNT -eq 1 ]]; then
-		write_echo "bug_report.sh issued $NOTICE_COUNT notice."
+		write_echo "jparse_bug_report.sh issued $NOTICE_COUNT notice."
 	    else
 		write_echo "All tests PASSED; $NOTICE_COUNT notices issued."
 	    fi
@@ -466,14 +462,14 @@ else
 	write_echo ""
 	if [[ $NOTICE_COUNT -gt 0 ]]; then
 	    if [[ $NOTICE_COUNT -eq 1 ]]; then
-		write_echo "bug_report.sh issued $NOTICE_COUNT notice."
+		write_echo "jparse_bug_report.sh issued $NOTICE_COUNT notice."
 	    else
-		write_echo "bug_report.sh issued $NOTICE_COUNT notices."
+		write_echo "jparse_bug_report.sh issued $NOTICE_COUNT notices."
 	    fi
 	fi
-	if [[ -e test_ioccc/test_ioccc.log ]]; then
+	if [[ -e test_jparse/test_jparse.log ]]; then
 	    write_echo ""
-	    write_echo "See test_ioccc/test_ioccc.log for more details."
+	    write_echo "See test_jparse/test_jparse.log for more details."
 	fi
     else
 	if [[ -n "$FAILURE_SUMMARY" ]]; then
@@ -490,9 +486,9 @@ else
 	else
 	    write_echo "One or more tests failed."
 	fi
-	if [[ -e test_ioccc/test_ioccc.log ]]; then
+	if [[ -e test_jparse/test_jparse.log ]]; then
 	    write_echo ""
-	    write_echo "See test_ioccc/test_ioccc.log for more details."
+	    write_echo "See test_jparse/test_jparse.log for more details."
 	fi
     fi
 fi

--- a/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json at line 28 column 18: <:>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json at line 28 column 18: <:>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 14 column 22: invalid token: 0x61 = <a>
-syntax error in file test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json at line 14 column 22: <a>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json at line 14 column 22: <a>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/braces-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/braces-comma-eof.json.err
@@ -1,2 +1,2 @@
-syntax error node type JTYPE_OBJECT in file test_JSON/./bad_loc/braces-comma-eof.json at line 1 column 3: <,>
-ERROR[1]: ../jparse: invalid JSON
+syntax error node type JTYPE_OBJECT in file test_jparse/test_JSON/./bad_loc/braces-comma-eof.json at line 1 column 3: <,>
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/first-line-first-column-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/first-line-first-column-comma-eof.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/first-line-first-column-comma-eof.json at line 1 column 1: <,>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/first-line-first-column-comma-eof.json at line 1 column 1: <,>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 1 column 2: invalid token: 0x22 = <">
-syntax error in file test_JSON/./bad_loc/open-brace-unbalanced-quotes-comma.json at line 1 column 2: <">
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/open-brace-unbalanced-quotes-comma.json at line 1 column 2: <">
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace-value-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace-value-comma.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/open-brace-value-comma.json at line 1 column 8: <,>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/open-brace-value-comma.json at line 1 column 8: <,>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/open-brace.json at line 2 column 17: empty text
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/open-brace.json at line 2 column 17: empty text
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/second-line-first-column-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/second-line-first-column-comma-eof.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/second-line-first-column-comma-eof.json at line 2 column 1: <,>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/second-line-first-column-comma-eof.json at line 2 column 1: <,>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/second-line-second-column-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/second-line-second-column-comma.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/second-line-second-column-comma.json at line 2 column 2: <,>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/second-line-second-column-comma.json at line 2 column 2: <,>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-0-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-0-auth.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/test-0-auth.json at line 29 column 17: <{>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/test-0-auth.json at line 29 column 17: <{>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 3 column 32: invalid token: 0x22 = <">
-syntax error in file test_JSON/./bad_loc/test-0-info.json at line 3 column 32: <">
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/test-0-info.json at line 3 column 32: <">
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 5 column 25: invalid token: 0x65 = <e>
-syntax error in file test_JSON/./bad_loc/test-1-auth.json at line 5 column 25: <e>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/test-1-auth.json at line 5 column 25: <e>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-1-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-1-info.json.err
@@ -1,3 +1,3 @@
-syntax error in file test_JSON/./bad_loc/test-1-info.json at line 43 column 26: <"formed_timestamp">
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/test-1-info.json at line 43 column 26: <"formed_timestamp">
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 1 column 2: invalid token: 0x74 = <t>
-syntax error in file test_JSON/./bad_loc/unquoted-name.json at line 1 column 2: <t>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/unquoted-name.json at line 1 column 2: <t>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
@@ -1,4 +1,4 @@
 Warning: jparse_lex: at line 3 column 1: invalid token: 0x0b = <>
-syntax error in file test_JSON/./bad_loc/vtab_comma.json at line 3 column 1: <>
-Warning: ../jparse: JSON parse tree is NULL
-ERROR[1]: ../jparse: invalid JSON
+syntax error in file test_jparse/test_JSON/./bad_loc/vtab_comma.json at line 3 column 1: <>
+Warning: ./jparse: JSON parse tree is NULL
+ERROR[1]: ./jparse: invalid JSON

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -540,11 +540,11 @@ extern_everything: extern_include extern_objs extern_liba extern_man extern_prog
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # Form unpatched semantic tables, without headers and trailers, from the reference info and auth JSON files
 #
@@ -631,7 +631,7 @@ reset_min_timestamp: reset_tstamp.sh
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -647,11 +647,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -679,13 +679,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -707,13 +707,13 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -729,7 +729,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 # install man pages
@@ -744,7 +744,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -768,13 +768,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -790,13 +790,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . ../dbg ../dyn_alloc ../jparse ../jparse/test_jparse; do \
@@ -807,7 +807,7 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clean_mkchk_sem:
 	${RM} -f chk_sem_info.c chk_sem_info.h chk_sem_info.o
@@ -815,19 +815,19 @@ clean_mkchk_sem:
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 ###################################
@@ -839,16 +839,16 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${ALL_OBJS}
 	${RM} -f .jsemcgen.out.*
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f .soup
 	${RM} -f tags ${LOCAL_DIR_TAGS}
@@ -856,22 +856,22 @@ clobber: legacy_clobber clean
 	${RM} -f ${TARGETS}
 	${RM} -rf ref
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 install: all install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_LIB}/soup.a
 	${RM} -r -f ${RM_V} ${DEST_DIR}/vermod.sh
@@ -891,7 +891,7 @@ uninstall:
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_usage.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/vermod.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ###############
 # make depend #
@@ -899,7 +899,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -939,7 +939,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 chk_sem_auth.o: ../dbg/dbg.h ../dyn_array/dyn_array.h \

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.7 2024-09-01"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.10 2024-09-05"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -420,7 +420,7 @@ fnamchk: fnamchk.o ../jparse/libjparse.a ../dyn_array/libdyn_array.a ../dbg/libd
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if [[ ! -x ./ioccc_test.sh ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./ioccc_test.sh" 1>&2; \
@@ -438,13 +438,13 @@ test:
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # sequence exit codes
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -460,11 +460,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -492,13 +492,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -520,13 +520,13 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -542,7 +542,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 # install man pages
@@ -557,7 +557,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -581,13 +581,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -603,13 +603,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${S} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . ../dbg ../dyn_alloc ../jparse ../jparse/test_jparse ../soup; do \
@@ -620,23 +620,23 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 
 
@@ -649,35 +649,35 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${OTHER_OBJS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f test_ioccc.log chkentry_test.log txzchk_test.log
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${RM} -rf test_iocccsize test_src test_work
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 install: all install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_DIR}/utf8_test
 	${RM} -r -f ${RM_V} ${DEST_DIR}/fnamchk
@@ -694,7 +694,7 @@ uninstall:
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/prep.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/utf8_test.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ###############
 # make depend #
@@ -702,7 +702,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -746,7 +746,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending"
+	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 fnamchk.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -453,7 +453,7 @@ if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: dyn_array/dyn_test non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
     FAILURE_SUMMARY="$FAILURE_SUMMARY
     dyn_array/dyn_test non-zero exit code: $status"
-    EXIT_CODE="26"
+    EXIT_CODE="24"
     echo | tee -a -- "$LOGFILE"
     echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
     echo | tee -a -- "$LOGFILE"
@@ -475,7 +475,7 @@ if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: jparse/test_jparse/jparse_test.sh for general.json non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
     FAILURE_SUMMARY="$FAILURE_SUMMARY
     jparse/test_jparse/jparse_test.sh for general.json non-zero exit code: $status"
-    EXIT_CODE="28"
+    EXIT_CODE="25"
     echo | tee -a -- "$LOGFILE"
     echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
     echo | tee -a -- "$LOGFILE"
@@ -508,7 +508,7 @@ if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: test_ioccc/txzchk_test.sh non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
     FAILURE_SUMMARY="$FAILURE_SUMMARY
     test_ioccc/txzchk_test.sh non-zero exit code: $status"
-    EXIT_CODE="31"
+    EXIT_CODE="26"
     echo | tee -a -- "$LOGFILE"
     echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
     echo | tee -a -- "$LOGFILE"
@@ -530,7 +530,7 @@ if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: test_ioccc/chkentry_test.sh non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
     FAILURE_SUMMARY="$FAILURE_SUMMARY
     test_ioccc/chkentry_test.sh non-zero exit code: $status"
-    EXIT_CODE="32"
+    EXIT_CODE="27"
     echo | tee -a -- "$LOGFILE"
     echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
     echo | tee -a -- "$LOGFILE"

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -17,7 +17,7 @@
 
 # setup
 #
-export IOCCC_TEST_VERSION="1.0.1 2023-02-05"
+export IOCCC_TEST_VERSION="1.0.2 2024-09-05"
 
 # attempt to fetch system specific path to the tools we need
 #
@@ -211,17 +211,6 @@ elif [[ ! -x test_ioccc/mkiocccentry_test.sh ]]; then
     echo "$0: ERROR: test_ioccc/mkiocccentry_test.sh is not executable" | tee -a -- "$LOGFILE"
     EXIT_CODE="5"
 fi
-# jstr_test.sh
-if [[ ! -e jparse/test_jparse/jstr_test.sh ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jstr_test.sh file not found" | tee -a -- "$LOGFILE"
-    EXIT_CODE="5"
-elif [[ ! -f jparse/test_jparse/jstr_test.sh ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jstr_test.sh is not a regular file" | tee -a -- "$LOGFILE"
-    EXIT_CODE="5"
-elif [[ ! -x jparse/test_jparse/jstr_test.sh ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jstr_test.sh is not executable" | tee -a -- "$LOGFILE"
-    EXIT_CODE="5"
-fi
 # jnum_chk
 if [[ ! -e jparse/test_jparse/jnum_chk ]]; then
     echo "$0: ERROR: jparse/test_jparse/jnum_chk file not found" | tee -a -- "$LOGFILE"
@@ -264,6 +253,17 @@ elif [[ ! -f jparse/test_jparse/json_teststr.txt ]]; then
     EXIT_CODE="5"
 elif [[ ! -r jparse/test_jparse/json_teststr.txt ]]; then
     echo "$0: ERROR: jparse/test_jparse/json_teststr.txt is not readable" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+fi
+# json_teststr_fail.txt: for jparse_test.sh
+if [[ ! -e jparse/test_jparse/json_teststr_fail.txt ]]; then
+    echo "$0: ERROR: jparse/test_jparse/json_teststr_fail.txt file not found" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+elif [[ ! -f jparse/test_jparse/json_teststr_fail.txt ]]; then
+    echo "$0: ERROR: jparse/test_jparse/jparse_test.sh is not a regular file" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+elif [[ ! -r jparse/test_jparse/json_teststr_fail.txt ]]; then
+    echo "$0: ERROR: jparse/test_jparse/json_teststr_fail.txt is not readable" | tee -a -- "$LOGFILE"
     EXIT_CODE="5"
 fi
 # txzchk
@@ -428,49 +428,18 @@ else
     echo "PASSED: test_ioccc/mkiocccentry_test.sh" | tee -a -- "$LOGFILE"
 fi
 
-# jstr_test.sh
-#
-echo | tee -a -- "$LOGFILE"
-echo "RUNNING: jparse/test_jparse/jstr_test.sh" | tee -a -- "$LOGFILE"
-echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jstr_test.sh -Z $TOPDIR -e $TOPDIR/jparse/jstrencode -d $TOPDIR/jparse/jstrdecode" | tee -a -- "$LOGFILE"
-jparse/test_jparse/jstr_test.sh -Z "$TOPDIR" -e "$TOPDIR/jparse/jstrencode" -d "$TOPDIR/jparse/jstrdecode" | tee -a -- "$LOGFILE"
-status="${PIPESTATUS[0]}"
-if [[ $status -ne 0 ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jstr_test.sh non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    jparse/test_jparse/jstr_test.sh non-zero exit code: $status"
-    EXIT_CODE="24"
-    echo | tee -a -- "$LOGFILE"
-    echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
-    echo | tee -a -- "$LOGFILE"
-    echo "FAILED: jparse/test_jparse/jstr_test.sh" | tee -a -- "$LOGFILE"
-else
-    echo | tee -a -- "$LOGFILE"
-    echo "PASSED: jparse/test_jparse/jstr_test.sh" | tee -a -- "$LOGFILE"
-fi
+# we do not run jstr_test.sh because make test in jparse/test_jparse will run
+# this and it has the correct paths (this is a workaround for the fact that
+# jparse/ is a subdirectory here but obviously not in the jparse repo).
 
-# jnum_chk
-#
-echo | tee -a -- "$LOGFILE"
-echo "RUNNING: jparse/test_jparse/jnum_chk" | tee -a -- "$LOGFILE"
-echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jnum_chk" | tee -a -- "$LOGFILE"
-jparse/test_jparse/jnum_chk -J "${J_FLAG}" | tee -a -- "$LOGFILE"
-status="${PIPESTATUS[0]}"
-if [[ $status -ne 0 ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jnum_chk non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    jparse/test_jparse/jnum_chk non-zero exit code: $status"
-    EXIT_CODE="25"
-    echo | tee -a -- "$LOGFILE"
-    echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
-    echo | tee -a -- "$LOGFILE"
-    echo "FAILED: jparse/test_jparse/jnum_chk" | tee -a -- "$LOGFILE"
-else
-    echo | tee -a -- "$LOGFILE"
-    echo "PASSED: jparse/test_jparse/jnum_chk" | tee -a -- "$LOGFILE"
-fi
+# we also do not run jnum_chk because make test in jparse/test_jparse will run
+# this and it has the correct paths (this is a workaround for the fact that
+# jparse/ is a subdirectory here but obviously not in the jparse repo).
+
+# we also do not run jparse_test.sh for jparse/test_jparse/test_JSON because
+# make test in jparse/test_jparse will run this and it has the correct paths
+# (this is a workaround for the fact that jparse/ is a subdirectory here but
+# obviously not in the jparse repo).
 
 # dyn_test
 #
@@ -494,37 +463,13 @@ else
     echo "PASSED: dyn_array/dyn_test" | tee -a -- "$LOGFILE"
 fi
 
-# jparse_test.sh for test_jparse/test_JSON
-#
-echo | tee -a -- "$LOGFILE"
-echo "RUNNING: jparse/test_jparse/jparse_test.sh for test_jparse/test_JSON" | tee -a -- "$LOGFILE"
-echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -d ./jparse/test_jparse/test_JSON -s . -j jparse/jparse jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
-#make -C jparse/test_jparse test | tee -a -- "$LOGFILE"
-
-jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -d ./jparse/test_jparse/test_JSON -s . -j jparse/jparse jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
-status="${PIPESTATUS[0]}"
-if [[ $status -ne 0 ]]; then
-    echo "$0: ERROR: jparse/test_jparse/jparse_test.sh for test_jparse/test_JSON non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"
-    FAILURE_SUMMARY="$FAILURE_SUMMARY
-    jparse/test_jparse/jparse_test.sh for test_jparse/test_JSON non-zero exit code: $status"
-    EXIT_CODE="27"
-    echo | tee -a -- "$LOGFILE"
-    echo "EXIT_CODE set to: $EXIT_CODE" | tee -a -- "$LOGFILE"
-    echo | tee -a -- "$LOGFILE"
-    echo "FAILED: jparse/test_jparse/jparse_test.sh for test_jparse/test_JSON" | tee -a -- "$LOGFILE"
-else
-    echo | tee -a -- "$LOGFILE"
-    echo "PASSED: jparse/test_jparse/jparse_test.sh for test_jparse/test_JSON" | tee -a -- "$LOGFILE"
-fi
-
 # jparse_test.sh for general.json
 #
 echo | tee -a -- "$LOGFILE"
 echo "RUNNING: jparse/test_jparse/jparse_test.sh for general.json" | tee -a -- "$LOGFILE"
 echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
-jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
+echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -Z $TOPDIR -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
+jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -Z "$TOPDIR" -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
 status="${PIPESTATUS[0]}"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: jparse/test_jparse/jparse_test.sh for general.json non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -468,8 +468,8 @@ fi
 echo | tee -a -- "$LOGFILE"
 echo "RUNNING: jparse/test_jparse/jparse_test.sh for general.json" | tee -a -- "$LOGFILE"
 echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -Z test_ioccc -d ./test_JSON -s general.json -j ../jparse/jparse ../jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
-jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -Z test_ioccc -d ./test_JSON -s general.json -j ../jparse/jparse ../jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
+echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -Z $TOPDIR -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
+jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -Z "$TOPDIR" -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
 status="${PIPESTATUS[0]}"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: jparse/test_jparse/jparse_test.sh for general.json non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -468,8 +468,8 @@ fi
 echo | tee -a -- "$LOGFILE"
 echo "RUNNING: jparse/test_jparse/jparse_test.sh for general.json" | tee -a -- "$LOGFILE"
 echo | tee -a -- "$LOGFILE"
-echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -Z $TOPDIR -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
-jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -Z "$TOPDIR" -d ./test_ioccc/test_JSON -s general.json -j jparse/jparse jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
+echo "jparse/test_jparse/jparse_test.sh -J $V_FLAG -Z test_ioccc -d ./test_JSON -s general.json -j ../jparse/jparse ../jparse/test_jparse/json_teststr.txt" | tee -a -- "$LOGFILE"
+jparse/test_jparse/jparse_test.sh -J "$V_FLAG" -Z test_ioccc -d ./test_JSON -s general.json -j ../jparse/jparse ../jparse/test_jparse/json_teststr.txt | tee -a -- "$LOGFILE"
 status="${PIPESTATUS[0]}"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: jparse/test_jparse/jparse_test.sh for general.json non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"

--- a/test_ioccc/test_JSON/general.json/bad_loc/party.json
+++ b/test_ioccc/test_JSON/general.json/bad_loc/party.json
@@ -1,0 +1,4 @@
+{
+	"event" : "A Long-expected Party",
+	"location" : "Bag End, Bagshot Row, Hobbiton, Westfarthing, the Shire, Middle-earth",
+}

--- a/test_ioccc/test_JSON/general.json/bad_loc/party.json.err
+++ b/test_ioccc/test_JSON/general.json/bad_loc/party.json.err
@@ -1,0 +1,3 @@
+syntax error in file ./test_ioccc/test_JSON/general.json/bad_loc/party.json at line 4 column 1: <}>
+Warning: jparse/jparse: JSON parse tree is NULL
+ERROR[1]: jparse/jparse: invalid JSON


### PR DESCRIPTION
        
In the Makefiles that do not come from another repo, any rule that had
the lines in the form of:
                     
    ... starting"
                
have been changed to:
            
    ... starting at `date`"

and the same thing for the lines that end with:

    ... ending:"

This does make more noise when things have to be done (but that's why 
not all rules have it) but it can help isolate issues sometimes and it 
matches other rules that already have it.
