### PR TITLE
Sync jparse one more time before freeze

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.5.25 2024-10-09
+
+Synced `jparse` from [jparse repo](https://github.com/xexyl/jparse/). This
+includes better (additional) testing of JSON encoding/decoding ('Beware of the
+<del>dragon</del> [fire
+drake](https://www.glyphweb.com/arda/f/firedrakes.html)!' :-) ), a new version
+string (UTF-8 version, which is now also displayed in the tools in this repo, as
+it also helps identify if there is a mismatch in versions in bug reporting or
+something else), amongst various other things.  Should one wish to further
+progress their dementia! :-) they can look at that repo's log or the
+jparse/CHANGES.md file.
+
+
 ## Release 1.5.24 2024-10-09
 
 Synced `jparse` from [jparse repo](https://github.com/xexyl/jparse/). This

--- a/chkentry.c
+++ b/chkentry.c
@@ -73,7 +73,8 @@ static const char * const usage_msg =
     "    >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -119,7 +120,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT,
-	    CHKENTRY_BASENAME, CHKENTRY_VERSION, JSON_PARSER_VERSION);
+	    CHKENTRY_BASENAME, CHKENTRY_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }
@@ -195,7 +196,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", CHKENTRY_BASENAME, CHKENTRY_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2);		/*ooo*/
 	    not_reached();
 	    break;

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,27 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.2.1 2024-10-10
+
+Add option `-F` to `test_jparse/jparse_test.sh` which means that files passed on
+the command line should be read as actual full JSON documents, rather than JSON
+blobs per line. In this case `stdin` is **NOT** read! The file `jparse.json` is
+now controlled this way.
+
+Added new function `jdecencchk()` to `json_parse.c` which `jstrencode` and
+`jstrdecode` use with the `-t` option. Beware of the dragon!
+
+Changed `JSON_PARSER_VERSION` to `JPARSE_LIBRARY_VERSION`.
+
+The `-V` and `-h` option of all tools (compiled tools, not scripts) now show the
+jparse UTF-8 version as well as the tool's version and the library version. The
+string format of the library version has been changed too (it now shows:
+`"jparse library version: %s"`).
+
+Improve the way `utf8len()` works. It now returns a `size_t` and the `size_t
+*bytes` was removed from it. Returns `-1` if an error occurs. This better fits
+the name and purpose of the function.
+
+
 ## Release 1.2.0 2024-10-09
 
 Remove `has_nul` in `struct json_string` as UTF-8 should, it is my

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -1306,4 +1306,4 @@ jstrencode.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h \
 util.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
     util.c util.h
 verge.o: ../dbg/dbg.h ../dyn_array/../dbg/dbg.h ../dyn_array/dyn_array.h \
-    util.h verge.c verge.h version.h
+    json_utf8.h util.h verge.c verge.h version.h

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -19,12 +19,12 @@
 
 /* Section 0: Declarations and option settings */
 /*
- * %option noyywrap prevents needing to link in the flex(1) library (flex(3)) which means those
- * without flex can compile the code. Even if everyone had flex(1), though, under
- * macOS you have to pass -ll to the compiler to link in the flex library
- * whereas in other systems you have to use -lfl which would cause a lot of
- * problems. Another way is to provide 'int yywrap() { return 1; }' but this is
- * unnecessary.
+ * %option noyywrap prevents needing to link in the flex(1) library (flex(3))
+ * which means those without flex can compile the code. Even if everyone had
+ * flex(1), though, under macOS you have to pass -ll to the compiler to link in
+ * the flex library whereas in other systems you have to use -lfl which would
+ * cause a lot of problems. Another way is to provide 'int yywrap() { return 1;
+ * }' but this is unnecessary.
  */
 %option noyywrap
 /*

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -785,12 +785,12 @@ static const flex_int32_t yy_rule_can_match_eol[16] =
  */
 /* Section 0: Declarations and option settings */
 /*
- * %option noyywrap prevents needing to link in the flex(1) library (flex(3)) which means those
- * without flex can compile the code. Even if everyone had flex(1), though, under
- * macOS you have to pass -ll to the compiler to link in the flex library
- * whereas in other systems you have to use -lfl which would cause a lot of
- * problems. Another way is to provide 'int yywrap() { return 1; }' but this is
- * unnecessary.
+ * %option noyywrap prevents needing to link in the flex(1) library (flex(3))
+ * which means those without flex can compile the code. Even if everyone had
+ * flex(1), though, under macOS you have to pass -ll to the compiler to link in
+ * the flex library whereas in other systems you have to use -lfl which would
+ * cause a lot of problems. Another way is to provide 'int yywrap() { return 1;
+ * }' but this is unnecessary.
  */
 /*
  * we also need a few other options set:

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -155,7 +155,7 @@ int jparse_debug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debu
 /*
  * JSON parser library version
  */
-const char *const json_parser_version = JSON_PARSER_VERSION;	/* library version format: major.minor YYYY-MM-DD */
+const char *const json_parser_version = JPARSE_LIBRARY_VERSION;	/* library version format: major.minor YYYY-MM-DD */
 const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
 
 

--- a/jparse/jparse.y
+++ b/jparse/jparse.y
@@ -102,7 +102,7 @@ int jparse_debug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debu
 /*
  * JSON parser library version
  */
-const char *const json_parser_version = JSON_PARSER_VERSION;	/* library version format: major.minor YYYY-MM-DD */
+const char *const json_parser_version = JPARSE_LIBRARY_VERSION;	/* library version format: major.minor YYYY-MM-DD */
 const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
 
 %}

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -59,14 +59,14 @@ static const char * const usage_msg =
     "    >=4\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
  * static functions
  */
 static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
-
 
 int
 main(int argc, char **argv)
@@ -115,7 +115,8 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", JPARSE_BASENAME, JPARSE_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -224,7 +225,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog,
-		  DBG_DEFAULT, json_verbosity_level, JPARSE_BASENAME, JPARSE_VERSION, JSON_PARSER_VERSION);
+		  DBG_DEFAULT, json_verbosity_level, JPARSE_BASENAME, JPARSE_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/jparse_main.h
+++ b/jparse/jparse_main.h
@@ -52,6 +52,4 @@
  */
 #define JPARSE_BASENAME "jparse"
 
-
-
 #endif /* INCLUDE_JPARSE_MAIN_H */

--- a/jparse/jsemtblgen.c
+++ b/jparse/jsemtblgen.c
@@ -104,8 +104,9 @@ static const char * const usage_msg =
     "    3\t\tcommand line error\n"
     "    >=10\tinternal error\n"
     "\n"
-    "jsemtblgen version: %s"
-    "JSON parser version: %s\n";
+    "jsemtblgen version: %s\n"
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -302,7 +303,8 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", JSEMTBLGEN_BASENAME, JSEMTBLGEN_VERSION);
-	    print("JSON parser version: %s", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -1525,7 +1527,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog,
-		  DBG_DEFAULT, json_verbosity_level, JSEMTBLGEN_VERSION, JSON_PARSER_VERSION);
+		  DBG_DEFAULT, json_verbosity_level, JSEMTBLGEN_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -398,7 +398,7 @@ jdecencchk(void)
 	not_reached();
     }
 
