### PR TITLE
Remove timestamps from Makefiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,28 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.11 2024-09-07
+
+Synced `jparse` subdirectory from the [jparse
+repo](https://github.com/xexyl/jparse/).
+
+It was decided that error messages in `jparse(1)` could be improved. This was
+done in the following ways:
+
+- If verbosity level is > 0, then it will show the invalid token and hex value
+of that token (along with the line and column).
+- If verbosity is not specified, then it will just show the syntax error (the
+bad token with the line and column) and then the warning that the JSON tree is
+NULL (just like if verbosity specified) and then the error message (from
+`jparse(1)` itself).
+
+The error files in the `bad_loc` have been updated as now the error output has
+changed.
+
+Updated `jparse(1)` version to 1.1.6 2024-09-07.
+
+Removed timestamps from `beginning`/`ending` messages in Makefiles.
+
+
 ## Release 1.5.10 2024-09-06
 
 Synced `jparse` subdirectory from the [jparse

--- a/Makefile
+++ b/Makefile
@@ -609,7 +609,7 @@ reset_min_timestamp: soup/Makefile
 # rule instead.
 #
 prep: test_ioccc/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE} -l "${TMP_BUILD_LOG}"; \
 	    EXIT_CODE="$$?"; \
@@ -625,13 +625,13 @@ prep: test_ioccc/prep.sh
 	    else \
 	        echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
+	    ${S} echo "${OUR_NAME}: make $@ ending"; \
 
 # a slower version of prep that does not write to a log file so one can see the
 # full details.
 #
 slow_prep: test_ioccc/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE}; \
 	    EXIT_CODE="$$?"; \
@@ -646,7 +646,7 @@ slow_prep: test_ioccc/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
+	    ${S} echo "${OUR_NAME}: make $@ ending"; \
 
 
 # make build release pull
@@ -664,7 +664,7 @@ slow_prep: test_ioccc/prep.sh
 build: release
 pull: release
 release: test_ioccc/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE} -e -o -l "${TMP_BUILD_LOG}"; \
 	    EXIT_CODE="$$?"; \
@@ -680,13 +680,13 @@ release: test_ioccc/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
+	    ${S} echo "${OUR_NAME}: make $@ ending"; \
 
 # a slower version of release that does not write to a log file so one can see the
 # full details.
 #
 slow_release: test_ioccc/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_ioccc/prep.sh -m${MAKE} -e -o; \
 	    EXIT_CODE="$$?"; \
