### PR TITLE
Sync jparse/ - sanity checks and other fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.6.5 2024-11-03
+
+Sync the `jparse/` directory from [jparse
+repo](https://github.com/xexyl/jparse/). This adds some extra sanity checks in
+`jstrencode(1)`/`jstrdecode(1)` and it also makes some fixes to the change in
+decode/encode terminology, namely to do with comments. An unused macro (after a
+fix) was removed. Comments were updated and improved in `jparse.l` and
+`jparse.y`. Regenerated parser backup files.
+
+
 ## Release 1.6.4 2024-11-01
 
 Sync the `jparse/` directory from [jparse

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,13 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.0.2 2024-11-03
+
+Remove unused macro from `json_utf8.h`. Updated `JPARSE_UTF8_VERSION`.
+
+Fixed and improved some comments in `json_parse.c` and `jparse.l` and
+`jparse.y`.
+
+
 ## Release 2.0.1 2024-11-01
 
 Remove blockage of certain UTF-8 codepoints like non-characters as it appears

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -900,8 +900,8 @@ picky: ${ALL_SRC} test_jparse/Makefile
 	    echo 1>&2; \
 	    exit 1; \
 	else \
-	    echo "${PICKY} -w132 -u -s -t8 -v -e -- ${C_SRC} ${H_SRC}"; \
-	    ${PICKY} -w132 -u -s -t8 -v -e -- ${C_SRC} ${H_SRC}; \
+	    echo "${PICKY} -w132 -u -s -t8 -v -e -8 -- ${C_SRC} ${H_SRC}"; \
+	    ${PICKY} -w132 -u -s -t8 -v -e -8 -- ${C_SRC} ${H_SRC}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \

--- a/jparse/README.md
+++ b/jparse/README.md
@@ -1,4 +1,4 @@
-# jparse - JSON parser and tools written in C
+# jparse -  JSON parser, library and tools written in C
 
 `jparse` is a JSON parser (a stand-alone tool and a library) written in C with
 the help of `flex(1)` and `bison(1)`. The library, and the additional tools,

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -19,7 +19,11 @@
 
 /* Section 0: Declarations and option settings */
 /*
- * %option noyywrap prevents needing to link in the flex(1) library (flex(3))
+ * The
+ *
+ *      %option noyywrap
+ *
+ * prevents needing to link in the flex(1) library (flex(3))
  * which means those without flex can compile the code. Even if everyone had
  * flex(1), though, under macOS you have to pass -ll to the compiler to link in
  * the flex library whereas in other systems you have to use -lfl which would
@@ -27,19 +31,30 @@
  * }' but this is unnecessary.
  */
 %option noyywrap
+
 /*
- * we also need a few other options set:
+ * We also need these options set:
  *
- * %option nodefault nounput noinput
- * %option yylineno 8bit
- * %option bison-bridge bison-locations reentrant
- * %option prefix="jparse_"
- * %option header-file="jparse.lex.h"
- * %option extra-type="struct json_extra *"
+ *      %option nodefault
+ *      %option nounput
+ *      %option noinput
+ *      %option yylineno
+ *      %option 8bit
+ *      %option bison-bridge
+ *      %option bison-locations
+ *      %option reentrant
+ *      %option prefix="jparse_"
+ *      %option header-file="jparse.lex.h"
+ *      %option extra-type="struct json_extra *"
  */
-%option nodefault nounput noinput
-%option yylineno 8bit
-%option bison-bridge bison-locations reentrant
+%option nodefault
+%option nounput
+%option noinput
+%option yylineno
+%option 8bit
+%option bison-bridge
+%option bison-locations
+%option reentrant
 %option prefix="jparse_"
 %option header-file="jparse.lex.h"
 %option extra-type="struct json_extra *"
@@ -49,7 +64,6 @@
  *
  * Code is copied verbatim near the top of the generated code.
  */
-
 
 /*
  * jparse - JSON parser
@@ -199,104 +213,137 @@ JSON_COMMA		","
 			    /*
 			     * Whitespace excluding newlines
 			     *
-			     * NOTE: we have to include this action (JSON_WS) as
+			     * NOTE: we MUST include this action (JSON_WS) as
 			     * otherwise the action '.' will return an invalid
-			     * token to the parser.
+			     * token to the parser!
 			     *
-			     * We don't need the below message but for debugging
-			     * purposes we print how many whitespaces are
-			     * ignored, if the JSON debug level is high enough.
+			     * We don't really need the below debug message but
+                             * when we were developing the scanner/parser we
+                             * used it to see how many whitespaces were ignored
+                             * (depending on if the JSON debug level was high
+                             * enough).
 			     */
 			    (void) json_dbg(JSON_DBG_VVHIGH, __func__, "\nignoring %ju whitespace%s\n",
 							     (uintmax_t)yyleng, yyleng==1?"":"s");
 			}
 
 {JSON_NL}		{
-			    yycolumn = 1; /* on newline we need to reset the column for error location tracking */
+                            /*
+                             * on newline (JSON_NL) we need to reset the column
+                             * for error location tracking.
+                             */
+			    yycolumn = 1;
 			}
 
 {JSON_STRING}		{
-			    /* string */
+			    /*
+                             * string (JSON_STRING)
+                             */
 			    return JSON_STRING;
 			}
 
 {JSON_NUMBER}		{
-			    /* number */
+			    /*
+                             * number (JSON_NUMBER)
+                             */
 			    return JSON_NUMBER;
 			}
 
 {JSON_NULL}		{
-			    /* null object */
+			    /*
+                             * null object (JSON_NULL)
+                             */
 			    return JSON_NULL;
 			}
 
 {JSON_TRUE}		{
-			    /* boolean: true */
+			    /*
+                             * true (JSON_TRUE)
+                             */
 			    return JSON_TRUE;
 			}
 {JSON_FALSE}		{
-			    /* boolean: false */
+			    /*
+                             * false (JSON_FALSE)
+                             *
+                             * NOTE: the fact this is false does not make it
+                             * really false, as we do need false! :-)
+                             */
 			    return JSON_FALSE;
 			}
 
 {JSON_OPEN_BRACE}	{
-			    /* start of object */
+			    /*
+                             * start of object - open brace i.e. "{" (JSON_OPEN_BRACE)
+                             */
 			    return JSON_OPEN_BRACE;
 			}
 {JSON_CLOSE_BRACE}	{
-			    /* end of object */
+			    /*
+                             * end of object - close brace i.e. "}" (JSON_CLOSE_BRACE)
+                             */
 			    return JSON_CLOSE_BRACE;
 			}
 
 {JSON_OPEN_BRACKET}	{
-			    /* start of array */
+			    /*
+                             * start of array - open bracket i.e. "[" (JSON_OPEN_BRACKET)
+                             */
 			    return JSON_OPEN_BRACKET;
 			}
 {JSON_CLOSE_BRACKET}	{
-			    /* end of array */
+			    /*
+                             * end of array - close bracket i.e. "]" (JSON_CLOSE_BRACKET)
+                             */
 			    return JSON_CLOSE_BRACKET;
 			}
 
 {JSON_COLON}		{
-			    /* colon or 'equals' */
+			    /*
+                             * colon or 'equals' (JSON_COLON)
+                             */
 			    return JSON_COLON;
 			}
 
 {JSON_COMMA}		{
-			    /* comma: name/value pair separator */
+			    /*
+                             * comma: name/value pair separator (JSON_COMMA)
+                             */
 			    return JSON_COMMA;
 			}
 
 .			{
-			    /* invalid token: any other character */
+			    /*
+                             * invalid token: any other character (regexp ".")
+                             */
 			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line,
                                     yylloc->first_column, *yytext, *yytext);
 
 			    /*
-			     * This is a hack for better error messages with
-			     * invalid tokens. Bison syntax error messages are
-			     * in the form of:
+			     * Returning 'token' (return token;) is a hack for
+                             * better error messages with invalid tokens. Bison
+                             * syntax error messages are in the form of:
 			     *
 			     *	    syntax error, unexpected <token name>
 			     *	    syntax error, unexpected <token name>, expecting } or JSON_STRING
 			     *
 			     * etc. where <token name> is whatever we return
-			     * here in the lexer actions (e.g.  JSON_STRING or
-			     * in this case literally token) to the parser. But
-			     * the problem is what do we call an invalid token
-			     * without knowing what what the token actually is?
-			     * Thus we call it token so that it will read
-			     * literally as 'unexpected token' which removes any
-			     * ambiguity (it could otherwise be read as 'it's
-			     * unexpected in this place but it is valid in other
-			     * contexts' but it's never actually valid: it's a
-			     * catch all for anything that's not valid).
+                             * here in the lexer actions (e.g.  JSON_STRING or
+                             * in this case literally token) to the parser. But
+                             * the problem is what do we call an invalid token
+                             * without knowing what what the token actually is?
+                             * Thus we call it token so that it will read
+                             * literally as 'unexpected token' which removes any
+                             * ambiguity (it could otherwise be read as 'it's
+                             * unexpected in this place but it is valid in other
+                             * contexts' but it's never actually valid: it's a
+                             * catch all for anything that's not valid).
 			     *
-			     * We also make use of yytext in yyerror()
-			     * which makes for a somewhat reasonable error
-			     * message even when yyerror() is called from
-			     * memory exhaustion. See that function and the
-			     * comments for '%token token' in jparse.y.
+			     * We also make use of yytext in yyerror() which
+                             * makes for a somewhat reasonable error message
+                             * even when yyerror() is called from memory
+                             * exhaustion. See that function and the comments
+                             * for '%token token' in jparse.y.
 			     */
 			    return token;
 			}
