### PR TITLE
Disable install -v by default in install rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -96,7 +96,7 @@ if [[ -z "$MAKE" ]]; then
 	MAKE="$(type -P make)"
 fi
 export MAKE
-export BUG_REPORT_VERSION="1.0.5 2024-11-16"
+export BUG_REPORT_VERSION="1.0.6 2024-12-31"
 export FAILURE_SUMMARY=
 export NOTICE_SUMMARY=
 export DBG_LEVEL="0"
@@ -105,7 +105,7 @@ export T_FLAG=""
 export X_FLAG=""
 export L_FLAG=""
 export EXIT_CODE=0
-export MAKE_FLAGS="V=@ S=@ Q= E=@ I= Q_V_OPTION=1 INSTALL_V='-v' MAKE_CD_Q="
+export MAKE_FLAGS="V=@ S=@ Q= E=@ I= Q_V_OPTION=1 INSTALL_V= MAKE_CD_Q="
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D level] [-t] [-x] [-l] [-L logfile] [-m make] [-M make_flags]
 
     -h              print help and exit

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -28,6 +28,9 @@ still be able to test the party.json error file. This problem has to do with the
 error message has to be exact and rebuilding the error location file was
 problematic with the above updates.
 
+To be more portable, don't use `-v` by default in `install` rule. If one needs
+it, they can do `make INSTALL_V=-v install`.
+
 
 ## Release 2.1.9 2024-12-26
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -109,7 +109,7 @@ endif
 # INSTALL_V= -v				install with -v (debug / verbose mode)
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #

--- a/jparse/jparse_bug_report.sh
+++ b/jparse/jparse_bug_report.sh
@@ -79,8 +79,8 @@ if [[ -z "$MAKE" ]]; then
     MAKE="$(type -P make)"
 fi
 export MAKE
-export MAKE_FLAGS="V=@ S=@ Q= E=@ I= Q_V_OPTION=1 INSTALL_V='-v' MAKE_CD_Q="
-export BUG_REPORT_VERSION="2.0.3 2024-11-30"
+export MAKE_FLAGS="V=@ S=@ Q= E=@ I= Q_V_OPTION=1 INSTALL_V= MAKE_CD_Q="
+export BUG_REPORT_VERSION="2.0.4 2024-12-31"
 export FAILURE_SUMMARY=
 export NOTICE_SUMMARY=
 export DBG_LEVEL="0"
@@ -1464,7 +1464,7 @@ if [[ -z "$T_FLAG" ]]; then
     # make all: compile everything before we do anything else
     #
     #   the answer to life, the universe and everything conveniently makes all :-)
-    # 
+    #
     # ...and yes, this actually happened by chance, not deliberately, at least
     # in the mkiocccentry repo. Later on, after this script in jparse was
     # updated to be correct, the numbers were kept the same even after the tools

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -108,7 +108,7 @@ endif
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -123,7 +123,7 @@ endif
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -118,7 +118,7 @@ endif
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #


### PR DESCRIPTION
To be more portable we cannot have install -v the default as not all install(1) implementations support it.

If one needs this functionality they can do:

    make INSTALL_V=-v install

The jparse repo was synced with this change. The dbg and dyn_array repos have not been updated yet but as the Makefile does not run make install in either of those directories (or for that matter jparse) it's okay - for the moment at least.