### PR TITLE
Improve is_available.sh - check for checknr(1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.5.22 2024-10-01
+
+Improve `soup/is_available.sh` to now verify that `checknr(1)` is reliable and
+if it is unreliable or cannot be found, the step is skipped in `prep.sh`. The
+original version of `checknr(1)` always returned 0 even with an error so this
+check in `is_available.sh` expects a non-zero value, not 0, in order to verify
+it works okay, as in order to make sure that it works right we construct a
+temporary erroneous man page.
+
+The `prep.sh` here now skips `check_man` rule if `checknr` cannot be found or is
+unreliable.
+
+The Makefiles (except for `dbg` and `dyn_array` as these repos do not yet have
+the script or the changes) have been updated to better explain the problem if
+`is_available.sh` reports non-zero.
+
+Sync `jparse` from [jparse repo](https://github.com/xexyl/jparse/) with the
+above changes (`jparse` is where it originated).
+
+
 ## Release 1.5.21 2024-09-30
 
 Bug fix `prep.sh` wrt skipped messages, and indent URL of each tool.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,19 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.0.18 2024-10-01
+
+Improve `test_jparse/is_available.sh`: it now will do a trivial test on
+`checknr`. This check is unlike the others in that if the tool returns 0 then it
+is an error. This is because it checks that an erroneous man page is declared
+invalid. The original version always returned 0 which meant that it was not as
+easy to determine if it was in error (in the test suites - one had to run it
+manually and look at the output). Thus to verify that it's reliable we check for
+a non-zero status on a man page with an error in it.
+
+The `prep.sh` script now skips the `check_man` rule if `checknr` cannot be found
+or is unreliable.
+
+
 ## Release 1.0.17 2024-09-30
 
 Make use of `test_jparse/is_available.sh` in the Makefiles and in

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -960,7 +960,7 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! ${IS_AVAILABLE} ${CHECKNR} >/dev/null 2>&1; then \
-	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
+	    echo 'The ${CHECKNR} command could not be found or is unreliable in your system.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for ${CHECKNR}:'; 1>&2; \

--- a/jparse/jstr_util.c
+++ b/jparse/jstr_util.c
@@ -56,7 +56,7 @@ alloc_jstr(char *string, size_t bufsiz)
     errno = 0;			    /* pre-clear errno for warnp() */
     jstr = calloc(1, sizeof *jstr);
     if (jstr == NULL) {
-	warn(__func__, "calloc() returned NULL for jstring struct");
+	warnp(__func__, "calloc() returned NULL for jstring struct");
 
 	if (string != NULL) {
 	    free(string);

--- a/jparse/test_jparse/prep.sh
+++ b/jparse/test_jparse/prep.sh
@@ -309,6 +309,27 @@ make_action() {
 
 	    return
 	fi
+    elif [[ "$RULE" = check_man ]]; then
+	if ! ./test_jparse/is_available.sh checknr; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $CODE $RULE: the checknr tool cannot be found or is unreliable on your system.
+	We cannot use the checknr tool.
+	Please consider installing or updating checknr tool from:
+
+	    https://github.com/lcn2/checknr.git
+
+	Please do NOT file a bug report with us as we do not maintain picky."
+
+	    return
+	fi
+
     fi
 
     # perform action

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -21,11 +21,16 @@
 #    define  INCLUDE_JPARSE_VERSION_H
 
 /*
+ * NOTE: only the repo release version, the jparse tool and the JSON parser
+ * versions are here. For the version of the other tools, see their source file.
+ */
+
+/*
  * official jparse repo release
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "1.0.16 2024-09-30"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.0.18 2024-10-01"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -717,14 +717,13 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! ${IS_AVAILABLE} ${CHECKNR} >/dev/null 2>&1; then \
-	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
+	    echo 'The ${CHECKNR} command could not be found or is unreliable in your system.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for ${CHECKNR}:'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/checknr' 1>&2; \
 	    echo ''; 1>&2; \
-	    echo 'Or use the package manager in your OS to install it.' 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
@@ -965,7 +964,7 @@ chk_validate.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
     ../jparse/version.h chk_sem_auth.h chk_sem_info.h chk_validate.c \
-    chk_validate.h entry_time.h entry_util.h location.h
+    chk_validate.h entry_time.h entry_util.h location.h version.h
 entry_time.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \

--- a/soup/is_available.sh
+++ b/soup/is_available.sh
@@ -16,7 +16,7 @@
 #
 # Share and enjoy! :-)
 
-export VERSION="1.1 2024-09-15"
+export VERSION="1.1.1 2024-10-01"
 NAME=$(basename "$0")
 export NAME
 export PRINT_WHERE=""
@@ -32,7 +32,7 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-w] tool
 
     tool	    tool to check if it is an executable file
 
-    NOTE: If tool is one of: shellcheck picky independ seqcexit
+    NOTE: If tool is one of: shellcheck picky independ seqcexit checknr
 	  then a sanity check using known good data and args will also be performed
 
 Exit codes:
@@ -407,6 +407,54 @@ EOF
 	echo "$0: debug[3]: tool passed the trivial test: $TOOL" 1>&2
     fi
     ;;
+
+checknr)
+
+    # form a trivial man page with an error
+    #
+    export TMP_MAN_PAGE=".tmp.$NAME.MAN_PAGE.$$.1"
+    trap 'rm -f $TMP_MAN_PAGE; exit' 0 1 2 3 15
+    rm -f "$TMP_MAN_PAGE"
+    if [[ -e $TMP_MAN_PAGE ]]; then
+	echo "$0: ERROR: cannot remove temporary erroneous man page: $TMP_MAN_PAGE" 1>&2
+	exit 21
+    fi
+    cat > "$TMP_MAN_PAGE" << EOF
+
+.TH foo 1 "11 July 2024" "foo" "foo"
+.SH NAME
+.B foo
+\- foo bar baz
+.SH SYNOPSIS
+\\fB
+EOF
+    if [[ ! -e $TMP_MAN_PAGE ]]; then
+	echo "$0: ERROR: cannot create temporary erroneous man page: $TMP_MAN_PAGE" 1>&2
+	exit 22
+    fi
+
+    # try checknr on the trivial (erroneous) man page
+    #
+    if [[ "$V_FLAG" -ge 3 ]]; then
+	echo "$0: debug[3]: about to run: $TOOL -- $TMP_MAN_PAGE" 1>&2
+    fi
+    TOOL_OUTPUT=$("$TOOL" -c.BR.SS.BI.IR.RB.RI -- "$TMP_MAN_PAGE" 2>&1)
+    status="$?"
+    export TOOL_OUTPUT
+    if [[ $status -eq 0 ]]; then
+	if [[ "$V_FLAG" -ge 1 ]]; then
+	    echo "$0: debug[1]: tool failed the trivial test: $TOOL" 1>&2
+	fi
+	if [[ "$V_FLAG" -ge 3 ]]; then
+	    echo "$0: debug[3]: $TOOL -c.BR.SS.BI.IR.RB.RI -- $TMP_MAN_PAGE failed," \
+		 "exit code expected to be non-zero, is: $status" 1>&2
+	fi
+	exit 1
+    elif [[ "$V_FLAG" -ge 3 ]]; then
+	echo "$0: debug[3]: tool passed the trivial test: $TOOL exited $status" 1>&2
+    fi
+    ;;
+
 
 # case: not a special tool, testing as an executable file is good enough (we hope)
 #

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -530,14 +530,12 @@ check_man: ${ALL_MAN_TARGETS}
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} if ! ${IS_AVAILABLE} ${CHECKNR} >/dev/null 2>&1; then \
-	    echo 'The ${CHECKNR} command could not be found.' 1>&2; \
+	    echo 'The ${CHECKNR} command could not be found or is unreliable in your system.' 1>&2; \
 	    echo 'The ${CHECKNR} command is required to run the $@ rule.' 1>&2; \
 	    echo ''; 1>&2; \
 	    echo 'See the following GitHub repo for ${CHECKNR}:'; 1>&2; \
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/checknr' 1>&2; \
-	    echo ''; 1>&2; \
-	    echo 'Or use the package manager in your OS to install it.' 1>&2; \
 	else \
 	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
 	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -310,6 +310,27 @@ make_action() {
 
 	    return
 	fi
+    elif [[ "$RULE" = check_man ]]; then
+	if ! ./soup/is_available.sh checknr; then
+	    if [[ -z "$LOGFILE" ]]; then
+		write_echo
+		write_echo "=-=-= SKIPPED: $MAKE $RULE =-=-="
+		write_echo
+	    else
+		write_echo "SKIPPED"
+	    fi
+	SKIPPED_SUMMARY="$SKIPPED_SUMMARY
+	make_action $CODE $RULE: the checknr tool cannot be found or is unreliable on your system.
+	We cannot use the checknr tool.
+	Please consider installing or updating checknr tool from:
+
+	    https://github.com/lcn2/checknr.git
+
+	Please do NOT file a bug report with us as we do not maintain picky."
+
+	    return
+	fi
+
     fi
     # perform action
     #


### PR DESCRIPTION
Improve soup/is_available.sh to now verify that checknr(1) is reliable and if it is unreliable or cannot be found, the step is skipped in prep.sh. The original version of checknr(1) always returned 0 even with an error so this check in is_available.sh expects a non-zero value, not 0, in order to verify it works okay, as in order to make sure that it works right we construct a temporary erroneous man page.

The prep.sh here now skips check_man rule if checknr cannot be found or is unreliable.

The Makefiles (except for dbg and dyn_array as these repos do not yet have the script or the changes) have been updated to better explain the problem if is_available.sh reports non-zero.

Sync jparse from the jparse repo (https://github.com/xexyl/jparse/) with the above changes (jparse is where it originated).