### PR TITLE
Sync jparse/ with jparse repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.14 2024-09-11
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). This
+includes a number of fixes and improvements to various tools and the Makefiles
+(including some that will likely be implemented in the Makefiles here).
+
+
 ## Release 1.5.13 2024-09-09
 
 Fix Eszett (`ß`) in `soup/utf8_posix_map.c` to map to `ss`, not just one `s`. In

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,16 +1,30 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.5 2024-09-11
+
+Fixes in `#include` paths in `test_jparse`, run `make depend`, add JSON parser
+version string to `jnum_gen` and `jnum_chk`.
+
+Rename Makefile variable `Q_V_OPTION` to `VERBOSITY` and add it to many rules so
+one can more easily do something like:
+
+```sh
+make VERBOSITY=3 test
+```
+
+or so. Not all rules have the `-v ${VERBOSITY}` as not all rules should have it.
+In many cases where this is true there is a comment in the Makefiles.
+
+The GitHub workflow has been updated to use `VERBOSITY=3` for more details in
+the case that there is a failure.
+
+Add to `-V` and `-h` options of `jparse` (the tool) and `jsemtblgen` the JSON
+parser version (this was already done in the tools in `test_jparse/` and will be
+done with `jstrencode` and `jstrdecode` along with some bug fixes when those
+have been properly addressed).
+
+
 ## Release 1.0.4 2024-09-09
-
-Bug fix and improve `jstrdecode`.
-
-As per issue #12 the tool added stray `"`s with the `-Q` option and it did not
-add a leading `"` to the output. This has been fixed.
-
-As per issue #12 another option was added, `-e` (for escaped quotes), which
-surrounds each decoded arg with escaped quotes. The use of `-Q` and `-e`
-together means that the entire output will be surrounded by `"`s and each
-decoded arg will be surrounded by escaped quotes (i.e. `\"`).
 
 Remove the IOCCC tools' paths from util.h. These have been moved to another file
 in that repo.

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -96,9 +96,9 @@ I=
 # else -v 1
 #
 ifeq ($(strip ${Q}),@)
-Q_V_OPTION="0"
+VERBOSITY="0"
 else
-Q_V_OPTION="1"
+VERBOSITY="1"
 endif
 
 # installing variables
@@ -140,7 +140,7 @@ MAKE_CD_Q= --no-print-directory
 
 # Disable parallel Makefile execution
 #
-# We do not support parallel make.  We have found most
+# We do NOT support parallel make.  We have found most
 # parallel make systems do not get the rule dependency order
 # correct, resulting in a failed attempt to compile.
 #
@@ -445,8 +445,10 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS} Makefile
 		     LD_DIR2="${LD_DIR2}"
 
 bug_report: jparse_bug_report.sh
-	-${Q} ./jparse_bug_report.sh -v 1
+	-${Q} ./jparse_bug_report.sh -v ${VERBOSITY}
 
+# NOTE: don't use -v ${VERBOSITY} here!
+#
 bug_report-tx: jparse_bug_report.sh
 	${S} echo "${OUR_NAME}: make $@: starting test of jparse_bug_report.sh -t -x"
 	${S} echo
@@ -454,6 +456,7 @@ bug_report-tx: jparse_bug_report.sh
 	${S} echo
 	${S} echo "${OUR_NAME}: ending test of jparse_bug_report.sh -t -x"
 
+# NOTE: don't use -v ${VERBOSITY} here!
 bug_report-txl: jparse_bug_report.sh
 	${S} echo "${OUR_NAME}: make $@: starting test of jparse_bug_report.sh -t -x -l"
 	${Q} ./jparse_bug_report.sh -t -x -l
@@ -527,7 +530,7 @@ json_sem.o: json_sem.c
 #
 jparse.tab.c jparse.tab.h: jparse.y jparse.h sorry.tm.ca.h run_bison.sh verge jparse.tab.ref.c jparse.tab.ref.h
 	${Q} ./run_bison.sh -g ./verge -s sorry.tm.ca.h -b ${BISON_BASENAME} ${BISON_DIRS} \
