### PR TITLE
Fix critical bug in jparse/test_jparse/Makefile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.0.1 2024-11-18
+
+Fix critical compilation error in `jparse/test_jparse/Makefile` for linux.
+
+Other bug fixes and improvements were added to `jparse/` from the jparse repo.
+
+
 ## Release 2.0 2024-11-17
 
 This is a formal release for public use.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,53 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.1.3 2024-11-18
+
+Improve function `parse_json_str()` and `parse_json()` by allowing for empty or
+NULL strings in the following way: `parse_json_str()` will pass a NULL filename
+to `parse_json()` which will keep the filename as NULL, which will, due to
+updates in the error function, not show a file (the difference is that it now
+checks that it's not NULL **AND** not a NUL string).
+Thus to parse a string rather than a file, one can use either
+`parse_json_str()` (a simplified version) or else `parse_json()` with a NULL
+filename. Using an empty filename in the latter function will set it to `"-"` for
+stdin, though it's important to realise that the function `parse_json()` acts on
+a `char *`. If one needs to read in a file, they should instead use
+`parse_json_file()` (if they have only a filename) or else `parse_json_stream()`
+if they have a `FILE *`.
+
+Renamed some internal functions that were too ambiguous with the `parse_json()`
+family of functions. In particular the functions that parse specific JSON types
+like `json_parse_string()` which used to be `parse_json_string()` (too similar
+to `parse_json_str()` which has a very different purpose). All of the
+`parse_json_()` functions were renamed to `json_parse_()` which also match the
+conversion and allocation functions in name format.
+
+Fixed `jparse.3` man page and added a new file (also a symlink like the others)
+for `parse_json_str()`.
+
+Fixed at least one issue with `jstrdecode(1)` by first using the jparse parser
+on the string prior to decoding. This will solve the problem of input like
+`'"foo\"'` not reporting an error (previously it would throw a warning but not
+an error but it is NOT valid JSON). Furthermore something like `'"\"\"\""\'`
+will now report an error:
+
+```
+syntax error node type JTYPE_STRING at line 1 column 9: <\>
+ERROR[15]: main: invalid JSON
+```
+
+In the case that one needs to or wants to not validate the JSON first, they can
+use the `-j` option. The `-J level` sets the JSON debug level.
+
+Fix compilation error in linux for `util_test` - add missing `-lm` to
+`test_jparse/Makefile`.
+
+Updated the version of `jstrdecode` to: "2.1.3 2024-11-18".
+Updated version of the jparse library to: `"2.2.0 2024-11-18"`.
+Updated version of `jparse(1)` to: `"1.2.4 2024-11-18"`.
+
+
 ## Release 2.1.2 2024-11-17
 
 The `-e` for `jstrdecode(1)`, only encloses each decoded arg in escaped

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -568,7 +568,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 
 
 /*
- * parse_json - parse a JSON document of a given length
+ * parse_json - parse a JSON file or string of a given length
  *
  * Given a pointer to char and a length, use the parser to determine if the JSON
  * is valid or not.
@@ -577,7 +577,8 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  *	ptr	    - pointer to start of JSON blob
  *	len	    - length of the JSON blob
- *	filename    - filename or NULL for stdin
+ *	filename    - filename, empty string or "-" for stdin or NULL to
+ *	              indicate it is a string
  *	is_valid    - non-NULL pointer to boolean to set depending on JSON validity
  *
  * return:
@@ -586,7 +587,9 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * NOTE: the reason this is in the scanner and not the parser is because
  * YY_BUFFER_STATE is part of the scanner and not the parser.
  *
- * NOTE: if filename is NULL we set it to "-" for stdin.
+ * NOTE: if filename is NULL, it will be set to "-" for stdin but if it is an
+ * empty string any error message will report it as a string (i.e. it will not
+ * show that it's a file).
  *
  * NOTE: this function only warns on error, except for NULL is_valid, in which
  *       case it is an error; warning on errors is so that an entire report of
@@ -616,6 +619,10 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	*is_valid = true;
     }
 
+    if (filename != NULL && *filename == '-') {
+        filename = "-";
+    }
+
     /*
      * firewall
      */
@@ -632,13 +639,6 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
          */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
-    }
-
-    if (filename == NULL) {
-        if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
-        }
-	filename = "-";	/* assume stdin */
     }
 
     /*
@@ -776,10 +776,13 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
  * Given a pointer to char and a length, use the parser to determine if the JSON
  * is valid or not.
  *
- * This is a simplified version of parse_json() in that it does not take a
- * filename arg. Instead it just sets the filename to "-". Although it might not
- * strictly be from stdin in every case, it works well enough. Let's call it a
- * misuse of the word stdin.
+ * This function assumes that the JSON is a string, rather than a file to be
+ * read, and it uses parse_json() with a NULL filename. Thus it can be seen as
+ * a simplified interface to parse_json() in the case of a string rather than a
+ * file. The error function checks if the filename is != NULL and if *filename
+ * != '\0' before claiming it is a file. The function parse_json() will, if
+ * filename != NULL && *filename == '-', set filename to "-", indicating the
+ * input comes from stdin.
  *
  * given:
  *
@@ -837,9 +840,9 @@ parse_json_str(char const *ptr, size_t len, bool *is_valid)
     }
 
     /*
-     * return a call to parse_json() with "-" as filename.
+     * return a call to parse_json() with NULL filename
      */
-    return parse_json(ptr, len, "-", is_valid);
+    return parse_json(ptr, len, NULL, is_valid);
 }
 
 
@@ -1046,10 +1049,10 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 
 
 /*
- * parse_json_file	    - parses file file
+ * parse_json_file	    - parse a JSON file in a given filename
  *
  * given:
- *	name	    - filename of file to parse
+ *	filename    - filename of file to parse
  *	is_valid    - non-NULL printer to boolean to set depending on json validity
  *
  * return:
@@ -1068,7 +1071,7 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_file(char const *name, bool *is_valid)
+parse_json_file(char const *filename, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     FILE *stream = NULL;		/* file stream to read from */
@@ -1087,8 +1090,8 @@ parse_json_file(char const *name, bool *is_valid)
 	 */
 	*is_valid = true;
     }
