### PR TITLE
Fixed make all test; make test failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@ to "1.2 2025-01-16".
 Changed `MKIOCCCENTRY_REPO_VERSION` from "2.3.9 2025-01-14"
 to "2.3.10 2025-01-16".
 
+Fixed `make all test; make test` failure.
+
 
 ## Release 2.3.9 2025-01-14
 

--- a/Makefile
+++ b/Makefile
@@ -1009,7 +1009,6 @@ test:
 		     LD_DIR="${LD_DIR}" LD_DIR2="${LD_DIR2}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C soup $@ C_SPECIAL="${C_SPECIAL}"
 	${E} ${MAKE} ${MAKE_CD_Q} -C test_ioccc $@ C_SPECIAL="${C_SPECIAL}"
-	${E} ${RM} -f jparse/test_jparse/pr_jparse_test
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 	${S} echo "All done!!! All done!! -- Jessica Noll, Age 2."

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -429,7 +429,7 @@ main(int argc, char *argv[])
 	 *	random_answers.answer_seed
 	 */
 	answer_len = (sizeof("random_answers.")-1) + SEED_DECIMAL_DIGITS + 1 + 1;   /* +1 for NULL, +1 for paranoia */
-	answers = malloc(answer_len + 1);	/* +1 for paranoia */
+	answers = malloc((size_t)answer_len + 1);	/* +1 for paranoia */
 	if (answers == NULL) {
 	    err(3, __func__, "failed to malloc %d bytes for answers filename", answer_len + 1); /*ooo*/
 	    not_reached();

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -192,7 +192,7 @@ C_OPT= -O3 -g3
 
 # Compiler warnings
 #
-WARN_FLAGS= -pedantic -Wall -Wextra -Wno-char-subscripts
+WARN_FLAGS= -pedantic -Wall -Wextra -Wno-char-subscripts -Wno-sign-conversion
 #WARN_FLAGS= -pedantic -Wall -Wextra -Werror
 
 # special compiler flags

--- a/soup/random_answers.h
+++ b/soup/random_answers.h
@@ -75,72 +75,73 @@
 /*
  * forward declarations
  */
-long biased_random_range(long min, long above);
-long top_skew_random_range(long min, long above);
+extern long biased_random_range(long min, long above);
+extern long top_skew_random_range(long min, long above);
 
-char random_alpha(void);
-char random_upper_alpha_char(void);
-char random_lower_alpha_char(void);
+extern char random_alpha(void);
+extern char random_upper_alpha_char(void);
+extern char random_lower_alpha_char(void);
 
-char random_alphanum_char(void);
-char random_upper_alphanum_char(void);
-char random_lower_alphanum_char(void);
+extern char random_alphanum_char(void);
+extern char random_upper_alphanum_char(void);
+extern char random_lower_alphanum_char(void);
 
-char random_posixsafe_char(void);
-char random_upper_posixsafe_char(void);
-char random_lower_posixsafe_char(void);
+extern char random_posixsafe_char(void);
+extern char random_upper_posixsafe_char(void);
+extern char random_lower_posixsafe_char(void);
 
-void random_alpha_str(char *str,
+extern void random_alpha_str(char *str,
 		      unsigned int minlen,
 		      unsigned int maxlen);
-void random_upper_alpha_str(char *str,
+extern void random_upper_alpha_str(char *str,
 			    unsigned int minlen,
 			    unsigned int maxlen);
-void random_lower_alpha_str(char *str,
+extern void random_lower_alpha_str(char *str,
 			    unsigned int minlen,
 			    unsigned int maxlen);
 
-void random_alphanum_str(char *str,
+extern void random_alphanum_str(char *str,
 			 unsigned int minlen,
 			 unsigned int maxlen);
-void random_upper_alphanum_str(char *str,
+extern void random_upper_alphanum_str(char *str,
 			       unsigned int minlen,
 			       unsigned int maxlen);
-void random_lower_alphanum_str(char *str,
+extern void random_lower_alphanum_str(char *str,
 			       unsigned int minlen,
 			       unsigned int maxlen);
 
-void random_posixsafe_str(char *str,
+extern void random_posixsafe_str(char *str,
 			  unsigned int minlen,
 			  unsigned int maxlen);
-void random_upper_posixsafe_str(char *str,
+extern void random_upper_posixsafe_str(char *str,
 				unsigned int minlen,
 				unsigned int maxlen);
-void random_lower_posixsafe_str(char *str,
+extern void random_lower_posixsafe_str(char *str,
 				unsigned int minlen,
 				unsigned int maxlen);
 
-void random_words_str(char *str,
+extern void random_words_str(char *str,
 		      unsigned int minlen,
 		      unsigned int maxlen);
-void random_upper_words_str(char *str,
+extern void random_upper_words_str(char *str,
 			    unsigned int minlen,
 			    unsigned int maxlen);
-void random_lower_words_str(char *str,
+extern void random_lower_words_str(char *str,
 			    unsigned int minlen,
 			    unsigned int maxlen);
 
-void random_posixsafe_words_str(char *str,
+extern void random_posixsafe_words_str(char *str,
 				unsigned int minlen,
 				unsigned int maxlen);
-void random_upper_posixsafe_words_str(char *str,
+extern void random_upper_posixsafe_words_str(char *str,
 				      unsigned int minlen,
 				      unsigned int maxlen);
-void random_lower_posixsafe_words_str(char *str,
+extern void random_lower_posixsafe_words_str(char *str,
 				      unsigned int minlen,
 				      unsigned int maxlen);
 
-void generate_answers(char const *answers);
+extern void generate_answers(char const *answers);
+extern char random_alpha_char(void);
 
 
 #endif /* INCLUDE_RANDOM_ANSWERS_H */


### PR DESCRIPTION

The problem was that the end of the make test rule in the Makefile a
stray rm -f on jparse/test_jparse/pr_jparse_test was performed.