### PR TITLE
Fix make check_man, sync jparse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.17 2024-09-15
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). Added
+function to check a string for UTF-8. Fixed make `check_man`.
+
+Added script `soup/is_available.sh`: it takes a single arg and if it can find a
+program by that name (as in by `type -P`) it will return 0; otherwise it returns
+1.
+
 ## Release 1.5.16 2024-09-13
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Added script `soup/is_available.sh`: it takes a single arg and if it can find a
 program by that name (as in by `type -P`) it will return 0; otherwise it returns
 1.
 
+Fix `check_man` Makefile rule in all Makefiles. Previously it ignored the result
+which meant that `prep.sh` never reported a problem in a problematic man page.
+
+
 ## Release 1.5.16 2024-09-13
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/).

--- a/dbg/Makefile
+++ b/dbg/Makefile
@@ -553,7 +553,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
+	${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
@@ -565,6 +565,11 @@ check_man: ${ALL_MAN_TARGETS}
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
+		exit 1; \
+	    fi; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"

--- a/dyn_array/Makefile
+++ b/dyn_array/Makefile
@@ -506,7 +506,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
+	${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
@@ -518,6 +518,11 @@ check_man: ${ALL_MAN_TARGETS}
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
+		exit 1; \
+	    fi; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,32 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.9 2024-09-15
+
+Add helper function `is_utf8()` to determine if a `char *` is a UTF-8 encoded
+string. This code, modified somewhat (including a typo fix and allowing all
+ASCII chars, including control chars, which are allowed), comes from
+<https://stackoverflow.com/a/1031773/9205647>, and we thank the answerer very
+much! This function, we believe, will be of use, in our fixing of a JSON
+decoding bug that is known and being resolved (or is being discussed to be
+resolved), hopefully sooner than later and better soon. Nonetheless this
+function is not yet used so we may discover it is not of use or there is a
+problem that has to be resolved.
+
+Added a warning comment in `json_util.c` to functions (and their respective
+structs, enums and macros in `json_util.h`) that are subject to change: they
+were being used for tools that were in the works (before this was its own repo)
+but were not completed due to illness and then, when well again, other
+priorities taking over (and they themselves have been removed until the 'right
+time').
+
+Fixed `check_man` make rule so that it would fail if `checknr` exits non-zero.
+This helped uncover a problem (though not in display) in` jparse.1`.
+
+Added helper script `test_jparse/is_available.sh` which exits 0 if the arg can
+be found via `type -P`, else 1. This will be used in prep.sh, in a future
+update, to help prevent superfluous bug reports.
+
+
 ## Release 1.0.8 2024-09-14
 
 Rename option `-e` in `jstrdecode(1)` to `-m` with the alias `-e`. Add missing

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -954,7 +954,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
+	${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
@@ -966,6 +966,11 @@ check_man: ${ALL_MAN_TARGETS}
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
+		exit 1; \
+	    fi; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"

--- a/jparse/jparse.h
+++ b/jparse/jparse.h
@@ -56,7 +56,7 @@
 /*
  * official jparse repo release
  */
-#define JPARSE_REPO_VERSION "1.0.7 2024-09-13"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.8 2024-09-15"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -69,6 +69,8 @@
 #define JSON_DBG_FORCED	    (-1)	    /* always print information, even if dbg_output_allowed == false */
 #define JSON_DBG_LEVEL	    (JSON_DBG_LOW)  /* default JSON debugging level json_verbosity_level */
 
+/* WARNING: the below enums, macros and structs are VERY subject to change, if they are not deleted */
+
 /* comparison enum - for json tools that might wish to compare JSON related values */
 enum JSON_UTIL_CMP_OP
 {
@@ -98,7 +100,7 @@ enum JSON_UTIL_CMP_OP
 
 /* structures */
 
-/* structures this may be useful for json tools that need to compare JSON related values */
+/* structures: this may be useful for json tools that need to compare JSON related values */
 
 struct json_util_number_range
 {
@@ -119,6 +121,8 @@ struct json_util_number
     /* for number ranges */
     struct json_util_number_range range;	/* for ranges */
 };
+
+/* End WARNING from above */
 
 
 /*
@@ -160,7 +164,9 @@ extern void json_tree_walk(struct json *node, unsigned int max_depth, unsigned i
 			   void (*vcallback)(struct json *, unsigned int, va_list), ...);
 extern void vjson_tree_walk(struct json *node, unsigned int max_depth, unsigned int depth, bool post_order,
 			    void (*vcallback)(struct json *, unsigned int, va_list), va_list ap);
+extern bool is_utf8(const char *str);
 
+/* WARNING: the below functions are VERY subject to change, if they are not deleted */
 bool json_util_parse_number_range(const char *option, char *optarg, bool allow_negative, struct json_util_number *number);
 bool json_util_number_in_range(intmax_t number, intmax_t total_matches, struct json_util_number *range);
 void json_util_parse_st_level_option(char *optarg, uintmax_t *num_level_spaces, bool *print_level_tab);
@@ -176,6 +182,7 @@ bool json_util_match_num(uintmax_t types);
 bool json_util_match_string(uintmax_t types);
 bool json_util_match_null(uintmax_t types);
 bool json_util_match_simple(uintmax_t types);
+/* End WARNING */
 
 
 #endif /* INCLUDE_JSON_UTIL_H */

--- a/jparse/man/man1/jparse.1
+++ b/jparse/man/man1/jparse.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 1 "12 September 2024" "jparse" "jparse tools"
+.TH jparse 1 "15 September 2024" "jparse" "jparse tools"
 .SH NAME
 .B jparse
 \- IOCCC JSON parser
@@ -143,7 +143,7 @@ to parse):
 .br
  []
 .br
- ^D\fP
+ ^D
 .br
 .ft R
 .RE

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -715,7 +715,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
+	${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
@@ -727,6 +727,11 @@ check_man: ${ALL_MAN_TARGETS}
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
+		exit 1; \
+	    fi; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"

--- a/soup/is_available.sh
+++ b/soup/is_available.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# is_available.sh - check if a tool is available
+#
+# This script was written in 2024 by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Share and enjoy! :-)
+#
+
+export IS_AVAILABLE_VERSION="1.0.0 2024-09-15"
+
+export USAGE="usage: $0 [-h] [-V] [-v level] tool_name
+
+    -h			    print help and exit
+    -V			    print version and exit
+    -v level		    set verbosity level for this script: (def level: 0)
+
+Exit codes:
+     0   all OK
+     1   tool not found
+     2   -h and help string printed or -V and version string printed
+     3   invalid command line
+ >= 10   internal error or missing file or directory
+
+is_available.sh version: $IS_AVAILABLE_VERSION"
+
+# parse args
+#
+export V_FLAG="0"
+while getopts :hVv: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$IS_AVAILABLE_VERSION"
+	exit 2
+	;;
+    v)	V_FLAG="$OPTARG";
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+   *)
+	;;
+    esac
+done
+
+# check args
+#
+shift $(( OPTIND - 1 ));
+if [[ $# -ne 1 ]]; then
+    echo "$0: ERROR: expected one arg, got $#" 1>&2
+    echo 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+elif [[ -z "$1" ]]; then
+    echo "$0: ERROR: expected one non-empty arg" 1>&2
+    echo 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+fi
+
+TOOL="$(type -P "$1")"
+if [[ -n "$TOOL" ]]; then
+    if [[ "$V_FLAG" -gt 0 ]]; then
+	echo "$TOOL" 1>&2
+    fi
+    exit 0
+else
+    if [[ "$V_FLAG" -gt 0 ]]; then
+	echo "\"$1\" not found" 1>&2
+    fi
+    exit 1
+fi

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.16 2024-09-12"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.17 2024-09-15"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -528,7 +528,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	-${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
+	${Q} if ! type -P ${CHECKNR} >/dev/null 2>&1; then \
 	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
@@ -540,6 +540,11 @@ check_man: ${ALL_MAN_TARGETS}
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
+		exit 1; \
+	    fi; \
 	fi
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"


### PR DESCRIPTION

Fix check_man Makefile rule in all Makefiles. Previously it ignored the result
which meant that prep.sh never reported a problem in a problematic man page.

The dbg and dyn_array repos need to have this fix applied and I will do
this as well.

Synced jparse repo for recent changes, which includes the above fix, a 
man page fix and a new helper function besides.
