### PR TITLE
Important bug fix in jparse/Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,7 @@ jobs:
       run: make slow_release
     - name: make clobber all test
       run: make clobber all test
+    - name: make bug_report
+      run: make bug_report
     - name: make clobber
       run: make clobber

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 1.6.2 2024-10-30
+
+Sync the `jparse/` directory from [jparse
+repo](https://github.com/xexyl/jparse/). This includes some important bug fixes,
+especially in the `make install` rule that did not install a header file. Not
+having this would cause a compilation error if one were to try and include
+`jparse/jparse.h` outside this repo.
+
+The `jparse_bug_report.sh` script has an improvement that will test compile a
+jparse program to see if the system can link in `libjparse.a`, `libdbg.a` and
+`libdyn_array.a`. This script is not needed for this repo though.
+
+
 ## Release 1.6.2 2024-10-23
 
 Fix annoying bug where the `MKIOCCCENTRY_ANSWERS_VERSION` could not be in

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,25 @@
 # Significant changes in the JSON parser repo
 
+## Release 1.2.9 2024-10-30
+
+Add function `utf8decode()` (from the same location as the `utf8encode()` but
+also modified to check for a NULL pointer.
+
+Make the updates of pointers `p` and `utf8` and the `int32_t` bytes in
+`decode_json_string()` the same order in the surrogate pairs as the single
+`\uxxxx` when processing `\u` in strings.
+
+Updated `JPARSE_UTF8_VERSION` to `"1.2.3 2024-10-30"`.
+
+Fix `make install` to install `json_utf8.h`.
+
+Improve `jparse_bug_report.sh` to test compile with `jparse/jparse.h` to try and
+determine if the `dbg`, `dyn_array` and `jparse` libraries are installed.
+
+Typo fix in `test_jparse/prep.sh`. A missing `G` in `LOGFILE`. This was a
+carry-over from the mkiocccentry repo script.
+
+
 ## Release 1.2.8 2024-10-27
 
 Remove duplicate code from jstrencode.c and jstrdecode.c as follows:

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -408,7 +408,7 @@ PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode
 #
 H_SRC_TARGETS= jparse.h jparse.lex.h jparse.lex.ref.h jparse.tab.h jparse.tab.ref.h \
 	       jparse_main.h json_parse.h json_sem.h json_util.h sorry.tm.ca.h util.h \
-	       version.h
+	       version.h json_utf8.h
 
 # what to make by all but NOT to removed by clobber
 #

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -1554,15 +1554,20 @@ decode_json_string(char const *ptr, size_t len, size_t mlen, size_t *retlen)
 		    }
 
 		    /*
+		     * bytes - 1 because we increment utf8 in the increment phase
+		     * of the loop
+		     */
+		    utf8 += bytes - 1;
+		    /*
+		     * however, for p we need to update the entire amount
+		     */
+		    p += bytes;
+
+		    /*
 		     * we increment by 11 because LITLEN("uxxxx") +
 		     * LITLEN("\\uxxxx") is 11.
 		     */
 		    i += 11;
-		    /*
-		     * these are like for a single \uxxxx found
-		     */
-		    utf8 += bytes - 1;
-		    p += bytes;
 		} else {
 		    /* error - clear allocated length and free buffer */
 		    if (retlen != NULL) {

--- a/jparse/json_utf8.c
+++ b/jparse/json_utf8.c
@@ -149,7 +149,7 @@ utf8len(const char *str, int32_t surrogate)
 }
 
 /*
- * The below function is based on code from
+ * The below functions are based on code from
  * https://lxr.missinglinkelectronics.com/linux+v5.19/fs/unicode/mkutf8data.c,
  * with a number of changes.
  */
@@ -269,6 +269,46 @@ utf8encode(char *str, unsigned int val)
     }
     return len;
 }
+
+unsigned int
+utf8decode(const char *str)
+{
+    const unsigned char *s = NULL;
+    unsigned int unichar = 0;
+
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+        err(12, __func__, "str is NULL");
+        not_reached();
+    }
+
+    s = (const unsigned char*)str;
+    if (*s < 0x80) {
+        unichar = *s;
+    } else if (*s < UTF8_3_BITS) {
+        unichar = *s++ & 0x1F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s & 0x3F;
+    } else if (*s < UTF8_4_BITS) {
+        unichar = *s++ & 0x0F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s++ & 0x3F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s & 0x3F;
+    } else {
+        unichar = *s++ & 0x0F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s++ & 0x3F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s++ & 0x3F;
+        unichar <<= UTF8_V_SHIFT;
+        unichar |= *s & 0x3F;
+    }
+    return unichar;
+}
+
 
 /*
  * The above function is based on code from

--- a/jparse/json_utf8.h
+++ b/jparse/json_utf8.h
@@ -36,7 +36,7 @@
 /*
  * official jparse UTF-8 version
  */
-#define JPARSE_UTF8_VERSION "1.2.2 2024-10-13"	/* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTF8_VERSION "1.2.3 2024-10-30"	/* format: major.minor YYYY-MM-DD */
 
 #define UNICODE_REPLACEMENT_CHAR 0xFFFD
 
@@ -44,7 +44,7 @@ extern size_t utf8len(const char *str, int32_t surrogate);
 extern bool is_unicode_noncharacter(int32_t x);
 
 /*
- * The below function and macros are based on code from
+ * The below functions and macros are based on code from
  * https://lxr.missinglinkelectronics.com/linux+v5.19/fs/unicode/mkutf8data.c,
  * with a number of changes.
  */
