### PR TITLE
Improve and rename test_extra_file()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.9 2025-01-14
+
+Renamed `test_extra_file()` to better account for what it is:
+`test_extra_filename()`. Improved the function to use two `char *[]`s so that we
+don't have to have checks on each file manually in each tool that uses it,
+though at present only `chkentry(1)` uses it (it is not clear if any other tool
+can use it in the future but this update allows for more easily maintaining the
+list of filenames that must be present and that must not be present).
+
+
+
 ## Release 2.3.8 2025-01-13
 
 Work done on new `mkiocccentry` options `-d` and `-s seed` (both will be

--- a/soup/chk_validate.c
+++ b/soup/chk_validate.c
@@ -1149,7 +1149,7 @@ chk_extra_file(struct json const *node,
     /*
      * validate decoded JSON string
      */
-    test = test_extra_file(str);
+    test = test_extra_filename(str);
     if (test == false) {
 	if (val_err != NULL) {
 	    *val_err = werr_sem_val(126, node, depth, sem, __func__, "invalid extra_file filename");

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -35,17 +35,26 @@
 /*
  * defines
  */
-#define INFO_JSON_FILENAME ".info.json"
-#define AUTH_JSON_FILENAME ".auth.json"
-#define PROG_C_FILENAME "prog.c"
-#define REMARKS_FILENAME "remarks.md"
-#define MAKEFILE_FILENAME "Makefile"
-#define INDEX_HTML_FILENAME "index.html"
-#define PROG_FILENAME "prog"
-#define PROG_ALT_FILENAME "prog.alt"
-#define PROG_ORIG_FILENAME "prog.orig"
-#define PROG_ORIG_C_FILENAME "prog.orig.c"
-#define README_MD_FILENAME "README.md"
+/*
+ * mandatory filenames in the top directory
+ */
+#define INFO_JSON_FILENAME ".info.json"         /* filename of the .info.json file */
+#define AUTH_JSON_FILENAME ".auth.json"         /* filename of the .auth.json file */
+#define PROG_C_FILENAME "prog.c"                /* submission/winning entry source code filename */
+#define REMARKS_FILENAME "remarks.md"           /* remarks filename that form README.md for winning entries */
+#define MAKEFILE_FILENAME "Makefile"            /* submission/winning entry Makefile filename */
+/*
+ * forbidden filenames in the top directory
+ */
+#define INDEX_HTML_FILENAME "index.html"        /* winning entry index.html filename */
+#define PROG_FILENAME "prog"                    /* compiled submission/winning entry code filename */
+#define PROG_ALT_FILENAME "prog.alt"            /* compiled submission/winning entry alt code filename */
+#define PROG_ORIG_FILENAME "prog.orig"          /* compiled winning entry code filename */
+#define PROG_ORIG_C_FILENAME "prog.orig.c"      /* entry source code filename */
+#define README_MD_FILENAME "README.md"          /* README.md file that forms index.html for winning entries */
+
+extern char *mandatory_filenames[];             /* filenames that MUST exist in the top level directory */
+extern char *forbidden_filenames[];             /* filenames that must NOT exist in the top level directory */
 
 /*
  * IOCCC author information
@@ -240,7 +249,7 @@ extern bool test_default_handle(bool boolean);
 extern bool test_email(char const *str);
 extern bool test_empty_override(bool boolean);
 extern bool test_submit_slot(int submit_slot);
-extern bool test_extra_file(char const *str);
+extern bool test_extra_filename(char const *str);
 extern bool test_filename_len(char const *str);
 extern bool test_first_rule_is_all(bool boolean);
 extern bool test_fnamchk_version(char const *str);

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,13 +66,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.8 2025-01-13"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.9 2025-01-14"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.6 2025-01-13"		/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "1.1.7 2025-01-14"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version


### PR DESCRIPTION
Renamed test_extra_file() to better account for what it is: test_extra_filename(). Improved the function to use two char *[]s so that we don't have to have checks on each file manually in each tool that uses it, though at present only chkentry(1) uses it (it is not clear if any other tool can use it in the future but this update allows for more easily maintaining the list of filenames that must be present and that must not be present).