### PR TITLE
Bad typo fix in prep.sh, improve test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,7 @@ jobs:
       run: make slow_release
     - name: make clobber all test
       run: make clobber all test
+    - name: make bug_report
+      run: make bug_report
     - name: make clobber
       run: make clobber

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -504,11 +504,11 @@ make_action 31 test
 
 # If we have a logfile, count the number of Notice: messages in the logfile
 #
-LOFILE_NOTICE_COUNT=0
+LOGFILE_NOTICE_COUNT=0
 export NOTICE_COUNT
 if [[ -n "$LOGFILE" ]]; then
-    LOFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
-    if [[ $LOFILE_NOTICE_COUNT -gt 0 ]]; then
+    LOGFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
+    if [[ $LOGFILE_NOTICE_COUNT -gt 0 ]]; then
 	write_logfile
 	write_logfile "=-=-= Summary of prep.sh notices follow:"
 	write_logfile
@@ -541,7 +541,7 @@ fi
 
 # Add any logfile notice count to the bug report log notice count.
 #
-((NOTICE_COUNT=NOTICE_COUNT+LOFILE_NOTICE_COUNT))
+((NOTICE_COUNT=NOTICE_COUNT+LOGFILE_NOTICE_COUNT))
 
 if [[ $EXIT_CODE -eq 0 ]]; then
     if [[ -z "$LOGFILE" ]]; then


### PR DESCRIPTION
The typo was that the variable LOGFILE had no G.

The workflow now runs make bug_report. This does run make test again but it seems like a good thing to run as it can help uncover more problems that might not be noticed otherwise. The bug_report.sh script is slow but this seems like a worthy thing to do.