@@ -61,9 +61,10 @@ extern bool is_unicode_noncharacter(int32_t x);
 #define UTF8_V_SHIFT    6
 
 extern int utf8encode(char *str, unsigned int val);
+extern unsigned int utf8decode(const char *str);
 
 /*
- * The above function and macros are based on code from
+ * The above functions and macros are based on code from
  * https://lxr.missinglinkelectronics.com/linux+v5.19/fs/unicode/mkutf8data.c,
  * with a number of changes.
  */

--- a/jparse/man/man1/jparse_bug_report.1
+++ b/jparse/man/man1/jparse_bug_report.1
@@ -10,7 +10,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse_bug_report.sh 1 "01 September 2024" "jparse_bug_report.sh" "jparse tools"
+.TH jparse_bug_report.sh 1 "30 October 2024" "jparse_bug_report.sh" "jparse tools"
 .SH NAME
 .B jparse_bug_report.sh
 \- run a series of tests, collecting system information in the process, to help report bugs and issues
@@ -31,6 +31,8 @@
 .IR make \|]
 .RB [\| \-M
 .IR make_flags \|]
+.RB [\| \-c
+.IR cc \|]
 .SH DESCRIPTION
 .B jparse_bug_report.sh
 runs a series of tests and scripts to gather as much information about your system as possible in order to help with reporting bugs or other issues.
@@ -57,6 +59,16 @@ then you can use the
 .B \-m
 .I make
 option to specify the path.
+.PP
+It also tries to locate
+.BR cc (1)
+or a test compiling of the library, though it is not considered a problem if the compile fails.
+If the script cannot find
+.BR cc (1)
+then one can use the
+.B \-c
+.I cc
+option.
 It is considered a command line error if
 .BR make (1)
 is not a regular executable file as without
@@ -97,6 +109,10 @@ We recommend you to
 use this when actually reporting bugs.
 This is because it will provide us some very useful information.
 Nevertheless it is there for the cases where it's useful.
+.TP
+.BI \-c\  cc
+Set path to
+.BR cc (1).
 .SH EXIT STATUS
 .TP
 0

--- a/jparse/test_jparse/prep.sh
+++ b/jparse/test_jparse/prep.sh
@@ -500,11 +500,11 @@ make_action 28 test
 
 # If we have a logfile, count the number of Notice: messages in the logfile
 #
-LOFILE_NOTICE_COUNT=0
+LOGFILE_NOTICE_COUNT=0
 export NOTICE_COUNT
 if [[ -n "$LOGFILE" ]]; then
-    LOFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
-    if [[ $LOFILE_NOTICE_COUNT -gt 0 ]]; then
+    LOGFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
+    if [[ $LOGFILE_NOTICE_COUNT -gt 0 ]]; then
 	write_logfile
 	write_logfile "=-=-= Summary of prep.sh notices follow:"
 	write_logfile
@@ -537,7 +537,7 @@ fi
 
 # Add any logfile notice count to the bug report log notice count.
 #
-((NOTICE_COUNT=NOTICE_COUNT+LOFILE_NOTICE_COUNT))
+((NOTICE_COUNT=NOTICE_COUNT+LOGFILE_NOTICE_COUNT))
 
 if [[ $EXIT_CODE -eq 0 ]]; then
     if [[ -z "$LOGFILE" ]]; then

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.6.2 2024-10-23"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.6.3 2024-10-30"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 
 /*

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -504,11 +504,11 @@ make_action 31 test
 
 # If we have a logfile, count the number of Notice: messages in the logfile
 #
-LOFILE_NOTICE_COUNT=0
+LOGFILE_NOTICE_COUNT=0
 export NOTICE_COUNT
 if [[ -n "$LOGFILE" ]]; then
-    LOFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
-    if [[ $LOFILE_NOTICE_COUNT -gt 0 ]]; then
+    LOGFILE_NOTICE_COUNT="$(grep -cE "[[:space:]]+Notice:[[:space:]]" "$LOGFILE")"
+    if [[ $LOGFILE_NOTICE_COUNT -gt 0 ]]; then
 	write_logfile
 	write_logfile "=-=-= Summary of prep.sh notices follow:"
 	write_logfile
@@ -541,7 +541,7 @@ fi
 
 # Add any logfile notice count to the bug report log notice count.
 #
-((NOTICE_COUNT=NOTICE_COUNT+LOFILE_NOTICE_COUNT))
+((NOTICE_COUNT=NOTICE_COUNT+LOGFILE_NOTICE_COUNT))
 
 if [[ $EXIT_CODE -eq 0 ]]; then
     if [[ -z "$LOGFILE" ]]; then


### PR DESCRIPTION
                
Sync the jparse/ directory from [jparse
repo](https://github.com/xexyl/jparse/). This includes some important bug fixes,
especially in the make install rule that did not install a header file. Not
having this would cause a compilation error if one were to try and include
jparse/jparse.h outside this repo.

The jparse_bug_report.sh script has an improvement that will test compile a
jparse program to see if the system can link in libjparse.a, libdbg.a and
libdyn_array.a. This script is not needed for this repo though.

Some cosmetic changes were made in a jparse function as well.