### PR TITLE
Bug fixes and enhancements in jstr{de,en}code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Major changes to the IOCCC entry toolkit
 
-## Release 1.5.15 2024-09-12
+## Release 1.5.16 2024-09-13
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/).
 
@@ -14,6 +14,11 @@ Add to `jstr_test.sh` tests for `jstrdecode(1)` options `-Q` and `-e` (both
 separately and together).
 
 Clarified comment in `jparse.l` and rebuilt backup `jparse.c` (`jparse.ref.c`).
+
+Add an extra sanity check to `jencchk()`: the macro `JSON_BYTE_VALUES` must
+equal 256. Previously we did check that the table length of `jenc` is
+`JSON_BYTE_VALUES` with the assumption that this was 256 but now we make sure
+that it is 256, before we check the table length.
 
 
 ## Release 1.5.14 2024-09-11

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.15 2024-09-12
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). This makes
+some important fixes to the tools `jstrdecode(1)` and `jstrencode(1)` where in
+`jstrdecode(1)` the `-Q` option did not work and for both the printing of
+everything should happen after everything is parsed (especially for the `-Q`
+option but not strictly for that reason). The `pr_jparse_test` tool had a bug
+fix as well where the `-h` option did not work.
+
+
 ## Release 1.5.14 2024-09-11
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). This

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,18 @@
 
 ## Release 1.5.15 2024-09-12
 
-Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). This makes
-some important fixes to the tools `jstrdecode(1)` and `jstrencode(1)` where in
-`jstrdecode(1)` the `-Q` option did not work and for both the printing of
-everything should happen after everything is parsed (especially for the `-Q`
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/).
+
+This makes some important fixes to the tools `jstrdecode(1)` and `jstrencode(1)`
+where in `jstrdecode(1)` the `-Q` option did not work and for both the printing
+of everything should happen after everything is parsed (especially for the `-Q`
 option but not strictly for that reason). The `pr_jparse_test` tool had a bug
 fix as well where the `-h` option did not work.
+
+Add to `jstr_test.sh` tests for `jstrdecode(1)` options `-Q` and `-e` (both
+separately and together).
+
+Clarified comment in `jparse.l` and rebuilt backup `jparse.c` (`jparse.ref.c`).
 
 
 ## Release 1.5.14 2024-09-11

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -5,6 +5,11 @@
 Extend `jstr_test.sh` to test that the `jstrdecode(1)` options `-Q` and `-e`
 work, each by themselves and together.
 
+Add an extra sanity check to `jencchk()`: the macro `JSON_BYTE_VALUES` must
+equal 256. Previously we did check that the table length of `jenc` is
+`JSON_BYTE_VALUES` with the assumption that this was 256 but now we make sure
+that it is 256, before we check the table length.
+
 
 ## Release 1.0.6 2024-09-12
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,45 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.6 2024-09-12
+
+Enhancements and bug fixes in `jstrdecode(1)` and `jstrencode(1)`. In
+`jstrdecode(1)` the `-Q` option did not work right in a number of ways.
+
+The tool `jstrdecode(1)` has a new option `-e` which says to enclose each
+decoded arg with escaped quotes. This option can be used with `-Q`.
+
+In order to resolve these problems a new set of files were added, `jstr_util.h`
+and `jstr_util.c`, which are strictly for the `jstr*` tools. A new `struct
+jstring` was added which holds a buffer (that is allocated already so no
+`strdup()` - due to the way the encoding/decoding functions work and how they
+have to work) and a size of the buffer along with a pointer to the next in the
+list. The new function `alloc_jstr()` allocates a new `struct jstring *` adding
+an ALREADY allocated `char *` with its size to it. This size is important due to
+the fact that these strings MAY contain a NUL byte. The function
+`free_jstring()` is what it sounds like: a function to free the memory of a
+single `struct jstring *`. With this function too it is assumed that the `char
+*` is allocated but since it MAY contain NUL bytes it could leave a memory leak
+in some cases.
+
+Making use of these functions and the struct, `jstrencode(1)` and
+`jstrdecode(1)` now each have their own list (encoded strings and decoded
+strings respectively) and a function each to add to the list and free the list
+(this is done this way to simplify things). The function that reads from a
+stream calls the function to add to the respective list, as long as no errors
+occur (NULL pointers). On the other hand, one can (and the tools do when not
+reading from stdin) call the `alloc_jstr()` function directly and then the add
+to list function (if needed). The add function adds to the end of the list so
+that the order is correct, and a list is used because the `char *`s can hold NUL
+bytes which causes problems for the dynamic array facility, and because for some
+options like `jstrdecode -Q` we have to wait until after everything is
+processed, particularly due to reading from stdin.
+
+The tool `pr_jparse_test` now shows the JSON parser version with `-V` and `-h`
+and `-h` now works (the function checks for `devnull` which is now opened before
+parsing args).
+
+
+
 ## Release 1.0.5 2024-09-11
 
 Fixes in `#include` paths in `test_jparse`, run `make depend`, add JSON parser
@@ -15,6 +55,10 @@ make VERBOSITY=3 test
 or so. Not all rules have the `-v ${VERBOSITY}` as not all rules should have it.
 In many cases where this is true there is a comment in the Makefiles.
 
+Other fixes in the Makefiles have been applied as well, in particular the tags
+related rules that referred to `../dbg` and (incorrectly) `../dyn_alloc` (the
+repo is actually `dyn_array`).
+
 The GitHub workflow has been updated to use `VERBOSITY=3` for more details in
 the case that there is a failure.
 
@@ -22,6 +66,7 @@ Add to `-V` and `-h` options of `jparse` (the tool) and `jsemtblgen` the JSON
 parser version (this was already done in the tools in `test_jparse/` and will be
 done with `jstrencode` and `jstrdecode` along with some bug fixes when those
 have been properly addressed).
+
 
 
 ## Release 1.0.4 2024-09-09

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,11 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.7 2024-09-13
+
+Extend `jstr_test.sh` to test that the `jstrdecode(1)` options `-Q` and `-e`
+work, each by themselves and together.
+
+
 ## Release 1.0.6 2024-09-12
 
 Enhancements and bug fixes in `jstrdecode(1)` and `jstrencode(1)`. In

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -211,9 +211,11 @@ CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${C_SPECIAL} ${LDFLAGS}
 # source files that are permanent (not made, nor removed)
 #
 C_SRC= jparse_main.c json_parse.c json_sem.c json_util.c \
-       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c
+       jsemtblgen.c jstrdecode.c jstrencode.c util.c verge.c jstr_util.c
 H_SRC= jparse.h jparse_main.h jsemtblgen.h json_parse.h json_sem.h json_util.h \
