### PR TITLE
Increment OPTIONAL_SUBMISSION_FILES by 1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.12 2025-01-18
+
+Increase the `OPTIONAL_SUBMISSION_FILES` to 3 due to the additional optional
+file `try.alt.sh`.
+
+
 ## Release 2.3.11 2025-01-17
 
 Bug fix `txzchk` to check for required files in top level directory only (with

--- a/soup/limit_ioccc.h
+++ b/soup/limit_ioccc.h
@@ -87,7 +87,7 @@
 #define MAX_TARBALL_LEN ((off_t)(3999971))	/* compressed tarball size limit in bytes */
 #define MAX_SUM_FILELEN ((off_t)(27651*1024))	/* maximum sum of the byte lengths of all files in the entry */
 #define MANDATORY_SUBMISSION_FILES (5)		/* number of required files in submission */
-#define OPTIONAL_SUBMISSION_FILES (2)		/* submission files, if they exist, that do NOT count towards the extra total */
+#define OPTIONAL_SUBMISSION_FILES (3)		/* submission files, if they exist, that do NOT count towards the extra total */
 #define MAX_EXTRA_FILE_COUNT (31)		/* maximum number of files not including mandatory submission files */
 /* maximum total file count, including mandatory files, for a submission */
 #define MAX_FILE_COUNT (MANDATORY_SUBMISSION_FILES+OPTIONAL_SUBMISSION_FILES+MAX_EXTRA_FILE_COUNT)

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,13 +66,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.11 2025-01-17"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.12 2025-01-18"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.8 2025-01-16"		/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "1.1.9 2025-01-18"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version


### PR DESCRIPTION
As try.alt.sh is now included as an optional file there are three optional files, not 2.

This does increase the total number of files included but as optional files are not extra files it is not a problem. Besides the new total should be 39, a prime.