### PR TITLE
More work on #1070

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.16 2025-01-26
+
+More work on #1070: the check on files being found now is done from the
+directory that the user specifies. This involved an enhancement to the jparse
+function `sane_relative_path()`. That enhancement allows filenames to start with
+`./` as when walking from `.` the function prepends `./` to each filename. There
+very possibly will be a new enhancement/utility function required before the
+filenames can be written to the .info.json file but that will have to be
+determined later.
+
+A memory error was fixed in the `jparse` function `count_comps()`.
+
+Updated `SOUP_VERSION` to `"1.1.13 2025-01-26"`.
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.6 2025-01-26"`.
+Updated `TXZCHK_VERSION` to `"1.1.6 2025-01-26"`.
+
+
 ## Release 2.3.15 2025-01-24
 
 More work done on #1070. The function `count_files()` in `soup/entry_util.c` has

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,23 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.10 2025-01-26
+
+Fix memory error in `count_comps()` (in `util.c`).
+
+Updated `sane_relative_path()` to allow for the path to start with `./`. This is
+necessary in some cases (whether it should check for `././` is another matter
+entirely but in that case it is an error). A string starting with `.//` is not a
+relative path as the first two characters being skipped will make it `/`. This
+update allows for one to use `fts_open()` on `"."` which would prepend a `./` to
+every filename. This process is done if the new boolean, the last parameter to the
+function, `dot_slash_okay`, is true.
+
+Updated util test code to test these new features.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.2 2025-01-26"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.5 2025-01-26"`.
+
+
 ## Release 2.2.9 2025-01-24
 
 Bug fixes in `sane_relative_path()` to do with return value checks. Also the

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -475,7 +475,7 @@ count_comps(char const *str, char comp, bool remove_all)
     /*
      * case: length is 0
      */
-    if (*copy == '\0' || len <= 0) {
+    if (len <= 0) {
         /*
          * string is empty
          */

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -228,7 +228,7 @@ extern bool posix_plus_safe(char const *str, bool lower_only, bool slash_ok, boo
 extern void posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe,
 			   bool *first_alphanum, bool *upper);
 extern enum path_sanity sane_relative_path(char const *str, uintmax_t max_path_len, uintmax_t max_filename_len,
-        uintmax_t max_depth);
+        uintmax_t max_depth, bool dot_slash_okay);
 extern char const *path_sanity_name(enum path_sanity sanity);
 extern char const *path_sanity_error(enum path_sanity sanity);
 extern void clearerr_or_fclose(FILE *stream);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.9 2025-01-24"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.10 2025-01-26"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.1 2025-01-24"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.2 2025-01-26"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -512,12 +512,22 @@ main(int argc, char *argv[])
     if (topdir == NULL) {
         err(55, __func__, "topdir is NULL");
         not_reached();
+    } else if (!is_dir(topdir[0]) || !is_read(topdir[0])) {
+        /*
+         * NOTE: this test will very possibly be done elsewhere as will the
+         * below code that lists files.
+         *
+         * XXX - report error - XXX
+         */
+        exit(1); /*ooo*/
+    } else {
+        dbg(DBG_MED, "topdir: %s", topdir[0]);
+        /*
+         * collect files (but for now it does not add it to any list)
+         */
+        total_files = collect_files(topdir);
+        dbg(DBG_LOW, "%ju files collected", (uintmax_t)total_files);
     }
-    /*
-     * collect files (but for now it does not add it to any list)
-     */
-    total_files = collect_files(topdir);
-    dbg(DBG_LOW, "%ju files collected", (uintmax_t)total_files);
 
     /*
      * for now this is all we can do
@@ -3293,7 +3303,7 @@ check_extra_data_files(struct info *infop, char const *submission_dir, char cons
 	    not_reached();
 	}
 
-        if (sane_relative_path(base, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH) != PATH_OK) {
+        if (sane_relative_path(base, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH, true) != PATH_OK) {
             fpara(stderr,
                   "",
                   "The basename of each directory and the final file in a path",

--- a/soup/version.h
+++ b/soup/version.h
@@ -72,7 +72,7 @@
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.12 2025-01-24"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "1.1.13 2025-01-26"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.5 2025-01-24"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.6 2025-01-26"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -104,7 +104,7 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "1.1.5 2025-01-18"	/* format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "1.1.6 2025-01-26"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official chkentry version

--- a/txzchk.c
+++ b/txzchk.c
@@ -655,7 +655,7 @@ check_txz_file(char const *tarball_path, char const *dir_name, struct txz_file *
          * sane_relative_path() will still flag it as invalid as it has a '.' in
          * it.
          */
-        sanity = sane_relative_path(file->filename, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH);
+        sanity = sane_relative_path(file->filename, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH, false);
         if (sanity != PATH_OK) {
             ++tarball.total_feathers; /* report it once and consider it only one feather */
             ++tarball.unsafe_chars;


### PR DESCRIPTION
The check on files being found now is done from the directory that the user specifies. This involved an enhancement to the jparse function sane_relative_path(). That enhancement allows filenames to start with "./" as when walking from "." the function prepends "./" to each filename. There very possibly will be a new enhancement/utility function required before the filenames can be written to the .info.json file but that will have to be determined later.

A memory error was fixed in the jparse function count_comps().

Updated SOUP_VERSION to "1.1.13 2025-01-26".
Updated MKIOCCCENTRY_VERSION to "1.2.6 2025-01-26". Updated TXZCHK_VERSION to "1.1.6 2025-01-26".