-	    -p jparse -v ${Q_V_OPTION} ${RUN_O_FLAG} -- ${BISON_FLAGS}
+	    -p jparse -v ${VERBOSITY} ${RUN_O_FLAG} -- ${BISON_FLAGS}
 
 # How to create jparse.c and jparse.lex.h
 #
@@ -540,7 +543,7 @@ jparse.tab.c jparse.tab.h: jparse.y jparse.h sorry.tm.ca.h run_bison.sh verge jp
 jparse.c jparse.lex.h: jparse.l jparse.h ./sorry.tm.ca.h jparse.tab.h ./run_flex.sh \
 	verge jparse.ref.c jparse.lex.ref.h
 	${Q} ./run_flex.sh -g ./verge -s sorry.tm.ca.h -f ${FLEX_BASENAME} ${FLEX_DIRS} \
-	    -p jparse -v ${Q_V_OPTION} ${RUN_O_FLAG} -- ${FLEX_FLAGS} -o jparse.c
+	    -p jparse -v ${VERBOSITY} ${RUN_O_FLAG} -- ${FLEX_FLAGS} -o jparse.c
 
 util.o: util.c util.h
 	${CC} ${CFLAGS} util.c -c
@@ -556,11 +559,15 @@ libjparse.a: ${LIB_OBJS}
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
 
-run_bison-v7: verge sorry.tm.ca.h
+# NOTE: we specifically have -v 7 so we do NOT use -v ${VERBOSITY}!
+#
+run_bison-v7 bison-v7: verge sorry.tm.ca.h
 	./run_bison.sh -v 7 -s ./sorry.tm.ca.h -g ./verge -D .
 
 
-run_flex-v7: verge sorry.tm.ca.h
+# NOTE: we specifically have -v 7 so we do NOT use -v ${VERBOSITY}!
+#
+run_flex-v7 flex-v7: verge sorry.tm.ca.h
 	./run_flex.sh -v 7 -s ./sorry.tm.ca.h -g ./verge -D .
 
 #########################################################
@@ -655,6 +662,8 @@ parser-o: jparse.y jparse.l
 # The point is: if you're working on this repo and make build fails, try this
 # rule instead.
 #
+# NOTE: do NOT use -v ${VERBOSITY} level here!
+#
 prep: test_jparse/prep.sh
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} ${RM_V} -f ${TMP_BUILD_LOG}
@@ -680,7 +689,7 @@ prep: test_jparse/prep.sh
 slow_prep: test_jparse/prep.sh
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} ${RM_V} -f ${TMP_BUILD_LOG}
-	${Q} ./test_jparse/prep.sh -m${MAKE}; \
+	${Q} ./test_jparse/prep.sh -m${MAKE} -v ${VERBOSITY}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo; \
@@ -707,6 +716,7 @@ slow_prep: test_jparse/prep.sh
 # so if bison and/or flex is not found or too old THIS RULE WILL FAIL!
 #
 # NOTE: Please try this rule BEFORE make prep.
+# NOTE: do NOT use -v ${VERBOSITY} level here!
 #
 build: release
 pull: release
@@ -729,13 +739,13 @@ release: test_jparse/prep.sh
 	    fi
 	    ${S} echo "${OUR_NAME}: make $@ ending";
 
-# a slower version of release that does not write to a log file so one can see the
-# full details.
+# a slower version of release that also writes to stdout so one can see the
+# full details as it runs.
 #
 slow_release: test_jparse/prep.sh
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${Q} ${RM} ${RM_V} -f ${TMP_BUILD_LOG}
-	${Q} ./test_jparse/prep.sh -m${MAKE} -e -o; \
+	${Q} ./test_jparse/prep.sh -m${MAKE} -v ${VERBOSITY} -e -o; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo; \
@@ -749,7 +759,6 @@ slow_release: test_jparse/prep.sh
 	         echo "All Done!!! All Done!!! -- Jessica Noll, Age 2"; \
 	    fi
 	    ${S} echo "${OUR_NAME}: make $@ ending";
-
 
 # load reference code from the previous successful make parser
 #
