### PR TITLE
Improve -V / -h options to all tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.19 2024-09-24
+
+Add `FOO_BASENAME` to all tools in this repo. This is used in both `-V` option
+and `-h` option.
+
+The `-V` and `-h` option of all tools now show the JSON parser version. This is
+because it is helpful to know what parser version is linked in, especially for
+any bug reports. This should not normally be a problem as the copies in this
+repo are linked in but in case there is a problem it is now done (for some the
+parser is actually used so it's even more important).
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). The changes
+consist of the `FOO_BASENAME` changes described above for the tools in this
+repo. This needs to be done for the dbg repo and the dyn_array repo.
+
 ## Release 1.5.18 2024-09-24
 
 Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/). The

--- a/Makefile
+++ b/Makefile
@@ -1737,16 +1737,16 @@ chkentry.o: chkentry.c chkentry.h dbg/dbg.h dyn_array/dyn_array.h \
     soup/utf8_posix_map.h soup/version.h
 iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
     soup/limit_ioccc.h soup/version.h
-mkiocccentry.o: dbg/dbg.h dyn_array/dyn_array.h iocccsize.h jparse/jparse.h \
-    jparse/jparse.tab.h jparse/json_parse.h jparse/json_sem.h \
-    jparse/json_utf8.h jparse/json_util.h jparse/util.h jparse/version.h \
-    mkiocccentry.c mkiocccentry.h soup/chk_sem_auth.h soup/chk_sem_info.h \
-    soup/chk_validate.h soup/entry_time.h soup/entry_util.h \
-    soup/limit_ioccc.h soup/location.h soup/sanity.h soup/soup.h \
-    soup/utf8_posix_map.h soup/version.h
-txzchk.o: dbg/dbg.h dyn_array/dyn_array.h jparse/jparse.h \
-    jparse/jparse.tab.h jparse/json_parse.h jparse/json_sem.h \
-    jparse/json_utf8.h jparse/json_util.h jparse/util.h jparse/version.h \
+mkiocccentry.o: dbg/dbg.h iocccsize.h jparse/jparse.h jparse/jparse.tab.h \
+    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
+    jparse/json_util.h jparse/util.h jparse/version.h mkiocccentry.c \
+    mkiocccentry.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
+    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
+    soup/entry_time.h soup/entry_util.h soup/limit_ioccc.h soup/location.h \
+    soup/sanity.h soup/soup.h soup/utf8_posix_map.h soup/version.h
+txzchk.o: dbg/dbg.h jparse/jparse.h jparse/jparse.tab.h jparse/json_parse.h \
+    jparse/json_sem.h jparse/json_utf8.h jparse/json_util.h jparse/util.h \
+    jparse/version.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
     soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
     soup/entry_time.h soup/entry_util.h soup/limit_ioccc.h soup/location.h \
     soup/sanity.h soup/soup.h soup/utf8_posix_map.h soup/version.h txzchk.c \

--- a/chkentry.c
+++ b/chkentry.c
@@ -35,11 +35,6 @@
  */
 #include "chkentry.h"
 
-/*
- * version - official IOCCC toolkit versions
- */
-#include "soup/version.h"
-
 
 /*
  * definitions
@@ -77,7 +72,8 @@ static const char * const usage_msg =
     "    4\t\tfile(s) not valid JSON; no semantic checks were performed\n"
     "    >=10\tinternal error\n"
     "\n"
-    "chkentry version: %s";
+    "%s version: %s\n"
+    "JSON parser version: %s";
 
 
 /*
@@ -108,7 +104,7 @@ usage(int exitcode, char const *prog, char const *str)
      * firewall
      */
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = CHKENTRY_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
     if (str == NULL) {
@@ -122,7 +118,8 @@ usage(int exitcode, char const *prog, char const *str)
     if (*str != '\0') {
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT, CHKENTRY_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT,
+	    CHKENTRY_BASENAME, CHKENTRY_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }
@@ -197,8 +194,8 @@ main(int argc, char *argv[])
 	    }
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("%s\n", CHKENTRY_VERSION);
-	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
+	    print("%s version: %s\n", CHKENTRY_BASENAME, CHKENTRY_VERSION);
+	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
 	    exit(2);		/*ooo*/
 	    not_reached();
 	    break;

