### PR TITLE
Sync jparse fixes

### DIFF
--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -41,6 +41,6 @@ build.log
 /test_jparse/pr_jparse_test
 /test_jparse/tags
 /test_jparse/util_test
-/test_jparse/util_test.c
 /test_jparse/util_test.o
+util_test.c
 /verge

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -1127,6 +1127,7 @@ clobber: legacy_clobber clean
 	${Q} ${RM} ${RM_V} -f ${TARGETS}
 	${Q} ${RM} ${RM_V} -f jparse.output lex.yy.c jparse.c lex.jparse_.c
 	${Q} ${RM} ${RM_V} -f jsemcgen.out.*
+	${Q} ${RM} ${RM_V} -f util_test.c
 	${Q} ${RM} ${RM_V} -f ${BUILD_LOG} jparse_test.log
 	${Q} ${RM} ${RM_V} -f Makefile.orig
 	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -2230,7 +2230,7 @@ json_tree_walk(struct json *node, unsigned int max_depth, unsigned int depth, bo
  * as foo() or (*foo)() we use the latter format for the callback function
  * to make it clearer that it is in fact a function that's passed in so
  * that we can use this function to do more than one thing. This is also
- * why we call it callback and not something else.
+ * why we call it vcallback and not something else.
  *
  * If max_depth is >= 0 and the tree depth > max_depth, then this function return.
  * In this case it will NOT operate on the node, or will be descend and further


### PR DESCRIPTION
The make clobber rule did not remove a temporary file that is part of the test suite (a recent update to it).

The .gitignore had to be updated for the same file that make clobber did not remove.

A name change of a function that happened many aeons ago was not updated in comments and now it has been updated.