@@ -790,7 +799,7 @@ rebuild_jnum_test:
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
-		     LD_DIR2="${LD_DIR2}"
+		     LD_DIR2="${LD_DIR2}" -v ${VERBOSITY}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -811,7 +820,7 @@ rebuild_jparse_err_files: jparse
 	${S} echo
 	${Q} ${RM} ${RM_V} -f test_jparse/test_JSON/bad_loc/*.err
 	-@for i in test_jparse/test_JSON/./bad_loc/*.json; do \
-	    ./jparse -- "$$i" 2> "$$i.err" ;  \
+	    ./jparse -v ${VERBOSITY} -- "$$i" 2> "$$i.err" ;  \
 	done
 	${S} echo
 	${S} echo "Make sure to run make test from the top level directory before doing a"
@@ -824,7 +833,7 @@ test:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ C_SPECIAL=${C_SPECIAL} \
+	${E} ${MAKE} ${MAKE_CD_Q} -C test_jparse $@ VERBOSITY=${VERBOSITY} C_SPECIAL=${C_SPECIAL} \
 		     LD_DIR2="${LD_DIR2}"
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending";
@@ -835,6 +844,8 @@ clean_generated_obj:
 	${Q} ${RM} ${RM_V} -f ${BUILT_OBJS}
 
 # sequence exit codes
+#
+# NOTE: do not USE -v ${VERBOSITY} here!
 #
 seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	${S} echo
@@ -860,6 +871,9 @@ seqcexit: ${FLEXFILES} ${BISONFILES} ${ALL_CSRC} test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: the -v in the picky command is NOT verbosity so do NOT
+# use -v ${VERBOSITY} here!
+#
 picky: ${ALL_SRC} test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -896,6 +910,8 @@ picky: ${ALL_SRC} test_jparse/Makefile
 
 # inspect and verify shell scripts
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -926,6 +942,8 @@ shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 
 # inspect and verify man pages
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -950,6 +968,8 @@ check_man: ${ALL_MAN_TARGETS}
 
 # install man pages
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 install_man: ${ALL_MAN_TARGETS}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${MAN1_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${MAN1_TARGETS} ${MAN1_DIR}
@@ -959,6 +979,8 @@ install_man: ${ALL_MAN_TARGETS}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${MAN3_TARGETS} ${MAN3_DIR}
 
 # vi/vim tags
+#
+# NOTE: do NOT use -v ${VERBOSITY} here!
 #
 tags:
 	${S} echo
@@ -990,6 +1012,8 @@ tags:
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1015,6 +1039,8 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1023,7 +1049,7 @@ all_tags:
 		     LD_DIR2="${LD_DIR2}"
 	${Q} echo
 	${Q} ${RM} ${RM_V} -f tags
-	${Q} for dir in . ../dbg ../dyn_alloc test_jparse; do \
+	${Q} for dir in . test_jparse; do \
 	    if [[ -s $$dir/${LOCAL_DIR_TAGS} ]]; then \
 		echo "${SED} -e 's;\t;\t'$${dir}'/;' $${dir}/${LOCAL_DIR_TAGS} >> tags"; \
 		${SED} -e 's;\t;\t'$${dir}'/;' "$${dir}/${LOCAL_DIR_TAGS}" >> tags; \
@@ -1033,6 +1059,8 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 legacy_clean: test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1043,6 +1071,8 @@ legacy_clean: test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 legacy_clobber: legacy_clean test_jparse/Makefile
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1061,6 +1091,8 @@ legacy_clobber: legacy_clean test_jparse/Makefile
 configure:
 	@echo nothing to $@
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 clean: clean_generated_obj
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1069,6 +1101,8 @@ clean: clean_generated_obj
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1084,6 +1118,8 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 install: all test_jparse/Makefile install_man
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1100,6 +1136,9 @@ install: all test_jparse/Makefile install_man
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
+#
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 legacy_uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1109,6 +1148,9 @@ legacy_uninstall:
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
+#
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 uninstall: legacy_uninstall
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -1190,7 +1232,7 @@ depend: ${ALL_CSRC}
 	    ${SED} -i.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
 	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
-	      ${INDEPEND} >> Makefile; \
+	      ${INDEPEND} -v ${VERBOSITY} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} ${RM_V} -f Makefile.orig; \
 	    else \

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,7 +56,7 @@
 /*
  * official jparse repo release
  */