-       jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h jparse.tab.ref.h
+       jstrdecode.h jstrencode.h sorry.tm.ca.h util.h verge.h jparse.tab.ref.h \
+       jstr_util.h
+
 # source files that do not conform to strict picky standards
 #
 LESS_PICKY_CSRC= jparse.ref.c jparse.tab.ref.c
@@ -494,16 +496,20 @@ jparse.o: jparse.c jparse.h
 jparse: jparse_main.o libjparse.a
 	${CC} ${CFLAGS} $^ -lm -o $@ ${LD_DIR} -ldbg -ldyn_array
 
+
+jstr_util.o: jstr_util.c jstr_util.h
+	${CC} ${CFLAGS} jstr_util.c -c
+
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
-jstrencode: jstrencode.o libjparse.a
+jstrencode: jstrencode.o libjparse.a jstr_util.o
 	${CC} ${CFLAGS} $^ -lm -o $@ ${LD_DIR} -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
-jstrdecode: jstrdecode.o libjparse.a
+jstrdecode: jstrdecode.o libjparse.a jstr_util.o
 	${CC} ${CFLAGS} $^ -lm -o $@ ${LD_DIR} -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
@@ -1269,10 +1275,15 @@ json_sem.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
     json_parse.h json_sem.c json_sem.h json_util.h util.h
 json_util.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
     ../dyn_array/dyn_array.h json_parse.h json_util.c json_util.h util.h
+jstr_util.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
+    ../dyn_array/dyn_array.h jparse.h jparse.tab.h json_parse.h json_sem.h \
+    json_util.h jstr_util.c jstr_util.h util.h
 jstrdecode.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
-    ../dyn_array/dyn_array.h json_parse.h jstrdecode.c jstrdecode.h util.h
+    ../dyn_array/dyn_array.h jparse.h jparse.tab.h json_parse.h json_sem.h \
+    json_util.h jstr_util.h jstrdecode.c jstrdecode.h util.h
 jstrencode.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
-    ../dyn_array/dyn_array.h json_parse.h jstrencode.c jstrencode.h util.h
+    ../dyn_array/dyn_array.h jparse.h jparse.tab.h json_parse.h json_sem.h \
+    json_util.h jstr_util.h jstrencode.c jstrencode.h util.h
 util.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
     util.c util.h
 verge.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,7 +56,7 @@
 /*
  * official jparse repo release
  */
-#define JPARSE_REPO_VERSION "1.0.6 2024-09-12"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.7 2024-09-13"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,7 +56,7 @@
 /*
  * official jparse repo release
  */
-#define JPARSE_REPO_VERSION "1.0.5 2024-09-11"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.6 2024-09-12"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -66,8 +66,8 @@ static YY_BUFFER_STATE bs;
  * then column 2, but the extra defence in the way it is done does not hurt
  * anything so we have left it as is. Thus if the token is not a newline and not
  * a tab we check if first_column is 0 or if last_column is 0 and if either one
- * is we explicitly set the respective variable to 1. Otherwise we increment the
- * first_column and last_column.
+ * is 0, we explicitly set the respective variable to 1. Otherwise we increment
+ * the first_column and last_column.
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -825,8 +825,8 @@ static YY_BUFFER_STATE bs;
  * then column 2, but the extra defence in the way it is done does not hurt
  * anything so we have left it as is. Thus if the token is not a newline and not
  * a tab we check if first_column is 0 or if last_column is 0 and if either one