-    dbg(DBG_MED, "decoded string: %s (len: %ju)", mstr2, mlen2);
+    dbg(DBG_HIGH, "decoded string: %s (len: %ju)", mstr2, mlen2);
 
 
     /*
@@ -410,7 +410,7 @@ jdecencchk(void)
 	err(148, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
 	not_reached();
     }
-    dbg(DBG_MED, "encoded string: %s (len: %ju)", mstr, mlen);
+    dbg(DBG_HIGH, "encoded string: %s (len: %ju)", mstr, mlen);
 
 
     /*
@@ -420,7 +420,7 @@ jdecencchk(void)
 	err(149, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
 	not_reached();
     } else {
-	dbg(DBG_LOW, "%s: %s == %s: true", decstr, mstr, mstr2);
+	dbg(DBG_MED, "%s: %s == %s: true", decstr, mstr, mstr2);
     }
 
     /*
@@ -451,7 +451,7 @@ jdecencchk(void)
 	not_reached();
     }
 
-    dbg(DBG_MED, "decoded string: %s (len: %ju)", mstr2, mlen2);
+    dbg(DBG_HIGH, "decoded string: %s (len: %ju)", mstr2, mlen2);
 
 
     /*
@@ -463,7 +463,7 @@ jdecencchk(void)
 	err(148, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
 	not_reached();
     }
-    dbg(DBG_MED, "encoded string: %s (len: %ju)", mstr, mlen);
+    dbg(DBG_HIGH, "encoded string: %s (len: %ju)", mstr, mlen);
 
 
     /*
@@ -473,7 +473,7 @@ jdecencchk(void)
 	err(149, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
 	not_reached();
     } else {
-	dbg(DBG_LOW, "%s: %s == %s: true", decstr, mstr, mstr2);
+	dbg(DBG_MED, "%s: %s == %s: true", decstr, mstr, mstr2);
     }
 
     /*

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -366,6 +366,80 @@ json_encode_str(char const *str, size_t *retlen, bool skip_quote)
     return ret;
 }
 
+/*
+ * jdecencchk  - validate that JSON encoding and decoding works
+ *
+ * This function performs various sanity checks in JSON encoding and decoding.
+ *
+ * This function does not return on error.
+ */
+void
+jdecencchk(void)
+{
+    char const *decstr;	/* string to decode */
+    char *mstr = NULL;	/* allocated encoding string */
+    size_t mlen = 0;	/* length of allocated encoding string */
+    char *mstr2 = NULL;	/* allocated decoding string */
+    size_t mlen2 = 0;	/* length of allocated decoding string */
+
+    /*
+     *	:-)
+     */
+    decstr = "\\ud83d\\ude4f\\uD83D\\uDD25\\uD83D\\uDC09";
+    /*
+     * test decoding the JSON encoded string
+     */
+    dbg(DBG_VVVHIGH, "testing json_decode_str(<%s>, &mlen2)", decstr);
+    /* test json_decode_str() */
+    mstr2 = json_decode_str(decstr, &mlen2);
+    if (mstr2 == NULL) {
+	err(147, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
+			   decstr, (uintmax_t)mlen2);
+	not_reached();
+    }
+
+    dbg(DBG_MED, "decoded string: %s (len: %ju)", mstr2, mlen2);
+
+
+    /*
+     * encode the string we just decoded
+     */
+    dbg(DBG_VVVHIGH, "testing json_encode(mstr2, 1, mlen): %s", mstr2);
+    mstr = json_encode(mstr2, mlen2, &mlen, false);
+    if (mstr == NULL) {
+	err(148, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
+	not_reached();
+    }
+    dbg(DBG_MED, "encoded string: %s (len: %ju)", mstr, mlen);
+
+
+    /*
+     * verify that the encoded string matches the original string
+     */
+    if (strcmp(mstr2, mstr) != 0) {
+	err(149, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
+	not_reached();
+    } else {
+	dbg(DBG_LOW, "%s: %s == %s: true", decstr, mstr, mstr2);
+    }
+
+    /*
+     * free strings
+     */
+    if (mstr != NULL) {
+	free(mstr);
+	mstr = NULL;
+    }
+    if (mstr2 != NULL) {
+	free(mstr2);
+	mstr2 = NULL;
+    }
+
+    /*
+     * Don't Panic, unless you're the praying human! :-)
+     */
+    return;
+}
 
 /*
  * chkbyte2asciistr - validate the contents of the byte2asciistr[] table
@@ -393,7 +467,7 @@ chkbyte2asciistr(void)
      * assert: bits in byte must be 8
      */
     if (BITS_IN_BYTE != 8) {
-	err(100, __func__, "BITS_IN_BYTE: %d != 8", BITS_IN_BYTE);
+	err(150, __func__, "BITS_IN_BYTE: %d != 8", BITS_IN_BYTE);
 	not_reached();
     }
 
@@ -401,7 +475,7 @@ chkbyte2asciistr(void)
      * assert: JSON_BYTE_VALUES must be 256
      */
     if (JSON_BYTE_VALUES != 256) {
-	err(101, __func__, "JSON_BYTE_VALUES: %d != 256", JSON_BYTE_VALUES);
+	err(151, __func__, "JSON_BYTE_VALUES: %d != 256", JSON_BYTE_VALUES);
 	not_reached();
     }
 
@@ -409,7 +483,7 @@ chkbyte2asciistr(void)
      * assert: table must be of size 256
      */
     if (TBLLEN(byte2asciistr) != JSON_BYTE_VALUES) {
-	err(102, __func__, "byte2asciistr table length is %ju instead of %d",
+	err(152, __func__, "byte2asciistr table length is %ju instead of %d",
 			   (uintmax_t)TBLLEN(byte2asciistr), JSON_BYTE_VALUES);
 	not_reached();
     }
@@ -419,7 +493,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].byte != i) {
-	    err(103, __func__, "byte2asciistr[0x%02x].byte: %d != %d", i, byte2asciistr[i].byte, i);
+	    err(153, __func__, "byte2asciistr[0x%02x].byte: %d != %d", i, byte2asciistr[i].byte, i);
 	    not_reached();
 	}
     }
@@ -429,7 +503,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].enc == NULL) {
-	    err(104, __func__, "byte2asciistr[0x%02x].enc == NULL", i);
+	    err(154, __func__, "byte2asciistr[0x%02x].enc == NULL", i);
 	    not_reached();
 	}
     }
