### PR TITLE
More work on issue #1070

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,26 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.15 2025-01-24
+
+More work done on #1070. The function `count_files()` in `soup/entry_util.c` has
+been renamed to `collect_files()` and it now only counts files that are valid,
+checking for unsafe names, depth too deep, too long filenames and so on. If too
+many files are found (it does not consider optional files or required files yet)
+it is also an error. Nothing is added to a list yet.
+
+The mkiocccentry tool has been updated to use this function, showing debug
+output if `-v 1`. It can no longer fake the paths to `prog.c`, `Makefile` and
+`remarks.md` so it exits 0 after the call to the `collect_files()` function.
+With low debug level (1) it will show what files are collected.
+
+Updated `SOUP_VERSION` to `"1.1.12 2025-01-24"`.
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.5 2025-01-24"`.
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` to fix some
+minor issues in `sane_relative_path()`.
+
+
 ## Release 2.3.14 2025-01-20
 
 The `test_ioccc/test_JSON` is now built by a new tool `test_ioccc/gen_test_JSON.sh`

--- a/Makefile
+++ b/Makefile
@@ -1719,27 +1719,27 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-chkentry.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h \
-    chkentry.c chkentry.h dbg/dbg.h jparse/jparse.h jparse/jparse.tab.h \
-    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
-    jparse/json_util.h jparse/util.h jparse/version.h soup/chk_sem_auth.h \
-    soup/chk_sem_info.h soup/chk_validate.h soup/default_handle.h \
-    soup/entry_util.h soup/foo.h soup/limit_ioccc.h soup/location.h \
-    soup/sanity.h soup/soup.h soup/version.h
-iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
-    soup/limit_ioccc.h soup/version.h
-mkiocccentry.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h \
-    dbg/dbg.h iocccsize.h jparse/jparse.h jparse/jparse.tab.h \
-    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
-    jparse/json_util.h jparse/util.h jparse/version.h mkiocccentry.c \
-    mkiocccentry.h soup/chk_sem_auth.h soup/chk_sem_info.h \
-    soup/chk_validate.h soup/default_handle.h soup/entry_util.h \
-    soup/limit_ioccc.h soup/location.h soup/random_answers.h soup/sanity.h \
-    soup/soup.h soup/version.h
-txzchk.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h dbg/dbg.h \
+chkentry.o: chkentry.c chkentry.h dbg/dbg.h dyn_array/dyn_array.h \
     jparse/jparse.h jparse/jparse.tab.h jparse/json_parse.h \
     jparse/json_sem.h jparse/json_utf8.h jparse/json_util.h jparse/util.h \
     jparse/version.h soup/chk_sem_auth.h soup/chk_sem_info.h \
-    soup/chk_validate.h soup/default_handle.h soup/entry_util.h \
+    soup/chk_validate.h soup/default_handle.h soup/entry_util.h soup/foo.h \
     soup/limit_ioccc.h soup/location.h soup/sanity.h soup/soup.h \
-    soup/version.h txzchk.c txzchk.h
+    soup/version.h
+iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
+    soup/limit_ioccc.h soup/version.h
+mkiocccentry.o: dbg/dbg.h iocccsize.h jparse/jparse.h jparse/jparse.tab.h \
+    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
+    jparse/json_util.h jparse/util.h jparse/version.h mkiocccentry.c \
+    mkiocccentry.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
+    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
+    soup/default_handle.h soup/entry_util.h soup/limit_ioccc.h \
+    soup/location.h soup/random_answers.h soup/sanity.h soup/soup.h \
+    soup/version.h
+txzchk.o: dbg/dbg.h jparse/jparse.h jparse/jparse.tab.h jparse/json_parse.h \
+    jparse/json_sem.h jparse/json_utf8.h jparse/json_util.h jparse/util.h \
+    jparse/version.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
+    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
+    soup/default_handle.h soup/entry_util.h soup/limit_ioccc.h \
+    soup/location.h soup/sanity.h soup/soup.h soup/version.h txzchk.c \
+    txzchk.h

--- a/Makefile
+++ b/Makefile
@@ -1719,27 +1719,27 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-chkentry.o: chkentry.c chkentry.h dbg/dbg.h dyn_array/dyn_array.h \
+chkentry.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h \
+    chkentry.c chkentry.h dbg/dbg.h jparse/jparse.h jparse/jparse.tab.h \
+    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
+    jparse/json_util.h jparse/util.h jparse/version.h soup/chk_sem_auth.h \
+    soup/chk_sem_info.h soup/chk_validate.h soup/default_handle.h \
+    soup/entry_util.h soup/foo.h soup/limit_ioccc.h soup/location.h \
+    soup/sanity.h soup/soup.h soup/version.h
+iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
+    soup/limit_ioccc.h soup/version.h
+mkiocccentry.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h \
+    dbg/dbg.h iocccsize.h jparse/jparse.h jparse/jparse.tab.h \
+    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
+    jparse/json_util.h jparse/util.h jparse/version.h mkiocccentry.c \
+    mkiocccentry.h soup/chk_sem_auth.h soup/chk_sem_info.h \
+    soup/chk_validate.h soup/default_handle.h soup/entry_util.h \
+    soup/limit_ioccc.h soup/location.h soup/random_answers.h soup/sanity.h \
+    soup/soup.h soup/version.h
+txzchk.o: /usr/local/include/dbg.h /usr/local/include/dyn_array.h dbg/dbg.h \
     jparse/jparse.h jparse/jparse.tab.h jparse/json_parse.h \
     jparse/json_sem.h jparse/json_utf8.h jparse/json_util.h jparse/util.h \
     jparse/version.h soup/chk_sem_auth.h soup/chk_sem_info.h \
-    soup/chk_validate.h soup/default_handle.h soup/entry_util.h soup/foo.h \
+    soup/chk_validate.h soup/default_handle.h soup/entry_util.h \
     soup/limit_ioccc.h soup/location.h soup/sanity.h soup/soup.h \
-    soup/version.h
-iocccsize.o: dbg/dbg.h iocccsize.c iocccsize.h soup/iocccsize_err.h \
-    soup/limit_ioccc.h soup/version.h
-mkiocccentry.o: dbg/dbg.h iocccsize.h jparse/jparse.h jparse/jparse.tab.h \
-    jparse/json_parse.h jparse/json_sem.h jparse/json_utf8.h \
-    jparse/json_util.h jparse/util.h jparse/version.h mkiocccentry.c \
-    mkiocccentry.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
-    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
-    soup/default_handle.h soup/entry_util.h soup/limit_ioccc.h \
-    soup/location.h soup/random_answers.h soup/sanity.h soup/soup.h \
-    soup/version.h
-txzchk.o: dbg/dbg.h jparse/jparse.h jparse/jparse.tab.h jparse/json_parse.h \
-    jparse/json_sem.h jparse/json_utf8.h jparse/json_util.h jparse/util.h \
-    jparse/version.h soup/../dbg/dbg.h soup/../dyn_array/dyn_array.h \
-    soup/chk_sem_auth.h soup/chk_sem_info.h soup/chk_validate.h \
-    soup/default_handle.h soup/entry_util.h soup/limit_ioccc.h \
-    soup/location.h soup/sanity.h soup/soup.h soup/version.h txzchk.c \
-    txzchk.h
+    soup/version.h txzchk.c txzchk.h

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,13 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.9 2025-01-24
+
+Bug fixes in `sane_relative_path()` to do with return value checks. Also the
+`PATH_ERR_UNKNOWN` value (enum `path_sanity`) changed to `0` and `PATH_OK` to 1.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.1 2025-01-24"`.
+
+
 ## Release 2.2.8 2025-01-18
 
 Fix warnings about args to `%x` specifier in `sscanf(3)` being `unsigned int

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -3910,7 +3910,7 @@ sane_relative_path(char const *str, uintmax_t max_path_len, uintmax_t max_filena
             dbg(DBG_VVVVHIGH, "%s: \"%s\" length %ju <= max %ju", __func__, dup, (uintmax_t)n, (uintmax_t)max_filename_len);
             dbg(DBG_VVVHIGH, "%s: about to call: posix_plus_safe(\"%s\", false, false, true)", __func__, dup);
             sane = posix_plus_safe(dup, false, false, true);
-            if (!sane) {
+            if (sane != PATH_OK) {
                 dbg(DBG_VVVHIGH, "%s: \"%s\" is not POSIX plus + safe chars", __func__, dup);
                 return PATH_ERR_NOT_POSIX_SAFE;
             } else {
@@ -3964,7 +3964,7 @@ sane_relative_path(char const *str, uintmax_t max_path_len, uintmax_t max_filena
              * additional components for sanity, doing the same steps as
              * above.
              */
-            if (sane) {
+            if (sane != PATH_ERR_UNKNOWN) {
                 /*
                  * here we extract the remaining components of the path (after
                  * the first '/'), by looking for the next path separator
@@ -4021,7 +4021,7 @@ sane_relative_path(char const *str, uintmax_t max_path_len, uintmax_t max_filena
                      */
                     dbg(DBG_VVVHIGH, "%s: about to call: posix_plus_safe(\"%s\", false, false, true)", __func__, p);
                     sane = posix_plus_safe(p, false, false, true);
-                    if (sane) {
+                    if (sane == PATH_OK) {
                         dbg(DBG_VVVHIGH, "%s: component \"%s\" is POSIX plus + safe chars", __func__, p);
                     } else {
                         dbg(DBG_VVVHIGH, "%s: component \"%s\" is not POSIX plus + safe chars", __func__, p);

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -167,8 +167,8 @@ typedef unsigned char bool;
  * for the path sanity functions
  */
 enum path_sanity {
-    PATH_ERR_UNKNOWN = -1,              /* unknown error code (default in switch) */
-    PATH_OK = 0,                        /* path (str) is a sane relative path */
+    PATH_ERR_UNKNOWN = 0,               /* unknown error code (default in switch) */
+    PATH_OK,                            /* path (str) is a sane relative path */
     PATH_ERR_PATH_IS_NULL,              /* path string (str) is NULL */
     PATH_ERR_PATH_EMPTY,                /* path string (str) is 0 length (empty) */
     PATH_ERR_PATH_TOO_LONG,             /* path (str) > max_path_len */

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.8 2025-01-18"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.9 2025-01-24"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.0 2025-01-17"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.1 2025-01-24"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -301,6 +301,6 @@ extern bool test_url(char const *str);
 extern bool test_alt_url(char const *str);
 extern bool test_wordbuf_warning(bool boolean);
 extern bool test_paths(char * const *args);
-extern int count_files(char * const *args);
+extern size_t collect_files(char * const *args);
 
 #endif /* INCLUDE_ENTRY_UTIL_H */

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,13 +66,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.14 2025-01-20"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.15 2025-01-24"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.11 2025-01-20"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "1.1.12 2025-01-24"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.4 2025-01-20"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.5 2025-01-24"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION

The function count_files() in soup/entry_util.c has been renamed to
collect_files() and it now only counts files that are valid, checking
for unsafe names, depth too deep, too long filenames and so on. If too
many files are found (it does not consider optional files or required
files yet) it is also an error. Nothing is added to a list yet.

The mkiocccentry tool has been updated to use this function, showing
debug output if -v 1. It can no longer fake the paths to prog.c,
Makefile and remarks.md so it exits 0 after the call to the
collect_files() function.  With low debug level (1) it will show what
files are collected.

Updated SOUP_VERSION to "1.1.12 2025-01-24".
Updated MKIOCCCENTRY_VERSION to "1.2.5 2025-01-24".

Sync jparse repo (https://github.com/xexyl/jparse/) to jparse/ to fix
some minor issues in sane_relative_path().