### PR TITLE
Various updates for subdirectories in mkiocccentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.5 2025-01-08
+
+Update `mkiocccentry_test.sh` to test the new subdirectory option of
+`mkiocccentry`, with the depth being valid and the depth being too high.
+
+Fix regexp in error message for basename of files according to how
+`sane_relative_path()` functions.
+
+Sync `jparse/` from [jparse repo](https://github.com/xexyl/jparse/) with a
+comment to `sane_relative_path()` (about regexp it enforces) and additional test
+cases to the util test code.
+
+Updated FAQ about how to use `mkiocccentry as well as the man page (with some
+details on how the mkiocccentry will copy directories now). The FAQ, guidelines
+and rules have to be updated in the winner repo and that'll come next unless
+something comes up here.
+
 ## Release 2.3.4 2025-01-07
 
 Submission tarballs can now have subdirectories! This is a major release that

--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ answers to a number of possible problems as well as to see how to report issues.
 If your problem is a problem compiling the tools or you have encountered what
 you think is a bug, please see the
 FAQ on "[reporting bugs](FAQ.md#bugs)".
+
+Additionally, if you have more questions on the use of the toolkit, see the FAQ
+section [Entering the IOCCC: the bare minimum you need to
+know](https:/www.ioccc.org/faq.html#enter_questions), the FAQ section [Entering
+the IOCCC: more help and
+details](https://www.ioccc.org/faq.html#submitting_help), the [IOCCC
+Guidelines](https://www.ioccc.org/next/guidelines.html) and the [IOCCC
+Rules](https://www.ioccc.org/next/rules.html) at the [Official IOCCC
+website](https://www.ioccc.org).

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,16 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.4 2025-01-08
+
+Add comment about the regexp that `sane_relative_path()` should enforce, namely:
+
+```regexp
+^([[:alnum:]_+-]+/)*([[:alnum:]_+-]+(\.[[:alnum:]_+-]+))?$
+```
+
+and update the util test code to test additional checks.
+
+
 ## Release 2.2.3 2025-01-07
 
 Updated comments in jparse.l and jparse.y and rebuilt backup files.

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -3295,6 +3295,10 @@ posix_plus_safe(char const *str, bool lower_only, bool slash_ok, bool first)
  * By sane we mean that no path component is an unsafe name according to
  * posix_plus_safe(str, false, false, true).
  *
+ * In other words, it must match the following regexp:
+ *
+ *      ^([[:alnum:]_+-]+/)*([[:alnum:]_+-]+(\.[[:alnum:]_+-]+))?$
+ *
  * given:
  *	str		    - string to test
  *      max_path_len        - max path length (length of str)
@@ -5188,7 +5192,7 @@ check_invalid_option(char const *prog, int ch, int opt)
  */
 #include "../json_utf8.h"
 
-#define UTIL_TEST_VERSION "1.0.1 2025-01-07" /* version format: major.minor YYYY-MM-DD */
+#define UTIL_TEST_VERSION "1.0.1 2025-01-08" /* version format: major.minor YYYY-MM-DD */
 
 int
 main(int argc, char **argv)
@@ -5461,12 +5465,34 @@ main(int argc, char **argv)
     }
 
     /*
+     * test another invalid path component
+     */
+    relpath = "foo/./";
+    sanity = sane_relative_path(relpath, 99, 25, 4);
+    if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
+        err(187, __func__, "%s(\"%s\", 99, 25, 4): expected PATH_ERR_NOT_POSIX_SAFE, got: %s", __func__,
+                relpath, path_sanity_name(sanity));
+        not_reached();
+    }
+
+    /*
+     * test another invalid path component
+     */
+    relpath = "./foo/";
+    sanity = sane_relative_path(relpath, 99, 25, 4);
+    if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
+        err(188, __func__, "%s(\"%s\", 99, 25, 4): expected PATH_ERR_NOT_POSIX_SAFE, got: %s", __func__,
+                relpath, path_sanity_name(sanity));
+        not_reached();
+    }
+
+    /*
      * test path with number in it
      */
     relpath = "foo1";
     sanity = sane_relative_path(relpath, 99, 25, 4);
     if (sanity != PATH_OK) {
-        err(187, __func__, "%s(\"%s\", 99, 25, 4): expected PATH_OK, got: %s", __func__,
+        err(189, __func__, "%s(\"%s\", 99, 25, 4): expected PATH_OK, got: %s", __func__,
                 relpath, path_sanity_name(sanity));
         not_reached();
     }

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.3 2025-01-07"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.4 2025-01-08"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3058,12 +3058,13 @@ check_extra_data_files(struct info *infop, char const *submission_dir, char cons
 	if (sane_relative_path(base, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH) != PATH_OK) {
 	    fpara(stderr,
 		  "",
-		  "The basename of an extra file must match the following regular expression:",
+		  "The basename of an extra file/directory must match the",
+                  "following regular expression:",
 		  "",
 		  "    ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
 		  "",
 		  NULL);
-	    err(125, __func__, "basename of %s does not match regexp: ^[0-9A-Za-z][0-9A-Za-z._+-]*$",
+	    err(125, __func__, "basename of %s does not match regexp: ^([[:alnum:]_+-]+/)*([[:alnum:]_+-]+(\.[[:alnum:]_+-]+))?$",
 			       args[i]);
 	    not_reached();
 	}

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "12 July 2024" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "08 January 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -20,11 +20,11 @@
 .I prog.c
 .I Makefile
 .I remarks.md
-.RI [\| file
+.RI [\| \[ file | directory \]
 .IR ... \|]
 .SH DESCRIPTION
 .B mkiocccentry
-gathers your source file, Makefile, remarks as well as any other files and creates an XZ compressed tarball.
+gathers your source file, Makefile and remarks as well as any other files and/or directories, and creates an XZ compressed tarball, assuming input is correct and everything is valid.
 The tool runs
 .B iocccsize
 on your
@@ -34,14 +34,13 @@ and it also runs tests on the
 the
 .IR remarks.md
 and any extra files as well to verify that everything seems in order.
-You can ignore the warnings except that the
-.I Makefile
-cannot be empty.
+You can ignore certain warnings but some warnings cannot be disabled; the program will let you know more about errors and you can correct them in that case.
 .PP
 Under the
 .I work_dir
 .B mkiocccentry
 will create an entry directory (based on the IOCCC contestant ID and entry number) that the program will copy the files to in order to create the tarball.
+One may pass in a directory name and the directory and everything under it will be copied to the work directory; however the filename restrictions still apply and there is a limit on the depth you may use, and if the filenames are not valid or the depth is higher than the max depth, it is an error.
 If the entry directory already exists the program will tell you to move it or delete it.
 The program does
 .B NOT

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -20,11 +20,11 @@
 .I prog.c
 .I Makefile
 .I remarks.md
-.RI [\| \[ file | directory \]
+.RI [\| \[ file | directory
 .IR ... \|]
 .SH DESCRIPTION
 .B mkiocccentry
-gathers your source file, Makefile and remarks as well as any other files and/or directories, and creates an XZ compressed tarball, assuming input is correct and everything is valid.
+gathers your source file, Makefile and remarks as well as any other files and/or directories, and assuming everything is correct and valid, it will create an XZ compressed tarball.
 The tool runs
 .B iocccsize
 on your
@@ -33,29 +33,31 @@ and it also runs tests on the
 .IR Makefile \|,
 the
 .IR remarks.md
-and any extra files as well to verify that everything seems in order.
-You can ignore certain warnings but some warnings cannot be disabled; the program will let you know more about errors and you can correct them in that case.
+and any extra files as well, to verify that everything seems in order.
+You can ignore certain warnings but some issues are errors; if invalid input or files are provided the program will let you know more about it so you can fix it.
 .PP
 Under the
 .I work_dir
 .B mkiocccentry
-will create an entry directory (based on the IOCCC contestant ID and entry number) that the program will copy the files to in order to create the tarball.
-One may pass in a directory name and the directory and everything under it will be copied to the work directory; however the filename restrictions still apply and there is a limit on the depth you may use, and if the filenames are not valid or the depth is higher than the max depth, it is an error.
-If the entry directory already exists the program will tell you to move it or delete it.
-The program does
+will create a submission directory (based on the IOCCC contestant ID and submission slot) that the program will copy the mandatory files to the work directory in order to create the tarball.
+If the submission directory under the work directory already exists, the program will tell you to move it or delete it; the program does
 .B NOT
-delete it for you.
+delete or move it for you.
+.PP
+One may pass in additional files or directories to be copied to the submission directory.
+Files are copied to the submission top level directory and directories are copied recursively as subdirectories.
+There is a maximum depth allowed for subdirectories and the basename of files and directories are restricted to POSIX plus \+ safe characters, plus a maximum name length.
 .PP
 Before forming the tarball,
 .B mkiocccentry
-will ask you for information about your entry including the number of authors and various information about the author(s).
-Once all the information has been collected it will copy the files to the entry directory under the
+will ask you for information about your submission including the number of authors and various information about the author(s).
+Once all the information has been collected it will copy the files to the submission directory under the
 .IR work_dir \|.
 At this point it will create the
 .I .info.json
 and
 .I .auth.json
-files with information about the entry and information about the authors (which is for winning entries).
+files with information about the submission and information about the authors (which are for winning entries).
 .PP
 After each file is formed it will run
 .BR chkentry (1)
@@ -266,13 +268,13 @@ The
 .BR fnamchk (1)
 tool was by necessity changed accordingly.
 .PP
-Astute proof readers might find circumstances where variables, comments, error messages and prompt strings use
+Astute proofreaders might find circumstances where variables, comments, error messages and prompt strings use
 .B entry
 instead of
 .BR submission .
 You are welcome to submit pull requests to
 .I https://github.com/ioccc-src/mkiocccentry/pulls
-correct such oversights in variables,
+to correct such oversights in variables,
 comments, error messages and prompt strings.
 Note, however, that there are many cases where the words
 .B entry
@@ -315,11 +317,11 @@ for future updates:
 .ft R
 .RE
 .PP
-Use the answers file from the previous invocation to quickly update the entry with an additional file added:
+Use the answers file from the previous invocation to quickly update the entry with an additional file and directory added:
 .sp
 .RS
 .ft B
- ./mkiocccentry \-i answers work_dir prog.c Makefile remarks.md data.txt
+ ./mkiocccentry \-i answers work_dir prog.c Makefile remarks.md data.txt subdir
 .ft R
 .RE
 .PP

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.4 2025-01-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.5 2025-01-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Update mkiocccentry_test.sh to test the new subdirectory option of mkiocccentry, with the depth being valid and the depth being too high.

Fix regexp in error message for basename of files according to how sane_relative_path() functions.

Sync jparse/ from jparse repo (https://github.com/xexyl/jparse/) with a comment to sane_relative_path() (about regexp it enforces) and additional test cases to the util test code.

Updated FAQ about how to use mkiocccentry as well as the man page (with some details on how the mkiocccentry will copy directories now). The FAQ, guidelines and rules have to be updated in the winner repo and that'll come next unless something comes up here.