--- a/chkentry.h
+++ b/chkentry.h
@@ -54,6 +54,10 @@
 /*
  * macros
  */
+
+/*
+ * chkentry tool basename
+ */
 #define CHKENTRY_BASENAME "chkentry"
 
 /*

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,11 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.15 2024-09-25
+
+Use `FOO_BASENAME` when `prog == NULL` in `usage()` functions of the tools
+written in C.
+
+
 ## Release 1.0.14 2024-09-24
 
 Implement boolean `unicode` of `struct json_string` in the decoding functions.

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -213,7 +213,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JPARSE_BASENAME;
 	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
     }
 

--- a/jparse/jsemtblgen.c
+++ b/jparse/jsemtblgen.c
@@ -1514,7 +1514,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JSEMTBLGEN_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -533,7 +533,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JSTRDECODE_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 

--- a/jparse/jstrencode.c
+++ b/jparse/jstrencode.c
@@ -623,7 +623,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JSTRENCODE_BASENAME;
 	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
     }
 

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -780,7 +780,7 @@ usage(int exitcode, char const *prog, char const *str)
      * firewall
      */
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JNUM_CHK_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
     if (str == NULL) {

--- a/jparse/test_jparse/jnum_gen.c
+++ b/jparse/test_jparse/jnum_gen.c
@@ -782,7 +782,7 @@ usage(int exitcode, char const *prog, char const *str)
      * firewall
      */
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = JNUM_GEN_BASENAME;
 	warn(__func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
     }
     if (str == NULL) {

--- a/jparse/test_jparse/pr_jparse_test.c
+++ b/jparse/test_jparse/pr_jparse_test.c
@@ -1045,7 +1045,7 @@ usage(int exitcode, char const *prog, char const *str)
      * firewall
      */
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = PR_JPARSE_TEST_BASENAME;
 	fwarn(stderr, __func__, "\nin usage(): program was NULL, forcing it to be: %s\n", prog);
     }
     if (str == NULL) {

--- a/jparse/verge.c
+++ b/jparse/verge.c
@@ -453,7 +453,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = VERGE_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -25,7 +25,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "1.0.13 2024-09-24"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.14 2024-09-25"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -163,7 +163,8 @@ static const char * const usage_msg4 =
     "     3   invalid command line, invalid option or option missing an argument\n"
     " >= 10   internal error\n"
     "\n"
-    "mkiocccentry version: %s";
+    "%s version: %s\n"
+    "JSON parser version: %s";
 
 /*
  * globals
@@ -260,8 +261,8 @@ main(int argc, char *argv[])
 	    msg_warn_silent = true;
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
-	    print("%s\n", MKIOCCCENTRY_VERSION);
-	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
+	    print("%s version: %s\n", MKIOCCCENTRY_BASENAME, MKIOCCCENTRY_VERSION);
+	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -883,7 +884,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = MKIOCCCENTRY_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 
@@ -899,7 +900,7 @@ usage(int exitcode, char const *prog, char const *str)
     fprintf_usage(DO_NOT_EXIT, stderr, usage_msg1, TAR_PATH_0, CP_PATH_0, LS_PATH_0, TXZCHK_PATH_0, FNAMCHK_PATH_0);
     fprintf_usage(DO_NOT_EXIT, stderr, usage_msg2, CHKENTRY_PATH_0);
     fprintf_usage(DO_NOT_EXIT, stderr, "%s", usage_msg3);
-    fprintf_usage(exitcode, stderr, usage_msg4, MKIOCCCENTRY_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg4, MKIOCCCENTRY_BASENAME, MKIOCCCENTRY_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -107,6 +107,11 @@
  */
 #include "soup/entry_util.h"
 
+/*
+ * mkiocccentry tool basename
+ */
+#define MKIOCCCENTRY_BASENAME "mkiocccentry"
+
 
 /*
  * definitions

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -412,7 +412,7 @@ location_util.o: location_util.c
 location_main.o: location_main.c
 	${CC} ${CFLAGS} location_main.c -c
 
-location: location_main.o location_tbl.o location_util.o ../dbg/libdbg.a ../dyn_array/libdyn_array.a ../jparse/libjparse.a
+location: location_main.o location_tbl.o location_util.o ../jparse/libjparse.a ../dyn_array/libdyn_array.a ../dbg/libdbg.a
 	${CC} ${CFLAGS} $^ -o $@
 
 foo.o: foo.c

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -412,7 +412,7 @@ location_util.o: location_util.c
 location_main.o: location_main.c
 	${CC} ${CFLAGS} location_main.c -c
 
-location: location_main.o location_tbl.o location_util.o ../dbg/libdbg.a
+location: location_main.o location_tbl.o location_util.o ../dbg/libdbg.a ../dyn_array/libdyn_array.a ../jparse/libjparse.a
 	${CC} ${CFLAGS} $^ -o $@
 
 foo.o: foo.c
@@ -977,16 +977,16 @@ entry_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
 foo.o: ../dbg/dbg.h foo.c foo.h oebxergfB.h
 location_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
-    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h location.h \
-    location_main.c
+    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
+    ../jparse/version.h location.h location_main.c
 location_tbl.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
-    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h location.h \
-    location_tbl.c
+    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
+    ../jparse/version.h location.h location_tbl.c
 location_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
-    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h location.h \
-    location_util.c
+    ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
+    ../jparse/version.h location.h location_util.c
 rule_count.o: ../dbg/dbg.h ../iocccsize.h iocccsize_err.h limit_ioccc.h \
     rule_count.c version.h
 sanity.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \

--- a/soup/location.h
+++ b/soup/location.h
@@ -43,16 +43,32 @@
 
 #include <ctype.h>
 
+
 /*
- * jparse - the parser
+ * jparse - the JSON parser
  */
 #include "../jparse/jparse.h"
+
+
+/*
+ * jparse/version - the JSON parser version
+ */
+#include "../jparse/version.h"
 
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
 #include "../dbg/dbg.h"
 
+
+/*
+ * macros
+ */
+
+/*
+ * location tool basename
+ */
+#define LOCATION_BASENAME "location"
 
 /*
  * location/country codes

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.17 2024-09-15"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.19 2024-09-25"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -763,5 +763,5 @@ fnamchk.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
 utf8_test.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../soup/limit_ioccc.h ../soup/utf8_posix_map.h ../soup/version.h \
-    utf8_test.c
+    ../jparse/version.h ../soup/limit_ioccc.h ../soup/utf8_posix_map.h \
+    ../soup/version.h utf8_test.c

--- a/test_ioccc/fnamchk.c
+++ b/test_ioccc/fnamchk.c
@@ -78,7 +78,8 @@ static const char * const usage_msg =
     "     4\t\t\"submit.test-\" separated token length != %ju\n"
     "     5\t\t\"submit.UUID-\" token length != %ju\n"
     "     >=10\tinternal error\n"
-    "fnamchk version: %s";
+    "%s version: %s\n"
+    "JSON parser version: %s";
 
 
 /*
@@ -138,8 +139,8 @@ main(int argc, char *argv[])
 	    msg_warn_silent = true;
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
-	    print("%s\n", FNAMCHK_VERSION);
-	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
+	    print("%s version: %s\n", FNAMCHK_BASENAME, FNAMCHK_VERSION);
+	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -393,7 +394,7 @@ usage(int exitcode, char const *prog, char const *str)
 	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
     }
     if (prog == NULL) {
-	prog = "((NULL prog))";
+	prog = FNAMCHK_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 
@@ -405,7 +406,8 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, (uintmax_t)(UUID_LEN+1+MAX_SUBMIT_SLOT_CHARS),
-	    (uintmax_t)(LITLEN("test-")+MAX_SUBMIT_SLOT_CHARS), FNAMCHK_VERSION);
+	    (uintmax_t)(LITLEN("test-")+MAX_SUBMIT_SLOT_CHARS), FNAMCHK_BASENAME, FNAMCHK_VERSION,
+	    JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/test_ioccc/fnamchk.h
+++ b/test_ioccc/fnamchk.h
@@ -55,6 +55,10 @@
  */
 #include "../soup/utf8_posix_map.h"
 
+/*
+ * fnamchk tool basename
+ */
+#define FNAMCHK_BASENAME "fnamchk"
 
 /*
  * globals

--- a/test_ioccc/utf8_test.c
+++ b/test_ioccc/utf8_test.c
@@ -60,14 +60,21 @@
 #include "../soup/utf8_posix_map.h"
 
 /*
- * jparse - the parser
+ * jparse - the JSON parser
  */
 #include "../jparse/jparse.h"
+
+/*
+ * jparse/version - the JSON parser version
+ */
+#include "../jparse/version.h"
+
 
 /*
  * definitions
  */
 #define UTF8_TEST_VERSION "1.3 2023-02-04"
+#define UTF8_TEST_BASENAME "utf8_test"
 
 
 /*
@@ -98,7 +105,8 @@ static char const * const usage_msg =
     "     3   invalid command line, invalid option or option missing an argument\n"
     " >= 10   internal error\n"
     "\n"
-    "utf8_test version: %s";
+    "%s version: %s\n"
+    "JSON parser version: %s";
 
 /*
  * functions
@@ -135,7 +143,8 @@ main(int argc, char *argv[])
 	    }
 	    break;
 	case 'V':	/* -V - print version and exit */
-            print("%s\n", UTF8_TEST_VERSION);
+            print("%s version: %s\n", UTF8_TEST_BASENAME, UTF8_TEST_VERSION);
+	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
             exit(2); /*ooo*/
             not_reached();
             break;
@@ -222,7 +231,7 @@ usage(int exitcode, char const *prog, char const *str)
      * firewall
      */
     if (prog == NULL) {
-	prog = "utf8_test";
+	prog = UTF8_TEST_BASENAME;
 	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
     if (str == NULL) {
@@ -237,7 +246,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, UTF8_TEST_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, UTF8_TEST_BASENAME, UTF8_TEST_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/txzchk.c
+++ b/txzchk.c
@@ -112,7 +112,8 @@ static const char * const usage_msg =
     "     3   invalid command line, invalid option or option missing an argument\n"
     " >= 10   internal error has occurred or unknown tar listing format has been encountered\n"
     "\n"
-    "txzchk version: %s";
+    "%s version: %s\n"
+    "JSON parser version: %s";
 
 
 /*
@@ -153,8 +154,8 @@ main(int argc, char **argv)
 	    }
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
-	    print("%s\n", TXZCHK_VERSION);
-	    print("JSON parser version %s\n", JSON_PARSER_VERSION);
+	    print("%s version: %s\n", TXZCHK_BASENAME, TXZCHK_VERSION);
+	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -305,30 +306,30 @@ show_tarball_info(char const *tarball_path)
 	para("", "The following information about the tarball was collected:", NULL);
 
 
-	dbg(DBG_MED, "%s %s a .info.json", tarball_path, has_does_not_have(tarball.has_info_json));
-	dbg(DBG_HIGH, "%s %s an empty .info.json", tarball_path, has_does_not_have(tarball.empty_info_json));
+	dbg(DBG_MED, "%s %s a .info.json", tarball_path, HAS_DOES_NOT_HAVE(tarball.has_info_json));
+	dbg(DBG_HIGH, "%s %s an empty .info.json", tarball_path, HAS_DOES_NOT_HAVE(tarball.empty_info_json));
 	dbg(DBG_HIGH, "%s .info.json size is %jd", tarball_path, (intmax_t)tarball.info_json_size);
-	dbg(DBG_MED, "%s %s a .auth.json", tarball_path, has_does_not_have(tarball.has_auth_json));
-	dbg(DBG_HIGH, "%s %s an empty .auth.json", tarball_path, has_does_not_have(tarball.empty_auth_json));
+	dbg(DBG_MED, "%s %s a .auth.json", tarball_path, HAS_DOES_NOT_HAVE(tarball.has_auth_json));
+	dbg(DBG_HIGH, "%s %s an empty .auth.json", tarball_path, HAS_DOES_NOT_HAVE(tarball.empty_auth_json));
 	dbg(DBG_HIGH, "%s .auth.json size is %jd", tarball_path, (intmax_t)tarball.auth_json_size);
-	dbg(DBG_MED, "%s %s a prog.c", tarball_path, has_does_not_have(tarball.has_prog_c));
-	dbg(DBG_HIGH, "%s %s an empty prog.c", tarball_path, has_does_not_have(tarball.empty_prog_c));
+	dbg(DBG_MED, "%s %s a prog.c", tarball_path, HAS_DOES_NOT_HAVE(tarball.has_prog_c));
+	dbg(DBG_HIGH, "%s %s an empty prog.c", tarball_path, HAS_DOES_NOT_HAVE(tarball.empty_prog_c));
 	dbg(DBG_HIGH, "%s prog.c size is %jd", tarball_path, (intmax_t)tarball.prog_c_size);
-	dbg(DBG_MED, "%s %s a remarks.md", tarball_path, has_does_not_have(tarball.has_remarks_md));
-	dbg(DBG_HIGH, "%s %s an empty remarks.md", tarball_path, has_does_not_have(tarball.empty_remarks_md));
+	dbg(DBG_MED, "%s %s a remarks.md", tarball_path, HAS_DOES_NOT_HAVE(tarball.has_remarks_md));
+	dbg(DBG_HIGH, "%s %s an empty remarks.md", tarball_path, HAS_DOES_NOT_HAVE(tarball.empty_remarks_md));
 	dbg(DBG_HIGH, "%s remarks.md size is %jd", tarball_path, (intmax_t)tarball.remarks_md_size);
-	dbg(DBG_MED, "%s %s a Makefile", tarball_path, has_does_not_have(tarball.has_Makefile));
-	dbg(DBG_HIGH, "%s %s an empty Makefile", tarball_path, has_does_not_have(tarball.empty_Makefile));
+	dbg(DBG_MED, "%s %s a Makefile", tarball_path, HAS_DOES_NOT_HAVE(tarball.has_Makefile));
+	dbg(DBG_HIGH, "%s %s an empty Makefile", tarball_path, HAS_DOES_NOT_HAVE(tarball.empty_Makefile));
 	dbg(DBG_HIGH, "%s Makefile size is %jd", tarball_path, (intmax_t)tarball.Makefile_size);
 	dbg(DBG_MED, "%s tarball size is %jd according to stat(2)", tarball_path, (intmax_t)tarball.size);
 	dbg(DBG_MED, "%s total file size is %jd", tarball_path, (intmax_t)tarball.files_size);
 	dbg(DBG_HIGH, "%s shrunk in files size %ju time%s", tarball_path, tarball.files_size_shrunk,
-		singular_or_plural(tarball.files_size_shrunk));
+		SINGULAR_OR_PLURAL(tarball.files_size_shrunk));
 	dbg(DBG_HIGH, "%s went below 0 in all files size %ju time%s", tarball_path, tarball.negative_files_size,
-		singular_or_plural(tarball.negative_files_size));
+		SINGULAR_OR_PLURAL(tarball.negative_files_size));
 	dbg(DBG_HIGH, "%s went above max files size %ju %ju time%s", tarball_path,
 		(uintmax_t)MAX_SUM_FILELEN, (uintmax_t)tarball.files_size_too_big,
-		singular_or_plural(tarball.files_size_too_big));
+		SINGULAR_OR_PLURAL(tarball.files_size_too_big));
 	dbg(DBG_MED, "%s has %ju file%s", tarball_path, tarball.total_files-tarball.abnormal_files,
 		tarball.total_files-tarball.abnormal_files == 1?"":"s");
 
@@ -340,17 +341,17 @@ show_tarball_info(char const *tarball_path)
 	}
 
 	dbg(DBG_MED, "%s has %ju invalid dot file%s", tarball_path, tarball.invalid_dot_files,
-		singular_or_plural(tarball.invalid_dot_files));
-	dbg(DBG_MED, "%s has %ju file%s named '.'", tarball_path, tarball.named_dot, singular_or_plural(tarball.named_dot));
+		SINGULAR_OR_PLURAL(tarball.invalid_dot_files));
+	dbg(DBG_MED, "%s has %ju file%s named '.'", tarball_path, tarball.named_dot, SINGULAR_OR_PLURAL(tarball.named_dot));
 	dbg(DBG_MED, "%s has %ju file%s with at least one unsafe char", tarball_path, tarball.unsafe_chars,
-		singular_or_plural(tarball.unsafe_chars));
+		SINGULAR_OR_PLURAL(tarball.unsafe_chars));
 	if (tarball.invalid_filenames) {
 	    dbg(DBG_MED, "%s has %ju invalidly named file%s", tarball_path, tarball.invalid_filenames,
-		    singular_or_plural(tarball.invalid_filenames));
+		    SINGULAR_OR_PLURAL(tarball.invalid_filenames));
 	}
 	if (tarball.total_feathers > 0) {
 	    dbg(DBG_VHIGH, "%s has %ju feather%s stuck in tarball :-(", tarball_path, tarball.total_feathers,
-		    singular_or_plural(tarball.total_feathers));
+		    SINGULAR_OR_PLURAL(tarball.total_feathers));
 	} else {
 	    dbg(DBG_VHIGH, "%s has 0 feathers stuck in tarball :-)", tarball_path);
 	}
@@ -386,7 +387,7 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     if (prog == NULL) {
-	prog = "txzchk";
+	prog = TXZCHK_BASENAME;
 	warn("txzchk", "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
     }
 
@@ -397,7 +398,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, TAR_PATH_0, FNAMCHK_PATH_0, TXZCHK_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, TAR_PATH_0, FNAMCHK_PATH_0,
+	    TXZCHK_BASENAME, TXZCHK_VERSION, JSON_PARSER_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/txzchk.h
+++ b/txzchk.h
@@ -67,13 +67,22 @@
 
 
 /*
+ * macros
+ */
+
+/*
+ * txzchk tool basename
+ */
+#define TXZCHK_BASENAME "txzchk"
+
+/*
  * utility macros
  *
  * These will work for our purposes but the singular or plural one is in truth
  * much more complicated than what we're making it seem like.
  */
-#define has_does_not_have(b) ((b)?"has":"does not have")
-#define singular_or_plural(x) ((x)==1?"":"s")
+#define HAS_DOES_NOT_HAVE(b) ((b)?"has":"does not have")
+#define SINGULAR_OR_PLURAL(x) ((x)==1?"":"s")
 
 
 /*


### PR DESCRIPTION
Add FOO_BASENAME to all tools in this repo. This is used in both -V option and -h option.

The -V and -h option of all tools now show the JSON parser version. This is because it is helpful to know what parser version is linked in, especially for any bug reports. This should not normally be a problem as the copies in this repo are linked in but in case there is a problem it is now done (for some the parser is actually used so it's even more important).

Sync jparse/ from the jparse repo (https://github.com/xexyl/jparse/). The changes consist of the FOO_BASENAME changes described above for the tools in this repo. This needs to be done for the dbg repo and the dyn_array repo.

The Makefiles were updated where necessary.