@@ -701,7 +701,7 @@ slow_release: test_ioccc/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`"; \
+	    ${S} echo "${OUR_NAME}: make $@ ending"; \
 
 
 # force test_ioccc/txzchk_test.sh results into test suite *.err files
@@ -784,7 +784,7 @@ rebuild_jparse_err_files: jparse/test_jparse/Makefile
 seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -806,12 +806,12 @@ seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -845,14 +845,14 @@ picky: ${ALL_SRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -880,14 +880,14 @@ shellcheck: ${SH_FILES} .shellcheckrc dbg/Makefile dyn_array/Makefile jparse/Mak
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify man pages
 #
 check_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -896,14 +896,14 @@ check_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # build a user convenience man directory
 #
 build_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${V} echo
-	${V} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${V} echo "${OUR_NAME}: make $@ starting"
 	${V} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg install_man \
 		     MAN1_DIR=../man/man1 MAN3_DIR=../man/man3 MAN8_DIR=../man/man8 I=@ \
@@ -922,14 +922,14 @@ build_man: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 		     MAN1_DIR=../man/man1 MAN3_DIR=../man/man3 MAN8_DIR=../man/man8 I=@ \
 		     INSTALL_V= C_SPECIAL="${C_SPECIAL}"
 	${V} echo
-	${V} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${V} echo "${OUR_NAME}: make $@ ending"
 
 # vi/vim tags
 #
 tags: ${ALL_CSRC} ${ALL_HSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -953,13 +953,13 @@ tags: ${ALL_CSRC} ${ALL_HSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -975,13 +975,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${E} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1003,13 +1003,13 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # perform all of the mkiocccentry repo required tests
 #
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1019,7 +1019,7 @@ test:
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${RM} -f jparse/test_jparse/pr_jparse_test
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 	${S} echo "All done!!! All done!! -- Jessica Noll, Age 2."
 
 # run test-chkentry on test_JSON files
@@ -1048,7 +1048,7 @@ mkchk_sem: soup/Makefile
 legacy_clean: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1058,14 +1058,14 @@ legacy_clean: dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # clobber legacy code and files - files that are no longer needed
 #
 legacy_clobber: legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	jparse/test_jparse/Makefile soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${Q} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1077,7 +1077,7 @@ legacy_clobber: legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ########################################################################
@@ -1136,7 +1136,7 @@ dbg.help:
 
 dbg.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-@if [[ -d dbg.clone ]]; then \
 	    ${MAKE} dbg.update_clone; \
@@ -1144,11 +1144,11 @@ dbg.setup:
 	    ${MAKE} dbg.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if [[ -d dbg.clone ]]; then \
 	    echo "ERROR: dbg.clone exists"; \
@@ -1161,53 +1161,53 @@ dbg.clone:
 	    ${GIT} clone git@github.com:lcn2/dbg.git dbg.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.clone_status: dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${GIT} status dbg.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.update_clone: dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} cd dbg.clone && ${GIT} fetch
 	${E} cd dbg.clone && ${GIT} fetch --prune --tags
 	${E} cd dbg.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} dbg.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RM} -rf dbg.clone
 	${E} ${MAKE} dbg.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.update_from_clone: dbg.clone/ dbg/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dbg.clone/ dbg
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg depend C_SPECIAL=-DINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.update_into_clone: dbg/ dbg.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dbg/ dbg.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg.clone depend C_SPECIAL=-UINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dbg.diff_dbg_clone: dbg.clone/ dbg/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude dbg.clone dbg
@@ -1239,7 +1239,7 @@ dyn_array.help:
 
 dyn_array.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-@if [[ -d dyn_array.clone ]]; then \
 	    ${MAKE} dyn_array.update_clone; \
@@ -1247,11 +1247,11 @@ dyn_array.setup:
 	    ${MAKE} dyn_array.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if [[ -d dyn_array.clone ]]; then \
 	    echo "ERROR: dyn_array.clone exists"; \
@@ -1264,53 +1264,53 @@ dyn_array.clone:
 	    ${GIT} clone git@github.com:lcn2/dyn_array.git dyn_array.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.clone_status: dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${GIT} status dyn_array.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.update_clone: dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} cd dyn_array.clone && ${GIT} fetch
 	${E} cd dyn_array.clone && ${GIT} fetch --prune --tags
 	${E} cd dyn_array.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} dyn_array.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RM} -rf dyn_array.clone
 	${E} ${MAKE} dyn_array.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.update_from_clone: dyn_array.clone/ dyn_array/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dyn_array.clone/ dyn_array
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array depend C_SPECIAL=-DINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.update_into_clone: dyn_array/ dyn_array.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v dyn_array/ dyn_array.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array.clone depend C_SPECIAL=-UINTERNAL_INCLUDE
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 dyn_array.diff_dyn_array_clone: dyn_array.clone/ dyn_array/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude dyn_array.clone dyn_array
@@ -1342,7 +1342,7 @@ jparse.help:
 
 jparse.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-@if [[ -d jparse.clone ]]; then \
 	    ${MAKE} jparse.update_clone; \
@@ -1350,11 +1350,11 @@ jparse.setup:
 	    ${MAKE} jparse.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if [[ -d jparse.clone ]]; then \
 	    echo "ERROR: jparse.clone exists"; \
@@ -1367,55 +1367,55 @@ jparse.clone:
 	    ${GIT} clone git@github.com:xexyl/jparse.git jparse.clone; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.clone_status: jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${GIT} status jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.update_clone: jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} cd jparse.clone && ${GIT} fetch
 	${E} cd jparse.clone && ${GIT} fetch --prune --tags
 	${E} cd jparse.clone && ${GIT} merge --ff-only || ${GIT} rebase --rebase-merges
 	${E} ${MAKE} jparse.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RM} -rf jparse.clone
 	${E} ${MAKE} jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.update_from_clone: jparse.clone/ jparse/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v jparse.clone/ jparse
 	${E} ${MAKE} ${MAKE_CD_Q} -C jparse depend C_SPECIAL=-DINTERNAL_INCLUDE \
 		     LD_DIR="${LD_DIR}" LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.update_into_clone: jparse/ jparse.clone/
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${RSYNC} -a -S -0 --exclude=.git -C --delete -v jparse/ jparse.clone
 	${E} ${MAKE} ${MAKE_CD_Q} -C jparse.clone depend C_SPECIAL=-UINTERNAL_INCLUDE \
 		     LD_DIR="${LD_DIR}" LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 jparse.diff_jparse_clone: jparse.clone/ jparse/ .exclude
 	-${E} ${DIFF} -u -r --exclude-from=.exclude jparse.clone jparse
@@ -1447,77 +1447,77 @@ all.help:
 
 all.setup:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.setup
 	${E} ${MAKE} dyn_array.setup
 	${E} ${MAKE} jparse.setup
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.clone
 	${E} ${MAKE} dyn_array.clone
 	${E} ${MAKE} jparse.clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.clone_status:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.clone_status
 	${E} ${MAKE} dyn_array.clone_status
 	${E} ${MAKE} jparse.clone_status
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.update_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.update_clone
 	${E} ${MAKE} dyn_array.update_clone
 	${E} ${MAKE} jparse.update_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.recreate_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.recreate_clone
 	${E} ${MAKE} dyn_array.recreate_clone
 	${E} ${MAKE} jparse.recreate_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.update_from_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.update_from_clone
 	${E} ${MAKE} dyn_array.update_from_clone
 	${E} ${MAKE} jparse.update_from_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.update_into_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.update_into_clone
 	${E} ${MAKE} dyn_array.update_into_clone
 	${E} ${MAKE} jparse.update_into_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.diff_dir_clone:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.diff_dbg_clone
 	${E} echo
@@ -1525,11 +1525,11 @@ all.diff_dir_clone:
 	${E} echo
 	${E} ${MAKE} jparse.diff_jparse_clone
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.diff_clone_dir:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.diff_clone_dbg
 	${E} echo
@@ -1537,11 +1537,11 @@ all.diff_clone_dir:
 	${E} echo
 	${E} ${MAKE} jparse.diff_clone_jparse
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 all.diff_summary:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} dbg.diff_summary
 	${E} echo
@@ -1549,7 +1549,7 @@ all.diff_summary:
 	${E} echo
 	${E} ${MAKE} jparse.diff_summary
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ###################################
@@ -1562,7 +1562,7 @@ configure:
 clean: clean_generated_obj legacy_clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1574,12 +1574,12 @@ clean: clean_generated_obj legacy_clean dbg/Makefile dyn_array/Makefile jparse/M
 	${RM} -f ${OTHER_OBJS} ${LESS_PICKY_OBJS}
 	${RM} -rf ${DSYMDIRS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	jparse/test_jparse/Makefile soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
@@ -1600,7 +1600,7 @@ clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${RM} -f jparse_test.log chkentry_test.log txzchk_test.log ${BUILD_LOG}
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # NOTE: We do NOT install dbg nor do we install dyn_array, nor jparse.
 #       This repo do not use installed dbg, nor dyn_array, nor jparse code.
@@ -1608,7 +1608,7 @@ clobber: legacy_clobber clean dbg/Makefile dyn_array/Makefile jparse/Makefile \
 install: all dbg/Makefile dyn_array/Makefile jparse/Makefile \
         soup/Makefile test_ioccc/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
@@ -1616,7 +1616,7 @@ install: all dbg/Makefile dyn_array/Makefile jparse/Makefile \
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall - uninstall all files installed and directories created via this repo
 #
@@ -1673,7 +1673,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dbg $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C dyn_array $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
@@ -1721,7 +1721,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 chkentry.o: chkentry.c chkentry.h dbg/dbg.h dyn_array/dyn_array.h \

--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -4,6 +4,7 @@
 .*.sw[a-zA-Z0-9]*
 .sw[a-zA-Z0-9]*
 .build.log.*
+build.log
 .DS_Store
 /bug-report*
 /.jsemcgen.*.out

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,22 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.2 2024-09-07
+
+Improve error messages if invalid JSON in the following ways:
+
+- If verbosity level is > 0, then it will show the invalid token and hex value
+of that token (along with the line and column).
+- If verbosity is not specified, then it will just show the syntax error (the
+bad token with the line and column) and then the warning that the JSON tree is
+NULL (just like if verbosity specified) and then the error message (from
+`jparse(1)` itself).
+
+The error files in the `bad_loc` have been updated as now the error output has
+changed.
+
+Updated `jparse(1)` version to 1.1.6 2024-09-07.
+
+
 ## Release 1.0.1 2024-09-06
 
 Add option `-L` to `jparse_test.sh` to skip error location tests. This is useful
@@ -12,6 +29,13 @@ on the command line.
 Updated man page `jparse_test.8`.
 
 The new version of `jparse_test.sh` is `1.0.6 2024-09-06`.
+
+Removed where necessary some references to the [IOCCC](https://www.ioccc.org)
+and the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), changing
+some to [this repo](https://github.com/xexyl/jparse).
+
+Don't report 'valid JSON' in `jparse` unless verbosity level > 0. It is still an
+error if the JSON is invalid.
 
 
 ## Release 1.0.0 2024-09-06

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -656,7 +656,7 @@ parser-o: jparse.y jparse.l
 # rule instead.
 #
 prep: test_jparse/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_jparse/prep.sh -m${MAKE} -l "${TMP_BUILD_LOG}"; \
 	    EXIT_CODE="$$?"; \
@@ -672,13 +672,13 @@ prep: test_jparse/prep.sh
 	    else \
 	        echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+	    ${S} echo "${OUR_NAME}: make $@ ending";
 
 # a slower version of prep that does not write to a log file so one can see the
 # full details.
 #
 slow_prep: test_jparse/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_jparse/prep.sh -m${MAKE}; \
 	    EXIT_CODE="$$?"; \
@@ -693,7 +693,7 @@ slow_prep: test_jparse/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+	    ${S} echo "${OUR_NAME}: make $@ ending";
 
 
 # make build release pull
@@ -711,7 +711,7 @@ slow_prep: test_jparse/prep.sh
 build: release
 pull: release
 release: test_jparse/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_jparse/prep.sh -m${MAKE} -e -o -l "${TMP_BUILD_LOG}"; \
 	    EXIT_CODE="$$?"; \
@@ -727,13 +727,13 @@ release: test_jparse/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+	    ${S} echo "${OUR_NAME}: make $@ ending";
 
 # a slower version of release that does not write to a log file so one can see the
 # full details.
 #
 slow_release: test_jparse/prep.sh
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} -f ${TMP_BUILD_LOG}
 	${Q} ./test_jparse/prep.sh -m${MAKE} -e -o; \
 	    EXIT_CODE="$$?"; \
@@ -748,7 +748,7 @@ slow_release: test_jparse/prep.sh
 	    else \
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
-	    ${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+	    ${S} echo "${OUR_NAME}: make $@ ending";
 
 
 # load reference code from the previous successful make parser
@@ -787,12 +787,12 @@ use_json_ref: jparse.tab.ref.c jparse.tab.ref.h jparse.ref.c jparse.lex.ref.h
 #
 rebuild_jnum_test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 bison: jparse.tab.c jparse.tab.h
 	@:
@@ -807,7 +807,7 @@ flex: jparse.c jparse.lex.h
 #
 rebuild_jparse_err_files: jparse
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f test_jparse/test_JSON/bad_loc/*.err
 	-@for i in test_jparse/test_JSON/./bad_loc/*.json; do \
@@ -817,17 +817,17 @@ rebuild_jparse_err_files: jparse
 	${S} echo "Make sure to run make test from the top level directory before doing a"
 	${S} echo "git add on all the *.json and *.json.err files in test_jparse/test_JSON/bad_loc!"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`";
