### PR TITLE
Update README.md files - #955

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -37,7 +37,7 @@ If you have not already done so, you may download the source by using `git
 clone`:
 
 
-``` <!---sh-->
+```sh
 git clone https://github.com/ioccc-src/mkiocccentry.git
 ```
 
@@ -54,13 +54,13 @@ and then extract that file.
 After downloading the repo (making sure that if you downloaded the zip file that
 you unzip it first) move into the `mkiocccentry` directory:
 
-``` <!---sh-->
+```sh
 cd mkiocccentry
 ```
 
 and compile everything from scratch:
 
-``` <!---sh-->
+```sh
 make clobber all
 ```
 
@@ -122,7 +122,7 @@ might need to put `./` before the name of a command.
 
 For example:
 
-``` <!---sh-->
+```sh
 ./mkiocccentry -h
 ```
 
@@ -157,7 +157,7 @@ options and arguments by use of the `-h` option of any tool:
 
 For instance:
 
-``` <!---sh-->
+```sh
 ./mkiocccentry -h
 ./iocccsize -h
 ./chkentry -h
@@ -173,7 +173,7 @@ directory at the top of the source directory.
 
 For example:
 
-``` <!---sh-->
+```sh
 man man/man1/mkiocccentry.1
 man man/man1/iocccsize.1
 man man/man1/chkentry.1