@@ -439,7 +513,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (strlen(byte2asciistr[i].enc) != byte2asciistr[i].len) {
-	    err(105, __func__, "byte2asciistr[0x%02x].enc length: %ju != byte2asciistr[0x%02x].len: %ju",
+	    err(155, __func__, "byte2asciistr[0x%02x].enc length: %ju != byte2asciistr[0x%02x].len: %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       i, (uintmax_t)byte2asciistr[i].len);
 	    not_reached();
@@ -451,18 +525,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x00; i <= 0x07; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(106, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(156, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(107, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(157, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(108, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(158, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -473,13 +547,13 @@ chkbyte2asciistr(void)
     indx = 0x08;
     encstr = "\\b";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(109, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(159, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(110, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(160, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -489,13 +563,13 @@ chkbyte2asciistr(void)
     indx = 0x09;
     encstr = "\\t";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(111, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(161, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(112, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(162, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -505,13 +579,13 @@ chkbyte2asciistr(void)
     indx = 0x0a;
     encstr = "\\n";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(113, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(163, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(114, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(164, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -521,13 +595,13 @@ chkbyte2asciistr(void)
     indx = 0x0b;
     encstr = "\\u000b";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(115, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(165, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(116, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(166, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -537,13 +611,13 @@ chkbyte2asciistr(void)
     indx = 0x0c;
     encstr = "\\f";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(117, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(167, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(118, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(168, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -553,13 +627,13 @@ chkbyte2asciistr(void)
     indx = 0x0d;
     encstr = "\\r";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(119, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(169, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(120, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(170, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -568,18 +642,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x0e; i <= 0x1f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(121, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(171, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(122, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(172, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(123, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(173, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -589,12 +663,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x20; i <= 0x21; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(124, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(174, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(125, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(175, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -605,13 +679,13 @@ chkbyte2asciistr(void)
     indx = 0x22;
     encstr = "\\\"";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(126, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(176, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(128, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(177, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -620,12 +694,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x23; i <= 0x5b; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(129, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(178, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(130, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(179, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -636,13 +710,13 @@ chkbyte2asciistr(void)
     indx = 0x5c;
     encstr = "\\\\";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(131, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(180, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(132, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(181, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -651,12 +725,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x5d; i <= 0x7e; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(133, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(182, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(134, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(183, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -666,18 +740,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x7f; i <= 0x7f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(135, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(184, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(136, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(185, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(137, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(186, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -687,17 +761,17 @@ chkbyte2asciistr(void)
      */
     for (i=0x80; i <= 0xff; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(138, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(187, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[0]) != i) {
-	    err(139, __func__, "byte2asciistr[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
+	    err(188, __func__, "byte2asciistr[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
 			       i, (uint8_t)(byte2asciistr[i].enc[0]) & 0xff, (uintmax_t)i);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[1]) != 0) {
-	    err(140, __func__, "byte2asciistr[0x%02x].enc[1]: 0x%02x is not 0",
+	    err(189, __func__, "byte2asciistr[0x%02x].enc[1]: 0x%02x is not 0",
 			       i, (uint8_t)(byte2asciistr[i].enc[1]) & 0xff);
 	    not_reached();
 	}
@@ -710,16 +784,16 @@ chkbyte2asciistr(void)
     memset(str, 0, sizeof(str));    /* clear all bytes in str, including the final '\0' */
     mstr = json_encode(str, 1,  &mlen, false);
     if (mstr == NULL) {
-	err(141, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
+	err(190, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
 	not_reached();
     }
     if (mlen != byte2asciistr[0].len) {
-	err(142, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
+	err(191, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
 			   (uintmax_t)mlen, (uintmax_t)(byte2asciistr[0].len));
 	not_reached();
     }
     if (strcmp(byte2asciistr[0].enc, mstr) != 0) {
-	err(143, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
+	err(192, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
 			   (uintmax_t)mlen, byte2asciistr[0].enc);
 	not_reached();
     }
@@ -744,17 +818,17 @@ chkbyte2asciistr(void)
 	mstr = json_encode_str(str, &mlen, false);
 	/* check encoding result */
 	if (mstr == NULL) {
-	    err(144, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
+	    err(193, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
 			       i, (uintmax_t)mlen);
 	    not_reached();
 	}
 	if (mlen != byte2asciistr[i].len) {
-	    err(145, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
+	    err(194, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
 			       i, (uintmax_t)mlen, (uintmax_t)byte2asciistr[i].len);
 	    not_reached();
 	}
 	if (strcmp(byte2asciistr[i].enc, mstr) != 0) {
-	    err(146, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
+	    err(195, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
 			       (uintmax_t)mlen, byte2asciistr[i].enc);
 	    not_reached();
 	}
@@ -763,21 +837,21 @@ chkbyte2asciistr(void)
 	/*
 	 * test decoding the JSON encoded string
 	 */
-	dbg(DBG_VVVHIGH, "testing json_decode_str(<%s>, *mlen, true)", mstr);
+	dbg(DBG_VVVHIGH, "testing json_decode_str(<%s>, *mlen)", mstr);
 	/* test json_decode_str() */
 	mstr2 = json_decode_str(mstr, &mlen2);
 	if (mstr2 == NULL) {
-	    err(147, __func__, "json_decode_str(<%s>, *mlen2: %ju, true) == NULL",
+	    err(196, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
 			       mstr, (uintmax_t)mlen2);
 	    not_reached();
 	}
 	if (mlen2 != byte2asciistr[i].decoded_len) {
-	    err(148, __func__, "json_decode_str(<%s>, *mlen2 %ju != %ju, true)",
+	    err(197, __func__, "json_decode_str(<%s>, *mlen2 %ju != %ju)",
 			       mstr, (uintmax_t)mlen2, byte2asciistr[i].decoded_len);
 	    not_reached();
 	}
 	if ((uint8_t)(mstr2[0]) != i) {
-	    err(149, __func__, "json_decode_str(<%s>, *mlen2: %ju, true): 0x%02x != 0x%02x",
+	    err(198, __func__, "json_decode_str(<%s>, *mlen2: %ju): 0x%02x != 0x%02x",
 			       mstr, (uintmax_t)mlen2, (uint8_t)(mstr2[0]) & 0xff, i);
 	    not_reached();
 	}
@@ -1267,8 +1341,8 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 		    return NULL;
 		} else if (scanned == 1 || (scanned == 2 && surrogates_to_unicode(xa, xb) < 0)) {
 		    surrogate = xa;
-		    bytes = 0; /* reset bytes */
-		    if (!utf8len(ptr + i, surrogate, &bytes)) {
+		    bytes = utf8len(ptr + i, surrogate);
+		    if (bytes <= 0) {
 			if (retlen != NULL) {
 			    *retlen = 0;
 			}
@@ -1297,8 +1371,8 @@ json_decode(char const *ptr, size_t len, size_t *retlen)
 		     * assuming no error from surrogates_to_unicode(), we will
 		     * try counting the bytes needed.
 		     */
-		    bytes = 0; /* reset bytes */
-		    if (!utf8len(NULL, surrogate, &bytes)) {
+		    bytes = utf8len(NULL, surrogate);
+		    if (bytes <= 0) {
 			if (retlen != NULL) {
 			    *retlen = 0;
 			}
@@ -1457,7 +1531,7 @@ parse_json_string(char const *string, size_t len)
      * firewall
      */
     if (string == NULL) {
-	err(150, __func__, "passed NULL string");
+	err(199, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1472,15 +1546,15 @@ parse_json_string(char const *string, size_t len)
     str = json_conv_string(string, len, true);
     /* paranoia - these tests should never result in an error */
     if (str == NULL) {
-        err(151, __func__, "converting JSON string returned NULL: <%s>", string);
+        err(200, __func__, "converting JSON string returned NULL: <%s>", string);
         not_reached();
     } else if (str->type != JTYPE_STRING) {
-        err(152, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
+        err(201, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
         not_reached();
     }
     item = &(str->item.string);
     if (!VALID_JSON_NODE(item)) {
-	err(153, __func__, "couldn't parse string: <%s>", string);
+	err(202, __func__, "couldn't parse string: <%s>", string);
 	not_reached();
     }
     return str;
@@ -1509,17 +1583,17 @@ parse_json_bool(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(154, __func__, "passed NULL string");
+	err(203, __func__, "passed NULL string");
 	not_reached();
     }
 
     boolean = json_conv_bool_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (boolean == NULL) {
-	err(155, __func__, "converting JSON bool returned NULL: <%s>", string);
+	err(204, __func__, "converting JSON bool returned NULL: <%s>", string);
 	not_reached();
     } else if (boolean->type != JTYPE_BOOL) {
-        err(156, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
+        err(205, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
         not_reached();
     }
     item = &(boolean->item.boolean);
@@ -1534,18 +1608,18 @@ parse_json_bool(char const *string)
 	 * If it's not we abort as there's a serious mismatch between the
 	 * scanner and the parser.
 	 */
-	err(157, __func__, "called on non-boolean string: <%s>", string);
+	err(206, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else if (item->as_str == NULL) {
 	/* extra sanity check - make sure the allocated string != NULL */
-	err(158, __func__, "boolean->as_str == NULL");
+	err(207, __func__, "boolean->as_str == NULL");
 	not_reached();
     } else if (strcmp(item->as_str, "true") && strcmp(item->as_str, "false")) {
 	/*
 	 * extra sanity check - make sure the allocated string is "true"
 	 * or "false"
 	 */
-	err(159, __func__, "boolean->as_str neither \"true\" nor \"false\"");
+	err(208, __func__, "boolean->as_str neither \"true\" nor \"false\"");
 	not_reached();
     } else {
 	/*
@@ -1554,16 +1628,16 @@ parse_json_bool(char const *string)
 	 */
 	char const *str = booltostr(item->value);
 	if (str == NULL) {
-	    err(160, __func__, "could not convert boolean->value back to a string");
+	    err(209, __func__, "could not convert boolean->value back to a string");
 	    not_reached();
 	} else if (strcmp(str, item->as_str)) {
-	    err(161, __func__, "boolean->as_str != item->value as a string");
+	    err(210, __func__, "boolean->as_str != item->value as a string");
 	    not_reached();
 	} else if (strtobool(item->as_str) != item->value) {
-	    err(162, __func__, "mismatch between boolean string and converted value");
+	    err(211, __func__, "mismatch between boolean string and converted value");
 	    not_reached();
 	} else if (strtobool(str) != item->value) {
-	    err(163, __func__, "mismatch between converted string value and converted value");
+	    err(212, __func__, "mismatch between converted string value and converted value");
 	    not_reached();
 	}
     }
@@ -1594,7 +1668,7 @@ parse_json_null(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(164, __func__, "passed NULL string");
+	err(213, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1604,16 +1678,16 @@ parse_json_null(char const *string)
     null = json_conv_null_str(string, NULL);
     if (null == NULL) {
 	/* ironically null is NULL and it actually should not be :-) */
-	err(165, __func__, "null is NULL");
+	err(214, __func__, "null is NULL");
 	not_reached();
     } else if (null->type != JTYPE_NULL) {
-        err(166, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
+        err(215, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
         not_reached();
     }
     item = &(null->item.null);
     if (!VALID_JSON_NODE(item)) {
 	/* why is it an error if we can't convert nothing ? :-) */
-	err(167,__func__, "couldn't convert null: <%s>", string);
+	err(216,__func__, "couldn't convert null: <%s>", string);
 	not_reached();
     }
 
@@ -1643,7 +1717,7 @@ parse_json_number(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(168, __func__, "passed NULL string");
+	err(217, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1653,15 +1727,15 @@ parse_json_number(char const *string)
     number = json_conv_number_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (number == NULL) {
-	err(169, __func__, "converting JSON number returned NULL: <%s>", string);
+	err(218, __func__, "converting JSON number returned NULL: <%s>", string);
         not_reached();
     } else if (number->type != JTYPE_NUMBER) {
-        err(170, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
+        err(219, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
         not_reached();
     }
     item = &(number->item.number);
     if (!VALID_JSON_NODE(item)) {
-	err(171, __func__, "couldn't convert number string: <%s>", string);
+	err(220, __func__, "couldn't convert number string: <%s>", string);
 	not_reached();
     }
     return number;
@@ -1694,11 +1768,11 @@ parse_json_array(struct json *elements)
      * firewall
      */
     if (elements == NULL) {
-	err(172, __func__, "passed NULL elements value");
+	err(221, __func__, "passed NULL elements value");
 	not_reached();
     }
     if (elements->type != JTYPE_ELEMENTS) {
-	err(173, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
+	err(222, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
 			   json_item_type_name(elements), elements->type);
 	not_reached();
     }
@@ -1712,7 +1786,7 @@ parse_json_array(struct json *elements)
     /* paranoia - these tests should never result in an error */
     item = &(elements->item.array);
     if (!VALID_JSON_NODE(item)) {
-	err(174, __func__, "couldn't convert array");
+	err(223, __func__, "couldn't convert array");
 	not_reached();
     }
     return elements;
@@ -1742,14 +1816,14 @@ parse_json_member(struct json *name, struct json *value)
      * firewall
      */
     if (name == NULL) {
-	err(175, __func__, "passed NULL name value");
+	err(224, __func__, "passed NULL name value");
 	not_reached();
     } else if (value == NULL) {
-	err(176, __func__, "passed NULL value");
+	err(225, __func__, "passed NULL value");
 	not_reached();
     }
     if (name->type != JTYPE_STRING) {
-	err(177, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
+	err(226, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
 	not_reached();
     }
 
@@ -1759,15 +1833,15 @@ parse_json_member(struct json *name, struct json *value)
     member = json_conv_member(name, value);
     /* paranoia - these tests should never result in an error */
     if (member == NULL) {
-	err(178, __func__, "converting JSON member returned NULL");
+	err(227, __func__, "converting JSON member returned NULL");
 	not_reached();
     } else if (member->type != JTYPE_MEMBER) {
-        err(179, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
+        err(228, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
         not_reached();
     }
     item = &(member->item.member);
     if (!VALID_JSON_NODE(item)) {
-	err(180, __func__, "couldn't convert member");
+	err(229, __func__, "couldn't convert member");
 	not_reached();
     }
     return member;
@@ -1816,7 +1890,7 @@ json_alloc(enum item_type type)
     errno = 0;			/* pre-clear errno for errp() */
     ret = calloc(1, sizeof(*ret));
     if (ret == NULL) {
-	errp(181, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
+	errp(230, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
 	not_reached();
     }
 
@@ -2644,7 +2718,7 @@ json_conv_number(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NUMBER);
     if (ret == NULL) {
-	errp(182, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
+	errp(231, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
 	not_reached();
     }
 
@@ -2714,7 +2788,7 @@ json_conv_number(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(183, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(232, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -2881,7 +2955,7 @@ json_conv_number_str(char const *str, size_t *retlen)
      */
     ret = json_conv_number(str, len);
     if (ret == NULL) {
-	err(184, __func__, "json_conv_number() returned NULL");
+	err(233, __func__, "json_conv_number() returned NULL");
 	not_reached();
     }
 
@@ -2934,7 +3008,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
      */
     ret = json_alloc(JTYPE_STRING);
     if (ret == NULL) {
-	errp(185, __func__, "json_alloc(JTYPE_STRING) returned NULL");
+	errp(234, __func__, "json_alloc(JTYPE_STRING) returned NULL");
 	not_reached();
     }
 
@@ -2997,7 +3071,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(186, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(235, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -3082,7 +3156,7 @@ json_conv_string_str(char const *str, size_t *retlen, bool quote)
      */
     ret = json_conv_string(str, len, quote);
     if (ret == NULL) {
-	err(187, __func__, "json_conv_string() returned NULL");
+	err(236, __func__, "json_conv_string() returned NULL");
 	not_reached();
     }
 
@@ -3129,7 +3203,7 @@ json_conv_bool(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_BOOL);
     if (ret == NULL) {
-	errp(188, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
+	errp(237, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
 	not_reached();
     }
 
@@ -3164,7 +3238,7 @@ json_conv_bool(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(189, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(238, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3238,7 +3312,7 @@ json_conv_bool_str(char const *str, size_t *retlen)
      */
     ret = json_conv_bool(str, len);
     if (ret == NULL) {
-	err(190, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
+	err(239, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
 	not_reached();
     }
 
@@ -3284,7 +3358,7 @@ json_conv_null(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NULL);
     if (ret == NULL) {
-	errp(191, __func__, "json_alloc(JTYPE_NULL) returned NULL");
+	errp(240, __func__, "json_alloc(JTYPE_NULL) returned NULL");
 	not_reached();
     }
 
@@ -3319,7 +3393,7 @@ json_conv_null(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(192, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(241, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3389,7 +3463,7 @@ json_conv_null_str(char const *str, size_t *retlen)
      */
     ret = json_conv_null(str, len);
     if (ret == NULL) {
-	err(193, __func__, "json_conv_null() returned NULL");
+	err(242, __func__, "json_conv_null() returned NULL");
 	not_reached();
     }
 
@@ -3449,7 +3523,7 @@ json_conv_member(struct json *name, struct json *value)
      */
     ret = json_alloc(JTYPE_MEMBER);
     if (ret == NULL) {
-	errp(194, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
+	errp(243, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
 	not_reached();
     }
 
@@ -3522,13 +3596,13 @@ json_conv_member(struct json *name, struct json *value)
     item->name_as_str = item2->as_str;
     /* paranoia */
     if (item->name_as_str == NULL) {
-	err(195, __func__, "item->name_as_str is NULL");
+	err(244, __func__, "item->name_as_str is NULL");
 	not_reached();
     }
     item->name_str = item2->str;
     /* paranoia */
     if (item->name_str == NULL) {
-	err(196, __func__, "item->name_str is NULL");
+	err(245, __func__, "item->name_str is NULL");
 	not_reached();
     }
     item->name_as_str_len = item2->as_str_len;
@@ -3570,7 +3644,7 @@ json_create_object(void)
      */
     ret = json_alloc(JTYPE_OBJECT);
     if (ret == NULL) {
-	errp(197, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
+	errp(246, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
 	not_reached();
     }
 
@@ -3589,7 +3663,7 @@ json_create_object(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(198, __func__, "dyn_array_create() returned NULL");
+	errp(247, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3643,20 +3717,20 @@ json_object_add_member(struct json *node, struct json *member)
      * firewall
      */
     if (node == NULL) {
-	err(199, __func__, "node is NULL");
+	err(248, __func__, "node is NULL");
 	not_reached();
     }
     if (member == NULL) {
-	err(200, __func__, "member is NULL");
+	err(249, __func__, "member is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_OBJECT) {
-	err(201, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
+	err(10, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
 		           JTYPE_OBJECT, node->type);
 	not_reached();
     }
     if (member->type != JTYPE_MEMBER) {
-	err(202, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
+	err(11, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
 		           JTYPE_MEMBER, node->type);
 	not_reached();
     }
@@ -3666,7 +3740,7 @@ json_object_add_member(struct json *node, struct json *member)
      */
     item = &(node->item.object);
     if (item->s == NULL) {
-	err(203, __func__, "item->s is NULL");
+	err(12, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -3723,7 +3797,7 @@ json_create_elements(void)
      */
     ret = json_alloc(JTYPE_ELEMENTS);
     if (ret == NULL) {
-	errp(204, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
+	errp(13, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
 	not_reached();
     }
 
@@ -3742,7 +3816,7 @@ json_create_elements(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(205, __func__, "dyn_array_create() returned NULL");
+	errp(14, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3794,15 +3868,15 @@ json_elements_add_value(struct json *node, struct json *value)
      * firewall
      */
     if (node == NULL) {
-	err(206, __func__, "node is NULL");
+	err(15, __func__, "node is NULL");
 	not_reached();
     }
     if (value == NULL) {
-	err(207, __func__, "value is NULL");
+	err(16, __func__, "value is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_ELEMENTS) {
-	err(208, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
+	err(17, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
 			   JTYPE_ELEMENTS, node->type);
 	not_reached();
     }
@@ -3818,11 +3892,11 @@ json_elements_add_value(struct json *node, struct json *value)
 	json_dbg(JSON_DBG_VHIGH, __func__, "JSON item type: %s", json_item_type_name(value));
 	break;
     case JTYPE_ELEMENTS:
-	err(209, __func__, "JSON type %s (type: %d) is invalid here",
+	err(18, __func__, "JSON type %s (type: %d) is invalid here",
 		json_item_type_name(node), JTYPE_ELEMENTS);
 	not_reached();
     default:
-	err(210, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
+	err(19, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
 			   value->type);
 	not_reached();
     }
@@ -3832,7 +3906,7 @@ json_elements_add_value(struct json *node, struct json *value)
      */
     item = &(node->item.elements);
     if (item->s == NULL) {
-	err(211, __func__, "item->s is NULL");
+	err(20, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -3888,7 +3962,7 @@ json_create_array(void)
      */
     ret = json_alloc(JTYPE_ARRAY);
     if (ret == NULL) {
-	errp(212, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
+	errp(21, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
 	not_reached();
     }
 
@@ -3907,7 +3981,7 @@ json_create_array(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(213, __func__, "dyn_array_create() returned NULL");
+	errp(22, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -436,7 +436,62 @@ jdecencchk(void)
     }
 
     /*
-     * Don't Panic, unless you're the praying human! :-)
+     *	:-)
+     */
+    decstr = "\\uD83D\\uDC8D\\uD83C\\uDF0B";
+    /*
+     * test decoding the JSON encoded string
+     */
+    dbg(DBG_VVVHIGH, "testing json_decode_str(<%s>, &mlen2)", decstr);
+    /* test json_decode_str() */
+    mstr2 = json_decode_str(decstr, &mlen2);
+    if (mstr2 == NULL) {
+	err(147, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
+			   decstr, (uintmax_t)mlen2);
+	not_reached();
+    }
+
+    dbg(DBG_MED, "decoded string: %s (len: %ju)", mstr2, mlen2);
+
+
+    /*
+     * encode the string we just decoded
+     */
+    dbg(DBG_VVVHIGH, "testing json_encode(mstr2, 1, mlen): %s", mstr2);
+    mstr = json_encode(mstr2, mlen2, &mlen, false);
+    if (mstr == NULL) {
+	err(148, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
+	not_reached();
+    }
+    dbg(DBG_MED, "encoded string: %s (len: %ju)", mstr, mlen);
+
+
+    /*
+     * verify that the encoded string matches the original string
+     */
+    if (strcmp(mstr2, mstr) != 0) {
+	err(149, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
+	not_reached();
+    } else {
+	dbg(DBG_LOW, "%s: %s == %s: true", decstr, mstr, mstr2);
+    }
+
+    /*
+     * free strings
+     */
+    if (mstr != NULL) {
+	free(mstr);
+	mstr = NULL;
+    }
+    if (mstr2 != NULL) {
+	free(mstr2);
+	mstr2 = NULL;
+    }
+
+
+    /*
+     * Don't Panic, unless you're the praying human or the One Ring (or, as
+     * close as possible with the existing emojis)! :-)
      */
     return;
 }

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -490,6 +490,7 @@ extern struct byte2asciistr byte2asciistr[];
 extern char *json_encode(char const *ptr, size_t len, size_t *retlen, bool skip_quote);
 extern char *json_encode_str(char const *str, size_t *retlen, bool skip_quote);
 extern void chkbyte2asciistr(void);
+extern void jdecencchk(void);
 extern char *json_decode(char const *ptr, size_t len, size_t *retlen);
 extern char *json_decode_str(char const *str, size_t *retlen);
 extern struct json *parse_json_string(char const *string, size_t len);

--- a/jparse/json_utf8.c
+++ b/jparse/json_utf8.c
@@ -39,8 +39,8 @@
  *
  * NOTE: *str should point to the \u!
  */
-bool
-utf8len(const char *str, int32_t surrogate, size_t *bytes)
+size_t
+utf8len(const char *str, int32_t surrogate)
 {
     unsigned char xa = 0;   /* first hex digit */
     unsigned char xb = 0;   /* second hex digit */
@@ -49,17 +49,6 @@ utf8len(const char *str, int32_t surrogate, size_t *bytes)
     unsigned int x = 0;	    /* the hex value we attempt to extract */
     size_t len = 0;	    /* the number of bytes which *bytes will be set to */
     int scanned = 0;	    /* how many values read */
-
-
-    /*
-     * firewall
-     */
-    if (bytes == NULL) {
-	warn(__func__, "bytes is NULL");
-	return false;
-    } else {
-	*bytes = 0;
-    }
 
     if (str == NULL) {
 	x = surrogate;
@@ -73,19 +62,10 @@ utf8len(const char *str, int32_t surrogate, size_t *bytes)
 	    len = 4;
 	} else {
 	    warn(__func__, "%x: illegal value\n", x);
-
-	    if (bytes != NULL) {
-		*bytes = 0;
-	    }
-
-	    return false;
+	    len = -1;
 	}
 
-	if (bytes != NULL) {
-	    *bytes = len;
-	}
-
-	return true;
+	return len;
     }
 
     /*
@@ -95,20 +75,18 @@ utf8len(const char *str, int32_t surrogate, size_t *bytes)
     if (scanned != 4) {
 	warn(__func__, "did not find \\u followed by four HEX digits: %ju values: <%s>: %x %x %x %x", scanned, str,
 		xa, xb, xc, xd);
-	if (bytes != NULL) {
-	    *bytes = 0;
-	}
-	return false;
+	len = -1;
+
+	return len;
     } else {
 	/*
 	 * extra sanity check
 	 */
 	if (!isxdigit(xa) || !isxdigit(xb) || !isxdigit(xc) || !isxdigit(xd)) {
 	    warn(__func__, "sscanf() found \\uxxxx but not all values are hex digits!");
-	    if (bytes != NULL) {
-		*bytes = 0;
-	    }
-	    return false;
+	    len = -1;
+
+	    return len;
 	}
     }
 
@@ -136,20 +114,11 @@ utf8len(const char *str, int32_t surrogate, size_t *bytes)
 	    len = 4;
 	} else {
 	    warn(__func__, "%x: illegal value\n", x);
-
-	    if (bytes != NULL) {
-		*bytes = 0;
-	    }
-
-	    return false;
-	}
-
-	if (bytes != NULL) {
-	    *bytes = len;
+	    len = -1;
 	}
     }
 
-    return true;
+    return len;
 }
 
 /*
@@ -232,11 +201,11 @@ utf8encode(char *str, unsigned int val)
 	warn(__func__, "codepoint: %X: illegal surrogate", val);
 	len = UNICODE_SURROGATE_PAIR;
     } else if (val < 0x80) {
-	dbg(DBG_MED, "%s: val: %X < 0x80", __func__, val);
+	dbg(DBG_VVHIGH, "%s: val: %X < 0x80", __func__, val);
 	str[0] = val;
 	len = 1;
     } else if (val < 0x800) {
-	dbg(DBG_MED, "%s: val: %X < 0x800", __func__, val);
+	dbg(DBG_VVHIGH, "%s: val: %X < 0x800", __func__, val);
 	str[1] = val & UTF8_V_MASK;
 	str[1] |= UTF8_N_BITS;
 	val >>= UTF8_V_SHIFT;
@@ -244,7 +213,7 @@ utf8encode(char *str, unsigned int val)
 	str[0] |= UTF8_2_BITS;
 	len = 2;
     } else if (val < 0x10000) {
-	dbg(DBG_MED, "%s: val: %X < 0x10000", __func__, val);
+	dbg(DBG_VVHIGH, "%s: val: %X < 0x10000", __func__, val);
 	str[2] = val & UTF8_V_MASK;
 	str[2] |= UTF8_N_BITS;
 	val >>= UTF8_V_SHIFT;
@@ -255,7 +224,7 @@ utf8encode(char *str, unsigned int val)
 	str[0] |= UTF8_3_BITS;
 	len = 3;
     } else if (val < 0x110000) {
-	dbg(DBG_MED, "%s: val: %X < 0x110000", __func__, val);
+	dbg(DBG_VVHIGH, "%s: val: %X < 0x110000", __func__, val);
 	str[3] = val & UTF8_V_MASK;
 	str[3] |= UTF8_N_BITS;
 	val >>= UTF8_V_SHIFT;

--- a/jparse/json_utf8.c
+++ b/jparse/json_utf8.c
@@ -31,11 +31,10 @@
  *	surrogate   if str == NULL then use this for the check
  *	bytes	    pointer to the number of bytes
  *
- * NOTE: if count is NULL we return false. Otherwise we attempt to
- * parse the string as %4x and then, assuming we extract a value, we count the
- * number of bytes required for the string and place it in *count, as long as
- * str != NULL. If, however str is NULL, we will simply check the value in
- * surrogate.  As long as this can be done we return true.
+ * NOTE: If str is NULL we use the value in surrogate; otherwise we attempt to
+ * extract the value by parsing the string as %4x and then, assuming we extract
+ * a value, we count the number of bytes required for the string. It is this
+ * value that is returned.
  *
  * NOTE: *str should point to the \u!
  */

--- a/jparse/json_utf8.h
+++ b/jparse/json_utf8.h
@@ -36,10 +36,10 @@
 /*
  * official jparse UTF-8 version
  */
-#define JPARSE_UTF8_VERSION "1.2.0 2024-10-09"	/* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTF8_VERSION "1.2.1 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
-extern bool utf8len(const char *str, int32_t surrogate, size_t *bytes);
+extern size_t utf8len(const char *str, int32_t surrogate);
 
 /*
  * The below function and macros are based on code from

--- a/jparse/json_util_README.md
+++ b/jparse/json_util_README.md
@@ -7,7 +7,7 @@ This document was prior to setting up this repo and it describes tools to be
 written (that were being worked on until one of us got sick). As such these
 tools have **NOT** been written yet. Additionally there might be some changes
 in how they work, when it is time to write them. As well, another utility is
-going to be created as well. All of these will happen at a later time as there
+going to be created. All of these will happen at a later time as there
 are other things that are of higher priority. When the tools exist then this
 note will be either removed (if the tools are complete) or modified (if the
 tools are still being worked on but do exist).

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -68,7 +68,8 @@ static const char * const usage_msg =
     " >= 10   internal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -302,7 +303,8 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", JSTRDECODE_BASENAME, JSTRDECODE_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -310,6 +312,9 @@ main(int argc, char **argv)
 	    print("%s: Beginning chkbyte2asciistr test of the byte2asciistr table...\n", program);
 	    chkbyte2asciistr();
 	    print("%s: ... passed byte2asciistr table test\n", program);
+	    print("%s: Beginning jdecencchk...\n", program);
+	    jdecencchk();
+	    print("%s: ... passed jdecencchk\n", program);
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;
@@ -536,7 +541,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSTRDECODE_BASENAME, JSTRDECODE_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSTRDECODE_BASENAME, JSTRDECODE_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrdecode version
  */
-#define JSTRDECODE_VERSION "1.2.0 2024-10-09"	/* format: major.minor YYYY-MM-DD */
+#define JSTRDECODE_VERSION "1.2.1 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jstrencode.c
+++ b/jparse/jstrencode.c
@@ -68,7 +68,8 @@ static const char * const usage_msg =
     " >= 10   internal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -366,7 +367,8 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", JSTRENCODE_BASENAME, JSTRENCODE_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -374,6 +376,9 @@ main(int argc, char **argv)
 	    print("%s: Beginning chkbyte2asciistr test of the byte2asciistr table...\n", program);
 	    chkbyte2asciistr();
 	    print("%s: ... passed byte2asciistr table test\n", program);
+	    print("%s: Beginning jdecencchk...\n", program);
+	    jdecencchk();
+	    print("%s: ... passed jdecencchk\n", program);
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;
@@ -625,7 +630,8 @@ usage(int exitcode, char const *prog, char const *str)
     if (*str != '\0') {
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSTRENCODE_BASENAME, JSTRENCODE_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSTRENCODE_BASENAME, JSTRENCODE_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrencode version
  */
-#define JSTRENCODE_VERSION "1.2.0 2024-10-09"	/* format: major.minor YYYY-MM-DD */
+#define JSTRENCODE_VERSION "1.2.1 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/json_dbg.3
+++ b/jparse/man/man3/json_dbg.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/json_dbg_allowed.3
+++ b/jparse/man/man3/json_dbg_allowed.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/json_err_allowed.3
+++ b/jparse/man/man3/json_err_allowed.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/json_warn_allowed.3
+++ b/jparse/man/man3/json_warn_allowed.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/parse_json.3
+++ b/jparse/man/man3/parse_json.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/parse_json_file.3
+++ b/jparse/man/man3/parse_json_file.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man3/parse_json_stream.3
+++ b/jparse/man/man3/parse_json_stream.3
@@ -24,7 +24,7 @@
 .sp
 \fB#define JPARSE_VERSION "..." /* format: major.minor YYYY-MM-DD */\fP
 .br
-\fB#define JSON_PARSER_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
+\fB#define JPARSE_LIBRARY_VERSION "..." /* library format: major.minor YYYY-MM-DD */\fP
 .br
 \fB#define VALID_JSON_NODE(item) ((item) != NULL && (((item)->parsed == true) || ((item)->converted == true)))\fP
 .br
@@ -255,7 +255,7 @@ tool.
 The string
 .BR json_parser_version ,
 which points to
-.BR JSON_PARSER_VERSION ,
+.BR JPARSE_LIBRARY_VERSION ,
 is the current version of the parser itself.
 .SH RETURN VALUE
 .PP

--- a/jparse/man/man8/jparse_test.8
+++ b/jparse/man/man8/jparse_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse_test.sh 8 "06 September 2024" "jparse_test.sh" "jparse tools"
+.TH jparse_test.sh 8 "10 October 2024" "jparse_test.sh" "jparse tools"
 .SH NAME
 .B jparse_test.sh
 \- test jparse on one or more files with one or more one\-line JSON blobs
@@ -35,6 +35,7 @@
 .RB [\| \-k \|]
 .RB [\| \-f \|]
 .RB [\| \-L \|]
+.RB [\| \-F \|]
 .RI [\| file
 .IR ... \|]
 .SH DESCRIPTION
@@ -67,7 +68,9 @@ However, in case someone has some strange paths, the error files will be incorre
 .B \-L
 option to avoid this.
 .PP
-One may also specify files which should be a file of one or more JSON blobs, as a string, one per line.
+One may also specify files which should be a file of one or more JSON blobs, as a string, one per line, unless
+.B \-F
+is used (see below).
 The file name
 .I \-
 means read from stdin.
@@ -86,6 +89,13 @@ But just like with the valid JSON strings file, if it is not a regular readable 
 .B \-f
 is to allow for other files to have invalid JSON strings.
 .PP
+If the
+.B \-F
+option is used then the files specified are meant to be tested as actual JSON files, not one or more JSON blobs per line.
+In this case, stdin is not read from, not even if
+.I \-
+is specified.
+.PP
 The script keeps a log of all the tests in
 .B jparse_test.log
 for later inspection.
@@ -94,7 +104,7 @@ If the
 option is specified, then the temporary stderr file is kept for inspection.
 This option allows one to compare the error messages with the error files in the
 .I bad_loc
-subdirectory.
+subdirectory, for example.
 .SH OPTIONS
 .TP
 .B \-h
@@ -152,15 +162,18 @@ and finally if that fails by checking for the file
 .BR ../../jparse.c .
 This allows the jparse test suite to properly run in the presumably rare case where one has a copy of the jparse repo in a subdirectory of their project.
 .TP
-.BI \-k
+.B \-k
 Keep temporary stderr files in the directory for investigation.
 This is only used for checking that location reporting in error messages is valid.
 .TP
-.BI \-f
+.B \-f
 Files given to the script are expected to have invalid, not valid, JSON strings (one per line).
 .TP
-.BI \-L
+.B \-L
 Skip error location tests.
+.TP
+.B \-F
+Test files given on the command line as actual full JSON documents, not JSON strings.
 .SH EXIT STATUS
 .TP
 0

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -359,7 +359,7 @@ jnum_gen.o: jnum_gen.c jnum_gen.h ../json_utf8.h ../version.h
 jnum_gen: jnum_gen.o ../libjparse.a
 	${CC} ${CFLAGS} $^ -lm -o $@ ${LD_DIR2} -ldyn_array -ldbg
 
-pr_jparse_test.o: pr_jparse_test.c pr_jparse_test.h ../version.h
+pr_jparse_test.o: pr_jparse_test.c pr_jparse_test.h ../json_utf8.h ../version.h
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
@@ -429,6 +429,16 @@ test:
 	else \
 	    echo "${OUR_NAME}: RUNNING: ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt"; \
 	    ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -p test_jparse/pr_jparse_test -d test_jparse/test_JSON -s . test_jparse/json_teststr.txt; \
+	    EXIT_CODE="$$?"; \
+	    if [[ $$EXIT_CODE -ne 0 ]]; then \
+		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \
+		exit "$$EXIT_CODE"; \
+	    else \
+		echo "${OUR_NAME}: PASSED: jparse_test.sh"; \
+	    fi; \
+	    echo; \
+	    echo "${OUR_NAME}: RUNNING:  ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -F jparse.json"; \
+	    ./jparse_test.sh -v ${VERBOSITY} -j ./jparse -F jparse.json; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: jparse_test.sh failed, error code: $$EXIT_CODE"; \

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -71,9 +71,8 @@ static const char * const usage_msg =
     "    >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
-
-
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 /*
  * forward declarations
@@ -127,7 +126,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", JNUM_CHK_BASENAME, JNUM_CHK_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -787,7 +787,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT, JNUM_CHK_BASENAME, JNUM_CHK_VERSION,
-	    JSON_PARSER_VERSION);
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/jnum_chk.h
+++ b/jparse/test_jparse/jnum_chk.h
@@ -57,6 +57,11 @@
 #include "../version.h"
 
 /*
+ * json_utf8.h - JSON UTF-8 decoder
+ */
+#include "../json_utf8.h"
+
+/*
  * official jnum_chk version
  */
 #define JNUM_CHK_VERSION "1.0.1 2024-03-02"      /* format: major.minor YYYY-MM-DD */

--- a/jparse/test_jparse/jnum_gen.c
+++ b/jparse/test_jparse/jnum_gen.c
@@ -66,7 +66,8 @@ static const char * const usage_msg =
     "\t>=10\t\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 /*
  * globals
@@ -124,7 +125,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", JNUM_GEN_BASENAME, JNUM_GEN_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -791,7 +793,8 @@ usage(int exitcode, char const *prog, char const *str)
     if (*str != '\0') {
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JNUM_GEN_BASENAME, JNUM_GEN_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JNUM_GEN_BASENAME, JNUM_GEN_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/jnum_gen.h
+++ b/jparse/test_jparse/jnum_gen.h
@@ -57,6 +57,11 @@
 #include "../version.h"
 
 /*
+ * json_utf8.h - JSON UTF-8 decoder
+ */
+#include "../json_utf8.h"
+
+/*
  * official jnum_gen version
  */
 #define JNUM_GEN_VERSION "1.0.1 2024-03-02"	/* format: major.minor YYYY-MM-DD */

--- a/jparse/test_jparse/pr_jparse_test.c
+++ b/jparse/test_jparse/pr_jparse_test.c
@@ -69,7 +69,8 @@ static const char * const usage_msg =
     "\t>=10\t\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -145,7 +146,9 @@ main(int argc, char *argv[])
 	    }
 	    break;
 	case 'V':		/* -V - print version and exit */
-	    print("pr_jparse_test version %s\nJSON parser version: %s\n", PR_JPARSE_TEST_VERSION, JSON_PARSER_VERSION);
+	    print("pr_jparse_test version %s\n", PR_JPARSE_TEST_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -1053,7 +1056,7 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, PR_JPARSE_TEST_BASENAME,
-	    PR_JPARSE_TEST_VERSION, JSON_PARSER_VERSION);
+	    PR_JPARSE_TEST_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/test_jparse/pr_jparse_test.h
+++ b/jparse/test_jparse/pr_jparse_test.h
@@ -57,10 +57,14 @@
 #include "../version.h"
 
 /*
+ * json_utf8.h - JSON UTF-8 decoder
+ */
+#include "../json_utf8.h"
+
+/*
  * official pr_jparse_test version
  */
 #define PR_JPARSE_TEST_VERSION "1.2.0 2024-10-09"	/* format: major.minor YYYY-MM-DD */
-
 
 /*
  * pr_jparse_test tool basename

--- a/jparse/verge.c
+++ b/jparse/verge.c
@@ -65,7 +65,8 @@ static const char * const usage_msg =
     "  >=10   internal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -110,7 +111,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", VERGE_BASENAME, VERGE_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -459,7 +461,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, VERGE_BASENAME, VERGE_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, VERGE_BASENAME, VERGE_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -35,6 +35,12 @@
  * util - common utility functions for the JSON parser
  */
 #include "util.h"
+
+/*
+ * json_utf8.h - JSON UTF-8 decoder
+ */
+#include "json_utf8.h"
+
 /*
  * version - JSON parser API and tool version
  */

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "1.2.0 2024-10-09"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "1.2.1 2024-10-10"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -40,7 +40,7 @@
 /*
  * official JSON parser version
  */
-#define JSON_PARSER_VERSION "1.2.0 2024-10-09"		/* library version format: major.minor YYYY-MM-DD */
+#define JPARSE_LIBRARY_VERSION "1.2.0 2024-10-09"		/* library version format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -164,7 +164,8 @@ static const char * const usage_msg4 =
     " >= 10   internal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 /*
  * globals
@@ -262,7 +263,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", MKIOCCCENTRY_BASENAME, MKIOCCCENTRY_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -900,7 +902,8 @@ usage(int exitcode, char const *prog, char const *str)
     fprintf_usage(DO_NOT_EXIT, stderr, usage_msg1, TAR_PATH_0, CP_PATH_0, LS_PATH_0, TXZCHK_PATH_0, FNAMCHK_PATH_0);
     fprintf_usage(DO_NOT_EXIT, stderr, usage_msg2, CHKENTRY_PATH_0);
     fprintf_usage(DO_NOT_EXIT, stderr, "%s", usage_msg3);
-    fprintf_usage(exitcode, stderr, usage_msg4, MKIOCCCENTRY_BASENAME, MKIOCCCENTRY_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg4, MKIOCCCENTRY_BASENAME, MKIOCCCENTRY_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -91,7 +91,8 @@ static const char * const usage_msg =
     "    >=4\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s\n";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 /*
  * forward declarations
@@ -139,7 +140,8 @@ main(int argc, char **argv)
             break;
         case 'V':               /* -V - print version and exit */
             print("%s version: %s\n", LOCATION_BASENAME, LOCATION_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
             exit(2); /*ooo*/
             not_reached();
             break;
@@ -347,7 +349,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, LOCATION_BASENAME, LOCATION_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, LOCATION_BASENAME, LOCATION_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.5.24 2024-10-09"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.5.25 2024-10-10"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/fnamchk.c
+++ b/test_ioccc/fnamchk.c
@@ -78,8 +78,10 @@ static const char * const usage_msg =
     "     4\t\t\"submit.test-\" separated token length != %ju\n"
     "     5\t\t\"submit.UUID-\" token length != %ju\n"
     "     >=10\tinternal error\n"
+    "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -140,7 +142,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", FNAMCHK_BASENAME, FNAMCHK_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -407,7 +410,7 @@ usage(int exitcode, char const *prog, char const *str)
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, (uintmax_t)(UUID_LEN+1+MAX_SUBMIT_SLOT_CHARS),
 	    (uintmax_t)(LITLEN("test-")+MAX_SUBMIT_SLOT_CHARS), FNAMCHK_BASENAME, FNAMCHK_VERSION,
-	    JSON_PARSER_VERSION);
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/test_ioccc/utf8_test.c
+++ b/test_ioccc/utf8_test.c
@@ -65,7 +65,7 @@
 #include "../jparse/jparse.h"
 
 /*
- * jparse/version - the JSON parser version
+ * jparse/version - the jparse library version
  */
 #include "../jparse/version.h"
 
@@ -106,7 +106,8 @@ static char const * const usage_msg =
     " >= 10   internal error\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 /*
  * functions
@@ -144,7 +145,8 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':	/* -V - print version and exit */
             print("%s version: %s\n", UTF8_TEST_BASENAME, UTF8_TEST_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
             exit(2); /*ooo*/
             not_reached();
             break;
@@ -246,7 +248,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
 
-    fprintf_usage(exitcode, stderr, usage_msg, prog, UTF8_TEST_BASENAME, UTF8_TEST_VERSION, JSON_PARSER_VERSION);
+    fprintf_usage(exitcode, stderr, usage_msg, prog, UTF8_TEST_BASENAME, UTF8_TEST_VERSION,
+	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/txzchk.c
+++ b/txzchk.c
@@ -113,7 +113,8 @@ static const char * const usage_msg =
     " >= 10   internal error has occurred or unknown tar listing format has been encountered\n"
     "\n"
     "%s version: %s\n"
-    "JSON parser version: %s";
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
 
 
 /*
@@ -155,7 +156,8 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", TXZCHK_BASENAME, TXZCHK_VERSION);
-	    print("JSON parser version: %s\n", JSON_PARSER_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
@@ -399,7 +401,7 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, TAR_PATH_0, FNAMCHK_PATH_0,
-	    TXZCHK_BASENAME, TXZCHK_VERSION, JSON_PARSER_VERSION);
+	    TXZCHK_BASENAME, TXZCHK_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }


### PR DESCRIPTION
Synced jparse from jparse repo (https://github.com/xexyl/jparse/). This includes better (additional) testing of JSON encoding/decoding ('Beware of the <del>dragon</del> fire drake[0]
(https://www.glyphweb.com/arda/f/firedrakes.html)!' :-) ), a new version string (UTF-8 version, which is now also displayed in the tools in this repo, as it also helps identify if there is a mismatch in versions in bug reporting or something else), amongst various other things.  Should one wish to further progress their dementia! :-) they can look at that repo's log or the jparse/CHANGES.md file.

[0] Now given that it's for a code freeze, the question is why not cold drakes? Well one can look at the code, or perhaps the output of a certain option to two tools in jparse, for the answer to that! :-)