-#define JPARSE_REPO_VERSION "1.0.3 2024-09-08"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.5 2024-09-11"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -58,8 +58,8 @@ static const char * const usage_msg =
     "    3\tcommand line error\n"
     "    >=4\tinternal error\n"
     "\n"
-    "JSON parser version: %s\n"
-    "jparse version: %s";
+    "jparse version: %s\n"
+    "JSON parser version: %s";
 
 
 /*
@@ -114,7 +114,7 @@ main(int argc, char **argv)
 	    msg_warn_silent = true;
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("%s\n", JPARSE_VERSION);
+	    print("jparse version %s\nJSON parser version %s\n", JPARSE_VERSION, JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -223,7 +223,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog,
-		  DBG_DEFAULT, json_verbosity_level, json_parser_version, JPARSE_VERSION);
+		  DBG_DEFAULT, json_verbosity_level, JPARSE_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/jsemtblgen.c
+++ b/jparse/jsemtblgen.c
@@ -104,8 +104,8 @@ static const char * const usage_msg =
     "    3\t\tcommand line error\n"
     "    >=10\tinternal error\n"
     "\n"
-    "JSON parser version: %s\n"
-    "jsemtblgen version: %s";
+    "jsemtblgen version: %s"
+    "JSON parser version: %s\n";
 
 
 /*
@@ -301,7 +301,7 @@ main(int argc, char **argv)
 	    msg_warn_silent = true;
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("%s\n", JSEMTBLGEN_VERSION);
+	    print("jsemtblgen version %s\nJSON parser version %s", JSEMTBLGEN_VERSION, JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -1524,7 +1524,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog,
-		  DBG_DEFAULT, json_verbosity_level, json_parser_version, JSEMTBLGEN_VERSION);
+		  DBG_DEFAULT, json_verbosity_level, JSEMTBLGEN_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -96,9 +96,9 @@ I=
 # else -v 1
 #
 ifeq ($(strip ${Q}),@)
-Q_V_OPTION="0"
+VERBOSITY="0"
 else
-Q_V_OPTION="1"
+VERBOSITY="1"
 endif
 
 # installing variables
@@ -129,9 +129,6 @@ PREFIX= /usr/local
 RM_V=
 
 
-
-
-
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
 #
@@ -140,7 +137,7 @@ MAKE_CD_Q= --no-print-directory
 
 # Disable parallel Makefile execution
 #
-# We do not support parallel make.  We have found most
+# We do NOT support parallel make.  We have found most
 # parallel make systems do not get the rule dependency order
 # correct, resulting in a failed attempt to compile.
 #
@@ -403,7 +400,7 @@ test_JSON/auth.json/good/auth.reference.json:
 rebuild_jnum_test: jnum_gen jnum.testset jnum_header.c
 	${Q} ${RM} ${RM_V} -f jnum_test.c
 	${CP} -f -v jnum_header.c jnum_test.c
-	./jnum_gen jnum.testset >> jnum_test.c
+	./jnum_gen -v ${VERBOSITY} jnum.testset >> jnum_test.c
 
 rebuild_jparse_err_files:
 	${S} echo
@@ -430,8 +427,8 @@ test:
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
 	    exit 1; \
 	else \
-	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt"; \
-	    ./jparse_test.sh -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt; \
+	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt"; \
+	    ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \
@@ -440,8 +437,8 @@ test:
 		echo "${OUR_NAME}: PASSED: jparse_test.sh"; \
 	    fi; \
 	    echo; \
-	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -f -j ./jparse test_jparse/json_teststr_fail.txt"; \
-	    ./jparse_test.sh -f -j ./jparse test_jparse/json_teststr_fail.txt >/dev/null 2>&1; \
+	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -v ${VERBOSITY} -f -j ./jparse test_jparse/json_teststr_fail.txt"; \
+	    ./jparse_test.sh -v ${VERBOSITY} -f -j ./jparse test_jparse/json_teststr_fail.txt >/dev/null 2>&1; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \
@@ -450,8 +447,8 @@ test:
 		echo "${OUR_NAME}: PASSED: jparse_test.sh"; \
 	    fi; \
 	    echo; \
-	    echo "${OUR_NAME}: RUNNING: ./jstr_test.sh"; \
-	    ./jstr_test.sh 2>&1; \
+	    echo "${OUR_NAME}: RUNNING: ./jstr_test.sh -v ${VERBOSITY}"; \
+	    ./jstr_test.sh -v ${VERBOSITY} 2>&1; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jstr_test.sh failed, error code: $$EXIT_CODE"; \
@@ -460,8 +457,8 @@ test:
 		echo ${OUR_NAME}: "PASSED: jstr_test.sh"; \
 	    fi; \
 	    echo; \
-	    echo "${OUR_NAME}: RUNNING: ./jnum_chk"; \
-	    ./jnum_chk 2>&1; \
+	    echo "${OUR_NAME}: RUNNING: ./jnum_chk -v ${VERBOSITY}"; \
+	    ./jnum_chk -v ${VERBOSITY} 2>&1; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jnum_chk failed, error code: $$EXIT_CODE"; \
@@ -474,6 +471,8 @@ test:
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # sequence exit codes
+#
+# NOTE: do NOT use -v ${VERBOSITY} here!
 #
 seqcexit: ${ALL_CSRC}
 	${S} echo
@@ -495,6 +494,10 @@ seqcexit: ${ALL_CSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+
+# NOTE: the -v in the picky command is NOT verbosity so do NOT
+# use -v ${VERBOSITY} here!
+#
 picky: ${ALL_SRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -529,6 +532,8 @@ picky: ${ALL_SRC}
 
 # inspect and verify shell scripts
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 shellcheck: ${SH_FILES} .shellcheckrc
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -557,6 +562,8 @@ shellcheck: ${SH_FILES} .shellcheckrc
 
 # inspect and verify man pages
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 check_man:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -567,11 +574,13 @@ check_man:
 
 # vi/vim tags
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${Q} for dir in ../../dbg ../../dyn_alloc ..; do \
+	${Q} for dir in .. .; do \
 	    if [[ -f $$dir/Makefile && ! -f $$dir/${LOCAL_DIR_TAGS} ]]; then \
 		echo ${MAKE} ${MAKE_CD_Q} -C $$dir local_dir_tags C_SPECIAL=${C_SPECIAL}; \
 		${MAKE} ${MAKE_CD_Q} -C $$dir local_dir_tags C_SPECIAL=${C_SPECIAL}; \
@@ -586,6 +595,8 @@ tags:
 
 # use the ${CTAGS} tool to form ${LOCAL_DIR_TAGS} of the source in this directory
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -597,12 +608,14 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 
 # for a tags file from all ${LOCAL_DIR_TAGS} in all of the other directories
 #
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f tags
-	${Q} for dir in . .. ../../dbg ../../dyn_alloc; do \
+	${Q} for dir in . ..; do \
 	    if [[ -s $$dir/${LOCAL_DIR_TAGS} ]]; then \
 		echo "${SED} -e 's;\t;\t'$${dir}'/;' $${dir}/${LOCAL_DIR_TAGS} >> tags"; \
 		${SED} -e 's;\t;\t'$${dir}'/;' "$${dir}/${LOCAL_DIR_TAGS}" >> tags; \
@@ -612,6 +625,8 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 legacy_clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -620,6 +635,8 @@ legacy_clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 legacy_clobber: legacy_clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -636,6 +653,8 @@ legacy_clobber: legacy_clean
 configure:
 	@echo nothing to $@
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -644,6 +663,8 @@ clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -654,6 +675,8 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 install: all
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -664,6 +687,9 @@ install: all
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 # uninstall: we provide this in case someone wants to deobfuscate their system. :-)
+#
+# NOTE: do NOT use -v ${VERBOSITY} here!
+#
 uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
@@ -709,7 +735,7 @@ depend: ${ALL_CSRC}
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
 	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 	      ${SED} -e 's;../../jparse/;../;g' | \
-	      ${INDEPEND} >> Makefile; \
+	      ${INDEPEND} -v ${VERBOSITY} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} ${RM_V} -f Makefile.orig; \
 	    else \
@@ -723,16 +749,16 @@ depend: ${ALL_CSRC}
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
 jnum_chk.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../json_parse.h ../json_util.h ../util.h \
-    jnum_chk.c jnum_chk.h
+    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
+    ../json_sem.h ../json_util.h ../util.h jnum_chk.c jnum_chk.h
 jnum_gen.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../json_parse.h ../json_util.h ../util.h \
-    jnum_gen.c jnum_gen.h
+    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
+    ../json_sem.h ../json_util.h ../util.h jnum_gen.c jnum_gen.h
 jnum_header.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../json_parse.h ../json_util.h ../util.h \
-    jnum_chk.h jnum_header.c
+    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
+    ../json_sem.h ../json_util.h ../util.h jnum_chk.h jnum_header.c
 jnum_test.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../json_parse.h ../json_util.h ../util.h \
-    jnum_chk.h jnum_test.c
+    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
+    ../json_sem.h ../json_util.h ../util.h jnum_chk.h jnum_test.c
 pr_jparse_test.o: ../../dyn_array/../dbg/dbg.h ../../dyn_array/dyn_array.h \
     ../util.h pr_jparse_test.c

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -75,7 +75,8 @@ static const char * const usage_msg =
     "    4\t\tcommand line error\n"
     "    >=10\tinternal error\n"
     "\n"
-    "jnum_chk version: %s";
+    "jnum_chk version: %s\n"
+    "JSON parser version: %s";
 
 
 
@@ -130,7 +131,7 @@ main(int argc, char *argv[])
 	    }
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("%s\n", JNUM_CHK_VERSION);
+	    print("jnum_chk version %s\nJSON parser version %s\n", JNUM_CHK_VERSION, JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -789,7 +790,7 @@ usage(int exitcode, char const *prog, char const *str)
     if (*str != '\0') {
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s", str);
     }
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT, JNUM_CHK_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT, JNUM_CHK_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/jnum_chk.h
+++ b/jparse/test_jparse/jnum_chk.h
@@ -39,13 +39,17 @@
 /*
  * json_parse - JSON parser support code
  */