@@ -203,7 +203,7 @@ mkiocccentry directory** (in other words, if you have [installed](#install) the
 toolkit you **MUST** still run this from the toolkit directory):
 
 
-``` <!---sh-->
+```sh
 make bug_report
 ```
 
@@ -211,7 +211,7 @@ and then attach the bug report log (see below about the filename).
 
 You may also run the `bug_report.sh` tool directly:
 
-``` <!---sh-->
+```sh
 ./bug_report.sh -v 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,242 +1,44 @@
 # Official IOCCC submission toolkit
 
+## mkiocccentry - make an IOCCC submission
 
-### Running the test suite
+The `mkiocccentry` toolkit is required to form a submission to enter the [IOCCC
+&lpar;International Obfuscated C Code Contest&rpar;](https://www.ioccc.org). If
+you do not know what that is then you are in the wrong place; otherwise read
+below.
 
-Perhaps the most important thing you can do for us is run the `bug_report.sh`
-script with all information like:
+## Requirements to use the mkiocccentry toolkit to submit to the IOCCC
 
-``` <!---sh-->
-make bug_report
-```
+First, a set of requirements for using the toolkit:
 
-This tool will run an exhaustive list of checks on your system, including the
-entire test suite, writing it to both stdout and a log file. If there are any
-issues found we encourage you (and thank you!) to post the entire log at the
-[GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues). Of
-course if it does not find any issues it does not necessarily mean there are no
-issues so you're certainly welcome to report other issues and are encouraged to
-do so.
+* Unix-like environment (see IOCCC [Rule
+20](https://ioccc-src.github.io/temp-test-ioccc/next/rules.html#rule20)).
+* GNU Make version 3.81 or later (see IOCCC
+FAQ on "[make
+compatibility](https://ioccc-src.github.io/temp-test-ioccc/faq.html#make_compatibility)".
+* A C compiler that understands "-std=gnu17"
+* `bash` version 5.1.8 or later
 
-If the script does not report any issues you may delete the file safely (it will
-tell you the log file name). Alternatively you can run:
+## Compiling and using the toolkit
 
-``` <!---sh-->
-./bug_report -x
-```
+For a quick step by step list of instructions on how to submit an entry,
+including obtaining this repo, compiling it and using it, please
+see the
+FAQ on "[submitting to the
+IOCCC](https://ioccc-src.github.io/temp-test-ioccc/faq.html#submit)".
 
-which will delete the log file for you if no issues are found.
-
-If it finds a problem please report it at the
-[GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues/new/choose),
-making sure to attach the bug report file it notes prior to exiting.
-
-The [FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) gives a
-bit more information on this.
+You might also wish to look at the
+guidelines about
+"[mkiocccentry](https://ioccc-src.github.io/temp-test-ioccc/next/guidelines.html#mkiocccentry)".
 
 
-### Static analysis and dynamic analysis
-
-If you wish to run static analysis you may wish to see the file
-[test_ioccc/static_analysis.md](test_ioccc/static_analysis.md). For help on
-running with valgrind you may see the document
-[test_ioccc/dynamic_analysis.md](test_ioccc/dynamic_analysis.md).
-
-
-### Reviewing the tools
-
-For a list of tools that you may wish to look at in more detail, see the below
-list.
-
-If at any stage you feel like you have an improvement you may open a new issue
-at the [GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues) or
-you may alternatively offer a fix and open a pull request.
-
-Finally we thank you once again in helping to make the IOCCC toolkit even better
-in order to improve the IOCCC itself!
-
-
-## Getting help / reporting issues
+## Getting further help / reporting issues
 
 If you have a problem with anything in this repo, including with compiling
-and/or installing (which is not required), please see the
-[FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) for answers
-to a number of possible problems as well as to see how to report issues.
-
-
-## The mkiocccentry toolkit
-
-
-### `mkiocccentry`
-
-Form an **IOCCC** submission as an XZ compressed tarball file.
-
-For examples and more information, try:
-
-
-``` <!---sh-->
-man ./soup/man/man1/mkiocccentry.1
-```
-
-
-### `iocccsize`
-
-The official **IOCCC** submission Rule 2b size tool.
-
-This code is based on code by *@SirWumpus* (**Anthony Howe**):
-
-[See @SirWumpus's iocccsize repo](https://github.com/SirWumpus/iocccsize)
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./soup/man/man1/iocccsize.1
-```
-
-**NOTE**: After doing a `make all`, this tool may be found as: `./iocccsize`.
-
-
-### `txzchk`
-
-The official **IOCCC** tarball validation tool.
-
-It is invoked by `mkiocccentry`; `txzchk` in turn uses `fnamchk` to make sure
-that the tarball was correctly named and formed (i.e. the `mkiocccentry` tool
-was used).
-
-`txzchk` verifies that the tarball does not have any feathers stuck in it (i.e.
-the tarball conforms to the IOCCC tarball rules). Invoked by `mkiocccentry`;
-`txzchk` in turn uses `fnamchk` to make sure that the tarball was correctly named
-and formed. In other words `txzchk` makes sure that the `mkiocccentry` tool was
-used and there was no screwing around with the resultant tarball.
-
-`txzchk` was written in 2022 by *@xexyl* (**Cody Boone Ferguson**). See
-[https://xexyl.net](https://xexyl.net) and
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net).
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./soup/man/man1/txzchk.1
-```
-
-**NOTE**: After doing a `make all`, this tool may be found as: `./txzchk`.
-
-
-### `chkentry`
-
-The official **IOCCC** `.info.json` and `.auth.json` sanity checker tool.
-Invoked by `mkiocccentry` on the `.info.json` file after it has been created and
-invoked on the `.auth.json` file after it has been created, it will attempt to
-validate the files. If there is any validation issue it is an error as there is
-a mismatch between what is expected and what is actually there; in this case
-`mkiocccentry` will fail.
-
-As a stand-alone tool it will report whether the files are validly formed.
-
-This tool was co-developed in 2022-2024 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-and:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./soup/man/man1/chkentry.1
-```
-
-**NOTE**: After doing a `make all`, this tool may be found as: `./chkentry`.
-
-
-###  `fnamchk`
-
-The official **IOCCC** XZ compressed tarball filename sanity checker tool.
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./test_ioccc/man/man1/fnamchk.1
-```
-
-**NOTE**: After doing a `make all`, this tool may be found as: `./test_ioccc/fnamchk`.
-
-This tool was written in 2022 by:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-with improvements for `txzchk(1)` and otherwise by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-
-### `bug_report.sh`
-
-Run a series of tests, collecting system information in the process, to help report bugs and issues.
-Without any arguments, this tool produces a bug report file of the form:
-
-```
-bug-report.YYYYMMDD.HHMMSS.txt
-```
-
-This bug report file is intended to be uploaded to a [mkiocccentry repo related
-bug
-report](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
-
-This tool was written in 2022 by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-with minor improvements by:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./soup/man/man1/bug_report.1
-```
-
-**NOTE**: this tool may be found as: `./bug_report.sh`.
-
-**NOTE**: this tool **MUST** be run from the mkiocccentry directory.
-
-
-### `location`
-
-The official **IOCCC** tool to look up ISO 3166 codes and location names to help
-aid users in finding country codes. With the `-s` option one can search by
-substring and with the `-a` option one can list all codes that match, though the `-a`
-option is less useful without `-n` and is only checked for with at least one arg
-specified.
-
-This tool was developed in 2023 by:
-
-*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
-
-with improvements (`-a` and `-s` options via new re-entrant functions) by:
-
-*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
-
-
-For more information and examples, try:
-
-``` <!---sh-->
-man ./soup/man/man1/location.1
-```
-
-**NOTE**: After doing a `make all`, this tool may be found as: `./soup/location`.
-
-
-## How do I submit my submission to the IOCCC?
-
-To submit your submission to the IOCCC, follow the
-[FAQ 1.0 - How do I submit my submission to the IOCCC](https://www.ioccc.org/faq.html#submit)
-instructions.
+and/or installing (which is not required), or other kinds of questions, please
+see the [FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) for
+answers to a number of possible problems as well as to see how to report issues.
+
+If your problem is a problem compiling the tools or you have encountered what
+you think is a bug, please see the
+FAQ on "[reporting bugs](FAQ.md#bugs)".

--- a/jparse/jparse.lex.ref.h
+++ b/jparse/jparse.lex.ref.h
@@ -21,8 +21,8 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code was originally in support of the
- * International Obfuscated C Code Contest (IOCCC) and that objecting to the
+ * Now some might be tempted to point out this code was originally in support of
+ * the International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of
  * the fundamental undertones of the IOCCC is the promotion of good programming
@@ -43,9 +43,9 @@
  * objectionable way. :-)
  *
  * P.S. In 2022 April 04, when this comment was initially formed, none of the
- *	people working on this repo were Canadian. But some of them have
- *	several	good friends who live in, or are from Canada. Those friends
- *	say sorry in a fun and friendly way, so we honour those friends
+ *	people working on this parser/scanner were Canadian. But some of them
+ *	have several good friends who live in, or are from Canada. Those
+ *	friends say sorry in a fun and friendly way, so we honour those friends
  *	accordingly.
  */
 #line 1 "./jparse.lex.h"

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -21,8 +21,8 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code was originally in support of the
- * International Obfuscated C Code Contest (IOCCC) and that objecting to the
+ * Now some might be tempted to point out this code was originally in support of
+ * the International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of
  * the fundamental undertones of the IOCCC is the promotion of good programming
@@ -43,9 +43,9 @@
  * objectionable way. :-)
  *
  * P.S. In 2022 April 04, when this comment was initially formed, none of the