@@ -304,7 +351,6 @@ JSON_COMMA		","
 %%
 
 /* Section 2: Code that's copied to the generated scanner */
-
 
 /*
  * low_byte_scan - detect certain low byte values
@@ -483,14 +529,14 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 	    ++(*low_bytes);
 
 	    /*
-	     * case below the report limit
+	     * case: below the report limit
 	     */
 	    if (*low_bytes <= MAX_LOW_BYTES_REPORTED) {
 		werr(36, __func__, "invalid LOW byte 0x%02x detected in line: %zu byte position: %zu",
 			 data[i], linenum, byte_pos);
 
 	    /*
-	     * case at or above the report limit
+	     * case: at or above the report limit
 	     */
 	    } else if (low_limit == false) {
 		werr(37, __func__, "too many LOW bytes ([\\x01-\\x08\\x0e-\\x1f] detected: "
@@ -540,9 +586,12 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * NOTE: the reason this is in the scanner and not the parser is because
  * YY_BUFFER_STATE is part of the scanner and not the parser.
  *
- * NOTE: this function only warns on error. This is so that an entire report of
- * all the problems can be given at the end if the verbosity level is high
- * enough (or otherwise if this information is requested).
+ * NOTE: if filename is NULL we set it to "-" for stdin.
+ *
+ * NOTE: this function only warns on error, except for NULL is_valid, in which
+ *       case it is an error; warning on errors is so that an entire report of
+ *       all the problems can be given at the end if the verbosity level is high
+ *       enough (or otherwise if this information is requested).
  */
 struct json *
 parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
@@ -560,9 +609,9 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON block is is valid; set *is_valid to true so that the
+         * caller does not need to worry about it (well they should in case this
+         * is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
@@ -571,20 +620,24 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
      * firewall
      */
     if (ptr == NULL) {
-
-	/* this should never happen */
 	werr(39, __func__, "ptr is NULL");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
 
     if (filename == NULL) {
-	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+        if (json_dbg_allowed(JSON_DBG_HIGH)) {
+	    json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+        }
 	filename = "-";	/* assume stdin */
     }
 
@@ -595,6 +648,12 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     ret = jparse_lex_init_extra(&extra, &scanner);
     if (ret != 0) {
 	werrp(40, __func__, "jparse_lex_init_extra failed");
+
+        /*
+         * if jparse_lex_init_extra() reports an error (!= 0) then *is_valid
+         * must be set to false and we must return NULL
+         */
+        *is_valid = false;
 	return NULL;
     }
     extra.filename = filename;
@@ -611,18 +670,23 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	 */
 	werr(41, __func__, "unable to scan string");
 
-	/* flag that we have invalid JSON */
+	/*
+         * since we cannot scan the bytes, we set *is_valid to false, even
+         * though it could very well be valid if it could be scanned.
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	jparse_lex_destroy(scanner);
 	return tree;
     }
 
     /*
-     * we cannot set the column and probably line number without first having a
-     * buffer which is why the yy_scan_bytes() is called first.
+     * we cannot set the column (and probably line number) without first having
+     * a buffer which is why the yy_scan_bytes() is called first (see above).
      *
      * For why we set the column to 0 but the line to 1 see the comments with
      * the YY_USER_ACTION macro.
@@ -631,7 +695,7 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     jparse_set_lineno(1, scanner);
 
     /*
-     * announce beginning to parse
+     * announce beginning of parse, if JSON debug level is high enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	fprstr(stderr, "*** BEGIN PARSE\n");
@@ -652,27 +716,52 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     bs = NULL;
 
     /*
-     * announce end of parse
+     * announce end of parse, if JSON debug level is high enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	fprstr(stderr, "*** END PARSE\n");
     }
 
     /*
-     * report scanner / parser success or failure
+     * report scanner / parser success or failure, if JSON debug level is high
+     * enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	json_dbg(JSON_DBG_VVHIGH, __func__, "jparse_parse() returned: %d", ret);
     }
+
     if (ret == 0) {
-	json_dbg(JSON_DBG_LOW, __func__, "valid JSON");
-	*is_valid = true; /* flag that we have valid JSON */
+        /*
+         * we will only report valid JSON (whatever that means :-) ) in debug
+         * message if JSON debug level is high enough (where high is low :-)
+         */
+        if (json_dbg_allowed(JSON_DBG_LOW)) {
+	    json_dbg(JSON_DBG_LOW, __func__, "valid JSON");
+        }
+        /*
+         * flag that we have valid JSON, even though we assumed it will be
+         */
+	*is_valid = true;
     } else {
-	json_dbg(JSON_DBG_LOW, __func__, "invalid JSON");
-	*is_valid = false; /* flag that we have invalid JSON */
+        /*
+         * we will only report invalid JSON in debug message if JSON debug level
+         * is high enough (where high is low :-)
+         */
+        if (json_dbg_allowed(JSON_DBG_LOW)) {
+	    json_dbg(JSON_DBG_LOW, __func__, "invalid JSON");
+        }
+
+        /*
+         * whereas if it's valid JSON it is redundant to set *is_valid, here we
+         * must set *is_valid to false as we always assume at first that it will
+         * be valid JSON (whatever that means :-) )
+         */
+	*is_valid = false;
     }
 
-    /* free scanner */
+    /*
+     * free the scanner of the so-called JSON <del>spec</del> nightmare
+     */
     jparse_lex_destroy(scanner);
 
     /*
@@ -703,10 +792,13 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
  *	 YY_BUFFER_STATE is part of the scanner and not the parser and that's required
  *	 for the parse_json_block() function.
  *
- * NOTE: this function only warns on error. It does this via the called function
- *	 parse_json(). This is done so that an entire report of all the problems can
- *	 be given at the end if the verbosity level is high enough (or otherwise if
- *	 this information is requested).
+ * NOTE: if filename is "-" and stream is NULL, then the stream is set to stdin,
+ * as if the filename was NULL.
+ *
+ * NOTE: this function only warns on error, except for NULL is_valid, in which
+ *       case it is an error; warning on errors is so that an entire report of
+ *       all the problems can be given at the end if the verbosity level is high
+ *       enough (or otherwise if this information is requested).
  */
 struct json *
 parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
@@ -726,9 +818,9 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON stream is is valid JSON; set *is_valid to true so
+         * that the caller does not need to worry about it (well they should in
+         * case this is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
@@ -743,25 +835,41 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 
     if (stream == NULL) {
 
-	/* report NULL stream */
+	/*
+         * report NULL stream
+         */
 	werr(43, __func__, "stream is NULL");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
+
+    /*
+     * if stream is not stdin check if the stream is open
+     */
     if (stream != stdin && fd_is_ready(__func__, false, fileno(stream)) == false) {
 
-	/* report closed stream */
+	/*
+         * report closed stream
+         */
 	werr(44, __func__, "stream is not open");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
@@ -772,11 +880,18 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     data = read_all(stream, &len);
     if (data == NULL) {
 
-	/* warn about read error */
+	/*
+         * warn about read error
+         */
 	werr(45, __func__, "could not read read stream");
+        /*
+         * we need to clearerr() or fclose(), depending on the stream.
+         */
 	clearerr_or_fclose(stream);
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
 	/* return a blank JSON tree */
@@ -785,12 +900,14 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
-     * pre-scan data for byte values from [\x00-\x08\x0e-\x1f]
+     * pre-scan data for byte values in range of [\x00-\x08\x0e-\x1f]
      */
     low_byte_detected = low_byte_scan(data, len, &low_bytes, &nul_bytes);
     if (low_byte_detected || low_bytes > 0 || nul_bytes > 0) {
 
-	/* report invalid JSON */
+	/*
+         * report invalid bytes
+         */
 	if (low_bytes > 0 && nul_bytes > 0) {
 	    werr(46, __func__, "%ju low byte%s and %ju NUL byte%s detected: data block is NOT valid JSON",
 		    (uintmax_t)low_bytes, low_bytes > 1 ? "s":"",
@@ -803,10 +920,14 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 		    (uintmax_t)nul_bytes, nul_bytes > 1 ? "s":"");
 	}
 
-	/* clean up input stream */
+	/*
+         * clearerr() or fclose() depending on stream
+         */
 	clearerr_or_fclose(stream);
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
 	/* free data */
@@ -821,9 +942,15 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
+     * if JSON debug level is high enough we will log the call with the length
+     */
+    if (json_dbg_allowed(JSON_DBG_HIGH)) {
+        json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
+    }
+
+    /*
      * JSON parse the data from the file
      */
-    json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
     tree = parse_json(data, len, filename, is_valid);
 
     /* free data */
@@ -833,9 +960,7 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
-     * clear error or close stream
-     *
-     * NOTE: clearerr_or_fclose() does nothing if stream is NULL.
+     * clear error or close stream, depending on stream
      */
     clearerr_or_fclose(stream);
     stream = NULL;
@@ -857,9 +982,8 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
  * return:
  *	pointer to a JSON parse tree
  *
- * If name is NULL or the name is not a readable file (or is empty) or
- * if read_all() read_all() fails, then this function warns and sets *is_valid
- * to false.
+ * If name is NULL or the name is not a readable file (or is empty) or if
+ * read_all() fails, then this function warns and sets *is_valid to false.
  *
  * NOTE: The reason this is in the scanner and not the parser is because
  *	 YY_BUFFER_STATE is part of the scanner and not the parser and that's required
@@ -884,45 +1008,53 @@ parse_json_file(char const *name, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON file is is valid JSON; set *is_valid to true so
+         * that the caller does not need to worry about it (well they should in
+         * case this is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
     if (name == NULL) {
-
-	/* this should actually never happen if called from jparse */
 	werr(50, __func__, "passed NULL name");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
     if (*name == '\0') { /* strlen(name) == 0 */
 
-	/* warn about bogus name */
+	/*
+         * warn about bogus name
+         */
 	werr(51, __func__, "passed empty filename");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
 
     /*
-     * if file is -, then we will parse stdin
+     * if file is "-", then we will parse stdin
      */
     if (strcmp(name, "-") == 0) {
 	stream = stdin;
 
     /*
-     * case will read from a file
+     * case: will read from a file
      */
     } else {
 
@@ -930,37 +1062,54 @@ parse_json_file(char const *name, bool *is_valid)
 	 * validate filename
 	 */
 	if (!exists(name)) {
-	    /* report missing file */
+	    /*
+             * report missing file
+             */
 	    werr(52, __func__, "passed filename that's not actually a file: %s", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 
 	}
 	if (!is_file(name)) {
-	    /* report that file is not a normal file */
+	    /*
+             * report that file is not a normal file
+             */
 	    werr(53, __func__, "passed filename not a normal file: %s", name);
 
-	    /* report invalid JSON */
+	    /*
+             * report invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
 	if (!is_read(name)) {
-
-	    /* report unreadable file */
+	    /*
+             * report unreadable file
+             */
 	    werr(54, __func__, "passed filename not a readable file: %s", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
@@ -972,13 +1121,19 @@ parse_json_file(char const *name, bool *is_valid)
 	stream = fopen(name, "r");
 	if (stream == NULL) {
 
-	    /* warn about file open error */
+	    /*
+             * warn about file open error
+             */
 	    werrp(55, __func__, "couldn't open file %s, ignoring", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}

--- a/jparse/jparse.lex.ref.h
+++ b/jparse/jparse.lex.ref.h
@@ -777,7 +777,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 304 "./jparse.l"
+#line 351 "./jparse.l"
 
 
 #line 732 "jparse.lex.h"

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -785,7 +785,11 @@ static const flex_int32_t yy_rule_can_match_eol[16] =
  */
 /* Section 0: Declarations and option settings */
 /*
- * %option noyywrap prevents needing to link in the flex(1) library (flex(3))
+ * The
+ *
+ *      %option noyywrap
+ *
+ * prevents needing to link in the flex(1) library (flex(3))
  * which means those without flex can compile the code. Even if everyone had
  * flex(1), though, under macOS you have to pass -ll to the compiler to link in
  * the flex library whereas in other systems you have to use -lfl which would
@@ -793,22 +797,26 @@ static const flex_int32_t yy_rule_can_match_eol[16] =
  * }' but this is unnecessary.
  */
 /*
- * we also need a few other options set:
+ * We also need these options set:
  *
- * %option nodefault nounput noinput
- * %option yylineno 8bit
- * %option bison-bridge bison-locations reentrant
- * %option prefix="jparse_"
- * %option header-file="jparse.lex.h"
- * %option extra-type="struct json_extra *"
+ *      %option nodefault
+ *      %option nounput
+ *      %option noinput
+ *      %option yylineno
+ *      %option 8bit
+ *      %option bison-bridge
+ *      %option bison-locations
+ *      %option reentrant
+ *      %option prefix="jparse_"
+ *      %option header-file="jparse.lex.h"
+ *      %option extra-type="struct json_extra *"
  */
 #define YY_NO_INPUT 1
-#line 48 "./jparse.l"
+#line 63 "./jparse.l"
 /* Declarations etc. go here.
  *
  * Code is copied verbatim near the top of the generated code.
  */
-
 
 /*
  * jparse - JSON parser
@@ -864,7 +872,7 @@ static YY_BUFFER_STATE bs;
 				} \
 			    } \
 			}
-#line 816 "jparse.c"
+#line 824 "jparse.c"
 /*
  * Section 1: Patterns (regular expressions) and actions.
  */
@@ -934,7 +942,7 @@ static YY_BUFFER_STATE bs;
  * JSON_COMMA		","
  */
 /* Actions. */
-#line 886 "jparse.c"
+#line 894 "jparse.c"
 
 #define INITIAL 0
 
@@ -1214,9 +1222,9 @@ YY_DECL
 		}
 
 	{
-#line 197 "./jparse.l"
+#line 211 "./jparse.l"
 
-#line 1168 "jparse.c"
+#line 1176 "jparse.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1287,18 +1295,20 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 198 "./jparse.l"
+#line 212 "./jparse.l"
 {
 			    /*
 			     * Whitespace excluding newlines
 			     *
-			     * NOTE: we have to include this action (JSON_WS) as
+			     * NOTE: we MUST include this action (JSON_WS) as
 			     * otherwise the action '.' will return an invalid
-			     * token to the parser.
+			     * token to the parser!
 			     *
-			     * We don't need the below message but for debugging
-			     * purposes we print how many whitespaces are
-			     * ignored, if the JSON debug level is high enough.
+			     * We don't really need the below debug message but
+                             * when we were developing the scanner/parser we
+                             * used it to see how many whitespaces were ignored
+                             * (depending on if the JSON debug level was high
+                             * enough).
 			     */
 			    (void) json_dbg(JSON_DBG_VVHIGH, __func__, "\nignoring %ju whitespace%s\n",
 							     (uintmax_t)yyleng, yyleng==1?"":"s");
@@ -1307,142 +1317,173 @@ YY_RULE_SETUP
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 214 "./jparse.l"
+#line 230 "./jparse.l"
 {
-			    yycolumn = 1; /* on newline we need to reset the column for error location tracking */
+                            /*
+                             * on newline (JSON_NL) we need to reset the column
+                             * for error location tracking.
+                             */
+			    yycolumn = 1;
 			}
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 218 "./jparse.l"
+#line 238 "./jparse.l"
 {
-			    /* string */
+			    /*
+                             * string (JSON_STRING)
+                             */
 			    return JSON_STRING;
 			}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 223 "./jparse.l"
+#line 245 "./jparse.l"
 {
-			    /* number */
+			    /*
+                             * number (JSON_NUMBER)
+                             */
 			    return JSON_NUMBER;
 			}
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 228 "./jparse.l"
+#line 252 "./jparse.l"
 {
-			    /* null object */
+			    /*
+                             * null object (JSON_NULL)
+                             */
 			    return JSON_NULL;
 			}
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 233 "./jparse.l"
+#line 259 "./jparse.l"
 {
-			    /* boolean: true */
+			    /*
+                             * true (JSON_TRUE)
+                             */
 			    return JSON_TRUE;
 			}
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 237 "./jparse.l"
+#line 265 "./jparse.l"
 {
-			    /* boolean: false */
+			    /*
+                             * false (JSON_FALSE)
+                             *
+                             * NOTE: the fact this is false does not make it
+                             * really false, as we do need false! :-)
+                             */
 			    return JSON_FALSE;
 			}
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 242 "./jparse.l"
+#line 275 "./jparse.l"
 {
-			    /* start of object */
+			    /*
+                             * start of object - open brace i.e. "{" (JSON_OPEN_BRACE)
+                             */
 			    return JSON_OPEN_BRACE;
 			}
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 246 "./jparse.l"
+#line 281 "./jparse.l"
 {
-			    /* end of object */
+			    /*
+                             * end of object - close brace i.e. "}" (JSON_CLOSE_BRACE)
+                             */
 			    return JSON_CLOSE_BRACE;
 			}
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 251 "./jparse.l"
+#line 288 "./jparse.l"
 {
-			    /* start of array */
+			    /*
+                             * start of array - open bracket i.e. "[" (JSON_OPEN_BRACKET)
+                             */
 			    return JSON_OPEN_BRACKET;
 			}
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 255 "./jparse.l"
+#line 294 "./jparse.l"
 {
-			    /* end of array */
+			    /*
+                             * end of array - close bracket i.e. "]" (JSON_CLOSE_BRACKET)
+                             */
 			    return JSON_CLOSE_BRACKET;
 			}
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 260 "./jparse.l"
+#line 301 "./jparse.l"
 {
-			    /* colon or 'equals' */
+			    /*
+                             * colon or 'equals' (JSON_COLON)
+                             */
 			    return JSON_COLON;
 			}
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 265 "./jparse.l"
+#line 308 "./jparse.l"
 {
-			    /* comma: name/value pair separator */
+			    /*
+                             * comma: name/value pair separator (JSON_COMMA)
+                             */
 			    return JSON_COMMA;
 			}
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 270 "./jparse.l"
+#line 315 "./jparse.l"
 {
-			    /* invalid token: any other character */
+			    /*
+                             * invalid token: any other character (regexp ".")
+                             */
 			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line,
                                     yylloc->first_column, *yytext, *yytext);
 
 			    /*
-			     * This is a hack for better error messages with
-			     * invalid tokens. Bison syntax error messages are
-			     * in the form of:
+			     * Returning 'token' (return token;) is a hack for
+                             * better error messages with invalid tokens. Bison
+                             * syntax error messages are in the form of:
 			     *
 			     *	    syntax error, unexpected <token name>
 			     *	    syntax error, unexpected <token name>, expecting } or JSON_STRING
 			     *
 			     * etc. where <token name> is whatever we return
-			     * here in the lexer actions (e.g.  JSON_STRING or
-			     * in this case literally token) to the parser. But
-			     * the problem is what do we call an invalid token
-			     * without knowing what what the token actually is?
-			     * Thus we call it token so that it will read
-			     * literally as 'unexpected token' which removes any
-			     * ambiguity (it could otherwise be read as 'it's
-			     * unexpected in this place but it is valid in other
-			     * contexts' but it's never actually valid: it's a
-			     * catch all for anything that's not valid).
+                             * here in the lexer actions (e.g.  JSON_STRING or
+                             * in this case literally token) to the parser. But
+                             * the problem is what do we call an invalid token
+                             * without knowing what what the token actually is?
+                             * Thus we call it token so that it will read
+                             * literally as 'unexpected token' which removes any
+                             * ambiguity (it could otherwise be read as 'it's
+                             * unexpected in this place but it is valid in other
+                             * contexts' but it's never actually valid: it's a
+                             * catch all for anything that's not valid).
 			     *
-			     * We also make use of yytext in yyerror()
-			     * which makes for a somewhat reasonable error
-			     * message even when yyerror() is called from
-			     * memory exhaustion. See that function and the
-			     * comments for '%token token' in jparse.y.
+			     * We also make use of yytext in yyerror() which
+                             * makes for a somewhat reasonable error message
+                             * even when yyerror() is called from memory
+                             * exhaustion. See that function and the comments
+                             * for '%token token' in jparse.y.
 			     */
 			    return token;
 			}
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 304 "./jparse.l"
+#line 351 "./jparse.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1394 "jparse.c"
+#line 1435 "jparse.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2604,11 +2645,10 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 304 "./jparse.l"
+#line 351 "./jparse.l"
 
 
 /* Section 2: Code that's copied to the generated scanner */
-
 
 /*
  * low_byte_scan - detect certain low byte values
@@ -2787,14 +2827,14 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 	    ++(*low_bytes);
 
 	    /*
-	     * case below the report limit
+	     * case: below the report limit
 	     */
 	    if (*low_bytes <= MAX_LOW_BYTES_REPORTED) {
 		werr(36, __func__, "invalid LOW byte 0x%02x detected in line: %zu byte position: %zu",
 			 data[i], linenum, byte_pos);
 
 	    /*
-	     * case at or above the report limit
+	     * case: at or above the report limit
 	     */
 	    } else if (low_limit == false) {
 		werr(37, __func__, "too many LOW bytes ([\\x01-\\x08\\x0e-\\x1f] detected: "
@@ -2844,9 +2884,12 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * NOTE: the reason this is in the scanner and not the parser is because
  * YY_BUFFER_STATE is part of the scanner and not the parser.
  *
- * NOTE: this function only warns on error. This is so that an entire report of
- * all the problems can be given at the end if the verbosity level is high
- * enough (or otherwise if this information is requested).
+ * NOTE: if filename is NULL we set it to "-" for stdin.
+ *
+ * NOTE: this function only warns on error, except for NULL is_valid, in which
+ *       case it is an error; warning on errors is so that an entire report of
+ *       all the problems can be given at the end if the verbosity level is high
+ *       enough (or otherwise if this information is requested).
  */
 struct json *
 parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
@@ -2864,9 +2907,9 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON block is is valid; set *is_valid to true so that the
+         * caller does not need to worry about it (well they should in case this
+         * is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
@@ -2875,20 +2918,24 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
      * firewall
      */
     if (ptr == NULL) {
-
-	/* this should never happen */
 	werr(39, __func__, "ptr is NULL");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
 
     if (filename == NULL) {
-	json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+        if (json_dbg_allowed(JSON_DBG_HIGH)) {
+	    json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
+        }
 	filename = "-";	/* assume stdin */
     }
 
@@ -2899,6 +2946,12 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     ret = jparse_lex_init_extra(&extra, &scanner);
     if (ret != 0) {
 	werrp(40, __func__, "jparse_lex_init_extra failed");
+
+        /*
+         * if jparse_lex_init_extra() reports an error (!= 0) then *is_valid
+         * must be set to false and we must return NULL
+         */
+        *is_valid = false;
 	return NULL;
     }
     extra.filename = filename;
@@ -2915,18 +2968,23 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	 */
 	werr(41, __func__, "unable to scan string");
 
-	/* flag that we have invalid JSON */
+	/*
+         * since we cannot scan the bytes, we set *is_valid to false, even
+         * though it could very well be valid if it could be scanned.
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	jparse_lex_destroy(scanner);
 	return tree;
     }
 
     /*
-     * we cannot set the column and probably line number without first having a
-     * buffer which is why the yy_scan_bytes() is called first.
+     * we cannot set the column (and probably line number) without first having
+     * a buffer which is why the yy_scan_bytes() is called first (see above).
      *
      * For why we set the column to 0 but the line to 1 see the comments with
      * the YY_USER_ACTION macro.
@@ -2935,7 +2993,7 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     jparse_set_lineno(1, scanner);
 
     /*
-     * announce beginning to parse
+     * announce beginning of parse, if JSON debug level is high enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	fprstr(stderr, "*** BEGIN PARSE\n");
@@ -2956,27 +3014,52 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
     bs = NULL;
 
     /*
-     * announce end of parse
+     * announce end of parse, if JSON debug level is high enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	fprstr(stderr, "*** END PARSE\n");
     }
 
     /*
-     * report scanner / parser success or failure
+     * report scanner / parser success or failure, if JSON debug level is high
+     * enough
      */
     if (json_dbg_allowed(JSON_DBG_VVHIGH)) {
 	json_dbg(JSON_DBG_VVHIGH, __func__, "jparse_parse() returned: %d", ret);
     }
+
     if (ret == 0) {
-	json_dbg(JSON_DBG_LOW, __func__, "valid JSON");
-	*is_valid = true; /* flag that we have valid JSON */
+        /*
+         * we will only report valid JSON (whatever that means :-) ) in debug
+         * message if JSON debug level is high enough (where high is low :-)
+         */
+        if (json_dbg_allowed(JSON_DBG_LOW)) {
+	    json_dbg(JSON_DBG_LOW, __func__, "valid JSON");
+        }
+        /*
+         * flag that we have valid JSON, even though we assumed it will be
+         */
+	*is_valid = true;
     } else {
-	json_dbg(JSON_DBG_LOW, __func__, "invalid JSON");
-	*is_valid = false; /* flag that we have invalid JSON */
+        /*
+         * we will only report invalid JSON in debug message if JSON debug level
+         * is high enough (where high is low :-)
+         */
+        if (json_dbg_allowed(JSON_DBG_LOW)) {
+	    json_dbg(JSON_DBG_LOW, __func__, "invalid JSON");
+        }
+
+        /*
+         * whereas if it's valid JSON it is redundant to set *is_valid, here we
+         * must set *is_valid to false as we always assume at first that it will
+         * be valid JSON (whatever that means :-) )
+         */
+	*is_valid = false;
     }
 
-    /* free scanner */
+    /*
+     * free the scanner of the so-called JSON <del>spec</del> nightmare
+     */
     jparse_lex_destroy(scanner);
 
     /*
@@ -3007,10 +3090,13 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
  *	 YY_BUFFER_STATE is part of the scanner and not the parser and that's required
  *	 for the parse_json_block() function.
  *
- * NOTE: this function only warns on error. It does this via the called function
- *	 parse_json(). This is done so that an entire report of all the problems can
- *	 be given at the end if the verbosity level is high enough (or otherwise if
- *	 this information is requested).
+ * NOTE: if filename is "-" and stream is NULL, then the stream is set to stdin,
+ * as if the filename was NULL.
+ *
+ * NOTE: this function only warns on error, except for NULL is_valid, in which
+ *       case it is an error; warning on errors is so that an entire report of
+ *       all the problems can be given at the end if the verbosity level is high
+ *       enough (or otherwise if this information is requested).
  */
 struct json *
 parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
@@ -3030,9 +3116,9 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON stream is is valid JSON; set *is_valid to true so
+         * that the caller does not need to worry about it (well they should in
+         * case this is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
@@ -3047,25 +3133,41 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 
     if (stream == NULL) {
 
-	/* report NULL stream */
+	/*
+         * report NULL stream
+         */
 	werr(43, __func__, "stream is NULL");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
+
+    /*
+     * if stream is not stdin check if the stream is open
+     */
     if (stream != stdin && fd_is_ready(__func__, false, fileno(stream)) == false) {
 
-	/* report closed stream */
+	/*
+         * report closed stream
+         */
 	werr(44, __func__, "stream is not open");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
@@ -3076,11 +3178,18 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     data = read_all(stream, &len);
     if (data == NULL) {
 
-	/* warn about read error */
+	/*
+         * warn about read error
+         */
 	werr(45, __func__, "could not read read stream");
+        /*
+         * we need to clearerr() or fclose(), depending on the stream.
+         */
 	clearerr_or_fclose(stream);
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
 	/* return a blank JSON tree */
@@ -3089,12 +3198,14 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
-     * pre-scan data for byte values from [\x00-\x08\x0e-\x1f]
+     * pre-scan data for byte values in range of [\x00-\x08\x0e-\x1f]
      */
     low_byte_detected = low_byte_scan(data, len, &low_bytes, &nul_bytes);
     if (low_byte_detected || low_bytes > 0 || nul_bytes > 0) {
 
-	/* report invalid JSON */
+	/*
+         * report invalid bytes
+         */
 	if (low_bytes > 0 && nul_bytes > 0) {
 	    werr(46, __func__, "%ju low byte%s and %ju NUL byte%s detected: data block is NOT valid JSON",
 		    (uintmax_t)low_bytes, low_bytes > 1 ? "s":"",
@@ -3107,10 +3218,14 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 		    (uintmax_t)nul_bytes, nul_bytes > 1 ? "s":"");
 	}
 
-	/* clean up input stream */
+	/*
+         * clearerr() or fclose() depending on stream
+         */
 	clearerr_or_fclose(stream);
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
 	/* free data */
@@ -3125,9 +3240,15 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
+     * if JSON debug level is high enough we will log the call with the length
+     */
+    if (json_dbg_allowed(JSON_DBG_HIGH)) {
+        json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
+    }
+
+    /*
      * JSON parse the data from the file
      */
-    json_dbg(JSON_DBG_HIGH, __func__, "calling parse_json on data block with length %ju:", (uintmax_t)len);
     tree = parse_json(data, len, filename, is_valid);
 
     /* free data */
@@ -3137,9 +3258,7 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
     }
 
     /*
-     * clear error or close stream
-     *
-     * NOTE: clearerr_or_fclose() does nothing if stream is NULL.
+     * clear error or close stream, depending on stream
      */
     clearerr_or_fclose(stream);
     stream = NULL;
@@ -3161,9 +3280,8 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
  * return:
  *	pointer to a JSON parse tree
  *
- * If name is NULL or the name is not a readable file (or is empty) or
- * if read_all() read_all() fails, then this function warns and sets *is_valid
- * to false.
+ * If name is NULL or the name is not a readable file (or is empty) or if
+ * read_all() fails, then this function warns and sets *is_valid to false.
  *
  * NOTE: The reason this is in the scanner and not the parser is because
  *	 YY_BUFFER_STATE is part of the scanner and not the parser and that's required
@@ -3188,45 +3306,53 @@ parse_json_file(char const *name, bool *is_valid)
 	not_reached();
     } else {
 	/*
-	 * set to true so that the caller does not need to worry about it (well
-	 * they should in case this is removed but we do it explicitly for them
-	 * anyway).
+	 * assume the JSON file is is valid JSON; set *is_valid to true so
+         * that the caller does not need to worry about it (well they should in
+         * case this is removed but we do it explicitly for them anyway).
 	 */
 	*is_valid = true;
     }
     if (name == NULL) {
-
-	/* this should actually never happen if called from jparse */
 	werr(50, __func__, "passed NULL name");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
     if (*name == '\0') { /* strlen(name) == 0 */
 
-	/* warn about bogus name */
+	/*
+         * warn about bogus name
+         */
 	werr(51, __func__, "passed empty filename");
 
-	/* flag that we have invalid JSON */
+	/*
+         * flag that we have invalid JSON
+         */
 	*is_valid = false;
 
-	/* return a blank JSON tree */
+	/*
+         * return a blank JSON tree
+         */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
 
     /*
-     * if file is -, then we will parse stdin
+     * if file is "-", then we will parse stdin
      */
     if (strcmp(name, "-") == 0) {
 	stream = stdin;
 
     /*
-     * case will read from a file
+     * case: will read from a file
      */
     } else {
 
@@ -3234,37 +3360,54 @@ parse_json_file(char const *name, bool *is_valid)
 	 * validate filename
 	 */
 	if (!exists(name)) {
-	    /* report missing file */
+	    /*
+             * report missing file
+             */
 	    werr(52, __func__, "passed filename that's not actually a file: %s", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 
 	}
 	if (!is_file(name)) {
-	    /* report that file is not a normal file */
+	    /*
+             * report that file is not a normal file
+             */
 	    werr(53, __func__, "passed filename not a normal file: %s", name);
 
-	    /* report invalid JSON */
+	    /*
+             * report invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
 	if (!is_read(name)) {
-
-	    /* report unreadable file */
+	    /*
+             * report unreadable file
+             */
 	    werr(54, __func__, "passed filename not a readable file: %s", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
@@ -3276,13 +3419,19 @@ parse_json_file(char const *name, bool *is_valid)
 	stream = fopen(name, "r");
 	if (stream == NULL) {
 
-	    /* warn about file open error */
+	    /*
+             * warn about file open error
+             */
 	    werrp(55, __func__, "couldn't open file %s, ignoring", name);
 
-	    /* flag that we have invalid JSON */
+	    /*
+             * flag that we have invalid JSON
+             */
 	    *is_valid = false;
 
-	    /* return a blank JSON tree */
+	    /*
+             * return a blank JSON tree
+             */
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -153,11 +153,11 @@
 int jparse_debug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debug on */
 
 /*
- * JSON parser library version
+ * JSON parser version strings (format: major.minor YYYY-MM-DD)
  */
-const char *const jparse_library_version = JPARSE_LIBRARY_VERSION;/* library version format: major.minor YYYY-MM-DD */
-const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
-const char *const jparse_utf8_version = JPARSE_UTF8_VERSION;	/* jparse utf8 version format: major.minor YYYY-MM-DD */
+const char *const jparse_library_version = JPARSE_LIBRARY_VERSION;  /* jparse library version */
+const char *const jparse_version = JPARSE_VERSION;		    /* jparse tool version */
+const char *const jparse_utf8_version = JPARSE_UTF8_VERSION;	    /* jparse utf8 version */
 
 
 #line 113 "jparse.tab.c"
@@ -580,9 +580,9 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   227,   227,   285,   316,   347,   378,   409,   439,   469,
-     501,   532,   562,   596,   635,   671,   702,   732,   766,   804,
-     837,   869
+       0,   230,   230,   288,   319,   350,   381,   412,   442,   472,
+     504,   535,   565,   599,   638,   674,   705,   735,   769,   807,
+     840,   872
 };
 #endif
 
@@ -1545,7 +1545,7 @@ yyreduce:
     switch (yyn)
       {
   case 2: /* json: json_element  */
-#line 228 "./jparse.y"
+#line 231 "./jparse.y"
     {
 	/*
 	 * $$ = $json
@@ -1603,7 +1603,7 @@ yyreduce:
     break;
 
   case 3: /* json_value: json_object  */
-#line 286 "./jparse.y"
+#line 289 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1636,7 +1636,7 @@ yyreduce:
     break;
 
   case 4: /* json_value: json_array  */
-#line 317 "./jparse.y"
+#line 320 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1669,7 +1669,7 @@ yyreduce:
     break;
 
   case 5: /* json_value: json_string  */
-#line 348 "./jparse.y"
+#line 351 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1702,7 +1702,7 @@ yyreduce:
     break;
 
   case 6: /* json_value: json_number  */
-#line 379 "./jparse.y"
+#line 382 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1735,7 +1735,7 @@ yyreduce:
     break;
 
   case 7: /* json_value: "true"  */
-#line 410 "./jparse.y"
+#line 413 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1767,7 +1767,7 @@ yyreduce:
     break;
 
   case 8: /* json_value: "false"  */
-#line 440 "./jparse.y"
+#line 443 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1799,7 +1799,7 @@ yyreduce:
     break;
 
   case 9: /* json_value: "null"  */
-#line 470 "./jparse.y"
+#line 473 "./jparse.y"
     {
 	/*
 	 * $$ = $json_value
@@ -1831,7 +1831,7 @@ yyreduce:
     break;
 
   case 10: /* json_object: "{" json_members "}"  */
-#line 502 "./jparse.y"
+#line 505 "./jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1864,7 +1864,7 @@ yyreduce:
     break;
 
   case 11: /* json_object: "{" "}"  */
-#line 533 "./jparse.y"
+#line 536 "./jparse.y"
     {
 	/*
 	 * $$ = $json_object
@@ -1894,7 +1894,7 @@ yyreduce:
     break;
 
   case 12: /* json_members: json_member  */
-#line 563 "./jparse.y"
+#line 566 "./jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -1930,7 +1930,7 @@ yyreduce:
     break;
 
   case 13: /* json_members: json_members "," json_member  */
-#line 597 "./jparse.y"
+#line 600 "./jparse.y"
     {
 	/*
 	 * $$ = $json_members
@@ -1969,7 +1969,7 @@ yyreduce:
     break;
 
   case 14: /* json_member: json_string ":" json_element  */
-#line 636 "./jparse.y"
+#line 639 "./jparse.y"
     {
 	/*
 	 * $$ = $json_member
@@ -2005,7 +2005,7 @@ yyreduce:
     break;
 
   case 15: /* json_array: "[" json_elements "]"  */
-#line 672 "./jparse.y"
+#line 675 "./jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2038,7 +2038,7 @@ yyreduce:
     break;
 
   case 16: /* json_array: "[" "]"  */
-#line 703 "./jparse.y"
+#line 706 "./jparse.y"
     {
 	/*
 	 * $$ = $json_array
@@ -2068,7 +2068,7 @@ yyreduce:
     break;
 
   case 17: /* json_elements: json_element  */
-#line 733 "./jparse.y"
+#line 736 "./jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2104,7 +2104,7 @@ yyreduce:
     break;
 
   case 18: /* json_elements: json_elements "," json_element  */
-#line 767 "./jparse.y"
+#line 770 "./jparse.y"
     {
 	/*
 	 * $$ = $json_elements
@@ -2142,7 +2142,7 @@ yyreduce:
     break;
 
   case 19: /* json_element: json_value  */
-#line 805 "./jparse.y"
+#line 808 "./jparse.y"
     {
 	/*
 	 * $$ = $json_element
@@ -2175,7 +2175,7 @@ yyreduce:
     break;
 
   case 20: /* json_string: JSON_STRING  */
-#line 838 "./jparse.y"
+#line 841 "./jparse.y"
     {
 	/*
 	 * $$ = $json_string
@@ -2207,7 +2207,7 @@ yyreduce:
     break;
 
   case 21: /* json_number: JSON_NUMBER  */
-#line 870 "./jparse.y"
+#line 873 "./jparse.y"
     {
 	/*
 	 * $$ = $json_number
@@ -2446,7 +2446,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 900 "./jparse.y"
+#line 903 "./jparse.y"
 
 
 

--- a/jparse/jparse.y
+++ b/jparse/jparse.y
@@ -100,11 +100,11 @@
 int jparse_debug = 0;	/* 0 ==> verbose bison debug off, 1 ==> verbose bison debug on */
 
 /*
- * JSON parser library version
+ * JSON parser version strings (format: major.minor YYYY-MM-DD)
  */
-const char *const jparse_library_version = JPARSE_LIBRARY_VERSION;/* library version format: major.minor YYYY-MM-DD */
-const char *const jparse_version = JPARSE_VERSION;		/* jparse version format: major.minor YYYY-MM-DD */
-const char *const jparse_utf8_version = JPARSE_UTF8_VERSION;	/* jparse utf8 version format: major.minor YYYY-MM-DD */
+const char *const jparse_library_version = JPARSE_LIBRARY_VERSION;  /* jparse library version */
+const char *const jparse_version = JPARSE_VERSION;		    /* jparse tool version */
+const char *const jparse_utf8_version = JPARSE_UTF8_VERSION;	    /* jparse utf8 version */
 
 %}
 
@@ -172,6 +172,9 @@ YY_DECL;
  *	%token JSON_FALSE "false"
  *	%token JSON_STRING
  *	%token JSON_NUMBER
+ *
+ * Observe that these exist in jparse.l. In the case that t here is no value,
+ * you might check jparse.l for the regexp.
  */
 %token JSON_OPEN_BRACE "{"
 %token JSON_CLOSE_BRACE "}"

--- a/jparse/json_utf8.h
+++ b/jparse/json_utf8.h
@@ -36,7 +36,7 @@
 /*
  * official jparse UTF-8 version
  */
-#define JPARSE_UTF8_VERSION "2.0.1 2024-11-01"	/* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTF8_VERSION "2.0.2 2024-11-03"	/* format: major.minor YYYY-MM-DD */
 
 
 extern size_t utf8len(const char *str, int32_t surrogate);
@@ -107,12 +107,6 @@ extern unsigned int utf8decode(const char *str);
  * which was greater than UNICODE_MAXIMUM or UNICODE_UTF8_4 into UTF-8 bytes.
  */
 #define UNICODE_TOO_BIG -7
-/*
- * This return value indicates that the Unicode code-point ended with either
- * 0xFFFF or 0xFFFE, meaning it cannot be used as a character code point, or it
- * was in the disallowed range FDD0 to FDEF.
- */
-#define UNICODE_NOT_CHARACTER -8
 
 extern int32_t surrogates_to_unicode (int32_t hi, int32_t lo);
 

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.0.1 2024-11-01"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.0.2 2024-11-03"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.6.5 2024-11-01"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.6.6 2024-11-03"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Sync the jparse/ directory from jparse repo
(https://github.com/xexyl/jparse/). This adds some extra sanity checks in jstrencode(1)/jstrdecode(1) and it also makes some fixes to the change in decode/encode terminology, namely to do with comments. An unused macro (after a fix) was removed. Comments were updated and improved in jparse.l and jparse.y. Regenerated parser backup files.