-    if (name == NULL) {
-	werr(52, __func__, "passed NULL name");
+    if (filename == NULL) {
+	werr(52, __func__, "passed NULL filename");
 
 	/*
          * flag that we have invalid JSON
@@ -1101,10 +1104,10 @@ parse_json_file(char const *name, bool *is_valid)
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
-    if (*name == '\0') { /* strlen(name) == 0 */
+    if (*filename == '\0') { /* strlen(filename) == 0 */
 
 	/*
-         * warn about bogus name
+         * warn about bogus filename
          */
 	werr(53, __func__, "passed empty filename");
 
@@ -1123,7 +1126,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * if file is "-", then we will parse stdin
      */
-    if (strcmp(name, "-") == 0) {
+    if (strcmp(filename, "-") == 0) {
 	stream = stdin;
 
     /*
@@ -1134,11 +1137,11 @@ parse_json_file(char const *name, bool *is_valid)
 	/*
 	 * validate filename
 	 */
-	if (!exists(name)) {
+	if (!exists(filename)) {
 	    /*
              * report missing file
              */
-	    werr(54, __func__, "passed filename that's not actually a file: %s", name);
+	    werr(54, __func__, "passed filename that's not actually a file: %s", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -1152,11 +1155,11 @@ parse_json_file(char const *name, bool *is_valid)
 	    return tree;
 
 	}
-	if (!is_file(name)) {
+	if (!is_file(filename)) {
 	    /*
              * report that file is not a normal file
              */
-	    werr(55, __func__, "passed filename not a normal file: %s", name);
+	    werr(55, __func__, "passed filename not a normal file: %s", filename);
 
 	    /*
              * report invalid JSON
@@ -1169,11 +1172,11 @@ parse_json_file(char const *name, bool *is_valid)
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
-	if (!is_read(name)) {
+	if (!is_read(filename)) {
 	    /*
              * report unreadable file
              */
-	    werr(56, __func__, "passed filename not a readable file: %s", name);
+	    werr(56, __func__, "passed filename not a readable file: %s", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -1191,13 +1194,13 @@ parse_json_file(char const *name, bool *is_valid)
 	 * open file for scanner to use
 	 */
 	errno = 0;
-	stream = fopen(name, "r");
+	stream = fopen(filename, "r");
 	if (stream == NULL) {
 
 	    /*
              * warn about file open error
              */
-	    werrp(57, __func__, "couldn't open file %s, ignoring", name);
+	    werrp(57, __func__, "couldn't open file %s, ignoring", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -1215,7 +1218,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    tree = parse_json_stream(stream, name, is_valid);
+    tree = parse_json_stream(stream, filename, is_valid);
 
     /*
      * return the JSON parse tree tree

--- a/jparse/jparse.ref.c
+++ b/jparse/jparse.ref.c
@@ -2866,7 +2866,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 
 
 /*
- * parse_json - parse a JSON document of a given length
+ * parse_json - parse a JSON file or string of a given length
  *
  * Given a pointer to char and a length, use the parser to determine if the JSON
  * is valid or not.
@@ -2875,7 +2875,8 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  *
  *	ptr	    - pointer to start of JSON blob
  *	len	    - length of the JSON blob
- *	filename    - filename or NULL for stdin
+ *	filename    - filename, empty string or "-" for stdin or NULL to
+ *	              indicate it is a string
  *	is_valid    - non-NULL pointer to boolean to set depending on JSON validity
  *
  * return:
@@ -2884,7 +2885,9 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
  * NOTE: the reason this is in the scanner and not the parser is because
  * YY_BUFFER_STATE is part of the scanner and not the parser.
  *
- * NOTE: if filename is NULL we set it to "-" for stdin.
+ * NOTE: if filename is NULL, it will be set to "-" for stdin but if it is an
+ * empty string any error message will report it as a string (i.e. it will not
+ * show that it's a file).
  *
  * NOTE: this function only warns on error, except for NULL is_valid, in which
  *       case it is an error; warning on errors is so that an entire report of
@@ -2914,6 +2917,10 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
 	*is_valid = true;
     }
 
+    if (filename != NULL && *filename == '-') {
+        filename = "-";
+    }
+
     /*
      * firewall
      */
@@ -2930,13 +2937,6 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
          */
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
-    }
-
-    if (filename == NULL) {
-        if (json_dbg_allowed(JSON_DBG_HIGH)) {
-	    json_dbg(JSON_DBG_HIGH, __func__, "filename is NULL, forcing it to be \"-\" for stdin");
-        }
-	filename = "-";	/* assume stdin */
     }
 
     /*
@@ -3074,10 +3074,13 @@ parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid)
  * Given a pointer to char and a length, use the parser to determine if the JSON
  * is valid or not.
  *
- * This is a simplified version of parse_json() in that it does not take a
- * filename arg. Instead it just sets the filename to "-". Although it might not
- * strictly be from stdin in every case, it works well enough. Let's call it a
- * misuse of the word stdin.
+ * This function assumes that the JSON is a string, rather than a file to be
+ * read, and it uses parse_json() with a NULL filename. Thus it can be seen as
+ * a simplified interface to parse_json() in the case of a string rather than a
+ * file. The error function checks if the filename is != NULL and if *filename
+ * != '\0' before claiming it is a file. The function parse_json() will, if
+ * filename != NULL && *filename == '-', set filename to "-", indicating the
+ * input comes from stdin.
  *
  * given:
  *
@@ -3135,9 +3138,9 @@ parse_json_str(char const *ptr, size_t len, bool *is_valid)
     }
 
     /*
-     * return a call to parse_json() with "-" as filename.
+     * return a call to parse_json() with NULL filename
      */
-    return parse_json(ptr, len, "-", is_valid);
+    return parse_json(ptr, len, NULL, is_valid);
 }
 
 
@@ -3344,10 +3347,10 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
 
 
 /*
- * parse_json_file	    - parses file file
+ * parse_json_file	    - parse a JSON file in a given filename
  *
  * given:
- *	name	    - filename of file to parse
+ *	filename    - filename of file to parse
  *	is_valid    - non-NULL printer to boolean to set depending on json validity
  *
  * return:
@@ -3366,7 +3369,7 @@ parse_json_stream(FILE *stream, char const *filename, bool *is_valid)
  *	 this information is requested).
  */
 struct json *
-parse_json_file(char const *name, bool *is_valid)
+parse_json_file(char const *filename, bool *is_valid)
 {
     struct json *tree = NULL;		/* the JSON parse tree */
     FILE *stream = NULL;		/* file stream to read from */
@@ -3385,8 +3388,8 @@ parse_json_file(char const *name, bool *is_valid)
 	 */
 	*is_valid = true;
     }
-    if (name == NULL) {
-	werr(52, __func__, "passed NULL name");
+    if (filename == NULL) {
+	werr(52, __func__, "passed NULL filename");
 
 	/*
          * flag that we have invalid JSON
@@ -3399,10 +3402,10 @@ parse_json_file(char const *name, bool *is_valid)
 	tree = json_alloc(JTYPE_UNSET);
 	return tree;
     }
-    if (*name == '\0') { /* strlen(name) == 0 */
+    if (*filename == '\0') { /* strlen(filename) == 0 */
 
 	/*
-         * warn about bogus name
+         * warn about bogus filename
          */
 	werr(53, __func__, "passed empty filename");
 
@@ -3421,7 +3424,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * if file is "-", then we will parse stdin
      */
-    if (strcmp(name, "-") == 0) {
+    if (strcmp(filename, "-") == 0) {
 	stream = stdin;
 
     /*
@@ -3432,11 +3435,11 @@ parse_json_file(char const *name, bool *is_valid)
 	/*
 	 * validate filename
 	 */
-	if (!exists(name)) {
+	if (!exists(filename)) {
 	    /*
              * report missing file
              */
-	    werr(54, __func__, "passed filename that's not actually a file: %s", name);
+	    werr(54, __func__, "passed filename that's not actually a file: %s", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -3450,11 +3453,11 @@ parse_json_file(char const *name, bool *is_valid)
 	    return tree;
 
 	}
-	if (!is_file(name)) {
+	if (!is_file(filename)) {
 	    /*
              * report that file is not a normal file
              */
-	    werr(55, __func__, "passed filename not a normal file: %s", name);
+	    werr(55, __func__, "passed filename not a normal file: %s", filename);
 
 	    /*
              * report invalid JSON
@@ -3467,11 +3470,11 @@ parse_json_file(char const *name, bool *is_valid)
 	    tree = json_alloc(JTYPE_UNSET);
 	    return tree;
 	}
-	if (!is_read(name)) {
+	if (!is_read(filename)) {
 	    /*
              * report unreadable file
              */
-	    werr(56, __func__, "passed filename not a readable file: %s", name);
+	    werr(56, __func__, "passed filename not a readable file: %s", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -3489,13 +3492,13 @@ parse_json_file(char const *name, bool *is_valid)
 	 * open file for scanner to use
 	 */
 	errno = 0;
-	stream = fopen(name, "r");
+	stream = fopen(filename, "r");
 	if (stream == NULL) {
 
 	    /*
              * warn about file open error
              */
-	    werrp(57, __func__, "couldn't open file %s, ignoring", name);
+	    werrp(57, __func__, "couldn't open file %s, ignoring", filename);
 
 	    /*
              * flag that we have invalid JSON
@@ -3513,7 +3516,7 @@ parse_json_file(char const *name, bool *is_valid)
     /*
      * JSON parse the open stream
      */
-    tree = parse_json_stream(stream, name, is_valid);
+    tree = parse_json_stream(stream, filename, is_valid);
 
     /*
      * return the JSON parse tree tree

--- a/jparse/jparse.tab.ref.c
+++ b/jparse/jparse.tab.ref.c
@@ -1748,11 +1748,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%ju>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_bool(jparse_get_text(scanner));");
+					       "$json_value = json_parse_bool(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	yyval = parse_json_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
+	yyval = json_parse_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -1780,11 +1780,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_bool(jparse_get_text(scanner))");
+					       "$json_value = json_parse_bool(jparse_get_text(scanner))");
 	}
 
 	/* action */
-	yyval = parse_json_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
+	yyval = json_parse_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -1812,11 +1812,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_null(jparse_get_text(scanner));");
+					       "$json_value = json_parse_null(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	yyval = parse_json_null(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_NULL type */
+	yyval = json_parse_null(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_NULL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -1986,11 +1986,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_member: $json_element type: %s",
 					       json_item_type_name(yyvsp[0]));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_member: about to perform: "
-					       "$json_member = parse_json_member($json_string, $json_element);");
+					       "$json_member = json_parse_member($json_string, $json_element);");
 	}
 
 	/* action */
-	yyval = parse_json_member(yyvsp[-2], yyvsp[0]);
+	yyval = json_parse_member(yyvsp[-2], yyvsp[0]);
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -2019,11 +2019,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_array: $json_elements type: %s",
 					       json_item_type_name(yyvsp[-1]));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_array: about to perform: "
-					       "$json_array = parse_json_array($json_elements);");
+					       "$json_array = json_parse_array($json_elements);");
 	}
 
 	/* action */
-	yyval = parse_json_array(yyvsp[-1]);
+	yyval = json_parse_array(yyvsp[-1]);
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -2188,11 +2188,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_string: about to perform: "
-					       "$json_string = parse_json_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner);");
+					       "$json_string = json_parse_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner);");
 	}
 
 	/* action */
-	yyval = parse_json_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner));
+	yyval = json_parse_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner));
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -2220,11 +2220,11 @@ yyreduce:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_number: about to perform: "
-					       "$json_number = parse_json_number(jparse_get_text(scanner));");
+					       "$json_number = json_parse_number(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	yyval = parse_json_number(jparse_get_text(scanner));
+	yyval = json_parse_number(jparse_get_text(scanner));
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -2492,7 +2492,7 @@ yyerror(JPARSE_LTYPE *yyltype, struct json **node, yyscan_t scanner, char const 
 	fprint(stderr, " node type %s", json_item_type_name(*node));
     }
     if (yyltype != NULL) {
-	    if (yyltype->filename != NULL) {
+	    if (yyltype->filename != NULL && *yyltype->filename != '\0') {
 		fprint(stderr, " in file %s", yyltype->filename);
 	    }
 	    fprint(stderr, " at line %d column %d: ", yyltype->first_line, yyltype->first_column);

--- a/jparse/jparse.y
+++ b/jparse/jparse.y
@@ -422,11 +422,11 @@ json_value:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%ju>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_bool(jparse_get_text(scanner));");
+					       "$json_value = json_parse_bool(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	$json_value = parse_json_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
+	$json_value = json_parse_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -452,11 +452,11 @@ json_value:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_bool(jparse_get_text(scanner))");
+					       "$json_value = json_parse_bool(jparse_get_text(scanner))");
 	}
 
 	/* action */
-	$json_value = parse_json_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
+	$json_value = json_parse_bool(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_BOOL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -482,11 +482,11 @@ json_value:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
-					       "$json_value = parse_json_null(jparse_get_text(scanner));");
+					       "$json_value = json_parse_null(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	$json_value = parse_json_null(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_NULL type */
+	$json_value = json_parse_null(jparse_get_text(scanner)); /* magic: json_value becomes JTYPE_NULL type */
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -652,11 +652,11 @@ json_member:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_member: $json_element type: %s",
 					       json_item_type_name($json_element));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_member: about to perform: "
-					       "$json_member = parse_json_member($json_string, $json_element);");
+					       "$json_member = json_parse_member($json_string, $json_element);");
 	}
 
 	/* action */
-	$json_member = parse_json_member($json_string, $json_element);
+	$json_member = json_parse_member($json_string, $json_element);
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -685,11 +685,11 @@ json_array:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_array: $json_elements type: %s",
 					       json_item_type_name($json_elements));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_array: about to perform: "
-					       "$json_array = parse_json_array($json_elements);");
+					       "$json_array = json_parse_array($json_elements);");
 	}
 
 	/* action */