-#include "../../jparse/json_parse.h"
+#include "../json_parse.h"
 
 /*
  * json_util - general JSON parser utility support functions
  */
-#include "../../jparse/json_util.h"
+#include "../json_util.h"
 
+/*
+ * jparse - JSON parser
+ */
+#include "../jparse.h"
 
 
 /*

--- a/jparse/test_jparse/jnum_gen.c
+++ b/jparse/test_jparse/jnum_gen.c
@@ -70,7 +70,8 @@ static const char * const usage_msg =
     "\t3\t\tcommand line error\n"
     "\t>=10\t\tinternal error\n"
     "\n"
-    "jnum_gen version: %s";
+    "jnum_gen version: %s\n"
+    "JSON parser version: %s";
 
 /*
  * globals
@@ -127,7 +128,7 @@ main(int argc, char *argv[])
 	    }
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("%s\n", JNUM_GEN_VERSION);
+	    print("jnum_gen version %s\nJSON parser version %s\n", JNUM_GEN_VERSION, JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -794,7 +795,7 @@ usage(int exitcode, char const *prog, char const *str)
     if (*str != '\0') {
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JNUM_GEN_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JNUM_GEN_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/jnum_gen.h
+++ b/jparse/test_jparse/jnum_gen.h
@@ -47,6 +47,12 @@
 #include "../json_util.h"
 
 /*
+ * jparse - JSON parser
+ */
+#include "../jparse.h"
+
+
+/*
  * dyn_array - dynamic array facility
  */
 #if defined(INTERNAL_INCLUDE)

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.14 2024-09-09"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.15 2024-09-11"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
This includes a number of fixes and improvements to various tools and the Makefiles (which will possibly be implemented here too). One change not mentioned in the changelog in the jparse repo was a legacy of jparse being at one time in this repo, where the tags related rules referred to ../dbg and (incorrectly) ../dyn_alloc (should have been ../dyn_array). These references have been removed outright.