- *	people working on this repo were Canadian. But some of them have
- *	several	good friends who live in, or are from Canada. Those friends
- *	say sorry in a fun and friendly way, so we honour those friends
+ *	people working on this parser/scanner were Canadian. But some of them
+ *	have several good friends who live in, or are from Canada. Those
+ *	friends say sorry in a fun and friendly way, so we honour those friends
  *	accordingly.
  */
 #line 1 "./jparse.c"

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -21,8 +21,8 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code was originally in support of the
- * International Obfuscated C Code Contest (IOCCC) and that objecting to the
+ * Now some might be tempted to point out this code was originally in support of
+ * the International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of
  * the fundamental undertones of the IOCCC is the promotion of good programming
@@ -43,9 +43,9 @@
  * objectionable way. :-)
  *
  * P.S. In 2022 April 04, when this comment was initially formed, none of the
- *	people working on this repo were Canadian. But some of them have
- *	several	good friends who live in, or are from Canada. Those friends
- *	say sorry in a fun and friendly way, so we honour those friends
+ *	people working on this parser/scanner were Canadian. But some of them
+ *	have several good friends who live in, or are from Canada. Those
+ *	friends say sorry in a fun and friendly way, so we honour those friends
  *	accordingly.
  */
 #line 1 "./jparse.tab.c"