+	${S} echo "${OUR_NAME}: make $@ ending";
 
 # rule used by prep.sh and make clean
 #
@@ -838,7 +838,7 @@ clean_generated_obj:
 #
 seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -858,11 +858,11 @@ seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 picky: ${ALL_SRC} test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -892,13 +892,13 @@ picky: ${ALL_SRC} test_jparse/Makefile
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -922,13 +922,13 @@ shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -944,7 +944,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 
@@ -962,7 +962,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -986,13 +986,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags C_SPECIAL=${C_SPECIAL}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -1011,13 +1011,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -1031,26 +1031,26 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clean: test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${V} echo
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clobber: legacy_clean test_jparse/Makefile
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${V} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ###################################
@@ -1062,15 +1062,15 @@ configure:
 
 clean: clean_generated_obj
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -1080,11 +1080,11 @@ clobber: legacy_clobber clean
 	${RM} -f ${BUILD_LOG}
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 install: all test_jparse/Makefile install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse all $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
@@ -1095,21 +1095,21 @@ install: all test_jparse/Makefile install_man
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
 legacy_uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${RM_V} ${DEST_INCLUDE}/jparse.h ${DEST_LIB}/jparse.a
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
 uninstall: legacy_uninstall
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	# uninstall files under test_jparse:
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
@@ -1149,7 +1149,7 @@ uninstall: legacy_uninstall
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_flex.sh.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/jsemcgen.sh.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ###############
@@ -1160,7 +1160,7 @@ depend: ${ALL_CSRC}
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -1198,7 +1198,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 jparse.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,13 +56,13 @@
 /*
  * official jparse repo release
  */
