### PR TITLE
Fix annoying answers version bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.6.2 2024-10-23
+
+Fix annoying bug where the `MKIOCCCENTRY_ANSWERS_VERSION` could not be in
+`soup/version.h` and the `MKIOCCCENTRY_ANSWERS_EOF` could not be in
+`mkiocccentry.h`.
+
+Fix `write_echo()` in `test_ioccc/prep.sh` to not leave lines in the log file
+that simply say `OK`.
+
+
 ## Release 1.6.1 2024-10-22
 
 Sync the `jparse/` directory with state, as of 2024-10-22, of the

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -96,24 +96,6 @@
 #define REQUIRED_ARGS (4)	/* number of required arguments on the command line */
 
 /*
- * Answers file constants.
- *
- * Version of answers file.
- * Use format:
- *
- *         MKIOCCCENTRY_ANSWERS-IOCCCMOCK-major.minor
- *         MKIOCCCENTRY_ANSWERS-IOCCC[0-9[0-9]-major.minor
- *
- * The following is NOT the version of this mkiocccentry tool!
- *
- * NOTE: these MUST be here and NOT in version.h or in mkiocccentry.h!
- */
-#define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0"
-/* Answers file EOF marker */
-#define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF"
-
-
-/*
  * usage message
  *
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -108,17 +108,11 @@
 #include "soup/entry_util.h"
 
 /*
- * mkiocccentry tool basename
- */
-#define MKIOCCCENTRY_BASENAME "mkiocccentry"
-
-
-/*
  * definitions
  *
- * NOTE: MKIOCCCENTRY_ANSWERS_VERSION and MKIOCCCENTRY_ANSWERS_EOF must be defined
- *	 in mkiocccentry.c and not here.
  */
+#define MKIOCCCENTRY_BASENAME "mkiocccentry"	/* mkiocccentry tool basename for -V/-h */
+#define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 #define ISO_3166_1_CODE_URL0 "\thttps://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements"
 #define ISO_3166_1_CODE_URL1 "\thttps://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
 #define ISO_3166_1_CODE_URL2 "\thttps://www.iso.org/obp/ui/#iso:pub:PUB500001:en"

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,8 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.6.1 2024-10-22"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.6.2 2024-10-23"	/* special release format: major.minor.patch YYYY-MM-DD */
+
 
 /*
  * official soup version (aka recipe :-) )
@@ -79,9 +80,10 @@
 #define IOCCCSIZE_VERSION "28.15 2024-06-27"	/* format: major.minor YYYY-MM-DD */
 
 /*
- * official mkiocccentry version
+ * official mkiocccentry versions (mkiocccentry itself and answers)
  */
 #define MKIOCCCENTRY_VERSION "1.0.8 2024-08-23"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 
 /*
  * Version of info for JSON the .info.json file.

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -338,7 +338,7 @@ EOF
 }
 rm -f answers.txt
 # Retrieve the answers version from mkiocccentry.c and write to answers file:
-grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' mkiocccentry.c | cut -d' ' -f3 | sed 's/"//g' >answers.txt
+grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' soup/version.h | cut -d' ' -f3 | sed 's/"//g' >answers.txt
 # Append answers + EOF marker
 #
 # We disable this shellcheck error because answers already is defined but we
@@ -445,7 +445,7 @@ EOF
 }
 rm -f answers.txt
 # Retrieve the answers version from mkiocccentry.c and write to answers file:
-grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' mkiocccentry.c | cut -d' ' -f3 | sed 's/"//g' >answers.txt
+grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' soup/version.h | cut -d' ' -f3 | sed 's/"//g' >answers.txt
 # Append answers + EOF marker
 #
 # We disable this shellcheck error because answers already is defined but we
@@ -531,7 +531,7 @@ EOF
 }
 rm -f answers.txt
 # Retrieve the answers version from mkiocccentry.c and write to answers file:
-grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' mkiocccentry.c | cut -d' ' -f3 | sed 's/"//g' >answers.txt
+grep -E '^#define MKIOCCCENTRY_ANSWERS_VERSION' soup/version.h | cut -d' ' -f3 | sed 's/"//g' >answers.txt
 # Append answers + EOF marker
 answers >>answers.txt
 

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -143,7 +143,11 @@ write_echo()
     local MSG="$*"
 
     if [[ -n "$LOGFILE" ]]; then
-	echo "$MSG" | tee -a -- "$LOGFILE"
+	if [[ "$MSG" != "OK" ]]; then
+	    echo "$MSG" | tee -a -- "$LOGFILE"
+	else
+	    echo "$MSG"
+	fi
     else
 	echo "$MSG" 1>&2
     fi


### PR DESCRIPTION
Now the answers version can go in soup/version.h and the EOF marker can go in mkiocccentry.h

At the same time the test_ioccc/prep.sh had a bug fix that prevents the line of the form (regex without quotes) '^OK$' from being let in the log file.

As these were annoying bugs, especially the answers version one, it seemed worth making another pull request, but this is likely my last one until the Great Fork Merge in the other repo: though I guess we'll have to wait and 'C'. :-)