--- a/jparse/jparse.tab.ref.h
+++ b/jparse/jparse.tab.ref.h
@@ -21,8 +21,8 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code was originally in support of the
- * International Obfuscated C Code Contest (IOCCC) and that objecting to the
+ * Now some might be tempted to point out this code was originally in support of
+ * the International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of
  * the fundamental undertones of the IOCCC is the promotion of good programming
@@ -43,9 +43,9 @@
  * objectionable way. :-)
  *
  * P.S. In 2022 April 04, when this comment was initially formed, none of the
- *	people working on this repo were Canadian. But some of them have
- *	several	good friends who live in, or are from Canada. Those friends
- *	say sorry in a fun and friendly way, so we honour those friends
+ *	people working on this parser/scanner were Canadian. But some of them
+ *	have several good friends who live in, or are from Canada. Those
+ *	friends say sorry in a fun and friendly way, so we honour those friends
  *	accordingly.
  */
 #line 1 "./jparse.tab.h"

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -190,7 +190,7 @@ free_json_decoded_strings(void)
  * NOTE: this function adds the allocated struct jstring * to the list of
  * decoded JSON strings.
  */
-static struct jstring*
+static struct jstring *
 jstrdecode_stream(FILE *in_stream)
 {
     char *input = NULL;		/* argument to process */

--- a/jparse/sorry.tm.ca.h
+++ b/jparse/sorry.tm.ca.h
@@ -21,8 +21,8 @@
  * files. See the Makefile for details on how this file was generated. See also
  * run_bison.sh and run_flex.sh.
  *
- * Now some might be tempted to point out this code was originally in support of the
- * International Obfuscated C Code Contest (IOCCC) and that objecting to the
+ * Now some might be tempted to point out this code was originally in support of
+ * the International Obfuscated C Code Contest (IOCCC) and that objecting to the
  * output of Bison and Flex borders on programming sanctimoniousness. At first
  * glance, this incongruence is unsustainable. In response we opine that one of
  * the fundamental undertones of the IOCCC is the promotion of good programming
@@ -43,8 +43,8 @@
  * objectionable way. :-)
  *
  * P.S. In 2022 April 04, when this comment was initially formed, none of the
- *	people working on this repo were Canadian. But some of them have
- *	several	good friends who live in, or are from Canada. Those friends
- *	say sorry in a fun and friendly way, so we honour those friends
+ *	people working on this parser/scanner were Canadian. But some of them
+ *	have several good friends who live in, or are from Canada. Those
+ *	friends say sorry in a fun and friendly way, so we honour those friends
  *	accordingly.
  */

