### PR TITLE
Add use of is_available.sh in prep.sh

### DIFF
--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -19,6 +19,7 @@
 # setup
 #
 export FAILURE_SUMMARY=
+export SKIPPED_SUMMARY=
 export LOGFILE=
 export PREP_VERSION="1.0.2 2024-07-03"
 export NOTICE_COUNT="0"
@@ -223,6 +224,93 @@ make_action() {
 	write_echo_n "make_action $CODE $RULE "
     fi
 
+    # if certain rules check for necessary tools and if they do not exist or
+    # they fail, skip the rule.
+    if [[ "$RULE" = shellcheck ]]; then
+	if ! ./soup/is_available.sh shellcheck; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $EXIT_CODE: the shellcheck tool cannot be found or is unreliable on your system.
+	We cannot use the shellcheck tool.
+	Please consider installing or updating shellcheck tool from:
+
+        https://github.com/koalaman/shellcheck.net
+
+	or if needed, filing a bug report with those who publish shellcheck.
+
+	Please do NOT file a bug report with us as the IOCCC does not maintain shellcheck."
+
+	    return
+	fi
+    elif [[ "$RULE" = picky ]]; then
+	if ! ./soup/is_available.sh picky; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $EXIT_CODE: the picky tool cannot be found or is unreliable on your system.
+	We cannot use the picky tool.
+	Please consider installing or updating picky tool from:
+
+        https://github.com/lcn2/picky.git
+
+	Please do NOT file a bug report with us as the IOCCC does not maintain picky."
+
+	    return
+	fi
+    elif [[ "$RULE" = depend ]]; then
+	if ! ./soup/is_available.sh independ; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $EXIT_CODE: the independ tool cannot be found or is unreliable on your system.
+	We cannot use the independ tool.
+	Please consider installing or updating independ tool from:
+
+        https://github.com/lcn2/independ.git
+
+	Please do NOT file a bug report with us as the IOCCC does not maintain independ."
+
+
+	    return
+	fi
+    elif [[ "$RULE" = seqcexit ]]; then
+	if ! ./soup/is_available.sh seqcexit; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $EXIT_CODE: the seqcexit tool cannot be found or is unreliable on your system.
+	We cannot use the seqcexit tool.
+	Please consider installing or updating seqcexit tool from:
+
+        https://github.com/lcn2/seqcexit.git
+
+	Please do NOT file a bug report with us as the IOCCC does not maintain seqcexit."
+
+
+	    return
+	fi
+    fi
     # perform action
     #
     exec_command "$MAKE" -f "$MAKEFILE" "$RULE"
@@ -272,6 +360,7 @@ make_action() {
 	    write_echo "OK"
 	fi
     fi
+
     return 0;
 }
 
@@ -440,6 +529,10 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 		write_echo "bug_report.sh issued $NOTICE_COUNT notices."
 	    fi
 	fi
+	if [[ -n "$SKIPPED_SUMMARY" ]]; then
+	    write_echo "One or more tests were skipped:"
+	    write_echo "$SKIPPED_SUMMARY"
+	fi
     else
 	if [[ $NOTICE_COUNT -gt 0 ]]; then
 	    if [[ $NOTICE_COUNT -eq 1 ]]; then
@@ -447,7 +540,12 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 	    else
 		write_echo "All tests PASSED; $NOTICE_COUNT notices issued."
 	    fi
-	else
+	fi
+	if [[ -n "$SKIPPED_SUMMARY" ]]; then
+	    write_echo "One or more tests were skipped:"
+	    write_echo "$SKIPPED_SUMMARY"
+	fi
+	if [[ $NOTICE_COUNT -eq 0 && -z "$SKIPPED_SUMMARY" ]]; then
 	    write_echo "All tests PASSED."
 	fi
     fi


### PR DESCRIPTION
For certain rules the is_available.sh script is used and if it fails the test is skipped. The tool is not used in the Makefiles (yet?) but it could be. In the case of prep.sh it's mostly for maintainers but since they are not vital tools they can allow others to proceed without having a problem (we can fix it instead).