-	$json_array = parse_json_array($json_elements);
+	$json_array = json_parse_array($json_elements);
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -850,11 +850,11 @@ json_string:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_string: about to perform: "
-					       "$json_string = parse_json_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner);");
+					       "$json_string = json_parse_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner);");
 	}
 
 	/* action */
-	$json_string = parse_json_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner));
+	$json_string = json_parse_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner));
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -882,11 +882,11 @@ json_number:
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yytext: <%s>", jparse_get_text(scanner));
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yyleng: <%jd>", (intmax_t)jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_number: about to perform: "
-					       "$json_number = parse_json_number(jparse_get_text(scanner));");
+					       "$json_number = json_parse_number(jparse_get_text(scanner));");
 	}
 
 	/* action */
-	$json_number = parse_json_number(jparse_get_text(scanner));
+	$json_number = json_parse_number(jparse_get_text(scanner));
 
 	/* post-action debugging */
 	if (json_dbg_allowed(JSON_DBG_HIGH)) {
@@ -945,7 +945,7 @@ yyerror(JPARSE_LTYPE *yyltype, struct json **node, yyscan_t scanner, char const 
 	fprint(stderr, " node type %s", json_item_type_name(*node));
     }
     if (yyltype != NULL) {
-	    if (yyltype->filename != NULL) {
+	    if (yyltype->filename != NULL && *yyltype->filename != '\0') {
 		fprint(stderr, " in file %s", yyltype->filename);
 	    }
 	    fprint(stderr, " at line %d column %d: ", yyltype->first_line, yyltype->first_column);

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -144,9 +144,9 @@ main(int argc, char **argv)
     if (string_flag_used == true) {
 
 	/* parse arg as a block of json input */
-	dbg(DBG_HIGH, "Calling parse_json(\"%s\", %ju, NULL, &valid_json):",
+	dbg(DBG_HIGH, "Calling parse_json_str(\"%s\", %ju, &valid_json):",
 		      argv[argc-1], (uintmax_t)strlen(argv[argc-1]));
-	tree = parse_json(argv[argc-1], strlen(argv[argc-1]), NULL, &valid_json);
+	tree = parse_json_str(argv[argc-1], strlen(argv[argc-1]), &valid_json);
 
     /*
      * case: process file arg

--- a/jparse/jparse_utils_README.md
+++ b/jparse/jparse_utils_README.md
@@ -170,18 +170,19 @@ cannot show it, or it is invalid, you might see a character indicating this.
 
 
 ```sh
- jstrdecode [-h] [-v level] [-q] [-V] [-t] [-n] [-N] [-Q] [-e] [-d] [-E level] [arg ...]
+jstrdecode [-h] [-v level] [-j] [-J level] [-q] [-V] [-t] [-n] [-N] [-Q] [-e] [-d] [-E level] [arg ...]
 ```
-
-
-Unlike the `jparse` utility, no JSON parsing functions are called, so there is
-no `-J level` option.
 
 Use of `-Q` will enclose output in double quotes whereas the use of `-e`
 will enclose each decoded string with escaped double quotes. Use of `-Q` and
 `-e` together will surround the entire output with unescaped quotes and each
 decoded arg will be surrounded with escaped (backslashed) quotes. To not require
 surrounding the input strings with double quotes (`"`s), use the `-d` option.
+
+Before attempting to decode the string, it will use the JSON parser on the
+string, to make sure it is valid JSON. If you need to disable this, use the `-j`
+option. The `-J level` option will set the jparse debug level, assuming `-j` is
+not used.
 
 If you use `-N` it ignores all newlines in input. This does not mean that the
 JSON allows for unescaped newlines but rather newlines on the command line are

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -1976,7 +1976,7 @@ json_decode_str(char const *str, bool quote, size_t *retlen)
 
 
 /*
- * parse_json_string - parse a json string
+ * json_parse_string - parse a json string
  *
  * given:
  *
@@ -1992,7 +1992,7 @@ json_decode_str(char const *str, bool quote, size_t *retlen)
  * NOTE: This function does not return if passed a NULL string or if conversion fails.
  */
 struct json *
-parse_json_string(char const *string, size_t len)
+json_parse_string(char const *string, size_t len)
 {
     struct json *str = NULL;
     struct json_string *item = NULL;
@@ -2032,7 +2032,7 @@ parse_json_string(char const *string, size_t len)
 
 
 /*
- * parse_json_bool - parse a json bool
+ * json_parse_bool - parse a json bool
  *
  * given:
  *
@@ -2044,7 +2044,7 @@ parse_json_string(char const *string, size_t len)
  * NOTE: This function does not return if passed a NULL string or conversion fails.
  */
 struct json *
-parse_json_bool(char const *string)
+json_parse_bool(char const *string)
 {
     struct json *boolean = NULL;
     struct json_boolean *item = NULL;
@@ -2117,7 +2117,7 @@ parse_json_bool(char const *string)
 
 
 /*
- * parse_json_null - parse a json null
+ * json_parse_null - parse a json null
  *
  * given:
  *
@@ -2129,7 +2129,7 @@ parse_json_bool(char const *string)
  * NOTE: This function does not return if passed a NULL string or if null becomes NULL :-)
  */
 struct json *
-parse_json_null(char const *string)
+json_parse_null(char const *string)
 {
     struct json *null = NULL;
     struct json_null *item = NULL;
@@ -2166,7 +2166,7 @@ parse_json_null(char const *string)
 
 
 /*
- * parse_json_number - parse a JSON number
+ * json_parse_number - parse a JSON number
  *
  * given:
  *
@@ -2178,7 +2178,7 @@ parse_json_null(char const *string)
  * NOTE: This function does not return if passed a NULL string or if conversion fails.
  */
 struct json *
-parse_json_number(char const *string)
+json_parse_number(char const *string)
 {
     struct json *number = NULL;
     struct json_number *item = NULL;
@@ -2213,12 +2213,12 @@ parse_json_number(char const *string)
 
 
 /*
- * parse_json_array - parse a JSON array given a JSON elements
+ * json_parse_array - parse a JSON array given a JSON elements
  *
  * Given a JSON elements, we turn it into a JSON array.
  *
  * IMPORTANT: The struct json_array must be identical to struct json_elements because
- *	      parse_json_array() converts by just changing the JSON item type.
+ *	      json_parse_array() converts by just changing the JSON item type.
  *
  * given:
  *
@@ -2230,7 +2230,7 @@ parse_json_number(char const *string)
  * NOTE: This function does not return if passed a NULL elements;
  */
 struct json *
-parse_json_array(struct json *elements)
+json_parse_array(struct json *elements)
 {
     struct json_array *item = NULL;
 
@@ -2264,7 +2264,7 @@ parse_json_array(struct json *elements)
 
 
 /*
- * parse_json_member - parse a JSON member
+ * json_parse_member - parse a JSON member
  *
  * given:
  *
@@ -2277,7 +2277,7 @@ parse_json_array(struct json *elements)
  * NOTE: This function does not return if passed a NULL name or value or if conversion fails.
  */
 struct json *
-parse_json_member(struct json *name, struct json *value)
+json_parse_member(struct json *name, struct json *value)
 {
     struct json *member = NULL;
     struct json_member *item = NULL;

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -382,7 +382,7 @@ struct json_object
  *	foo.set[i-1]
  *
  * IMPORTANT: The struct json_array must be identical to struct json_elements because
- *	      parse_json_array() converts by just changing the JSON item type.
+ *	      json_parse_array() converts by just changing the JSON item type.
  */
 struct json_array
 {
@@ -409,7 +409,7 @@ struct json_array
  *	foo.set[i-1]
  *
  * IMPORTANT: The struct json_array must be identical to struct json_elements because
- *	      parse_json_array() converts by just changing the JSON item type.
+ *	      json_parse_array() converts by just changing the JSON item type.
  */
 struct json_elements
 {
@@ -493,12 +493,12 @@ extern void chkbyte2asciistr(void);
 extern void jdecencchk(int entertainment);
 extern char *json_decode(char const *ptr, size_t len, bool quote, size_t *retlen);
 extern char *json_decode_str(char const *str, bool quote, size_t *retlen);
-extern struct json *parse_json_string(char const *string, size_t len);
-extern struct json *parse_json_bool(char const *string);
-extern struct json *parse_json_null(char const *string);
-extern struct json *parse_json_number(char const *string);
-extern struct json *parse_json_array(struct json *elements);
-extern struct json *parse_json_member(struct json *name, struct json *value);
+extern struct json *json_parse_string(char const *string, size_t len);
+extern struct json *json_parse_bool(char const *string);
+extern struct json *json_parse_null(char const *string);
+extern struct json *json_parse_number(char const *string);
+extern struct json *json_parse_array(struct json *elements);
+extern struct json *json_parse_member(struct json *name, struct json *value);
 extern struct json *json_alloc(enum item_type type);
 extern struct json *json_conv_number(char const *ptr, size_t len);
 extern struct json *json_conv_number_str(char const *str, size_t *retlen);

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -919,13 +919,16 @@ json_item_type_name(const struct json *node)
  *
  * given:
  *	node	    pointer to a JSON parser tree node to get matching string from
- *	encoded	    true if we should return the encoded string
+ *	encoded	    true ==> return the encoded string, if it is a string type
  *
  * returns:
  *	A constant (read-only) string that originally matched in the
  *	lexer/parser
  *
- * NOTE: This string returned is read only: It's not allocated on the stack.
+ * NOTE: the string returned is read only; it's NOT allocated on the stack.
+ *
+ * NOTE: if encoded is true and the type is a string, then we return the encoded
+ * string.
  *
  * NOTE: this function can return a NULL pointer. It is the responsibility of
  * the caller to check for a NULL return value.
@@ -987,13 +990,11 @@ json_get_type_str(struct json *node, bool encoded)
 		}
 	    }
 	    break;
-	case JTYPE_OBJECT:
-	    break;
-	case JTYPE_ARRAY:
-	    break;
-	case JTYPE_ELEMENTS:
-	    break;
+	case JTYPE_OBJECT:      /*fallthrough*/
+	case JTYPE_ARRAY:       /*fallthrough*/
+	case JTYPE_ELEMENTS:    /*fallthrough*/
 	default:
+            str = NULL;
 	    break;
     }
 

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -46,10 +46,12 @@
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-q] [-V] [-t] [-n] [-N] [-Q] [-e] [-d] [-E level] [arg ...]\n"
+    "usage: %s [-h] [-v level] [-j] [-J level] [-q] [-V] [-t] [-n] [-N] [-Q] [-e] [-d] [-E level] [arg ...]\n"
     "\n"
     "\t-h\t\tprint help message and exit\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
+    "\t-j\t\tdisable parsing of encoded JSON before decoding (def: parse)\n"
+    "\t-J level\tset JSON verbosity level (def level: %d)\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: loud :-) )\n"
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform tests of JSON decode/encode functionality\n"
@@ -79,7 +81,7 @@ static const char * const usage_msg =
  * forward declarations
  */
 static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
-static struct jstring *jstrdecode_stream(FILE *in_stream, bool ignore_nl, bool quote);
+static struct jstring *jstrdecode_stream(FILE *in_stream, bool ignore_nl, bool quote, bool skip_parsing);
 static struct jstring *add_decoded_string(char *string, size_t bufsiz);
 
 /*
@@ -220,6 +222,7 @@ dup_without_nl(char *input, size_t *inputlen)
  *	in_stream	open file stream to decode
  *	ignore_nl	true ==> ignore all newline characters
  *	quote           true ==> require leading and trailing double quotes
+ *	skip_parsing    true ==> skip parsing encoded JSON first
  *
  * returns:
  *	allocated struct jstring * ==> decoding was successful,
@@ -229,14 +232,16 @@ dup_without_nl(char *input, size_t *inputlen)
  * decoded JSON strings.
  */
 static struct jstring *
-jstrdecode_stream(FILE *in_stream, bool ignore_nl, bool quote)
+jstrdecode_stream(FILE *in_stream, bool ignore_nl, bool quote, bool skip_parsing)
 {
-    char *input = NULL;		/* argument to process */
-    size_t inputlen;		/* length of input buffer */
-    size_t bufsiz;		/* length of the buffer */
-    char *buf = NULL;		/* decode buffer */
+    char *input = NULL;		    /* argument to process */
+    size_t inputlen;		    /* length of input buffer */
+    size_t bufsiz;		    /* length of the buffer */
+    char *buf = NULL;		    /* decode buffer */
     struct jstring *jstr = NULL;    /* decoded string added to list */
-    char *dup_input = NULL;	/* duplicate of input w/o newlines */
+    struct json *tree = NULL;       /* to parse JSON if !skip_parsing */
+    bool is_valid = true;           /* if json is valid */
+    char *dup_input = NULL;	    /* duplicate of input w/o newlines */
 
     /*
      * firewall
@@ -278,6 +283,20 @@ jstrdecode_stream(FILE *in_stream, bool ignore_nl, bool quote)
 	input = dup_input;
     }
 
+    /*
+     * if skip_parsing is false, first try parsing JSON
+     */
+    if (!skip_parsing) {
+        tree = parse_json_str(input, inputlen, &is_valid);
+        if (tree == NULL || !is_valid) {
+            err(12, __func__, "invalid JSON");
+            not_reached();
+        } else {
+            json_tree_free(tree, JSON_INFINITE_DEPTH);
+            free(tree);
+            tree = NULL;
+        }
+    }
     /*
      * decode data read from input stream
      */
@@ -333,8 +352,11 @@ main(int argc, char **argv)
     bool write_quote = false;	/* true ==> output enclosing quotes */
     bool esc_quotes = false;	/* true ==> escape quotes */
     bool quote = true;          /* true ==> require surrounding quotes */
+    bool skip_parsing = false;  /* true ==> skip parsing encoded JSON before decoding */
     int ret;			/* libc return code */
     int i;
+    struct json *tree = NULL;   /* for parsing json if not -j */
+    bool is_valid = true;       /* if not -j and JSON is valid */
     struct jstring *jstr = NULL;    /* decoded string */
     char *dup_input = NULL;	/* duplicate of arg string */
 
@@ -342,7 +364,7 @@ main(int argc, char **argv)
      * set locale
      */
     if (setlocale(LC_ALL, "") == NULL) {
-	err(12, __func__, "failed to set locale");
+	err(13, __func__, "failed to set locale");
 	not_reached();
     }
 
@@ -350,7 +372,7 @@ main(int argc, char **argv)
      * parse args
      */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hv:qVtnNQedE:")) != -1) {
+    while ((i = getopt(argc, argv, ":hv:jJ:qVtnNQedE:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 2 */
 	    usage(2, program, ""); /*ooo*/
@@ -363,6 +385,19 @@ main(int argc, char **argv)
 	    verbosity_level = parse_verbosity(optarg);
 	    if (verbosity_level < 0) {
 		usage(3, program, "invalid -v verbosity"); /*ooo*/
+		not_reached();
+	    }
+	    break;
+        case 'j':
+            skip_parsing = true;
+            break;
+	case 'J': /* -J json_verbosity_level */
+	    /*
+	     * parse json verbosity level
+	     */
+	    json_verbosity_level = parse_verbosity(optarg);
+	    if (verbosity_level < 0) {
+		usage(3, program, "invalid -J json_verbosity"); /*ooo*/
 		not_reached();
 	    }
 	    break;
@@ -431,6 +466,7 @@ main(int argc, char **argv)
     dbg(DBG_LOW, "silence warnings: %s", booltostr(msg_warn_silent));
     dbg(DBG_LOW, "escaped quotes: %s", booltostr(esc_quotes));
     dbg(DBG_LOW, "ignore surrounding quotes: %s", booltostr(quote));
+    dbg(DBG_LOW, "skip parsing encoded string: %s", booltostr(skip_parsing));
 
     /*
      * case: process arguments on command line
@@ -454,7 +490,7 @@ main(int argc, char **argv)
 		 * NOTE: the function jstrdecode_stream() adds the allocated
 		 * struct jstring * to the list of decoded JSON strings
 		 */
-		jstr = jstrdecode_stream(stdin, ignore_nl, quote);
+		jstr = jstrdecode_stream(stdin, ignore_nl, quote, skip_parsing);
 		if (jstr != NULL) {
 		    dbg(DBG_MED, "decode length: %ju", jstr->bufsiz);
 		} else {
@@ -481,7 +517,7 @@ main(int argc, char **argv)
 		     */
 		    dup_input = dup_without_nl(input, &inputlen);
 		    if (dup_input == NULL) {
-			err(13, __func__, "dup_without_nl failed");
+			err(14, __func__, "dup_without_nl failed");
 			not_reached();
 		    }
 
@@ -493,6 +529,20 @@ main(int argc, char **argv)
 		    dbg(DBG_VHIGH, "-N and arg length is now: %ju", (uintmax_t)inputlen);
 		}
 
+                /*
+                 * if not -j, make sure it's valid JSON first
+                 */
+                if (!skip_parsing) {
+                    tree = parse_json_str(input, inputlen, &is_valid);
+                    if (!is_valid || tree == NULL) {
+                        err(15, __func__, "invalid JSON");
+                        not_reached();
+                    } else {
+                        json_tree_free(tree, JSON_INFINITE_DEPTH);
+                        free(tree);
+                        tree = NULL;
+                    }
+                }
 		/*
 		 * decode arg
 		 */
@@ -534,7 +584,7 @@ main(int argc, char **argv)
 	 * NOTE: the function jstrdecode_stream() adds the allocated
 	 * struct jstring * to the list of decoded JSON strings
 	 */
-	jstr = jstrdecode_stream(stdin, ignore_nl, quote);
+	jstr = jstrdecode_stream(stdin, ignore_nl, quote, skip_parsing);
 
 	if (jstr != NULL) {
 	    dbg(DBG_MED, "decode length: %ju", jstr->bufsiz);

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrdecode version
  */
-#define JSTRDECODE_VERSION "2.1.2 2024-11-17"	/* format: major.minor YYYY-MM-DD */
+#define JSTRDECODE_VERSION "2.1.3 2024-11-18"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "16 November 2024" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "18 November 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
 \- JSON decode command line strings
@@ -17,6 +17,9 @@
 .B jstrdecode
 .RB [\| \-h \|]
 .RB [\| \-v
+.IR level \|]
+.RB [\| \-j \]
+.RB [\| \-J
 .IR level \|]
 .RB [\| \-q \|]
 .RB [\| \-V \|]
@@ -69,6 +72,18 @@ If it is desired to not require surrounding double quotes ("s) in the input, use
 .B \-d
 option.
 .PP
+By default, the tool will use the
+.B jparse
+library to validate that the string is valid JSON, before decoding.
+If you need to disable this feature, use the
+.B \-j
+option.
+If you do not use the
+.B \-j
+option and you use the
+.BI \-j\  level
+option, it will set the JSON debug level.
+.PP
 If given the
 .B \-t
 option it performs a test on the JSON decode and encode functions.
@@ -81,6 +96,12 @@ Show help and exit
 Set verbosity level to
 .IR level
 (def: 0).
+.TP
+.B \-j
+Disable parsing each string before decoding.
+.TP
+.BI \-J\  level
+Set the JSON debug level.
 .TP
 .B \-q
 Suppresses some of the output (def: loud :-) ).

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -9,9 +9,10 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 3  "01 November 2024" "jparse"
+.TH jparse 3  "18 November 2024" "jparse"
 .SH NAME
 .BR parse_json() \|,
+.BR parse_json_str() \|,
 .BR parse_json_stream() \|,
 .BR parse_json_file() \|,
 .BR json_dbg_allowed() \|,
@@ -30,17 +31,19 @@
 .br
 \fB#define CONVERTED_JSON_NODE(item) ((item) != NULL && (item)->converted == true)\fP
 .sp
-.B "extern const char *const jparse_library_version;	/* library version format: major.minor YYYY-MM-DD */"
-.br
-.B "extern const char *const jparse_version;		/* jparse version format: major.minor YYYY-MM-DD */"
+.B "extern const char *const jparse_library_version;	/* jparse library version format: major.minor YYYY-MM-DD */"
 .br
 .B "extern const char *const jparse_utf8_version;	/* jparse utf8 version format: major.minor YYYY-MM-DD */"
 .sp
+.B "extern const char *const jparse_version;		/* jparse tool version format: major.minor YYYY-MM-DD */"
+.br
 .B "extern struct json *parse_json(char const *ptr, size_t len, char const *filename, bool *is_valid);"
+.br
+.B "extern struct json *parse_json_str(char const *ptr, size_t len, bool *is_valid);"
 .br
 .B "extern struct json *parse_json_stream(FILE *stream, char const *filename, bool *is_valid);"
 .br
-.B "extern struct json *parse_json_file(char const *name, bool *is_valid);"
+.B "extern struct json *parse_json_file(char const *filename, bool *is_valid);"
 .sp
 .B "extern char const *json_get_type_str(struct json *node, bool encoded);"
 .sp
@@ -54,39 +57,74 @@
 .SH DESCRIPTION
 The
 .B jparse
-library provides a way for C applications to parse JSON in a file (including stdin) or a string, returning a tree of the parsed JSON that one may then manipulate.
+library provides a way for C applications to parse JSON in a file (including stdin) or a string, returning a tree (a
+.B struct json *\&
+\c tree)
+of the parsed JSON that one may then traverse or manipulate in many ways.
+The functions to actually parse the JSON, as well as debug output functions (although not in great detail but rather just what they are), are described in this man page.
+.PP
 The function
-.B parse_json
+.BR parse_json ()
 parses a JSON string
 .I ptr
 of length
-.I len
-in file
-.IR filename .
-If
-.I is_valid
-is not NULL, it will set
-.I *is_valid
-to true prior to returning the tree but it is an error if it is NULL.
+.IR len .
 The
 .I ptr
-is a pointer to the start of the JSON data.
+is a pointer to the start of the JSON data, so that one may scan part of a document, should they wish.
 The function will scan up to
 .I len
-bytes so that as long as one knows where in the string the JSON is, they can parse a document with other kinds of data.
+bytes so that one may scan part of a document or string, which might have other kinds of data, in other words is only partly JSON.
+This function takes a
+.I filename
+arg which is used for messages, in particular error messages.
+If the wrong filename is specified, it will affect output as this function will not try and open the file; for that, use the function
+.BR parse_json_file (),
+described later.
+.PP
 If
 .I filename
-is NULL then it will read from
-.B stdin
-which can also be done by passing in \fI"\-"\fP.
+is not NULL and is an empty string, then it will set the filename to
+.BR \- ,
+indicating that the input comes from stdin.
+If it is a NULL pointer, the filename in the parser extra data will be set to NULL, and messages will not show a filename.
+.PP
+The variable
+.BR is_valid ,
+which is a pointer to a bool, must not be NULL, and it is an error if it is.
+Its purpose, along with the return value, is to indicate to the caller if the JSON is invalid.
+If in the calling function
+.B is_valid
+is false after calling this function, then the
+.B struct json *
+returned should be NULL, although it is best practice to check if the
+.B struct json *
+is NULL and if
+.B is_valid
+is false.
 The function will return the parsed JSON as a tree of type
 .BR struct\ json\ * .
-If the parse fails a blank JSON tree is returned instead.
+If
+.B ptr
+is NULL or if the block cannot be scanned, a blank JSON tree is returned instead.
+.PP
+The function
+.BR parse_json_str ()
+is like
+.BR parse_json ()
+except that it does not take a filename; instead it passes in a NULL filename to
+.BR parse_json (),
+which affects the error message to not say it is a filename: rather it is a string, as described above.
+The function
+.BR parse_json_str ()
+is essentially a wrapper to
+.BR parse_json ()
+where the filename arg is a NULL string, to simplify parsing a string.
 .sp
 The function
-.B parse_json_stream
+.BR parse_json_stream ()
 is like
-.B parse_json
+.BR parse_json ()
 except that it parses an entire
 .B FILE *
 and does not accept a number of bytes to scan.
@@ -94,30 +132,27 @@ The
 .I filename
 is for messages and is not used to determine what file to open as the stream should already be open.
 If you wish to do that you should use the
-.B parse_json_file()
-function instead.
+.BR parse_json_file ()
+function instead, which takes a filename and the
+.B is_valid
+variable.
 Unless
 .I stream
 is
 .B stdin
 the state of it should be considered unsafe to use after the return of the function as it will be closed.
-The function returns the parsed JSON as a
-.BR struct\ json\ * .
-.sp
+.PP
 The
-.B parse_json_file
-function is essentially a wrapper to the
-.B parse_json_stream
-function as it will open the file
-.I filename
-and then call
-.B parse_json_stream
-on the stream, returning a
-.B struct json *
-tree.
+.BR parse_json_file ()
+function will try and open the filename given in
+.B filename
+and then, as long as it can be opened, pass the
+.B FILE *
+to
+.BR parse_json_stream ().
 .SS Matching functions
 The
-.B json_get_type_str
+.BR json_get_type_str ()
 returns a
 .B char const *
 with what was matched in the parser.
@@ -127,18 +162,18 @@ boolean is true or not, it returns the encoded or decoded string, assuming the J
 .SS Debug, warn and error functions
 .PP
 The function
-.B json_dbg_allowed
+.BR json_dbg_allowed ()
 will return true if debug output would be displayed at the verbosity level
 .IR json_dbg_lvl .
 .br
 The functions
-.B json_warn_allowed
+.BR json_warn_allowed ()
 and
-.B json_err_allowed
+.BR json_err_allowed ()
 will return true if warnings and error output is allowed, respectively.
 .sp
 The function
-.B json_dbg
+.BR json_dbg ()
 allows for your application to give debug information to the user.
 The
 .I json_dbg_lvl
@@ -175,7 +210,6 @@ struct json
     enum item_type type;		/* union item specifier */
     union json_union {
 .in +4n
-.nf
 	struct json_number number;	/* JTYPE_NUMBER - value is number (integer or floating point) */
 	struct json_string string;	/* JTYPE_STRING - value is a string */
 	struct json_boolean boolean;	/* JTYPE_BOOL - value is a JSON boolean */
@@ -184,15 +218,13 @@ struct json
 	struct json_object object;	/* JTYPE_OBJECT - value is a JSON { members } */
 	struct json_array array;	/* JTYPE_ARRAY - value is a JSON [ elements ] */
 	struct json_elements elements;	/* JTYPE_ELEMENTS - zero or more JSON values */
-.in
     } item;
 
+.in -4n
     /*
      * JSON parse tree links
      */
     struct json *parent;	/* parent node in the JSON parse tree, or NULL if tree root or unlinked */
-.fi
-.in
 };
 .SS Checking for converted and/or parsed JSON nodes
 .PP
@@ -244,41 +276,52 @@ checks that the node's
 boolean is true.
 .SS Version strings
 The string
+.BR jparse_library_version ,
+which points to
+.BR JPARSE_LIBRARY_VERSION ,
+is the current version of the jparse library itself.
+The string
+.BR jparse_utf8_version ,
+which points to
+.BR JPARSE_UTF8_VERSION ,
+is the current jparse UTF\-8 version.
+The string
 .BR jparse_version ,
 which points to
 .BR JPARSE_VERSION ,
 is the current version of the
 .B jparse
 tool.
-The string
-.BR jparse_library_version ,
-which points to
-.BR JPARSE_LIBRARY_VERSION ,
-is the current version of the parser itself.
 .SH RETURN VALUE
 .PP
 The functions
-.BR parse_json ,
-.B parse_json_stream
+.BR parse_json (),
+.BR parse_json_str (),
+.BR parse_json_stream ()
 and
-.B parse_json_file
+.BR parse_json_file ()
 return a
 .B struct json *
-which is either blank or, if the parse was successful, a tree of the entire parsed JSON.
+which is either blank (unset type) or, if the parse was successful, a tree of the entire parsed JSON.
+Otherwise, if the JSON is invalid, a NULL pointer is returned, and the bool
+.B is_valid
+in the calling function is set to false (this also happens if an unset type is returned).
+Certain error conditions will prevent the function from returning.
 .PP
 The functions
-.BR json_dbg_allowed ,
-.B json_warn_allowed
+.BR json_dbg_allowed (),
+.BR json_warn_allowed (),
 and
-.B json_err_allowed
+.BR json_err_allowed ()
 will return true if debug, warn or error messages are allowed, respectively, and otherwise false.
 .SH NOTES
 .PP
 This JSON parser was written as a collaboration between Cody Boone Ferguson and Landon Curt Noll, one of the IOCCC Judges, to support
-IOCCCMOCK, IOCCC28 and beyond.
+IOCCC28 and beyond.
 .PP
 For more detailed history that goes beyond this humble man page we recommend you check
 .BR jparse (1),
+the
 .IR README.md ,
 and the GitHub git log as well as reading the source code (or not :\-) ).
 Understand that by source we refer to the
@@ -296,10 +339,12 @@ This might happen if, for example, a number is too big for the C types but as lo
 .PP
 .SH BUGS
 Although error reporting does have locations it is only line numbers and columns.
-Additionally the column can be misleading because of characters that take up more than one column but are counted as just one (tabs for example).
+Additionally the column can be misleading because of characters that take up more than one column but are counted as just one (say, because of tabs).
 .sp
 Although the scanner and parser are re-entrant only one parse at one time in a process has been tested.
 .sp
 If it's not clear this means that having more than one parse active in the same process at the same time is not tested so even though it should be okay there might be some issues that have yet to be discovered.
 .SH SEE ALSO
 .BR jparse (1),
+.BR jstrdecode (1),
+.BR jstrencode (1)

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -451,7 +451,7 @@ util_test.o: util_test.c
 	${CC} ${CFLAGS} -DUTIL_TEST util_test.c -c
 
 util_test: util_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ ${LD_DIR2} -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ ${LD_DIR2} -ldbg -ldyn_array -lm
 
 # sequence exit codes
 #

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -24,7 +24,7 @@ export JSTRENCODE="./jstrencode"
 export TEST_FILE="./test_jparse/jstr_test.out"
 export TEST_FILE2="./test_jparse/jstr_test2.out"
 export JSTR_TEST_TXT="./test_jparse/jstr_test.txt"
-export JSTR_TEST_VERSION="1.2.3 2024-11-17" # version format: major.minor YYYY-MM-DD
+export JSTR_TEST_VERSION="1.2.4 2024-11-18" # version format: major.minor YYYY-MM-DD
 export TOPDIR=
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode] [-Z topdir]
@@ -280,9 +280,9 @@ if [[ -z "$ERROR" ]]; then
 fi
 
 echo "$0: about to run test #4" 1>&2
-echo "$JSTRDECODE -d -Q -n foo bar"
+echo "$JSTRDECODE -j -d -Q -n foo bar"
 EXPECTED='"foobar"'
-RESULT="$($JSTRDECODE -d -Q -n foo bar)"
+RESULT="$($JSTRDECODE -j -d -Q -n foo bar)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #4 passed" 1>&2
 else
@@ -293,9 +293,9 @@ else
 fi
 
 echo "$0: about to run test #5" 1>&2
-echo "$JSTRDECODE -d -Q -e -n foo bar"
+echo "$JSTRDECODE -j -d -Q -e -n foo bar"
 EXPECTED='"\"foo\"\"bar\""'
-RESULT="$($JSTRDECODE -d -Q -e -n foo bar)"
+RESULT="$($JSTRDECODE -j -d -Q -e -n foo bar)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #5 passed" 1>&2
 else
@@ -306,9 +306,9 @@ else
 fi
 
 echo "$0: about to run test #6" 1>&2
-echo "$JSTRDECODE -d -e -n foo bar"
+echo "$JSTRDECODE -j -d -e -n foo bar"
 EXPECTED='\"foo\"\"bar\"'
-RESULT="$($JSTRDECODE -d -e -n foo bar)"
+RESULT="$($JSTRDECODE -j -d -e -n foo bar)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #6 passed" 1>&2
 else
@@ -319,8 +319,8 @@ else
 fi
 
 echo "$0: about to run test #7" 1>&2
-echo "$JSTRDECODE -d '\\u0153\\u00df\\u00e5\\u00e9'" 1>&2
-"$JSTRDECODE" -d "\\u0153\\u00df\\u00e5\\u00e9" > "$TEST_FILE"
+echo "$JSTRDECODE -j -d '\\u0153\\u00df\\u00e5\\u00e9'" 1>&2
+"$JSTRDECODE" -j -d "\\u0153\\u00df\\u00e5\\u00e9" > "$TEST_FILE"
 if cmp "$JSTR_TEST_TXT" "$TEST_FILE"; then
     echo "$0: test #7 passed" 1>&2
 else
@@ -329,9 +329,9 @@ else
 fi
 
 echo "$0: about to run test #8" 1>&2
-echo "$JSTRDECODE" "$("$JSTRENCODE" '\\u0153\\u00df\\u00e5\\u00e9')" 1>&2
+echo "$JSTRDECODE" -j "$("$JSTRENCODE" '\\u0153\\u00df\\u00e5\\u00e9')" 1>&2
 EXPECTED="\\u0153\\u00df\\u00e5\\u00e9"
-RESULT=$("$JSTRDECODE" "$("$JSTRENCODE" '\u0153\u00df\u00e5\u00e9')")
+RESULT=$("$JSTRDECODE" -j "$("$JSTRENCODE" '\u0153\u00df\u00e5\u00e9')")
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #8 passed" 1>&2
 else
@@ -342,8 +342,8 @@ else
 fi
 
 echo "$0: about to run test #9" 1>&2
-echo "$JSTRDECODE" "$("$JSTRENCODE" "$("$JSTRDECODE" -d '\\u0153\\u00df\\u00e5\\u00e9'))")"
-"$JSTRDECODE" "$("$JSTRENCODE" "$("$JSTRDECODE" -d '\u0153\u00df\u00e5\u00e9')")" > "$TEST_FILE"
+echo "$JSTRDECODE" -j "$("$JSTRENCODE" "$("$JSTRDECODE" -j -d '\\u0153\\u00df\\u00e5\\u00e9'))")"
+"$JSTRDECODE" -j "$("$JSTRENCODE" "$("$JSTRDECODE" -j -d '\u0153\u00df\u00e5\u00e9')")" > "$TEST_FILE"
 if cmp "$JSTR_TEST_TXT" "$TEST_FILE"; then
     echo "$0: test #9 passed" 1>&2
 else
@@ -352,9 +352,9 @@ else
 fi
 
 echo "$0: about to run test #10" 1>&2
-echo "$JSTRDECODE -d -n foo bar"
+echo "$JSTRDECODE -j -d -n foo bar"
 EXPECTED='foobar'
-RESULT="$($JSTRDECODE -d -n foo bar)"
+RESULT="$($JSTRDECODE -j -d -n foo bar)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #10 passed" 1>&2
 else
@@ -365,9 +365,9 @@ else
 fi
 
 echo "$0: about to run test #11" 1>&2
-echo "$JSTRDECODE -d -Q -n foo"
+echo "$JSTRDECODE -j -d -Q -n foo"
 EXPECTED='"foo"'
-RESULT="$($JSTRDECODE -d -Q -n foo)"
+RESULT="$($JSTRDECODE -j -d -Q -n foo)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #11 passed" 1>&2
 else
@@ -378,9 +378,9 @@ else
 fi
 
 echo "$0: about to run test #12" 1>&2
-echo "$JSTRDECODE -d -Q -e -n foo"
+echo "$JSTRDECODE -j -d -Q -e -n foo"
 EXPECTED='"foo"'
-RESULT="$($JSTRDECODE -d -Q -e -n foo)"
+RESULT="$($JSTRDECODE -j -d -Q -e -n foo)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #12 passed" 1>&2
 else
@@ -391,9 +391,9 @@ else
 fi
 
 echo "$0: about to run test #13" 1>&2
-echo "$JSTRDECODE -d -e -n foo"
+echo "$JSTRDECODE -j -d -e -n foo"
 EXPECTED='foo'
-RESULT="$($JSTRDECODE -d -e -n foo)"
+RESULT="$($JSTRDECODE -j -d -e -n foo)"
 if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #13 passed" 1>&2
 else

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,17 +30,17 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.1.2 2024-11-17"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.1.3 2024-11-18"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
  */
-#define JPARSE_VERSION "1.2.3 2024-11-13"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_VERSION "1.2.4 2024-11-18"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official JSON parser version
  */
-#define JPARSE_LIBRARY_VERSION "2.1.1 2024-11-17"	/* library version format: major.minor YYYY-MM-DD */
+#define JPARSE_LIBRARY_VERSION "2.2.0 2024-11-18"	/* library version format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */


### PR DESCRIPTION
For linux the test_jparse/Makefile needs -lm for util_test. Without this it will not compile and this will cause a big problem with using the library here.

Other improvements and bug fixes in jparse were made as well that might as well be synced up.