-#define JPARSE_REPO_VERSION "1.0.1 2024-09-06"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.2 2024-09-07"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.1.5 2024-09-04"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.1.6 2024-09-07"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * definitions

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -210,7 +210,7 @@ JSON_COMMA		","
 
 .			{
 			    /* invalid token: any other character */
-			    warn(__func__, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
+			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
 
 			    /*
 			     * This is a hack for better error messages with

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -1346,7 +1346,7 @@ YY_RULE_SETUP
 #line 211 "./jparse.l"
 {
 			    /* invalid token: any other character */
-			    warn(__func__, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
+			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line, yylloc->first_column, *yytext, *yytext);
 
 			    /*
 			     * This is a hack for better error messages with

--- a/jparse/jparse_bug_report.sh
+++ b/jparse/jparse_bug_report.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# bug_report.sh - produce a file suitable for filing a bug report
+# jparse_bug_report.sh - produce a file suitable for filing a bug report
 #
-# Collect system information to help user report bugs and issues
-# using the mkiocccentry tools.
+# Collect system information to help users report bugs and issues
+# using the jparse tools.
 #
 # When you run this script without any arguments:
 #
@@ -24,7 +24,8 @@
 #
 # Please upload the bug-report.YYYYMMDD.HHMMSS.txt file as part of your report.
 #
-# This script was written in 2022 for the mkiocccentry repo by:
+# This script was written in 2022 for the mkiocccentry repo
+# (https://github.com/ioccc-src/mkiocccentry) by:
 #
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson
@@ -43,7 +44,7 @@
 #
 # Maintain this list towards the top of file, in sorted order.
 #
-# Do NOT put this tool (bug_report.sh) in the list, it will
+# Do NOT put this tool (jparse_bug_report.sh) in the list, it will
 # cause an infinite loop.
 #
 export TOOLS="
@@ -105,7 +106,7 @@ Exit codes:
      4	    error in function call
  >= 10	    at least one check failed
 
-bug_report.sh version: $BUG_REPORT_VERSION"
+jparse_bug_report.sh version: $BUG_REPORT_VERSION"
 
 # Determine the name of the log file
 #
@@ -1025,7 +1026,7 @@ run_check()
     # Once upon a time there was a bug in this script in this function.
     # PIPESTATUS was needed to fix a bug introduced in commit
     # 8343c4b8cb97e52df64fe8973e68f0d83c6090e1 in the mkiocccentry repo (where
-    # this script was originally developed)  where the exit status of each
+    # this script was originally developed) where the exit status of each
     # command was not checked properly which meant that even if a test failed it
     # would not be reported as an issue which rather defeated the purpose of
     # this script.

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -176,7 +176,10 @@ main(int argc, char **argv)
 	not_reached();
     }
 
-    msg("valid JSON");
+    if (verbosity_level > 0) {
+	msg("valid JSON");
+    }
+
     exit(0); /*ooo*/
 }
 

--- a/jparse/json_README.md
+++ b/jparse/json_README.md
@@ -5,9 +5,8 @@ not constitute a "JSON specification".  For that see [so-called JSON
 spec](#so-called-json-spec).
 
 We define these **JSON terms** to assist you in understanding the JSON related
-code, code comments, data structures and documentation found in this GitHub repo
-particularly under the [jparse
-directory](https://github.com/ioccc-src/mkiocccentry/tree/master/jparse).
+code, code comments, data structures and documentation found in this GitHub
+repo.
 
 
 ## JSON document

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -80,7 +80,7 @@ internal error
 .PP
 If you have an issue with the tool you can report it at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Decode the JSON string

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -81,7 +81,7 @@ internal error
 .PP
 If you have an issue with the tool you can report it at
 .br
-\fI\<https://github.com/ioccc\-src/mkiocccentry/issues\>\fP.
+\fI\<https://github.com/xexyl/jparse/issues\>\fP.
 .SH EXAMPLES
 .PP
 Encode the JSON string

--- a/jparse/man/man8/jnum_chk.8
+++ b/jparse/man/man8/jnum_chk.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jnum_chk 8 "29 January 2023" "jnum_chk" "jparse tools"
+.TH jnum_chk 8 "06 September 2024" "jnum_chk" "jparse tools"
 .SH NAME
 .B jnum_chk
 \- tool to check JSON number string conversions
@@ -92,14 +92,11 @@ Otherwise there is an issue.
 The strict mode option
 .B \-S
 is for informational purposes only.
-If it fails on your system this is okay: the mkiocccentry repo does not need
-.B \-S
-to pass in order to be able to create a valid IOCCC entry compressed tarball.
 .SH BUGS
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH SEE ALSO
 .BR jnum_gen (8),
 .BR jparse (1)

--- a/jparse/man/man8/jnum_gen.8
+++ b/jparse/man/man8/jnum_gen.8
@@ -82,7 +82,7 @@ file to verify that the conversions work as expected.
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH SEE ALSO
 .BR jnum_chk (8),
 .BR jparse (1),

--- a/jparse/man/man8/jsemcgen.8
+++ b/jparse/man/man8/jsemcgen.8
@@ -408,7 +408,7 @@ was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC 
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH SEE ALSO
 .BR jsemtblgen (8),
 .BR jparse (3)

--- a/jparse/man/man8/jsemcgen.sh.8
+++ b/jparse/man/man8/jsemcgen.sh.8
@@ -408,7 +408,7 @@ was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC 
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH SEE ALSO
 .BR jsemtblgen (8),
 .BR jparse (3)

--- a/jparse/man/man8/jsemtblgen.8
+++ b/jparse/man/man8/jsemtblgen.8
@@ -453,7 +453,7 @@ was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC 
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLE
 Rather than use this tool directly one should use
 .BR jsemcgen (8)

--- a/jparse/man/man8/jstr_test.8
+++ b/jparse/man/man8/jstr_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstr_test.sh 8 "08 August 2023" "jstr_test.sh" "jparse tools"
+.TH jstr_test.sh 8 "06 September 2024" "jstr_test.sh" "jparse tools"
 .SH NAME
 .B jstr_test.sh
 \- JSON string encoding and decoding tests
@@ -33,7 +33,7 @@ and
 the
 .B jstr_test.sh
 script runs a series of tests to make sure that both encoding and decoding of JSON strings work as expected.
-This is important because if either is not working right then there will be a problem with the JSON parser as well as these tools use the same routines that the JSON parser uses.
+This is important because if either is not working right then there will be a problem with the JSON parser as well as these tools that use the same routines that the JSON parser uses.
 .SH OPTIONS
 .TP
 .B \-h
@@ -63,23 +63,30 @@ tool to
 Declare the top level directory of this repository.
 The
 .B topdir
-directory must contain the source file
-.IR mkiocccentry.c .
+directory must contain the source files
+.IR jparse.c ,
+.IR json_parse.c ,
+.IR json_parse.h ,
+.IR jstrdecode.c ,
+.IR jstrencode.c ,
+.I util.h
+and
+.IR util.c .
 By default, the source file
-.I mkiocccentry.c
+.I jparse.c
 is searched for in the current directory, and then the parent of current directory.
 .sp 1
 If
 .BI \-Z\  topdir
 is used on the command line, then the source file
-.I mkiocccentry.c
+.I jparse.c
 need not exist in the
 .B topdir
 directory.
 If
 .BI \-Z\  topdir
 is not used on the command line, and the source file
-.I mkiocccentry.c
+.I jparse.c
 is not found in the current directory nor the parent of current directory, then this command exits as if there was a command line error.
 .sp 1
 Once the
@@ -156,9 +163,10 @@ was co\-developed by Cody Boone Ferguson and Landon Curt Noll (one of the IOCCC 
 If you have a problem with the tool (not JSON itself! :\-) ) you can report it at the GitHub issues page.
 It can be found at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH SEE ALSO
 .BR jparse (1),
 .BR jparse (3),
 .BR jstrencode (1),
-.BR jstrdecode (1)
+.BR jstrdecode (1),
+\<https://www.ioccc.org\>

--- a/jparse/man/man8/run_bison.8
+++ b/jparse/man/man8/run_bison.8
@@ -226,7 +226,7 @@ is a target in the Makefile, of course.
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Run

--- a/jparse/man/man8/run_bison.sh.8
+++ b/jparse/man/man8/run_bison.sh.8
@@ -226,7 +226,7 @@ is a target in the Makefile, of course.
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Run

--- a/jparse/man/man8/run_flex.8
+++ b/jparse/man/man8/run_flex.8
@@ -222,7 +222,7 @@ This appears to be because foo is actually referenced in the Makefile as a targe
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Run

--- a/jparse/man/man8/run_flex.sh.8
+++ b/jparse/man/man8/run_flex.sh.8
@@ -222,7 +222,7 @@ This appears to be because foo is actually referenced in the Makefile as a targe
 .PP
 If you have any issues with the tool you can open an issue at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Run

--- a/jparse/man/man8/verge.8
+++ b/jparse/man/man8/verge.8
@@ -76,7 +76,7 @@ files.
 .PP
 If you have an issue with the tool you can report it at
 .br
-.IR \<https://github.com/ioccc\-src/mkiocccentry/issues\> .
+.IR \<https://github.com/xexyl/jparse/issues\> .
 .SH EXAMPLES
 .PP
 Determine if first version,

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env make
 #
-# test_jparse - mkiocccentry jparse test tools
+# test_jparse - jparse test tools
 #
 # "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
 #
@@ -407,16 +407,16 @@ rebuild_jnum_test: jnum_gen jnum.testset jnum_header.c
 
 rebuild_jparse_err_files:
 	${S} echo
-	${S} echo "${OUT_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUT_NAME}: make $@ starting"
 	${S} echo
 	${Q} cd .. ; \
 	    ${MAKE} $@
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} if [[ ! -x ./jparse_test.sh ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./jparse_test.sh" 1>&2; \
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
@@ -471,13 +471,13 @@ test:
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -493,11 +493,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -525,13 +525,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -553,23 +553,23 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify man pages
 #
 check_man:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # vi/vim tags
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} for dir in ../../dbg ../../dyn_alloc ..; do \
 	    if [[ -f $$dir/Makefile && ! -f $$dir/${LOCAL_DIR_TAGS} ]]; then \
@@ -582,24 +582,24 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags C_SPECIAL=${C_SPECIAL}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . .. ../../dbg ../../dyn_alloc; do \
@@ -610,23 +610,23 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ###################################
@@ -638,41 +638,41 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f jparse_test.log chkentry_test.log txzchk_test.log
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 install: all
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_DIR}/jnum_chk
 	${RM} -r -f ${RM_V} ${DEST_DIR}/jnum_gen
 	${RM} -r -f ${RM_V} ${DEST_DIR}/pr_jparse_test
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ###############
 # make depend #
@@ -680,7 +680,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -719,7 +719,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 jnum_chk.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -66,8 +66,6 @@ static const char * const usage_msg =
     "\n"
     "\tNOTE: The -S mode is for informational purposes only, and may fail\n"
     "\t      on your system due to hardware and/or other system differences.\n"
-    "\t      The IOCCC mkiocccentry repo does not need -S to pass in order\n"
-    "\t      to be able to create a valid IOCCC entry compressed tarball.\n"
     "\n"
     "Exit codes:\n"
     "    0\t\tall is OK\n"

--- a/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 14 column 22: invalid token: 0x61 = <a>
 syntax error in file test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json at line 14 column 22: <a>
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 1 column 2: invalid token: 0x22 = <">
 syntax error in file test_jparse/test_JSON/./bad_loc/open-brace-unbalanced-quotes-comma.json at line 1 column 2: <">
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 3 column 32: invalid token: 0x22 = <">
 syntax error in file test_jparse/test_JSON/./bad_loc/test-0-info.json at line 3 column 32: <">
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 5 column 25: invalid token: 0x65 = <e>
 syntax error in file test_jparse/test_JSON/./bad_loc/test-1-auth.json at line 5 column 25: <e>
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 1 column 2: invalid token: 0x74 = <t>
 syntax error in file test_jparse/test_JSON/./bad_loc/unquoted-name.json at line 1 column 2: <t>
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
@@ -1,4 +1,3 @@
-Warning: jparse_lex: at line 3 column 1: invalid token: 0x0b = <>
 syntax error in file test_jparse/test_JSON/./bad_loc/vtab_comma.json at line 3 column 1: <>
 Warning: ./jparse: JSON parse tree is NULL
 ERROR[1]: ./jparse: invalid JSON

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -540,11 +540,11 @@ extern_everything: extern_include extern_objs extern_liba extern_man extern_prog
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # Form unpatched semantic tables, without headers and trailers, from the reference info and auth JSON files
 #
@@ -631,7 +631,7 @@ reset_min_timestamp: reset_tstamp.sh
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -647,11 +647,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -679,13 +679,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -707,13 +707,13 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -729,7 +729,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 # install man pages
@@ -744,7 +744,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -768,13 +768,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -790,13 +790,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . ../dbg ../dyn_alloc ../jparse ../jparse/test_jparse; do \
@@ -807,7 +807,7 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clean_mkchk_sem:
 	${RM} -f chk_sem_info.c chk_sem_info.h chk_sem_info.o
@@ -815,19 +815,19 @@ clean_mkchk_sem:
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 ###################################
@@ -839,16 +839,16 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${ALL_OBJS}
 	${RM} -f .jsemcgen.out.*
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f .soup
 	${RM} -f tags ${LOCAL_DIR_TAGS}
@@ -856,22 +856,22 @@ clobber: legacy_clobber clean
 	${RM} -f ${TARGETS}
 	${RM} -rf ref
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 install: all install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_LIB}/soup.a
 	${RM} -r -f ${RM_V} ${DEST_DIR}/vermod.sh
@@ -891,7 +891,7 @@ uninstall:
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/run_usage.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/vermod.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ###############
 # make depend #
@@ -899,7 +899,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -939,7 +939,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 chk_sem_auth.o: ../dbg/dbg.h ../dyn_array/dyn_array.h \

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -420,7 +420,7 @@ fnamchk: fnamchk.o ../jparse/libjparse.a ../dyn_array/libdyn_array.a ../dbg/libd
 
 test:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if [[ ! -x ./ioccc_test.sh ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./ioccc_test.sh" 1>&2; \
@@ -438,13 +438,13 @@ test:
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SEQCEXIT} >/dev/null 2>&1; then \
 	    echo 'The ${SEQCEXIT} tool could not be found.' 1>&2; \
@@ -460,11 +460,11 @@ seqcexit: ${ALL_CSRC}
 	    ${SEQCEXIT} -D werr_sem_val -D werrp_sem_val -- ${ALL_CSRC}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 picky: ${ALL_SRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${PICKY} >/dev/null 2>&1; then \
 	    echo 'The ${PICKY} tool could not be found.' 1>&2; \
@@ -492,13 +492,13 @@ picky: ${ALL_SRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify shell scripts
 #
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${SHELLCHECK} >/dev/null 2>&1; then \
 	    echo 'The ${SHELLCHECK} command could not be found.' 1>&2; \
@@ -520,13 +520,13 @@ shellcheck: ${SH_FILES} .shellcheckrc
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # inspect and verify man pages
 #
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
@@ -542,7 +542,7 @@ check_man: ${ALL_MAN_TARGETS}
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 # install man pages
@@ -557,7 +557,7 @@ install_man: ${ALL_MAN_TARGETS}
 #
 tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -581,13 +581,13 @@ tags:
 	${Q} echo
 	${E} ${MAKE} all_tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! type -P ${CTAGS} >/dev/null 2>&1; then \
 	    echo 'The ${CTAGS} command could not be found.' 1>&2; \
@@ -603,13 +603,13 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
 	-${S} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
 all_tags:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} -f tags
 	${Q} for dir in . ../dbg ../dyn_alloc ../jparse ../jparse/test_jparse ../soup; do \
@@ -620,23 +620,23 @@ all_tags:
 	done
 	${E} ${SORT} tags -o tags
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 legacy_clobber: legacy_clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${V} echo "${OUR_NAME}: nothing to do"
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 
 
@@ -649,35 +649,35 @@ configure:
 
 clean:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${OTHER_OBJS}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 clobber: legacy_clobber clean
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f test_ioccc.log chkentry_test.log txzchk_test.log
 	${RM} -f tags ${LOCAL_DIR_TAGS}
 	${RM} -rf test_iocccsize test_src test_work
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 install: all install_man
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 uninstall:
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${RM} -r -f ${RM_V} ${DEST_DIR}/utf8_test
 	${RM} -r -f ${RM_V} ${DEST_DIR}/fnamchk
@@ -694,7 +694,7 @@ uninstall:
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/prep.8
 	${RM} -r -f ${RM_V} ${MAN8_DIR}/utf8_test.8
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ###############
 # make depend #
@@ -702,7 +702,7 @@ uninstall:
 
 depend: ${ALL_CSRC}
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ starting at: `date`"
+	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} if ! type -P ${INDEPEND} >/dev/null 2>&1; then \
 	    echo '${OUR_NAME}: The ${INDEPEND} command could not be found.' 1>&2; \
 	    echo '${OUR_NAME}: The ${INDEPEND} command is required to run the $@ rule'; 1>&2; \
@@ -746,7 +746,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	fi
 	${S} echo
-	${S} echo "${OUR_NAME}: make $@ ending at: `date`"
+	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 fnamchk.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \


### PR DESCRIPTION

Although it can be useful at times it can also be a bit much, especially
with 'make -C foo depend' and so on.

The CHANGES.md file was updated for the above but also for 
0192122984a42294154f1a2eacd6af0a17df428f as it was left out by accident.