### PR TITLE
Add helper script soup/is_available.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.17 2024-09-15
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). Added
+function to check a string for UTF-8. Fixed make `check_man`.
+
+Added script `soup/is_available.sh`: it takes a single arg and if it can find a
+program by that name (as in by `type -P`) it will return 0; otherwise it returns
+1.
+
 ## Release 1.5.16 2024-09-13
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/).

--- a/soup/is_available.sh
+++ b/soup/is_available.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# is_available.sh - check if a tool is available
+#
+# This script was written in 2024 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Share and enjoy! :-)
+#
+
+export IS_AVAILABLE_VERSION="1.0.0 2024-09-15"
+
+export USAGE="usage: $0 [-h] [-V] [-v level] tool_name
+
+    -h			    print help and exit
+    -V			    print version and exit
+    -v level		    set verbosity level for this script: (def level: 0)
+
+Exit codes:
+     0   all OK
+     1   tool not found
+     2   -h and help string printed or -V and version string printed
+     3   invalid command line
+ >= 10   internal error or missing file or directory
+
+is_available.sh version: $IS_AVAILABLE_VERSION"
+
+# parse args
+#
+export V_FLAG="0"
+while getopts :hVv: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$IS_AVAILABLE_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+   *)
+	;;
+    esac
+done
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+if [[ $# -ne 1 ]]; then
+    echo "$0: ERROR: expected one arg, got $#" 1>&2
+    echo 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+elif [[ -z "$1" ]]; then
+    echo "$0: ERROR: expected one non-empty arg" 1>&2
+    echo 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+fi
+
+TOOL="$(type -P "$1")"
+if [[ -n "$TOOL" ]]; then
+    if [[ "$V_FLAG" -gt 0 ]]; then
+	echo "$TOOL" 1>&2
+    fi
+    exit 0
+else
+    if [[ "$V_FLAG" -gt 0 ]]; then
+	echo "\"$1\" not found" 1>&2
+    fi
+    exit 1
+fi

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.16 2024-09-12"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.17 2024-09-15"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
This script takes a single arg and exits 0 if it can be found via 'type -P', otherwise 1. If -v 1 or greater it gives either the tool's path or says it cannot be found.

This script will be used in prep.sh for a rather important enhancement to help prevent superfluous bug reports.