--- a/soup/README.md
+++ b/soup/README.md
@@ -1,0 +1,32 @@
+# Requirements for repo maintainers/developers
+
+**IMPORTANT NOTE:** if you are submitting to the IOCCC, you do **NOT** need to
+meet the requirements below!
+
+For those who need to develop and maintain this repo, **in addition to the
+list of requirements in
+[test_ioccc/README.md](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/README.md)**,
+you will need:
+
+* bison version 3.8.2 or later[^0]
+* flex version 2.6.4 or later[^0]
+* `independ`, version 1.00 2022-12-27 or later (see [independ
+repo](https://github.com/lcn2/independ)).
+* `shellcheck` version 0.10.0 or later (see [shellcheck GitHub
+repo](https://github.com/koalaman/shellcheck.net)).
+* `seqcexit(1)` version 1.12 2022-11-09 or later (see [seqcexit
+repo](https://github.com/lcn2/seqcexit)).
+* `picky` version 2.6 or later (see [picky
+repo](https://github.com/lcn2/picky)).
+* a sense of humour :-)
+
+
+[^0]: With respect to `bison` and `flex`: strictly speaking, you do **NOT** need the
+required versions of flex/bison for the JSON parser `jparse`, or even `bison`
+and `flex` at all, as only the maintainers of the [jparse
+repo](https://github.com/xexyl/jparse/), and only when modifying certain files,
+need these tools. This is because this repo, which has a clone of the jparse
+repo, has backup files of the generated code, for those who do not have a recent
+enough version; and since only maintainers of the jparse repo will create the
+backup files (when necessary), one does not need to have the tools to maintain
+this repo.

--- a/test_ioccc/README.md
+++ b/test_ioccc/README.md
@@ -1,0 +1,271 @@
+# Official IOCCC submission toolkit
+
+Below are some details on the test suite of the repo. We do not give all details
+but we at least show you a few things. If you wish for an overview of the tools
+in this repo, click [here](#the-mkiocccentry-toolkit).
+
+## Running the test suite
+
+An exhaustive script is the `bug_report.sh` script. This is not strictly
+necessary to use unless you are reporting a bug but it runs an exhaustive list
+of checks on your system and it runs the entire test suite, writing to both
+stdout and a lot file.
+
+You are welcome to do this even if you do not have a problem. Should you find a
+problem we welcome you opening an issue, or if you have a fix, opening a pull
+request.
+
+To run the script:
+
+```sh
+make bug_report
+```
+
+If there are any issues found we encourage you (and thank you!) to post the
+entire log at the [GitHub issues
+page](https://github.com/ioccc-src/mkiocccentry/issues). Of course if it does
+not find any issues it does not necessarily mean there are no issues so you're
+certainly welcome to report other issues and are encouraged to do so.
+
+If the script does not report any issues you may delete the file safely (it will
+tell you the log file name). Alternatively you can run:
+
+``` <!---sh-->
+./bug_report -x
+```
+
+which will delete the log file for you if no issues are found.
+
+The [FAQ](https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md) gives a
+bit more information on this.
+
+
+## Static analysis and dynamic analysis
+
+If you wish to run static analysis you may wish to see the file
+[static_analysis.md](static_analysis.md). For help on
+running with valgrind you may see the document
+[dynamic_analysis.md](dynamic_analysis.md).
+
+Note that doing these are NOT important now, but if you wish to do so for some
+reason, you are welcome to do so.
+
+## Making pull requests
+
+If you do wish to make a pull request, please make sure that running:
+
+```sh
+make prep
+```
+
+works fine. You should **NOT** need to run `make release` as that force rebuilds
+the JSON parser, which is only necessary for those working on the [jparse
+repo](https://github.com/xexyl/jparse/) and only if one modifies specific files.
+
+
+## Reviewing the tools
+
+For a list of tools that you may wish to look at in more detail, see the below
+list.
+
+If at any stage you feel like you have an improvement you may open a new issue
+at the [GitHub issues page](https://github.com/ioccc-src/mkiocccentry/issues) or
+you may alternatively offer a fix and open a pull request.
+
+Finally we thank you once again in helping to make the IOCCC toolkit even better
+in order to improve the IOCCC itself!
+
+
+## The mkiocccentry toolkit
+
+
+### `mkiocccentry`
+
+Form an **IOCCC** submission as an XZ compressed tarball file.
+
+For examples and more information, try:
+
+
+``` <!---sh-->
+man ./soup/man/man1/mkiocccentry.1
+```
+
+
+### `iocccsize`
+
+The official **IOCCC** submission Rule 2b size tool.
+
+This code is based on code by *@SirWumpus* (**Anthony Howe**):
+
+[See @SirWumpus's iocccsize repo](https://github.com/SirWumpus/iocccsize)
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./soup/man/man1/iocccsize.1
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./iocccsize`.
+
+
+### `txzchk`
+
+The official **IOCCC** tarball validation tool.
+
+It is invoked by `mkiocccentry`; `txzchk` in turn uses `fnamchk` to make sure
+that the tarball was correctly named and formed (i.e. the `mkiocccentry` tool
+was used).
+
+`txzchk` verifies that the tarball does not have any feathers stuck in it (i.e.
+the tarball conforms to the IOCCC tarball rules). Invoked by `mkiocccentry`;
+`txzchk` in turn uses `fnamchk` to make sure that the tarball was correctly named
+and formed. In other words `txzchk` makes sure that the `mkiocccentry` tool was
+used and there was no screwing around with the resultant tarball.
+
+`txzchk` was written in 2022 by *@xexyl* (**Cody Boone Ferguson**). See
+[https://xexyl.net](https://xexyl.net) and
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net).
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./soup/man/man1/txzchk.1
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./txzchk`.
+
+
+### `chkentry`
+
+The official **IOCCC** `.info.json` and `.auth.json` sanity checker tool.
+Invoked by `mkiocccentry` on the `.info.json` file after it has been created and
+invoked on the `.auth.json` file after it has been created, it will attempt to
+validate the files. If there is any validation issue it is an error as there is
+a mismatch between what is expected and what is actually there; in this case
+`mkiocccentry` will fail.
+
+As a stand-alone tool it will report whether the files are validly formed.
+
+This tool was co-developed in 2022-2024 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./soup/man/man1/chkentry.1
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./chkentry`.
+
+
+###  `fnamchk`
+
+The official **IOCCC** XZ compressed tarball filename sanity checker tool.
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./test_ioccc/man/man1/fnamchk.1
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./test_ioccc/fnamchk`.
+
+This tool was written in 2022 by:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+with improvements for `txzchk(1)` and otherwise by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+
+### `bug_report.sh`
+
+Although we briefly mentioned this script earlier in this file, we provide
+additional details here.
+
+This script runs a series of tests, collecting system information in the
+process, to help report bugs and issues.  Without any arguments, this tool
+produces a bug report file of the form:
+
+```
+bug-report.YYYYMMDD.HHMMSS.txt
+```
+
+This bug report file is intended to be uploaded to a [mkiocccentry repo related
+bug
+report](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
+
+This tool was written in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+with minor improvements by:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./soup/man/man1/bug_report.1
+```
+
+**NOTE**: this tool may be found as: `./bug_report.sh`.
+
+**NOTE**: this tool **MUST** be run from the mkiocccentry directory.
+
+
+### `location`
+
+The official **IOCCC** tool to look up ISO 3166 codes and location names to help
+aid users in finding country codes. With the `-s` option one can search by
+substring and with the `-a` option one can list all codes that match, though the `-a`
+option is less useful without `-n` and is only checked for with at least one arg
+specified.
+
+This tool was developed in 2023 by:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+with improvements (`-a` and `-s` options via new re-entrant functions) by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+
+For more information and examples, try:
+
+``` <!---sh-->
+man ./soup/man/man1/location.1
+```
+
+**NOTE**: After doing a `make all`, this tool may be found as: `./soup/location`.
+
+
+### `jparse`: JSON parser
+
+The mkiocccentry toolkit creates and validates JSON files. The JSON parser
+`jparse`, which is cloned into this repo, was co-developed in 2022 by:
+
+*@xexyl* (**Cody Boone Ferguson**, [https://xexyl.net](https://xexyl.net),
+[https://ioccc.xexyl.net](https://ioccc.xexyl.net))
+
+and:
+
+*chongo* (**Landon Curt Noll**, [http://www.isthe.com/chongo/index.html](http://www.isthe.com/chongo/index.htm)) /\oo/\
+
+See the [jparse repo](https://github.com/xexyl/jparse/) for the original.
+
+**NOTE**: you do **NOT** need a copy of this repo installed in order to use this
+toolkit as we have a clone of it here. It is even possible that there are
+divergences as once this repo is in a code freeze state, unless a critical bug
+is fixed, any changes in the repo will not be synced to this repo.


### PR DESCRIPTION

The top level README.md has been greatly simplified by removing extra
details. It now only talks about using the repo to package a submission
to the IOCCC with some links to the FAQ.

The new soup/README.md file has information for those who wish to
develop for this repo: in particular requirements.

The new test_ioccc/README.md file has much of what used to be in the top
level README.md file. This includes a list of the tools in the repo, or
at least the main ones. It is possible this belongs in soup/README.md
instead.

The FAQ has been updated with some formatting fixes.
