### PR TITLE
More work on mkiocccentry command line enhancement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ the `test_ioccc/test_JSON` tree.
 
 Fixed a number of broken tests in the `test_ioccc/test_JSON` tree.
 
-Updated and sorted `.gitignore'.
+Updated and sorted `.gitignore`.
 
 Fixed debug message that incorrectly stated that was unknown.
 
@@ -26,6 +26,17 @@ to "2.3.14 2025-01-20".
 
 Changed `SOUP_VERSION` from "1.1.10 2025-01-19"
 to "1.1.11 2025-01-20".
+
+Change `mkiocccentry_test.sh` to not test `-d` as it now sets `-E` which causes
+a failure.
+
+Add to the macro `MKIOCCCENTRY_DEV` so that for now it at least will run the
+tests on `prog.c`, `Makefile` and `remarks.md` and form the tarball even though
+it's not complete (it won't ignore the right files, it doesn't do anything with
+the other files etc. but this way at least the program won't fail when working
+on the issue).
+
+Changed `MKIOCCCENTRY_VERSION` to `"1.2.4 2025-01-20"`.
 
 
 ## Release 2.3.13 2025-01-19

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -206,11 +206,10 @@ main(int argc, char *argv[])
     extern int optind;				/* argv index of the next arg */
     struct timeval tp;				/* gettimeofday time value */
     char const *workdir = NULL;		/* where the submission directory and tarball are formed */
-#if !defined(MKIOCCCENTRY_DEV)
-    char const *prog_c = NULL;			/* path to prog.c */
-    char const *Makefile = NULL;		/* path to Makefile */
-    char const *remarks_md = NULL;		/* path to remarks.md */
-#else
+    char *prog_c = NULL;			/* path to prog.c */
+    char *Makefile = NULL;		/* path to Makefile */
+    char *remarks_md = NULL;		/* path to remarks.md */
+#if defined(MKIOCCCENTRY_DEV)
     char const *topdir = NULL;          /* directory from which files are to be copied to the workdir */
 #endif
     char *tar = TAR_PATH_0;			/* path to tar executable that supports the -J (xz) option */
@@ -357,10 +356,10 @@ main(int argc, char *argv[])
 	    errno = 0;		/* pre-clear errno for warnp() */
 	    answer_seed = (long)strtol(optarg, NULL, 0);
 	    if (errno != 0) {
-		warnp(__func__, "invalid -s argument, most be an integer >= 0, disabling -s seed");
+		warnp(__func__, "invalid -s argument, must be an integer >= 0, disabling -s seed");
 		answer_seed = NO_SEED;
 	    } else if (answer_seed < 0) {
-		warnp(__func__, "invalid -s argument, most be >= 0, disabling -s seed");
+		warnp(__func__, "invalid -s argument, must be >= 0, disabling -s seed");
 		answer_seed = NO_SEED;
 	    } else {
 		seed_used = true;
@@ -510,6 +509,25 @@ main(int argc, char *argv[])
 #else
     topdir = argv[optind + 1];
     dbg(DBG_MED, "topdir: %s", topdir);
+    prog_c = calloc_path(topdir, "prog.c");
+    if (prog_c == NULL) {
+        err(55, __func__, "couldn't allocate prog.c path");
+        not_reached();
+    }
+    dbg(DBG_MED, "prog.c: %s", prog_c);
+    Makefile = calloc_path(topdir, "Makefile");
+    if (Makefile == NULL) {
+        err(55, __func__, "couldn't allocate Makefile path");
+        not_reached();
+    }
+    dbg(DBG_MED, "Makefile: %s", Makefile);
+
+    remarks_md = calloc_path(topdir, "remarks.md");
+    if (Makefile == NULL) {
+        err(55, __func__, "couldn't allocate remarks.md path");
+        not_reached();
+    }
+    dbg(DBG_MED, "remarks.md: %s", remarks_md);
 #endif
     if (answers != NULL) {
         dbg(DBG_MED, "answers file: %s", answers);
@@ -694,7 +712,6 @@ main(int argc, char *argv[])
 	}
     }
 
-#if !defined(MKIOCCCENTRY_DEV)
     /*
      * check prog.c
      */
@@ -730,6 +747,7 @@ main(int argc, char *argv[])
 	para("... completed remarks.md check.", "", NULL);
     }
 
+#if !defined(MKIOCCCENTRY_DEV)
     /*
      * check, if needed, extra data files
      */
@@ -944,7 +962,6 @@ main(int argc, char *argv[])
 		if (!ignore_warnings) {
 		    need_confirm = true;
 
-#if !defined(MKIOCCCENTRY_DEV)
 		    if (info.empty_override) {
 			warn_empty_prog(prog_c);
 		    }
@@ -972,7 +989,6 @@ main(int argc, char *argv[])
 		    if (info.Makefile_override) {
 			warn_Makefile(Makefile, &info);
 		    }
-#endif
 		}
 	    } while (0);
 	}
@@ -1004,6 +1020,21 @@ main(int argc, char *argv[])
     free_auth(&auth);
     memset(&auth, 0, sizeof(auth));
 
+#if defined(MKIOCCCENTRY_DEV)
+    if (prog_c != NULL) {
+        free(prog_c);
+        prog_c = NULL;
+    }
+    if (Makefile != NULL) {
+        free(Makefile);
+        Makefile = NULL;
+    }
+
+    if (remarks_md != NULL) {
+        free(remarks_md);
+        remarks_md = NULL;
+    }
+#endif
 
     /*
      * All Done!!! All Done!!! -- Jessica Noll, Age 2

--- a/soup/version.h
+++ b/soup/version.h
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.3 2025-01-19"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.4 2025-01-20"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -74,7 +74,7 @@ LS="$(type -P ls 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="1.0.4 2025-01-16"
+export MKIOCCCENTRY_TEST_VERSION="1.0.5 2025-01-20"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-c cp] [-F fnamchk] [-Z topdir]
 
     -h              print help and exit
@@ -831,15 +831,6 @@ if [[ ${status} -eq 0 ]]; then
 else
     echo "$0: NOTE: the above error is expected as we were testing that the max depth" 1>&2
     echo "$0: NOTE: limit works." 1>&2
-fi
-
-# run test using -d (which uses -s seed)
-#
-./mkiocccentry -d "${workdir}" "${src_dir}"/{prog.c,Makefile,remarks.md}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
-    exit "${status}"
 fi
 
 


### PR DESCRIPTION
Add to the macro MKIOCCCENTRY_DEV so that for now it at least will run the tests on prog.c, Makefile and remarks.md and form the tarball even though it's not complete (it won't ignore the right files, it doesn't do anything with the other files etc. but this way at least the program won't fail when working on the issue).

Changed MKIOCCCENTRY_VERSION to "1.2.4 2025-01-20".

Change mkiocccentry_test.sh to not test -d as it now sets -E which causes a failure.