### PR TITLE
Improve jparse wording and debug output

### DIFF
--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,23 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.0.6 2024-11-09
+
+After some discussion, part of the change to `fprint_line_buf()` from  yesterday
+was rolled back. In particular, the `fprint_line_buf()` function should print,
+as part of debug output, the raw data and not encoded/decoded strings. Thus if
+`'\a'` is encountered it should print just `"\a"`, not `"\\a"`, and if `Ã` is
+encountered then it should print `"\xc3\x83"`, not `"\\xc3\\x83"`, and so on.
+
+The return value error fix was kept in place and as an extra sanity check before
+checking `isprint()` check `isascii(c)`, though this might not matter in some or
+maybe most cases.
+
+Improve man page for `jstrencode` and `jstrdecode` with more examples, more
+details and also reword what the programs do. The `jparse_utils_README.md` has
+had the same sort of improvements. The source code and header files for these
+two tools have also had the update (the summary of what the tool does).
+
+
 ## Release 2.0.5 2024-11-08
 
 Important bug fixes in `fprint_line_buf()` in `util.c`, as follows. First, for

--- a/jparse/json_README.md
+++ b/jparse/json_README.md
@@ -250,7 +250,7 @@ range of character values that _must_ be decoded (transformed into
 _not_ required to be decoded as a character sequence that starts
 with `"\uxxxx"` where _xxxx_ are 4 hexadecimal digits.
 
-While one is not required to backslash an decoded slash character (ASCII
+While one is not required to backslash a decoded slash character (ASCII
 `0x2f` - `U+002F`), one is allowed to do so.  The solidus or slash
 character (ASCII `0x2f` - `U+002F`) is allowed to be, but is _not required_,
 to be backslash decoded:
@@ -328,7 +328,7 @@ is encoded into the following string that includes a trailing newline
 (control-J - `'\n'` - ASCII `0x0a` - `U+000A`):
 
 ```
-Hello, with \-escaped and ß-like chars, world!
+Hello, with \-escaped and Ã-like chars, world!
 ```
 
 _NOTE_: A **JSON encoded string** is _not_ allowed in a [JSON

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -2129,7 +2129,7 @@ json_dbg_tree_print(int json_dbg_lvl, char const *name, struct json *tree, unsig
 /*
  * json_tree_walk - walk a JSON parse tree calling a function on each node
  *
- * Walk a JSON parse tree, Depth-first Post-order (LRN) order.  See:
+ * Walk a JSON parse tree, Depth-first Post-order (LRN).  See:
  *
  *	https://en.wikipedia.org/wiki/Tree_traversal#Post-order,_LRN
  *
@@ -2204,7 +2204,7 @@ json_tree_walk(struct json *node, unsigned int max_depth, unsigned int depth, bo
  *
  * This is the va_list form of json_tree_walk().
  *
- * Walk a JSON parse tree, Depth-first Post-order (LRN) order.  See:
+ * Walk a JSON parse tree, Depth-first Post-order (LRN).  See:
  *
  *	https://en.wikipedia.org/wiki/Tree_traversal#Post-order,_LRN
  *

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -1,5 +1,5 @@
 /*
- * jstrdecode - tool to decode a string for JSON
+ * jstrdecode - tool to convert JSON encoded strings into normal strings
  *
  * "JSON: when a minimal design falls below a critical minimum." :-)
  *
@@ -54,9 +54,9 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform tests of JSON encode/decode functionality\n"
     "\t-n\t\tdo not output newline after decode output (def: print final newline)\n"
-    "\t-N\t\tignore all newline characters\n"
-    "\t-Q\t\tdo not decode double quotes that enclose the concatenation of args (def: do decode)\n"
-    "\t-e\t\tdo not output double quotes that enclose each arg (def: do not remove)\n"
+    "\t-N\t\tignore all newline characters in input\n"
+    "\t-Q\t\tskip double quotes that enclose each arg's concatenation\n"
+    "\t-e\t\tskip double quotes that enclose each arg\n"
     "\t-E level\tentertainment mode\n"
     "\n"
     "\t[string ...]\tdecode the concatenation of string args (def: decode stdin)\n"

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -1,5 +1,5 @@
 /*
- * jstrdecode - tool to decode a string for JSON
+ * jstrdecode - tool to convert JSON encoded strings into normal strings
  *
  * "JSON: when a minimal design falls below a critical minimum." :-)
  *

--- a/jparse/jstrencode.c
+++ b/jparse/jstrencode.c
@@ -1,5 +1,5 @@
 /*
- * jstrencode - tool to encode JSON decoded strings
+ * jstrencode - tool to JSON encode command line strings
  *
  * "JSON: when a minimal design falls below a critical minimum." :-)
  *
@@ -54,7 +54,7 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform tests of JSON encode/decode functionality\n"
     "\t-n\t\tdo not output newline after encode output\n"
-    "\t-N\t\tignore all newline characters\n"
+    "\t-N\t\tignore all newline characters in input\n"
     "\t-Q\t\tenclose output in double quotes (def: do not)\n"
     "\t-e\t\tenclose each encoded string with escaped double quotes (def: do not)\n"
     "\t-E level\tentertainment mode\n"

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -1,5 +1,5 @@
 /*
- * jstrencode - tool to encode JSON decoded strings
+ * jstrencode - tool to JSON encode command line strings
  *
  * "JSON: when a minimal design falls below a critical minimum." :-)
  *

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -9,10 +9,10 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "31 October 2024" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "09 November 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
-\- decode JSON encoded strings
+\- convert JSON encoded strings into normal strings
 .SH SYNOPSIS
 .B jstrdecode
 .RB [\| \-h \|]
@@ -31,13 +31,27 @@
 .IR ... \|]
 .SH DESCRIPTION
 .B jstrdecode
-Concatenate the string arguments and decode the result as if it were a JSON string.
+converts JSON encoded strings into a normal strings.
+If given the
+.B \-Q
+option, the program skips double quotes that enclose each arg's concatenation.
+If given the
+.B \-e
+option it will skip double quotes that enclose each arg.
+To ignore newlines in the input, use the
+.B \-N
+option.
+On the other hand, if you do not want a newline printed after the output, use the
+.B \-n
+option.
+By default the program reads from
+.BR stdin ,
+if no arg is specified.
+Otherwise it will act on the arguments to the program.
+.PP
 If given the
 .B \-t
 option it performs a test on the JSON decode and encode functions.
-.PP
-By default the program reads from
-.BR stdin .
 .SH OPTIONS
 .TP
 .B \-h
@@ -61,13 +75,13 @@ Run tests on the JSON decode/encode functions
 Do not output a newline after the decode function
 .TP
 .B \-N
-Ignore and skip over all newlines, for easier typing commands.
+Ignore all newline characters in input
 .TP
 .B \-Q
-Do not decode double quotes that enclose the concatenation of args (def: do decode)
+Skip double quotes that enclose each arg's concatenation
 .TP
 .B \-e
-Do not decode double quotes that enclose each arg (def: do decode)
+Skip double quotes that enclose each arg
 .TP
 .BI \-E\  level
 Entertainment mode at level
@@ -99,7 +113,7 @@ but this occurs in other applications as well so we note this issue here.
 .PP
 It is worth remembering that, for the
 .B \-Q
-option, a double quote in the string will still be decoded, if it is a second arg or if another arg is specified, as it will not be a leading or trailing quote.
+option, if the string is not enclosed in double quotes (in other words, the first character and last character are both double quotes), the quote will not be removed, as it's not enclosed in double quotes.
 .PP
 If you have an issue with the tool you can report it at
 .br
@@ -138,6 +152,21 @@ Decode just a negative number:
 .RS
 .ft B
  jstrdecode \-\- \-5
+.ft R
+.RE
+Ignore newlines in input:
+.sp
+.RS
+.ft B
+ printf "foo\\\\nbar" | jstrdecode -N 
+.ft R
+.RE
+.PP
+Skip double quotes that enclose each arg's concatenation:
+.sp
+.RS
+.ft B
+ jstrdecode -Q '"foo"' bar baz
 .ft R
 .RE
 .PP

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -9,10 +9,10 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "04 November 2024" "jstrencode" "jparse tools"
+.TH jstrencode 1 "09 November 2024" "jstrencode" "jparse tools"
 .SH NAME
 .B jstrencode
-\- encode JSON decoded strings
+\- JSON encode command line strings
 .SH SYNOPSIS
 .B jstrencode
 .RB [\| \-h \|]
@@ -31,25 +31,41 @@
 .IR ... \|]
 .SH DESCRIPTION
 .B jstrencode
-encodes JSON decoded strings given on the command line.
-If given the
-.B \-t
-option it performs a test on the JSON encode and decode functions.
-By default the program reads from
-.BR stdin .
+encodes command line strings in JSON format according to the so-called JSON specification.
+It will, in the case of UTF\-8 or UTF\-16 codepoints in the JSON format of
+.B
+.B \\\\uxxxx
+or
+.BR \\\\uxxxx\\\\uxxxx ,
+where
+.B x
+is a hexadecimal digit, encode to the proper Unicode symbol, although if your system cannot show it or it is invalid, you might see a symbol that indicates this.
+.PP
 If given the
 .B \-Q
-option it will enclose the output in quotes.
+option it will enclose the entire output in quotes.
 If given the
-.B \-m
-(aliased as
-.BR \-e )
-option it will surround each decoded arg (after encoding it) with escaped (backslash) quotes.
+.B \-e
+option it will enclose each encoded string with escaped double quotes.
 The use of
 .B \-Q
 and
 .B \-e
-together will surround the entire output with unescaped quotes and each decoded arg's (after encoding) output will be surrounded with escaped (backslashed) quotes.
+together will surround the entire output with unescaped quotes and each encoded arg will be surrounded with escaped (backslashed) quotes.
+To ignore newlines in the input, use the
+.B \-N
+option.
+On the other hand, if you do not want a newline printed after the output, use the
+.B \-n
+option.
+By default the program reads from
+.BR stdin ,
+if no arg is specified.
+Otherwise it will act on the arguments to the program.
+.PP
+If given the
+.B \-t
+option it performs a test on the JSON encode and decode functions.
 .SH OPTIONS
 .TP
 .B \-h
@@ -73,7 +89,7 @@ Run tests on the JSON encode/decode functions
 Do not output a newline after the encode function
 .TP
 .B \-N
-Ignore and skip over all newlines, for easier typing commands.
+Ignore all newline characters in input
 .TP
 .B \-Q
 Enclose output in double quotes
@@ -156,6 +172,22 @@ Display the dragon emoji (U+1F409):
 .RS
 .ft B
  jstrencode "\\uD83D\\uDC09"
+.ft R
+.RE
+.PP
+Ignore newlines in input:
+.sp
+.RS
+.ft B
+ printf "foo\\\\nbar" | jstrencode -N 
+.ft R
+.RE
+.PP
+Enclose output in double quotes:
+.sp
+.RS
+.ft B
+ jstrencode -Q foo bar baz
 .ft R
 .RE
 .PP

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,17 +30,17 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.0.5 2024-11-08"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.0.6 2024-11-09"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.2.1 2024-11-08"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.2.2 2024-11-09"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official JSON parser version
  */
-#define JPARSE_LIBRARY_VERSION "2.0.1 2024-11-08"	/* library version format: major.minor YYYY-MM-DD */
+#define JPARSE_LIBRARY_VERSION "2.0.2 2024-11-09"	/* library version format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */


### PR DESCRIPTION
Synced jparse/ from the jparse repo (https://github.com/xexyl/jparse/). This came from discussion on JSON debug output as well as discussion about wording. A fix in one of the man pages was also made (no longer true statement) and the man pages and utils README.md were all expanded with more details and examples.