### PR TITLE
Add new option -N to jstrencode and jstrdecode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ something else), amongst various other things.  Should one wish to further
 progress their dementia! :-) they can look at that repo's log or the
 jparse/CHANGES.md file.
 
+New option `-N` to `jstrdecode(1)` and `jstrencode(1)` to ignore (in decoding
+and encoding internal to the tool itself, not JSON) final newline in input.
+
 
 ## Release 1.5.24 2024-10-09
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -21,6 +21,13 @@ Improve the way `utf8len()` works. It now returns a `size_t` and the `size_t
 *bytes` was removed from it. Returns `-1` if an error occurs. This better fits
 the name and purpose of the function.
 
+Add new option `-N` to `jstrdecode(1)`. This option ignores a final newline in
+the input for easier typing of commands. It does not change the validity
+checking of JSON.
+
+Add new option `-N` to `jstrencode(1)`. This option ignores a final newline in
+the input. It does not change the validity checking of JSON.
+
 
 ## Release 1.2.0 2024-10-09
 

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrdecode version
  */
-#define JSTRDECODE_VERSION "1.2.1 2024-10-10"	/* format: major.minor YYYY-MM-DD */
+#define JSTRDECODE_VERSION "1.2.2 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrencode version
  */
-#define JSTRENCODE_VERSION "1.2.1 2024-10-10"	/* format: major.minor YYYY-MM-DD */
+#define JSTRENCODE_VERSION "1.2.2 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "14 September 2024" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "10 October 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
 \- decode JSON encoded strings
@@ -22,6 +22,7 @@
 .RB [\| \-V \|]
 .RB [\| \-t \|]
 .RB [\| \-n \|]
+.RB [\| \-N \|]
 .RB [\| \-Q \|]
 .RB [\| \-e \|]
 .RI [\| string
@@ -68,6 +69,9 @@ Run tests on the JSON decode/encode functions
 .TP
 .B \-n
 Do not output a newline after the decode function
+.TP
+.B \-N
+Skip final newline in input, for easier typing commands.
 .TP
 .B \-Q
 Enclose output in double quotes

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "14 September 2024" "jstrencode" "jparse tools"
+.TH jstrencode 1 "10 October 2024" "jstrencode" "jparse tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -22,6 +22,7 @@
 .RB [\| \-V \|]
 .RB [\| \-t \|]
 .RB [\| \-n \|]
+.RB [\| \-N \|]
 .RB [\| \-Q \|]
 .RI [\| string
 .IR ... \|]
@@ -55,6 +56,9 @@ Run tests on the JSON encode/encode functions
 .TP
 .B \-n
 Do not output a newline after the encode function
+.TP
+.B \-N
+Ignore trailing newline in input
 .TP
 .B \-Q
 Do not encode double quotes that enclose the concatenation of args (def: do encode)


### PR DESCRIPTION
As requested this new option ignores a final newline in input for encoding/decoding. It does NOT change the JSON encoding/decoding rule that an unescaped newline is not allowed; it simply changes the mechanics of the tools. Further rules for this option are being discussed.