### PR TITLE
jparse related fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.2 2025-01-01
+
+Fix exit code errors in `jparse_test.sh`.
+
+Remove rule `rebuild_jparse_err_files` from top level Makefile. This rule should
+only be in jparse/. The reason it would cause a failure is because of `argv[0]`
+being in error messages and since in this repo `jparse` binary is in a
+subdirectory it changes the name of the program so the error files are
+incorrect. It might be possible to do a `cd jparse && ...` but this is not
+necessary as there are no error location files in this repo itself due to
+precisely this reason.
+
+Happy New Year!
+
+
 ## Release 2.3.1 2024-12-31
 
 Fix a minor issue relating to the invalid UUID error message.

--- a/Makefile
+++ b/Makefile
@@ -771,15 +771,6 @@ all_sem_ref_ptch: soup/Makefile
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
 
 
-# rebuild jparse error files for testing
-#
-# IMPORTANT: DO NOT run this rule unless you KNOW that the output produced by
-#	     jparse on each file is CORRECT!
-#
-rebuild_jparse_err_files: jparse/test_jparse/Makefile
-	${E} ${MAKE} ${MAKE_CD_Q} -C jparse/test_jparse $@ C_SPECIAL="${C_SPECIAL}" \
-		     LD_DIR2="${LD_DIR2}"
-
 # sequence exit codes
 #
 seqcexit: ${ALL_CSRC} dbg/Makefile dyn_array/Makefile jparse/Makefile \

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,17 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.0 2025-01-01
+
+Bug fixes to do with exit codes in `test_jparse/jparse_test.sh`. Some functions
+being passed invalid data did not exit but rather change the exit code which
+could then be changed by a function that runs later. Also in the case that a
+test passed, in one location, it would change the exit code back to 0, thus
+changing the result of a failed test back to not failing, giving a false result.
+As the exit code starts at 0 now if any test fails it'll never be a 0 exit code
+(though if an internal error occurs later the exit code won't indicate a test
+failed, if there was one).
+
+
 ## Release 2.1.10 2024-12-31
 
 Improve invalid JSON token error message (`yyerror()`)

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -830,8 +830,7 @@ rebuild_jparse_err_files: jparse
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f test_jparse/test_JSON/bad_loc/*.err
-	-${Q} for i in test_jparse/test_JSON/./bad_loc/*.json; do \
-	    echo './jparse -v 0 -- "'$$i'" 2> "'$$i'.err"' ;  \
+	-@for i in test_jparse/test_JSON/./bad_loc/*.json; do \
 	    ./jparse -v 0 -- "$$i" 2> "$$i.err" ;  \
 	done
 	${S} echo

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -748,7 +748,6 @@ run_string_test()
     if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
 	echo "$0: ERROR: in run_string_test: pass_fail neither 'pass' nor 'fail'" 1>&2
 	exit 12
-	return
     fi
 
     # debugging

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -73,7 +73,7 @@
 
 # setup
 #
-export JPARSE_TEST_VERSION="1.2.2 2024-10-13"	    # version format: major.minor YYYY-MM-DD */
+export JPARSE_TEST_VERSION="1.2.3 2025-01-01"	    # version format: major.minor YYYY-MM-DD */
 export CHK_TEST_FILE="./test_jparse/json_teststr.txt"
 export CHK_INVALID_TEST_FILE="./test_jparse/json_teststr_fail.txt"
 export JPARSE="./jparse"
@@ -535,7 +535,7 @@ run_location_err_test()
 	fi
 
 	echo | tee -a -- "${LOGFILE}" 1>&2
-	EXIT_CODE=50
+	EXIT_CODE=1
     elif [[ "$V_FLAG" -ge 1 ]]; then
 	echo "$0: debug[1]: fail test OK, $JPARSE -- $jparse_test_file matches error file" | tee -a -- "$LOGFILE"
     fi
@@ -575,8 +575,7 @@ run_file_test()
 
     if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
 	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	EXIT_CODE=11
-	return
+	exit 10
     fi
 
     # debugging
@@ -708,7 +707,7 @@ run_print_test()
     else
 	echo "$0: in test that must pass: print_test FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 	PRINT_TEST_FAILURE="1"
-	EXIT_CODE=2
+	EXIT_CODE=1
     fi
     echo >> "${LOGFILE}"
 
@@ -748,7 +747,7 @@ run_string_test()
 
     if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
 	echo "$0: ERROR: in run_string_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	EXIT_CODE=11
+	exit 12
 	return
     fi
 
@@ -805,7 +804,6 @@ run_string_test()
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 	    fi
-	    EXIT_CODE=0
 	fi
     fi
     echo >> "${LOGFILE}"

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.1.10 2024-12-31"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.0 2025-01-01"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.1 2024-12-31"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.2 2025-01-01"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Fix exit code errors in jparse_test.sh.

Remove rule rebuild_jparse_err_files from top level Makefile. This rule should only be in jparse/. The reason it would cause a failure is because of argv[0] being in error messages and since in this repo jparse binary is in a subdirectory it changes the name of the program so the error files are incorrect. It might be possible to do a 'cd jparse && ...' but this is not necessary as there are no error location files in this repo itself due to precisely this reason.

Happy New Year!