### PR TITLE
Important bug fix in jparse/util.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 1.6.8 2024-11-08
+
+Synced `jparse/` from the [jparse repo](https://github.com/xexyl/jparse/). This
+includes some important bug fixes in a utility function that resulted, in debug
+output, invalid JSON, plus an incorrect calculation in one case.
+
 ## Release 1.6.7 2024-11-07
 
 Synced `jparse/` from the [jparse repo](https://github.com/xexyl/jparse/) to

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,26 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.0.5 2024-11-08
+
+Important bug fixes in `fprint_line_buf()` in `util.c`, as follows. First, for
+example, the text `"\xf0"` is NOT valid JSON but `"\\xf0"` is. However, that
+function printed the former, not the latter, and thus if one were to copy paste
+the debug output to a file it would be invalid JSON. Second, there was a
+miscalculation in the increment of count in one case, possibly due to the
+earlier function.
+
+What prompted this fix is that it was thought that it might be nice to have
+debug output print unicode characters (emojis, non-ASCII characters etc.). Now
+this might be nice with a new flag for the tools but this means modifying a lot
+of functions and might or might not be worth it. What is definitely worth it is
+these fixes, however, so that is done for now. If a new option is desired to
+print unicode symbols then that can be considered later.
+
+The `JPARSE_VERSION` was updated to `"1.2.1 2024-11-08"`.
+
+The `JPARSE_LIBRARY_VERSION` was updated to `"2.0.1 2024-11-08"`.
+
+
 ## Release 2.0.4 2024-11-07
 
 Removed `utf8decode()` from `json_utf8.c` as it appears we will not need it
@@ -14,6 +35,8 @@ function difference is that if either is `< 0` it is warned about as it should
 never happen).
 
 Updated `JPARSE_UTF8_VERSION` to `"2.0.3 2024-11-07"`.
+
+Further improvements to `jparse_bug_report.sh`.
 
 
 ## Release 2.0.3 2024-11-05

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,17 +30,17 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.0.4 2024-11-07"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.0.5 2024-11-08"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.2.0 2024-10-09"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.2.1 2024-11-08"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official JSON parser version
  */
-#define JPARSE_LIBRARY_VERSION "2.0.0 2024-10-31"		/* library version format: major.minor YYYY-MM-DD */
+#define JPARSE_LIBRARY_VERSION "2.0.1 2024-11-08"	/* library version format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/soup/oebxergfB.h
+++ b/soup/oebxergfB.h
@@ -40,11 +40,11 @@
  * jrql jrt ziuole entries. Cj'u xtqzzc jrqj simple. Vod cis xtqzzc tkwtyj
  * uiftjrole tzut? Eiz.
  *
- * BTW: If after looking at this file you think Cody is a bit crazy this is more
- * than understandable and Cody is quite okay with it. In fact he rather
- * relishes the idea! :-)
+ * BTW: If after looking at this file you think Cody is more than a bit
+ * eccentric this is more than understandable and Cody is quite okay with it. In
+ * fact he rather relishes the idea! :-)
  *
- * "Because Cody enjoys being a bit eccentric and he is rather proud of it too!" :-)
+ * "Because Cody enjoys being eccentric and he is rather proud of it too!" :-)
  *
  * "Share and Enjoy!"
  *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "1.6.7 2024-11-07"	/* special release format: major.minor.patch YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "1.6.8 2024-11-08"	/* special release format: major.minor.patch YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Synced jparse/ from the jparse repo (https://github.com/xexyl/jparse/). This includes some important bug fixes in a utility function that resulted, in debug output, invalid JSON, plus an incorrect calculation in one case.