### PR TITLE
Start work on #1070 and fix NULL ptr dereference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,20 @@ violating rule 17.
 
 Change `MKIOCCCENTRY_VERSION` to `"1.2.3 2025-01-19"`.
 
+Start work on issue #1070. To not interfere with the current system and to allow
+others (namely Landon) to work on it too, it uses a macro: `MKIOCCCENTRY_DEV`.
+If this is defined it will require 2 args and it will not set the prog.c,
+remarks.md or Makefile variables as they won't exist. This means the functions
+that pass in those variables are not called either. The usage message is
+simplified for the dev version. If it is defined it will set the topdir too.
+Also changed the `work_dir` variable to `workdir` (in both modes). If
+`MKIOCCCENTRY_DEV` is used to compile the tool then `make test` **WILL** fail!
+This is because the script uses the old four mandatory arguments (and the
+optional files in some cases too).
+
+Fixed a NULL pointer dereference in `mkiocccentry`: `answers` was passed to
+dbg() even if it was NULL (none of the answers options were used).
+
 
 ## Release 2.3.12 2025-01-18
 

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -155,12 +155,12 @@ static void warn_wordbuf(char const *prog_c);
 static void warn_ungetc(char const *prog_c);
 static void warn_rule_2b_size(struct info *infop, char const *prog_c);
 static RuleCount check_prog_c(struct info *infop, char const *submission_dir, char const *cp, char const *prog_c);
-static void mkiocccentry_sanity_chks(struct info *infop, char const *work_dir, char const *tar, char const *cp,
+static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar, char const *cp,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry);
 static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, bool *read_answers_flag_used);
 static int get_submit_slot(struct info *infop);
-static char *mk_submission_dir(char const *work_dir, char const *ioccc_id, int submit_slot,
+static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);
 static bool inspect_Makefile(char const *Makefile, struct info *infop);
 static void warn_Makefile(char const *Makefile, struct info *infop);
@@ -175,12 +175,12 @@ static void verify_submission_dir(char const *submission_dir, char const *ls);
 static void write_info(struct info *infop, char const *submission_dir, char const *chkentry, char const *fnamchk);
 static void form_auth(struct auth *authp, struct info *infop, int author_count, struct author *authorp);
 static void write_auth(struct auth *authp, char const *submission_dir, char const *chkentry, char const *fnamchk);
-static void form_tarball(char const *work_dir, char const *submission_dir, char const *tarball_path, char const *tar,
+static void form_tarball(char const *workdir, char const *submission_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk);
-static void remind_user(char const *work_dir, char const *submission_dir, char const *tar, char const *tarball_path,
+static void remind_user(char const *workdir, char const *submission_dir, char const *tar, char const *tarball_path,
 	bool test_mode, int submit_slot);
 static void show_registration_url(void);
-static void show_submit_url(char const *work_dir, char const *tarball_path, int slot_number);
+static void show_submit_url(char const *workdir, char const *tarball_path, int slot_number);
 
 static long answer_seed = NO_SEED;	/* if != 0 ==> srandom argument used to seed generation of answers */
 #endif /* INCLUDE_MKIOCCCENTRY_H */


### PR DESCRIPTION
Start work on issue #1070. To not interfere with the current system and to allow others (namely Landon) to work on it too, it uses a macro: MKIOCCCENTRY_DEV. If this is defined it will require 2 args and it will not set the prog.c, remarks.md or Makefile variables as they won't exist. This means the functions that pass in those variables are not called either. The usage message is simplified for the dev version. If it is defined it will set the topdir too. Also changed the work_dir variable to workdir (in both modes). If MKIOCCCENTRY_DEV is used to compile the tool then make test WILL fail! This is because the script uses the old four mandatory arguments (and the optional files in some cases too).

Fixed a NULL pointer dereference in mkiocccentry: answers was passed to dbg() even if it was NULL (none of the answers options were used).