### PR TITLE
Somewhat important fixes in bug_report and prep

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -85,14 +85,14 @@ your system.
 
 ## 2.  How may I install the tools if I wish to, and is it required?
 
-You do not need to install the code (see below) but it can be helpful to do so
-as you can then run the tools from any directory including your submission
-directory, so you do not have to specify paths.
+You do not need to install the code (see below) but it can be helpful to do so,
+so you can run the tools from any directory including your submission directory;
+that way, you do not have to specify paths.
 
 If you do wish to install the toolkit, you can do:
 
 ```sh
-    make install
+make install
 ```
 
 as either root or via sudo. By default this will install with the `PREFIX` of
@@ -104,7 +104,7 @@ install with the `PREFIX` of `/usr`:
 
 
 ```sh
-    make PREFIX=/usr install
+make PREFIX=/usr install
 ```
 
 
@@ -222,7 +222,7 @@ You may also run the `bug_report.sh` tool directly:
 ```
 
 The bug report filename is in the format:
-`bug-report.$(/bin/date +%Y%m%d.%H%M%S).txt` where:
+`bug-report.$(date +%Y%m%d.%H%M%S).txt` where:
 
 
 - `%Y` is the four digit year (e.g. 2024).
@@ -337,7 +337,7 @@ If you have installed the tools and you wish to uninstall them, you can do so
 from the top level repo directory by typing:
 
 ```sh
-    make uninstall
+make uninstall
 ```
 
 as either root or via sudo.
@@ -348,7 +348,7 @@ pages. For instance if you installed with the `PREFIX` of `/usr` you would type
 instead:
 
 ```sh
-    make PREFIX=/usr uninstall
+make PREFIX=/usr uninstall
 ```
 
 After this all the files installed should be removed. If this is not the case by

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -96,7 +96,7 @@ if [[ -z "$MAKE" ]]; then
 	MAKE="$(type -P make)"
 fi
 export MAKE
-export BUG_REPORT_VERSION="1.0.4 2024-06-26"
+export BUG_REPORT_VERSION="1.0.5 2024-11-16"
 export FAILURE_SUMMARY=
 export NOTICE_SUMMARY=
 export DBG_LEVEL="0"
@@ -134,7 +134,7 @@ bug_report.sh version: $BUG_REPORT_VERSION"
 # NOTE: log file does not have an underscore in the name because we want to
 # distinguish it from this script which does have an underscore in it.
 #
-LOGFILE="bug-report.$(/bin/date +%Y%m%d.%H%M%S).txt"
+LOGFILE="bug-report.$(date +%Y%m%d.%H%M%S).txt"
 
 # parse args
 #

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -21,7 +21,7 @@
 export FAILURE_SUMMARY=
 export SKIPPED_SUMMARY=
 export LOGFILE=
-export PREP_VERSION="1.0.3 2024-09-30"
+export PREP_VERSION="1.0.4 2024-11-16"
 export NOTICE_COUNT="0"
 export USAGE="usage: $0 [-h] [-v level] [-V] [-e] [-o] [-m make] [-M Makefile] [-l logfile]
 
@@ -132,7 +132,7 @@ fi
 # NOTE: this log file does not have an underscore in the name because we want to
 # distinguish it from this script which does have an underscore in it.
 #
-BUG_REPORT_LOGFILE="bug-report.$(/bin/date +%Y%m%d.%H%M%S).txt"
+BUG_REPORT_LOGFILE="bug-report.$(date +%Y%m%d.%H%M%S).txt"
 export BUG_REPORT_LOGFILE
 
 # write_echo - write a message to either the log file or both the log file and


### PR DESCRIPTION
Rather than assume that date(1) is at /bin/date, just use 'date'.

Minor format fixes/clarifications in FAQ.