### PR TITLE
Synced jparse/ from jparse repo (script fixes)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Both `make prep` and `make release` will issue a notice (via
 containing more than just comments.  This will allow for one to
 keep a `Makefile.local` with only comments in it, without raising
 a notice as such a file will not impact the make procedure.
-Then if one needs to temporary add comments (perhaps by un-commenting
+Then if one needs to temporary add comments (perhaps by uncommenting
 lines in a `Makefile.local` file), one can.  However if one then
 forgets, then the notice will alert you to the potential problem.
 
@@ -20,6 +20,13 @@ to "1.0.5 2025-01-03".
 
 Changed `MKIOCCCENTRY_REPO_VERSION` from "2.3.1 2025-01-01"
 to "2.3.3 2025-01-04".
+
+Synced `jparse/` from [jparse repo](https://github.com/xexyl/jparse/) with the
+new script `not_a_comment.sh` which is now used in `jparse/test_jparse/prep.sh`
+as well. Thanks Landon! Doing this also uncovered a bug in
+`jparse/test_jparse/prep.sh`: namely that shellcheck failed due to the fact the
+script was missing from `jparse/test_jparse/Makefile` (this goes all the way
+back to the initial import of `jparse` as there was no `prep.sh` at the time!).
 
 
 ## Release 2.3.2 2025-01-01

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,37 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.2 2025-01-04
+
+Add `test_jparse/not_a_comment.sh` and update `test_jparse/prep.sh` to use it.
+This will test if any Makefile.local files exist and if any do it'll warn at the
+end so that the user of `make prep` or `make release` can be aware of it and be
+sure it does not skew the results.
+
+The script `not_a_comment.sh` is from the mkiocccentry repo and was
+written by Landon Curt Noll (thanks!).
+
+Fix `shellcheck` for `test_jparse/prep.sh` and add script to missing `SH_FILES`
+in `test_jparse/Makefile` (the reason it was not caught by `make shellcheck` is
+because the script was missing from the Makefile).
+
+
+## Release 2.2.1 2025-01-02
+
+Disable 2 invalid JSON encode/decode string tests in `jstr_test.sh`.
+
+
+## Release 2.2.0 2025-01-01
+
+Bug fixes to do with exit codes in `test_jparse/jparse_test.sh`. Some functions
+being passed invalid data did not exit but rather change the exit code which
+could then be changed by a function that runs later. Also in the case that a
+test passed, in one location, it would change the exit code back to 0, thus
+changing the result of a failed test back to not failing, giving a false result.
+As the exit code starts at 0 now if any test fails it'll never be a 0 exit code
+(though if an internal error occurs later the exit code won't indicate a test
+failed, if there was one).
+
+
 ## Release 2.1.10 2024-12-31
 
 Improve invalid JSON token error message (`yyerror()`)

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -830,7 +830,8 @@ rebuild_jparse_err_files: jparse
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f test_jparse/test_JSON/bad_loc/*.err
-	-@for i in test_jparse/test_JSON/./bad_loc/*.json; do \
+	-${Q} for i in test_jparse/test_JSON/./bad_loc/*.json; do \
+	    echo './jparse -v 0 - "'$$i'" 2> "'$$i'.err"'; \
 	    ./jparse -v 0 -- "$$i" 2> "$$i.err" ;  \
 	done
 	${S} echo

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -220,7 +220,7 @@ LESS_PICKY_HSRC=
 
 # all shell scripts
 #
-SH_FILES= jparse_test.sh jstr_test.sh
+SH_FILES= prep.sh jparse_test.sh jstr_test.sh
 
 
 ######################

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -73,7 +73,7 @@
 
 # setup
 #
-export JPARSE_TEST_VERSION="1.2.2 2024-10-13"	    # version format: major.minor YYYY-MM-DD */
+export JPARSE_TEST_VERSION="1.2.3 2025-01-01"	    # version format: major.minor YYYY-MM-DD */
 export CHK_TEST_FILE="./test_jparse/json_teststr.txt"
 export CHK_INVALID_TEST_FILE="./test_jparse/json_teststr_fail.txt"
 export JPARSE="./jparse"
@@ -535,7 +535,7 @@ run_location_err_test()
 	fi
 
 	echo | tee -a -- "${LOGFILE}" 1>&2
-	EXIT_CODE=50
+	EXIT_CODE=1
     elif [[ "$V_FLAG" -ge 1 ]]; then
 	echo "$0: debug[1]: fail test OK, $JPARSE -- $jparse_test_file matches error file" | tee -a -- "$LOGFILE"
     fi
@@ -575,8 +575,7 @@ run_file_test()
 
     if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
 	echo "$0: ERROR: in run_file_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	EXIT_CODE=11
-	return
+	exit 10
     fi
 
     # debugging
@@ -708,7 +707,7 @@ run_print_test()
     else
 	echo "$0: in test that must pass: print_test FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 	PRINT_TEST_FAILURE="1"
-	EXIT_CODE=2
+	EXIT_CODE=1
     fi
     echo >> "${LOGFILE}"
 
@@ -748,8 +747,7 @@ run_string_test()
 
     if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
 	echo "$0: ERROR: in run_string_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	EXIT_CODE=11
-	return
+	exit 12
     fi
 
     # debugging
@@ -805,7 +803,6 @@ run_string_test()
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 	    fi
-	    EXIT_CODE=0
 	fi
     fi
     echo >> "${LOGFILE}"

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -24,7 +24,7 @@ export JSTRENCODE="./jstrencode"
 export TEST_FILE="./test_jparse/jstr_test.out"
 export TEST_FILE2="./test_jparse/jstr_test2.out"
 export JSTR_TEST_TXT="./test_jparse/jstr_test.txt"
-export JSTR_TEST_VERSION="1.2.5 2024-12-26" # version format: major.minor YYYY-MM-DD
+export JSTR_TEST_VERSION="1.2.7 2025-01-02" # version format: major.minor YYYY-MM-DD
 export TOPDIR=
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode] [-Z topdir]
@@ -184,37 +184,43 @@ else
     EXIT_CODE=4
 fi
 
-# test JSON decoding and encoding pipe
-echo "$0: about to run test #1"
-echo "$JSTRENCODE -v $V_FLAG -n < $JSTRENCODE | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
-# This warning is not correct in our case:
-#
-# SC2094 (info): Make sure not to read and write the same file in the same pipeline.
-# https://www.shellcheck.net/wiki/SC2094
-# shellcheck disable=SC2094
-"$JSTRENCODE" -v "$V_FLAG" -n < "$JSTRENCODE" | $JSTRDECODE -v "$V_FLAG" -n > "$TEST_FILE"
-if cmp -s "$JSTRENCODE" "$TEST_FILE"; then
-    echo "$0: test #1 passed" 1>&2
-else
-    echo "$0: test #1 failed" 1>&2
-    EXIT_CODE=4
-fi
+###################################################################################
+# NOTE: We disable these 2 tests as per https://github.com/xexyl/jparse/issues/32 #
+#	with perhaps restoring them to some extent when this issue is resolved:   #
+#	https://github.com/xexyl/jparse/issues/31				  #
+###################################################################################
 
-echo "$0: about to run test #2"
-echo "$JSTRENCODE -v $V_FLAG -n < $JSTRDECODE | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
-# This warning is incorrect in our case:
-#
-# SC2094 (info): Make sure not to read and write the same file in the same pipeline.
-# https://www.shellcheck.net/wiki/SC2094
-# shellcheck disable=SC2094
-#
-"$JSTRENCODE" -v "$V_FLAG" -n < "$JSTRDECODE" | "$JSTRDECODE" -v "$V_FLAG" -n > "$TEST_FILE"
-if cmp -s "$JSTRDECODE" "$TEST_FILE"; then
-    echo "$0: test #2 passed"
-else
-    echo "$0: test #2 failed" 1>&2
-    EXIT_CODE=4
-fi
+# disabled ## test JSON decoding and encoding pipe
+# disabled #echo "$0: about to run test #1"
+# disabled #echo "$JSTRENCODE -v $V_FLAG -n < $JSTRENCODE | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
+# disabled ## This warning is not correct in our case:
+# disabled ##
+# disabled ## SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+# disabled ## https://www.shellcheck.net/wiki/SC2094
+# disabled ## shellcheck disable=SC2094
+# disabled #"$JSTRENCODE" -v "$V_FLAG" -n < "$JSTRENCODE" | $JSTRDECODE -v "$V_FLAG" -n > "$TEST_FILE"
+# disabled #if cmp -s "$JSTRENCODE" "$TEST_FILE"; then
+# disabled #    echo "$0: test #1 passed" 1>&2
+# disabled #else
+# disabled #    echo "$0: test #1 failed" 1>&2
+# disabled #    EXIT_CODE=4
+# disabled #fi
+
+# disabled #echo "$0: about to run test #2"
+# disabled #echo "$JSTRENCODE -v $V_FLAG -n < $JSTRDECODE | $JSTRDECODE -v $V_FLAG -n > $TEST_FILE"
+# disabled ## This warning is incorrect in our case:
+# disabled ##
+# disabled ## SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+# disabled ## https://www.shellcheck.net/wiki/SC2094
+# disabled ## shellcheck disable=SC2094
+# disabled ##
+# disabled #"$JSTRENCODE" -v "$V_FLAG" -n < "$JSTRDECODE" | "$JSTRDECODE" -v "$V_FLAG" -n > "$TEST_FILE"
+# disabled #if cmp -s "$JSTRDECODE" "$TEST_FILE"; then
+# disabled #    echo "$0: test #2 passed"
+# disabled #else
+# disabled #    echo "$0: test #2 failed" 1>&2
+# disabled #    EXIT_CODE=4
+# disabled #fi
 
 # test some text holes in the decoding and encoding pipe
 #

--- a/jparse/test_jparse/not_a_comment.sh
+++ b/jparse/test_jparse/not_a_comment.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# not_a_comment.sh - Check of there are any "non-comment" lines in a file
+#
+# A "non-comment" line is a non-empty line that does NOT start
+# with zero or more whitespace followed by a #.
+#
+# A use case for this tool is to detect of a file such as "Makefile.local"
+# contains lines that contain make directives or other content that
+# a Makefile might respond to.
+#
+# An empty file, or a file contains just whitespace, or a file containing
+# just Makefile comments would not impact the execution of, say, make release.
+# This tool, given such a file, would return true,
+#
+# Copyright (c) 2025 by Landon Curt Noll.  All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
+#
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+# EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+# USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+#
+# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# Share and enjoy! :-)
+
+
+# setup
+#
+export VERSION="1.0 2025-01-03"
+NAME=$(basename "$0")
+export NAME
+#
+export V_FLAG=0
+export EXIT_CODE=0
+
+
+# usage
+#
+export USAGE="usage: $0 [-h] [-v level] [-V] [-n] [-N] [file ..]
+
+	-h		print help message and exit
+	-v level	set verbosity level (def level: $V_FLAG)
+	-V		print version string and exit
+
+	file		the file to check, - ==> read stdin
+
+	NOTE: Empty, missing, and non-files are ignored.
+
+	NOTE: By default (no args), this will exit 0.
+
+Exit codes:
+     0         all files are missing, empty, or contain only whitespace and/or # comments
+     1	       some file contains non-comment / non-whitespace text
+     2         -h and help string printed or -V and version string printed
+     3         command line error
+ >= 10         internal error
+
+$NAME version: $VERSION"
+
+
+# parse command line
+#
+while getopts :hv:V flag; do
+  case "$flag" in
+    h) echo "$USAGE"
+	exit 2
+	;;
+    v) V_FLAG="$OPTARG"
+	;;
+    V) echo "$VERSION"
+	exit 2
+	;;
+    \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    :) echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+    *) echo "$0: ERROR: unexpected value from getopts: $flag" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+  esac
+done
+#
+# remove the options
+#
+shift $(( OPTIND - 1 ));
+
+
+# print running info if verbose
+#
+# If -v 3 or higher, print exported variables in order that they were exported.
+#
+if [[ $V_FLAG -ge 3 ]]; then
+    echo "$0: debug[3]: VERSION=$VERSION" 1>&2
+    echo "$0: debug[3]: NAME=$NAME" 1>&2
+    echo "$0: debug[3]: V_FLAG=$V_FLAG" 1>&2
+fi
+
+
+# process each arg
+#
+for file in "$@"; do
+
+    # case: file is not -
+    #
+    if [[ $file != "-" ]]; then
+
+	# ignore missing, empty and non-files
+	#
+	if [[ $V_FLAG -ge 3 ]]; then
+	    echo "$0: debug[3]: processing: $file" 1>&2
+	fi
+	if [[ ! -e $file ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: debug[1]: ignoring missing: $file" 1>&2
+	    fi
+	    continue
+	fi
+	if [[ ! -f $file ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: debug[1]: ignoring non-file: $file" 1>&2
+	    fi
+	    continue
+	fi
+	if [[ ! -s $file ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: debug[1]: ignoring empty file: $file" 1>&2
+	    fi
+	    continue
+	fi
+    fi
+
+    # case: is - or is a not-empty file
+    #
+    if grep -E -v -q '^\s*$|^\s*#' "$file" >/dev/null 2>&1; then
+
+	# case: file as non-comments found
+	#
+	if [[ $V_FLAG -ge 1 ]]; then
+	    echo "$0: debug[1]: found non #-comments in: $file" 1>&2
+	fi
+	EXIT_CODE=1
+	continue
+    fi
+
+    # case: file is empty or only contains whitespace and/or #-comments
+    #
+    if [[ $V_FLAG -ge 1 ]]; then
+	echo "$0: debug[1]: file empty or only contains whitespace and/or #-comments: $file" 1>&2
+    fi
+    continue
+done
+
+
+# All Done!!! -- Jessica Noll, Age 2
+#
+exit "$EXIT_CODE"

--- a/jparse/test_jparse/prep.sh
+++ b/jparse/test_jparse/prep.sh
@@ -20,7 +20,7 @@
 export FAILURE_SUMMARY=
 export SKIPPED_SUMMARY=
 export LOGFILE=
-export PREP_VERSION="1.2.0 2024-10-09"
+export PREP_VERSION="1.2.1 2025-01-04"
 export NOTICE_COUNT="0"
 export USAGE="usage: $0 [-h] [-v level] [-V] [-e] [-o] [-m make] [-M Makefile] [-l logfile]
 
@@ -415,7 +415,7 @@ make_jparse_bug_report() {
 
     # perform action
     #
-    exec_command "./jparse_bug_report.sh" -t -x -l VERBOSITY=$V_FLAG -L "$BUG_REPORT_LOGFILE"
+    exec_command "./jparse_bug_report.sh" -t -x -l VERBOSITY="$V_FLAG" -L "$BUG_REPORT_LOGFILE"
     status="$?"
 
     # Finally we report on the exit status of the jparse_bug_report.sh
@@ -615,6 +615,46 @@ else
 	fi
     fi
 fi
+
+# Note at the very end if we find a non-empty Makefile.local containing non-comments
+#
+# Because this is just a potential warning, we do not perform this as an action.
+#
+export NOT_A_COMMENT="test_jparse/not_a_comment.sh"
+if [[ ! -e $NOT_A_COMMENT ]]; then
+    write_echo "Warning: executable not found: $NOT_A_COMMENT"
+elif [[ ! -f $NOT_A_COMMENT ]]; then
+    write_echo "Warning: not a file: $NOT_A_COMMENT"
+elif [[ ! -x $NOT_A_COMMENT ]]; then
+    write_echo "Warning: not an executable file: $NOT_A_COMMENT"
+else
+    # SC2046 (warning): Quote this to prevent word splitting.
+    #
+    # The paths printed by find will not word split.
+    #
+    # https://www.shellcheck.net/wiki/SC2046
+    # shellcheck disable=SC2046
+    if ! "$NOT_A_COMMENT" $(find . -name 'Makefile.local' -print 2>/dev/null) >/dev/null 2>&1; then
+	write_echo ""
+	write_echo "Notice: Found non-comments in some Makefile.local file(s)."
+	write_echo "Notice: Be sure that these Makefile.local file(s) are not skew the results above."
+	write_logfile
+	write_logfile "=-=-= output from soup/not_a_comment.sh -v 1 follows:"
+	write_logfile
+	# SC2046 (warning): Quote this to prevent word splitting.
+	#
+	# The paths printed by find will not word split.
+	#
+	# https://www.shellcheck.net/wiki/SC2046
+	# shellcheck disable=SC2046
+	FOUND=$("$NOT_A_COMMENT" -v 1 $(find . -name 'Makefile.local' -print 2>/dev/null) 2>&1)
+	write_logfile "$FOUND"
+	write_logfile
+	write_logfile "=-=-= End of output from soup/not_a_comment.sh -v 1"
+    fi
+fi
+
+
 
 # All Done!!! All Done!!! -- Jessica Noll, Age 2
 #

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.1.10 2024-12-31"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.2 2025-01-04"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version


### PR DESCRIPTION
Synced jparse/ from jparse repo (https://github.com/xexyl/jparse/) with the new script not_a_comment.sh which is now used in jparse/test_jparse/prep.sh as well. Thanks Landon! Doing this also uncovered a bug in jparse/test_jparse/prep.sh: namely that shellcheck failed due to the fact the script was missing from jparse/test_jparse/Makefile (this goes all the way back to the initial import of jparse as there was no prep.sh at the time!).