- * is we explicitly set the respective variable to 1. Otherwise we increment the
- * first_column and last_column.
+ * is 0, we explicitly set the respective variable to 1. Otherwise we increment
+ * the first_column and last_column.
  */
 #define YY_USER_ACTION \
 			yylloc->filename = yyextra != NULL ? yyextra->filename:""; \

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -391,10 +391,18 @@ jencchk(void)
     }
 
     /*
+     * assert: JSON_BYTE_VALUES must be 256
+     */
+    if (JSON_BYTE_VALUES != 256) {
+	err(101, __func__, "JSON_BYTE_VALUES: %d != 256", JSON_BYTE_VALUES);
+	not_reached();
+    }
+
+    /*
      * assert: table must be of size 256
      */
     if (TBLLEN(jenc) != JSON_BYTE_VALUES) {
-	err(101, __func__, "jenc table length is %ju instead of %d",
+	err(102, __func__, "jenc table length is %ju instead of %d",
 			   (uintmax_t)TBLLEN(jenc), JSON_BYTE_VALUES);
 	not_reached();
     }
@@ -404,7 +412,7 @@ jencchk(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (jenc[i].byte != i) {
-	    err(102, __func__, "jenc[0x%02x].byte: %d != %d", i, jenc[i].byte, i);
+	    err(103, __func__, "jenc[0x%02x].byte: %d != %d", i, jenc[i].byte, i);
 	    not_reached();
 	}
     }
@@ -414,7 +422,7 @@ jencchk(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (jenc[i].enc == NULL) {
-	    err(103, __func__, "jenc[0x%02x].enc == NULL", i);
+	    err(104, __func__, "jenc[0x%02x].enc == NULL", i);
 	    not_reached();
 	}
     }
@@ -424,7 +432,7 @@ jencchk(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (strlen(jenc[i].enc) != jenc[i].len) {
-	    err(104, __func__, "jenc[0x%02x].enc length: %ju != jenc[0x%02x].len: %ju",
+	    err(105, __func__, "jenc[0x%02x].enc length: %ju != jenc[0x%02x].len: %ju",
 			       i, (uintmax_t)strlen(jenc[i].enc),
 			       i, (uintmax_t)jenc[i].len);
 	    not_reached();
@@ -436,18 +444,18 @@ jencchk(void)
      */
     for (i=0x00; i <= 0x07; ++i) {
 	if (jenc[i].len != LITLEN("\\uxxxx")) {
-	    err(105, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	    err(106, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(jenc[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(jenc[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(106, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
+	    err(107, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(107, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
+	    err(108, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
 	    not_reached();
 	}
     }
@@ -458,13 +466,13 @@ jencchk(void)
     indx = 0x08;
     encstr = "\\b";
     if (jenc[indx].len != LITLEN("\\b")) {
-	err(108, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(109, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(109, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(110, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -474,13 +482,13 @@ jencchk(void)
     indx = 0x09;
     encstr = "\\t";
     if (jenc[indx].len != LITLEN("\\b")) {
-	err(110, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(111, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(111, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(112, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -490,13 +498,13 @@ jencchk(void)
     indx = 0x0a;
     encstr = "\\n";
     if (jenc[indx].len != strlen(encstr)) {
-	err(112, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(113, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(113, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(114, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -506,13 +514,13 @@ jencchk(void)
     indx = 0x0b;
     encstr = "\\u000b";
     if (jenc[indx].len != strlen(encstr)) {
-	err(114, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(115, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(115, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(116, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -522,13 +530,13 @@ jencchk(void)
     indx = 0x0c;
     encstr = "\\f";
     if (jenc[indx].len != strlen(encstr)) {
-	err(116, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(117, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(117, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(118, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -538,13 +546,13 @@ jencchk(void)
     indx = 0x0d;
     encstr = "\\r";
     if (jenc[indx].len != strlen(encstr)) {
-	err(118, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(119, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(119, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(120, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -553,18 +561,18 @@ jencchk(void)
      */
     for (i=0x0e; i <= 0x1f; ++i) {
 	if (jenc[i].len != LITLEN("\\uxxxx")) {
-	    err(120, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	    err(121, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(jenc[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(jenc[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(121, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
+	    err(122, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(122, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
+	    err(123, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
 	    not_reached();
 	}
     }
@@ -574,12 +582,12 @@ jencchk(void)
      */
     for (i=0x20; i <= 0x21; ++i) {
 	if (jenc[i].len != 1) {
-	    err(123, __func__, "jenc[0x%02x].enc length: %ju != %d",
+	    err(124, __func__, "jenc[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(jenc[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(jenc[i].enc[0]) != i) {
-	    err(124, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
+	    err(125, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -590,13 +598,13 @@ jencchk(void)
     indx = 0x22;
     encstr = "\\\"";
     if (jenc[indx].len != strlen(encstr)) {
-	err(125, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(126, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(126, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(128, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -605,12 +613,12 @@ jencchk(void)
      */
     for (i=0x23; i <= 0x5b; ++i) {
 	if (jenc[i].len != 1) {
-	    err(128, __func__, "jenc[0x%02x].enc length: %ju != %d",
+	    err(129, __func__, "jenc[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(jenc[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(jenc[i].enc[0]) != i) {
-	    err(129, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
+	    err(130, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -621,13 +629,13 @@ jencchk(void)
     indx = 0x5c;
     encstr = "\\\\";
     if (jenc[indx].len != strlen(encstr)) {
-	err(130, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	err(131, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(jenc[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(jenc[indx].enc, encstr) != 0) {
-	err(131, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
+	err(132, __func__, "jenc[0x%02x].enc: <%s> != <%s>", indx, jenc[indx].enc, encstr);
 	not_reached();
     }
 
@@ -636,12 +644,12 @@ jencchk(void)
      */
     for (i=0x5d; i <= 0x7e; ++i) {
 	if (jenc[i].len != 1) {
-	    err(132, __func__, "jenc[0x%02x].enc length: %ju != %d",
+	    err(133, __func__, "jenc[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(jenc[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(jenc[i].enc[0]) != i) {
-	    err(133, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
+	    err(134, __func__, "jenc[0x%02x].enc: <%s> is not <%c>", i, jenc[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -651,18 +659,18 @@ jencchk(void)
      */
     for (i=0x7f; i <= 0x7f; ++i) {
 	if (jenc[i].len != LITLEN("\\uxxxx")) {
-	    err(134, __func__, "jenc[0x%02x].enc length: %ju != %ju",
+	    err(135, __func__, "jenc[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(jenc[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(jenc[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(135, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
+	    err(136, __func__, "jenc[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, jenc[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(136, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
+	    err(137, __func__, "jenc[0x%02x].enc: <%s> != <\\u%04x> form", i, jenc[i].enc, i);
 	    not_reached();
 	}
     }
@@ -672,17 +680,17 @@ jencchk(void)
      */
     for (i=0x80; i <= 0xff; ++i) {
 	if (jenc[i].len != 1) {
-	    err(137, __func__, "jenc[0x%02x].enc length: %ju != %d",
+	    err(138, __func__, "jenc[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(jenc[i].enc), 1);
 	    not_reached();
 	}
 	if ((uint8_t)(jenc[i].enc[0]) != i) {
-	    err(138, __func__, "jenc[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
+	    err(139, __func__, "jenc[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
 			       i, (uint8_t)(jenc[i].enc[0]) & 0xff, (uintmax_t)i);
 	    not_reached();
 	}
 	if ((uint8_t)(jenc[i].enc[1]) != 0) {
-	    err(139, __func__, "jenc[0x%02x].enc[1]: 0x%02x is not 0",
+	    err(140, __func__, "jenc[0x%02x].enc[1]: 0x%02x is not 0",
 			       i, (uint8_t)(jenc[i].enc[1]) & 0xff);
 	    not_reached();
 	}
@@ -695,16 +703,16 @@ jencchk(void)
     memset(str, 0, sizeof(str));    /* clear all bytes in str, including the final '\0' */
     mstr = json_encode(str, 1,  &mlen, false);
     if (mstr == NULL) {
-	err(140, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
+	err(141, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
 	not_reached();
     }
     if (mlen != jenc[0].len) {
-	err(141, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
+	err(142, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
 			   (uintmax_t)mlen, (uintmax_t)(jenc[0].len));
 	not_reached();
     }
     if (strcmp(jenc[0].enc, mstr) != 0) {
-	err(142, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
+	err(143, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
 			   (uintmax_t)mlen, jenc[0].enc);
 	not_reached();
     }
@@ -729,17 +737,17 @@ jencchk(void)
 	mstr = json_encode_str(str, &mlen, false);
 	/* check encoding result */
 	if (mstr == NULL) {
-	    err(143, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
+	    err(144, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
 			       i, (uintmax_t)mlen);
 	    not_reached();
 	}
 	if (mlen != jenc[i].len) {
-	    err(144, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
+	    err(145, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
 			       i, (uintmax_t)mlen, (uintmax_t)jenc[i].len);
 	    not_reached();
 	}
 	if (strcmp(jenc[i].enc, mstr) != 0) {
-	    err(145, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
+	    err(146, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
 			       (uintmax_t)mlen, jenc[i].enc);
 	    not_reached();
 	}
@@ -752,17 +760,17 @@ jencchk(void)
 	/* test json_decode_str() */
 	mstr2 = json_decode_str(mstr, &mlen2);
 	if (mstr2 == NULL) {
-	    err(146, __func__, "json_decode_str(<%s>, *mlen2: %ju, true) == NULL",
+	    err(147, __func__, "json_decode_str(<%s>, *mlen2: %ju, true) == NULL",
 			       mstr, (uintmax_t)mlen2);
 	    not_reached();
 	}
 	if (mlen2 != 1) {
-	    err(147, __func__, "json_decode_str(<%s>, *mlen2 %ju != 1, true)",
+	    err(148, __func__, "json_decode_str(<%s>, *mlen2 %ju != 1, true)",
 			       mstr, (uintmax_t)mlen2);
 	    not_reached();
 	}
 	if ((uint8_t)(mstr2[0]) != i) {
-	    err(148, __func__, "json_decode_str(<%s>, *mlen2: %ju, true): 0x%02x != 0x%02x",
+	    err(149, __func__, "json_decode_str(<%s>, *mlen2: %ju, true): 0x%02x != 0x%02x",
 			       mstr, (uintmax_t)mlen2, (uint8_t)(mstr2[0]) & 0xff, i);
 	    not_reached();
 	}
@@ -1252,7 +1260,7 @@ parse_json_string(char const *string, size_t len)
      * firewall
      */
     if (string == NULL) {
-	err(149, __func__, "passed NULL string");
+	err(150, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1267,15 +1275,15 @@ parse_json_string(char const *string, size_t len)
     str = json_conv_string(string, len, true);
     /* paranoia - these tests should never result in an error */
     if (str == NULL) {
-        err(150, __func__, "converting JSON string returned NULL: <%s>", string);
+        err(151, __func__, "converting JSON string returned NULL: <%s>", string);
         not_reached();
     } else if (str->type != JTYPE_STRING) {
-        err(151, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
+        err(152, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
         not_reached();
     }
     item = &(str->item.string);
     if (!VALID_JSON_NODE(item)) {
-	err(152, __func__, "couldn't decode string: <%s>", string);
+	err(153, __func__, "couldn't decode string: <%s>", string);
 	not_reached();
     }
     return str;
@@ -1304,17 +1312,17 @@ parse_json_bool(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(153, __func__, "passed NULL string");
+	err(154, __func__, "passed NULL string");
 	not_reached();
     }
 
     boolean = json_conv_bool_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (boolean == NULL) {
-	err(154, __func__, "converting JSON bool returned NULL: <%s>", string);
+	err(155, __func__, "converting JSON bool returned NULL: <%s>", string);
 	not_reached();
     } else if (boolean->type != JTYPE_BOOL) {
-        err(155, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
+        err(156, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
         not_reached();
     }
     item = &(boolean->item.boolean);
@@ -1329,18 +1337,18 @@ parse_json_bool(char const *string)
 	 * If it's not we abort as there's a serious mismatch between the
 	 * scanner and the parser.
 	 */
-	err(156, __func__, "called on non-boolean string: <%s>", string);
+	err(157, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else if (item->as_str == NULL) {
 	/* extra sanity check - make sure the allocated string != NULL */
-	err(157, __func__, "boolean->as_str == NULL");
+	err(158, __func__, "boolean->as_str == NULL");
 	not_reached();
     } else if (strcmp(item->as_str, "true") && strcmp(item->as_str, "false")) {
 	/*
 	 * extra sanity check - make sure the allocated string is "true"
 	 * or "false"
 	 */
-	err(158, __func__, "boolean->as_str neither \"true\" nor \"false\"");
+	err(159, __func__, "boolean->as_str neither \"true\" nor \"false\"");
 	not_reached();
     } else {
 	/*
@@ -1349,16 +1357,16 @@ parse_json_bool(char const *string)
 	 */
 	char const *str = booltostr(item->value);
 	if (str == NULL) {
-	    err(159, __func__, "could not convert boolean->value back to a string");
+	    err(160, __func__, "could not convert boolean->value back to a string");
 	    not_reached();
 	} else if (strcmp(str, item->as_str)) {
-	    err(160, __func__, "boolean->as_str != item->value as a string");
+	    err(161, __func__, "boolean->as_str != item->value as a string");
 	    not_reached();
 	} else if (strtobool(item->as_str) != item->value) {
-	    err(161, __func__, "mismatch between boolean string and converted value");
+	    err(162, __func__, "mismatch between boolean string and converted value");
 	    not_reached();
 	} else if (strtobool(str) != item->value) {
-	    err(162, __func__, "mismatch between converted string value and converted value");
+	    err(163, __func__, "mismatch between converted string value and converted value");
 	    not_reached();
 	}
     }
@@ -1389,7 +1397,7 @@ parse_json_null(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(163, __func__, "passed NULL string");
+	err(164, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1399,16 +1407,16 @@ parse_json_null(char const *string)
     null = json_conv_null_str(string, NULL);
     if (null == NULL) {
 	/* ironically null is NULL and it actually should not be :-) */
-	err(164, __func__, "null is NULL");
+	err(165, __func__, "null is NULL");
 	not_reached();
     } else if (null->type != JTYPE_NULL) {
-        err(165, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
+        err(166, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
         not_reached();
     }
     item = &(null->item.null);
     if (!VALID_JSON_NODE(item)) {
 	/* why is it an error if we can't convert nothing ? :-) */
-	err(166,__func__, "couldn't convert null: <%s>", string);
+	err(167,__func__, "couldn't convert null: <%s>", string);
 	not_reached();
     }
 
@@ -1438,7 +1446,7 @@ parse_json_number(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(167, __func__, "passed NULL string");
+	err(168, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1448,15 +1456,15 @@ parse_json_number(char const *string)
     number = json_conv_number_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (number == NULL) {
-	err(168, __func__, "converting JSON number returned NULL: <%s>", string);
+	err(169, __func__, "converting JSON number returned NULL: <%s>", string);
         not_reached();
     } else if (number->type != JTYPE_NUMBER) {
-        err(169, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
+        err(170, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
         not_reached();
     }
     item = &(number->item.number);
     if (!VALID_JSON_NODE(item)) {
-	err(170, __func__, "couldn't convert number string: <%s>", string);
+	err(171, __func__, "couldn't convert number string: <%s>", string);
 	not_reached();
     }
     return number;
@@ -1489,11 +1497,11 @@ parse_json_array(struct json *elements)
      * firewall
      */
     if (elements == NULL) {
-	err(171, __func__, "passed NULL elements value");
+	err(172, __func__, "passed NULL elements value");
 	not_reached();
     }
     if (elements->type != JTYPE_ELEMENTS) {
-	err(172, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
+	err(173, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
 			   json_item_type_name(elements), elements->type);
 	not_reached();
     }
@@ -1507,7 +1515,7 @@ parse_json_array(struct json *elements)
     /* paranoia - these tests should never result in an error */
     item = &(elements->item.array);
     if (!VALID_JSON_NODE(item)) {
-	err(173, __func__, "couldn't convert array");
+	err(174, __func__, "couldn't convert array");
 	not_reached();
     }
     return elements;
@@ -1537,14 +1545,14 @@ parse_json_member(struct json *name, struct json *value)
      * firewall
      */
     if (name == NULL) {
-	err(174, __func__, "passed NULL name value");
+	err(175, __func__, "passed NULL name value");
 	not_reached();
     } else if (value == NULL) {
-	err(175, __func__, "passed NULL value");
+	err(176, __func__, "passed NULL value");
 	not_reached();
     }
     if (name->type != JTYPE_STRING) {
-	err(176, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
+	err(177, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
 	not_reached();
     }
 
@@ -1554,15 +1562,15 @@ parse_json_member(struct json *name, struct json *value)
     member = json_conv_member(name, value);
     /* paranoia - these tests should never result in an error */
     if (member == NULL) {
-	err(177, __func__, "converting JSON member returned NULL");
+	err(178, __func__, "converting JSON member returned NULL");
 	not_reached();
     } else if (member->type != JTYPE_MEMBER) {
-        err(178, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
+        err(179, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
         not_reached();
     }
     item = &(member->item.member);
     if (!VALID_JSON_NODE(item)) {
-	err(179, __func__, "couldn't convert member");
+	err(180, __func__, "couldn't convert member");
 	not_reached();
     }
     return member;
@@ -1611,7 +1619,7 @@ json_alloc(enum item_type type)
     errno = 0;			/* pre-clear errno for errp() */
     ret = calloc(1, sizeof(*ret));
     if (ret == NULL) {
-	errp(180, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
+	errp(181, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
 	not_reached();
     }
 
@@ -2439,7 +2447,7 @@ json_conv_number(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NUMBER);
     if (ret == NULL) {
-	errp(181, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
+	errp(182, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
 	not_reached();
     }
 
@@ -2509,7 +2517,7 @@ json_conv_number(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(182, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(183, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -2676,7 +2684,7 @@ json_conv_number_str(char const *str, size_t *retlen)
      */
     ret = json_conv_number(str, len);
     if (ret == NULL) {
-	err(183, __func__, "json_conv_number() returned NULL");
+	err(184, __func__, "json_conv_number() returned NULL");
 	not_reached();
     }
 
@@ -2729,7 +2737,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
      */
     ret = json_alloc(JTYPE_STRING);
     if (ret == NULL) {
-	errp(184, __func__, "json_alloc(JTYPE_STRING) returned NULL");
+	errp(185, __func__, "json_alloc(JTYPE_STRING) returned NULL");
 	not_reached();
     }
 
@@ -2793,7 +2801,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(185, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(186, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -2878,7 +2886,7 @@ json_conv_string_str(char const *str, size_t *retlen, bool quote)
      */
     ret = json_conv_string(str, len, quote);
     if (ret == NULL) {
-	err(186, __func__, "json_conv_string() returned NULL");
+	err(187, __func__, "json_conv_string() returned NULL");
 	not_reached();
     }
 
@@ -2925,7 +2933,7 @@ json_conv_bool(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_BOOL);
     if (ret == NULL) {
-	errp(187, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
+	errp(188, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
 	not_reached();
     }
 
@@ -2960,7 +2968,7 @@ json_conv_bool(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(188, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(189, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3034,7 +3042,7 @@ json_conv_bool_str(char const *str, size_t *retlen)
      */
     ret = json_conv_bool(str, len);
     if (ret == NULL) {
-	err(189, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
+	err(190, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
 	not_reached();
     }
 
@@ -3080,7 +3088,7 @@ json_conv_null(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NULL);
     if (ret == NULL) {
-	errp(190, __func__, "json_alloc(JTYPE_NULL) returned NULL");
+	errp(191, __func__, "json_alloc(JTYPE_NULL) returned NULL");
 	not_reached();
     }
 
@@ -3115,7 +3123,7 @@ json_conv_null(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(191, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(192, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3185,7 +3193,7 @@ json_conv_null_str(char const *str, size_t *retlen)
      */
     ret = json_conv_null(str, len);
     if (ret == NULL) {
-	err(192, __func__, "json_conv_null() returned NULL");
+	err(193, __func__, "json_conv_null() returned NULL");
 	not_reached();
     }
 
@@ -3245,7 +3253,7 @@ json_conv_member(struct json *name, struct json *value)
      */
     ret = json_alloc(JTYPE_MEMBER);
     if (ret == NULL) {
-	errp(193, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
+	errp(194, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
 	not_reached();
     }
 
@@ -3318,13 +3326,13 @@ json_conv_member(struct json *name, struct json *value)
     item->name_as_str = item2->as_str;
     /* paranoia */
     if (item->name_as_str == NULL) {
-	err(194, __func__, "item->name_as_str is NULL");
+	err(195, __func__, "item->name_as_str is NULL");
 	not_reached();
     }
     item->name_str = item2->str;
     /* paranoia */
     if (item->name_str == NULL) {
-	err(195, __func__, "item->name_str is NULL");
+	err(196, __func__, "item->name_str is NULL");
 	not_reached();
     }
     item->name_as_str_len = item2->as_str_len;
@@ -3366,7 +3374,7 @@ json_create_object(void)
      */
     ret = json_alloc(JTYPE_OBJECT);
     if (ret == NULL) {
-	errp(196, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
+	errp(197, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
 	not_reached();
     }
 
@@ -3385,7 +3393,7 @@ json_create_object(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(197, __func__, "dyn_array_create() returned NULL");
+	errp(198, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3439,20 +3447,20 @@ json_object_add_member(struct json *node, struct json *member)
      * firewall
      */
     if (node == NULL) {
-	err(198, __func__, "node is NULL");
+	err(199, __func__, "node is NULL");
 	not_reached();
     }
     if (member == NULL) {
-	err(199, __func__, "member is NULL");
+	err(200, __func__, "member is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_OBJECT) {
-	err(200, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
+	err(201, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
 		           JTYPE_OBJECT, node->type);
 	not_reached();
     }
     if (member->type != JTYPE_MEMBER) {
-	err(201, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
+	err(202, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
 		           JTYPE_MEMBER, node->type);
 	not_reached();
     }
@@ -3462,7 +3470,7 @@ json_object_add_member(struct json *node, struct json *member)
      */
     item = &(node->item.object);
     if (item->s == NULL) {
-	err(202, __func__, "item->s is NULL");
+	err(203, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -3519,7 +3527,7 @@ json_create_elements(void)
      */
     ret = json_alloc(JTYPE_ELEMENTS);
     if (ret == NULL) {
-	errp(203, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
+	errp(204, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
 	not_reached();
     }
 
@@ -3538,7 +3546,7 @@ json_create_elements(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(204, __func__, "dyn_array_create() returned NULL");
+	errp(205, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3590,15 +3598,15 @@ json_elements_add_value(struct json *node, struct json *value)
      * firewall
      */
     if (node == NULL) {
-	err(205, __func__, "node is NULL");
+	err(206, __func__, "node is NULL");
 	not_reached();
     }
     if (value == NULL) {
-	err(206, __func__, "value is NULL");
+	err(207, __func__, "value is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_ELEMENTS) {
-	err(207, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
+	err(208, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
 			   JTYPE_ELEMENTS, node->type);
 	not_reached();
     }
@@ -3614,11 +3622,11 @@ json_elements_add_value(struct json *node, struct json *value)
 	json_dbg(JSON_DBG_VHIGH, __func__, "JSON item type: %s", json_item_type_name(value));
 	break;
     case JTYPE_ELEMENTS:
-	err(208, __func__, "JSON type %s (type: %d) is invalid here",
+	err(209, __func__, "JSON type %s (type: %d) is invalid here",
 		json_item_type_name(node), JTYPE_ELEMENTS);
 	not_reached();
     default:
-	err(209, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
+	err(210, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
 			   value->type);
 	not_reached();
     }
@@ -3628,7 +3636,7 @@ json_elements_add_value(struct json *node, struct json *value)
      */
     item = &(node->item.elements);
     if (item->s == NULL) {
-	err(210, __func__, "item->s is NULL");
+	err(211, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -3684,7 +3692,7 @@ json_create_array(void)
      */
     ret = json_alloc(JTYPE_ARRAY);
     if (ret == NULL) {
-	errp(211, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
+	errp(212, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
 	not_reached();
     }
 
@@ -3703,7 +3711,7 @@ json_create_array(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(212, __func__, "dyn_array_create() returned NULL");
+	errp(213, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -27,7 +27,7 @@ document](./json_README.md#json-document).
 There does exist multiple [JSON](./json_README.md) [APIs (Application Program
 Interfaces)](https://en.wikipedia.org/wiki/API) for various programming
 languages such as: JavaScript, C, Java, Python, Perl, Go, Rust, PHP, etc.  This
-[mkiocccentry repo](https://https://github.com/ioccc-src/mkiocccentry) contains
+[jparse repo](https://github.com/xexyl/jparse/) is
 a rich JSON parser API C programs can use, as well as a semantic JSON check
 interface for C.  However all those APIs require the user to "program" in a
 specific language in order to do something as simple as obtain a selective [JSON

--- a/jparse/jstr_util.c
+++ b/jparse/jstr_util.c
@@ -1,0 +1,114 @@
+/*
+ * jstr_util - common utility functions for the JSON string encoder/decoder
+ * tools
+ *
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ *
+ * This JSON parser was co-developed in 2022 by:
+ *
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "jstr_util.h"
+
+/*
+ * alloc_jstr	    -	allocate a struct jstring for the jstr tools
+ *
+ * given:
+ *	string	    pointer to an ALLOCATED char *
+ *	bufsiz	    size of the buffer
+ *
+ * NOTE: it is ASSUMED that the string is a calloc()/malloc()/strdup()d char *
+ * so we do NOT strdup() it nor can we due to the fact that NUL bytes can exist.
+ * This is why we have the bufsiz, for the cases where it must be written or
+ * read.
+ */
+struct jstring *
+alloc_jstr(char *string, size_t bufsiz)
+{
+    struct jstring *jstr = NULL; /* for jstring list */
+
+    /*
+     * firewall
+     */
+    if (string == NULL) {
+	err(10, __func__, "string is NULL");
+	not_reached();
+    }
+
+    /* allocate jstring struct */
+    errno = 0;			    /* pre-clear errno for warnp() */
+    jstr = calloc(1, sizeof *jstr);
+    if (jstr == NULL) {
+	warn(__func__, "calloc() returned NULL for jstring struct");
+
+	if (string != NULL) {
+	    free(string);
+	    string = NULL;
+	}
+
+	return NULL;
+    }
+
+    /*
+     * set up allocated jstring struct
+     */
+    jstr->jstr = string;
+    jstr->bufsiz = bufsiz;
+    jstr->next = NULL;
+
+    return jstr;
+}
+
+/*
+ * free_jstring	    - free a single struct jstring *
+ *
+ * given:
+ *	jstr	    - a struct jstring * allocated on the stack
+ *
+ * This function returns void.
+ *
+ * NOTE: it is ASSUMED that the string in the struct if != NULL is allocated via
+ * calloc()/malloc()/strdup() due to the way the encoding/decoding tools work.
+ *
+ * NOTE: as the strings CAN have NUL bytes it is entirely possible that there
+ * might be a memory leak in some cases.
+ *
+ * NOTE: we do NOT take a struct jstring ** so as to set the pointer to NULL in
+ * the calling function.
+ */
+void
+free_jstring(struct jstring *jstr)
+{
+    /*
+     * firewall
+     */
+    if (jstr != NULL) {
+	/* free the string if not NULL */
+	if (jstr->jstr != NULL) {
+	    free(jstr->jstr);
+	    jstr->jstr = NULL;
+	}
+	/* free the struct itself */
+	free(jstr);
+	jstr = NULL;
+    }
+
+    return;
+}

--- a/jparse/jstr_util.h
+++ b/jparse/jstr_util.h
@@ -1,5 +1,5 @@
 /*
- * jstrdecode - tool to JSON decode JSON encoded strings
+ * jstr_util - tool to JSON decode JSON encoded strings
  *
  * "JSON: when a minimal design falls below a critical minimum." :-)
  *
@@ -18,8 +18,8 @@
  */
 
 
-#if !defined(INCLUDE_JSTRDECODE_H)
-#    define  INCLUDE_JSTRDECODE_H
+#if !defined(INCLUDE_JSTR_UTIL_H)
+#    define  INCLUDE_JSTR_UTIL_H
 
 
 /*
@@ -40,7 +40,6 @@
 #include <dyn_array.h>
 #endif
 
-
 /*
  * util - common utility functions for the JSON parser
  */
@@ -52,28 +51,28 @@
 #include "json_parse.h"
 
 /*
- * jstr_util - jstrencode/jstrdecode utilities
- */
-#include "jstr_util.h"
-
-/*
  * jparse - JSON parser
  */
 #include "jparse.h"
 
-
+/*
+ * struct for jstr utilities
+ */
+struct jstring
+{
+    char *jstr;
+    size_t bufsiz;
+    struct jstring *next;   /* next in list */
+};
 
 /*
  * globals
  */
 
-
 /*
  * function prototypes
  */
-static struct jstring *jstrdecode_stream(FILE *in_stream);
-static struct jstring *add_decoded_string(char *string, size_t bufsiz);
-static void free_json_decoded_strings(void);
+extern struct jstring *alloc_jstr(char *string, size_t bufsiz);
+extern void free_jstring(struct jstring *jstr);
 
-
-#endif /* INCLUDE_JSTRDECODE_H */
+#endif /* INCLUDE_JSTR_UTIL_H */

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -32,6 +32,16 @@
 #endif
 
 /*
+ * dyn_array - dynamic array facility
+ */
+#if defined(INTERNAL_INCLUDE)
+#include "../dyn_array/dyn_array.h"
+#else
+#include <dyn_array.h>
+#endif
+
+
+/*
  * util - common utility functions for the JSON parser
  */
 #include "util.h"
@@ -41,7 +51,15 @@
  */
 #include "json_parse.h"
 
+/*
+ * jstr_util - jstrencode/jstrdecode utilities
+ */
+#include "jstr_util.h"
 
+/*
+ * jparse - JSON parser
+ */
+#include "jparse.h"
 
 /*
  * globals
@@ -51,7 +69,9 @@
 /*
  * forward declarations
  */
-static bool jstrencode_stream(FILE *in_stream, FILE *out_stream, bool skip_quote);
+static struct jstring *jstrencode_stream(FILE *in_stream, bool skip_quote);
+static struct jstring *add_encoded_string(char *string, size_t bufsiz);
+static void free_json_encoded_strings(void);
 
 
 #endif /* INCLUDE_JSTRENCODE_H */

--- a/jparse/man/man1/jparse.1
+++ b/jparse/man/man1/jparse.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 1 "14 July 2023" "jparse" "jparse tools"
+.TH jparse 1 "12 September 2024" "jparse" "jparse tools"
 .SH NAME
 .B jparse
 \- IOCCC JSON parser
@@ -124,7 +124,9 @@ Parse the JSON string
 .BR {\ "test_mode"\ :\ false\ } :
 .sp
 .RS
-.B ./jparse \-s '{ "test_mode" : false }'
+.ft B
+ jparse \-s '{ "test_mode" : false }'
+.ft R
 .RE
 .PP
 Parse input from
@@ -137,19 +139,21 @@ to parse):
 .sp
 .RS
 .ft B
- ./jparse \-
+ jparse \-
 .br
  []
 .br
  ^D\fP
 .br
-.fi
+.ft R
 .RE
 .PP
 Parse just a negative number:
 .PP
 .RS
-.B ./jparse \-s \-\- \-5
+.ft B
+ jparse \-s \-\- \-5
+.ft R
 .RE
 .PP
 Parse
@@ -158,11 +162,11 @@ file:
 .sp
 .RS
 .ft B
- ./jparse .info.json
+ jparse .info.json
 .ft R
 .RE
 .PP
-Run the
+From the repo directory, run the
 .B jparse_test.sh
 script using the default
 .I json_teststr.txt

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "30 January 2023" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "12 September 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
 \- decode JSON encoded strings
@@ -23,6 +23,7 @@
 .RB [\| \-t \|]
 .RB [\| \-n \|]
 .RB [\| \-Q \|]
+.RB [\| \-e \|]
 .RI [\| string
 .IR ... \|]
 .SH DESCRIPTION
@@ -33,6 +34,17 @@ If given the
 option it performs a test on the JSON decode and encode functions.
 By default the program reads from
 .BR stdin .
+If given the
+.B \-Q
+option it will enclose the output in quotes.
+If given the
+.B \-e
+option it will surround each decoded arg with escape (backslash) quotes.
+The use of
+.B \-Q
+and
+.B \-e
+together will surround the entire output with unescaped quotes and each decoded arg's output will be surrounded with escaped (backslashed) quotes.
 .SH OPTIONS
 .TP
 .B \-h
@@ -57,6 +69,9 @@ Do not output a newline after the decode function.
 .TP
 .B \-Q
 Enclose output in quotes.
+.TP
+.B \-e
+Surround each decoded arg with escaped quotes.
 .SH EXIT STATUS
 .TP
 0
@@ -78,6 +93,10 @@ command line error
 internal error
 .SH BUGS
 .PP
+A known problem with macOS Terminal is that one has to hit ctrl\-d twice in order for it to properly send
+.B EOF
+but this occurs in other applications as well so we note this issue here.
+.PP
 If you have an issue with the tool you can report it at
 .br
 .IR \<https://github.com/xexyl/jparse/issues\> .
@@ -88,7 +107,7 @@ Decode the JSON string
 .sp
 .RS
 .ft B
- ./jstrdecode { "test_mode" : false }
+ jstrdecode { "test_mode" : false }
 .ft R
 .RE
 .sp
@@ -104,7 +123,7 @@ to decode):
 .sp
 .RS
 .ft B
- ./jstrdecode
+ jstrdecode
  \-5
  ^D
 .ft R
@@ -113,7 +132,9 @@ to decode):
 Decode just a negative number:
 .sp
 .RS
-.B ./jstrdecode \-\- \-5
+.ft B
+ jstrdecode \-\- \-5
+.ft R
 .RE
 .SH SEE ALSO
 .PP

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "05 February 2023" "jstrencode" "jparse tools"
+.TH jstrencode 1 "12 September 2024" "jstrencode" "jparse tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -78,6 +78,10 @@ command line error
 >= 10
 internal error
 .SH BUGS
+.PP
+A known problem with macOS Terminal is that one has to hit ctrl\-d twice in order for it to properly send
+.B EOF
+but this occurs in other applications as well so we note this issue here.
 .PP
 If you have an issue with the tool you can report it at
 .br

--- a/jparse/run_bison.sh
+++ b/jparse/run_bison.sh
@@ -50,7 +50,7 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-V] [-o] [-b bison]
 			NOTE: This is ignored if the final arg is NOT bison.
     -D dir	    look for prefix file in this directory
     --		    end of $0 flags
-    bison_flags    optional flags to give to bison before the prefix.y argument
+    bison_flags	    optional flags to give to bison before the prefix.y argument
 
 Exit codes:
      0   bison output files formed or backup files used instead

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -760,5 +760,6 @@ jnum_header.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
 jnum_test.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
     ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
     ../json_sem.h ../json_util.h ../util.h jnum_chk.h jnum_test.c
-pr_jparse_test.o: ../../dyn_array/../dbg/dbg.h ../../dyn_array/dyn_array.h \
-    ../util.h pr_jparse_test.c
+pr_jparse_test.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
+    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
+    ../json_sem.h ../json_util.h ../util.h pr_jparse_test.c

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -23,7 +23,7 @@ export JSTRENCODE="./jstrencode"
 export JSTRDECODE="./jstrdecode"
 export TEST_FILE="./test_jparse/jstr_test.out"
 export TEST_FILE2="./test_jparse/jstr_test2.out"
-export JSTR_TEST_VERSION="1.0.2 2024-09-04"
+export JSTR_TEST_VERSION="1.0.3 2024-09-13" # version format: major.minor YYYY-MM-DD
 export TOPDIR=
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode] [-Z topdir]
@@ -51,7 +51,7 @@ jstr_test.sh version: $JSTR_TEST_VERSION"
 
 # parse args
 #
-export V_FLAG="0"
+export V_FLAG=0
 while getopts :hVv:e:d:Z: flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
@@ -168,11 +168,11 @@ trap "rm -f \$TEST_FILE \$TEST_FILE2; exit" 0 1 2 3 15
 
 # run the basic encoding test
 #
-echo "$0: about to run test #0"
+echo "$0: about to run test #0" 1>&2
 "$JSTRENCODE" -v "$V_FLAG" -t
 status="$?"
 if [[ $status -eq 0 ]]; then
-    echo "$0: test #0 passed"
+    echo "$0: test #0 passed" 1>&2
 else
     echo "$0: test #0 failed" 1>&2
     EXIT_CODE=4
@@ -189,7 +189,7 @@ echo "$JSTRENCODE -v $V_FLAG -n < $JSTRENCODE | $JSTRDECODE -v $V_FLAG -n > $TES
 # shellcheck disable=SC2094
 "$JSTRENCODE" -v "$V_FLAG" -n < "$JSTRENCODE" | $JSTRDECODE -v "$V_FLAG" -n > "$TEST_FILE"
 if cmp -s "$JSTRENCODE" "$TEST_FILE"; then
-    echo "$0: test #1 passed"
+    echo "$0: test #1 passed" 1>&2
 else
     echo "$0: test #1 failed" 1>&2
     EXIT_CODE=5
@@ -211,7 +211,7 @@ fi
 
 # test some text holes in the encoding and decoding pipe
 #
-echo "$0: about to run test #3"
+echo "$0: about to run test #3" 1>&2
 export SRC_SET="jparse.c json_parse.c json_parse.h jstrdecode.c jstrencode.c util.h util.c"
 echo "cat \$SRC_SET | $JSTRENCODE -v $V_FLAG -n | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
 # We cannot double-quote $SRC_SET because doing so would make the shell try
@@ -263,12 +263,44 @@ if [[ -z "$ERROR" ]]; then
 	echo "$0: test #3 failed" 1>&2
 	EXIT_CODE=7
     elif cmp -s "$TEST_FILE2" "$TEST_FILE"; then
-	echo "$0: test #3 passed"
+	echo "$0: test #3 passed" 1>&2
     else
 	echo "$0: test #3 failed" 1>&2
 	EXIT_CODE=7
     fi
 fi
+
+echo "$0: about to run test #4" 1>&2
+echo "$JSTRDECODE -Q -n foo bar"
+RESULT="$($JSTRDECODE -Q -n foo bar)"
+if [[ "$RESULT" = '"foobar"' ]]; then
+    echo "$0: debug[1]: test #4 passed" 1>&2
+else
+    echo "$0: test #4 failed" 1>&2
+    EXIT_CODE=8
+fi
+
+echo "$0: about to run test #5" 1>&2
+echo "$JSTRDECODE -Q -e -n foo bar"
+RESULT="$($JSTRDECODE -Q -e -n foo bar)"
+if [[ "$RESULT" = '"\"foo\"\"bar\""' ]]; then
+    echo "$0: debug[1]: test #5 passed" 1>&2
+else
+    echo "$0: test #5 failed" 1>&2
+    EXIT_CODE=9
+fi
+
+echo "$0: about to run test #6" 1>&2
+echo "$JSTRDECODE -e -n foo bar"
+RESULT="$($JSTRDECODE -e -n foo bar)"
+if [[ "$RESULT" = '\"foo\"\"bar\"' ]]; then
+    echo "$0: debug[1]: test #6 passed" 1>&2
+else
+    echo "$0: test #6 failed" 1>&2
+    EXIT_CODE=9
+fi
+
+
 
 # All Done!!! All Done!!! -- Jessica Noll, Age 2
 #

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -274,7 +274,7 @@ echo "$0: about to run test #4" 1>&2
 echo "$JSTRDECODE -Q -n foo bar"
 RESULT="$($JSTRDECODE -Q -n foo bar)"
 if [[ "$RESULT" = '"foobar"' ]]; then
-    echo "$0: debug[1]: test #4 passed" 1>&2
+    echo "$0: test #4 passed" 1>&2
 else
     echo "$0: test #4 failed" 1>&2
     EXIT_CODE=8
@@ -284,7 +284,7 @@ echo "$0: about to run test #5" 1>&2
 echo "$JSTRDECODE -Q -e -n foo bar"
 RESULT="$($JSTRDECODE -Q -e -n foo bar)"
 if [[ "$RESULT" = '"\"foo\"\"bar\""' ]]; then
-    echo "$0: debug[1]: test #5 passed" 1>&2
+    echo "$0: test #5 passed" 1>&2
 else
     echo "$0: test #5 failed" 1>&2
     EXIT_CODE=9
@@ -294,7 +294,7 @@ echo "$0: about to run test #6" 1>&2
 echo "$JSTRDECODE -e -n foo bar"
 RESULT="$($JSTRDECODE -e -n foo bar)"
 if [[ "$RESULT" = '\"foo\"\"bar\"' ]]; then
-    echo "$0: debug[1]: test #6 passed" 1>&2
+    echo "$0: test #6 passed" 1>&2
 else
     echo "$0: test #6 failed" 1>&2
     EXIT_CODE=9

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1,33 +1,21 @@
 /*
  * util - common utility functions for the JSON parser
  *
- * "Because even printf has a return value worth paying attention to." :-)
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
  *
- * Copyright (c) 2021,2022 by Landon Curt Noll.  All Rights Reserved.
+ * This JSON parser was co-developed in 2022 by:
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * Share and enjoy! :-)
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
  */
-
 
 /* special comments for the seqcexit tool */
 /* exit code out of numerical order - ignore in sequencing - ooo */

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -1,31 +1,21 @@
 /*
  * util - common utility functions for the JSON parser
  *
- * Copyright (c) 1989,1997,2018-2022 by Landon Curt Noll.  All Rights Reserved.
+ * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
  *
- * Permission to use, copy, modify, and distribute this software and
- * its documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright, this permission notice and text
- * this comment, and the disclaimer below appear in all of the following:
+ * This JSON parser was co-developed in 2022 by:
  *
- *       supporting documentation
- *       source copies
- *       source works derived from this source
- *       binaries derived from this source or from derived source
+ *	@xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
- *
- * Share and enjoy! :-)
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
  */
-
 
 #if !defined(INCLUDE_UTIL_H)
 #    define  INCLUDE_UTIL_H

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.15 2024-09-11"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.16 2024-09-12"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
Synced jparse/ from the jparse repo (https://github.com/xexyl/jparse/). This makes some important fixes to the tools jstrdecode(1) and jstrencode(1) where in jstrdecode(1) the -Q option did not work and for both the printing of everything should happen after everything is parsed (especially for the -Q option but not strictly for that reason). The pr_jparse_test tool had a bug fix as well where the -h option did not work.