### PR TITLE
Make more progress on #1070

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,38 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.17 2025-01-28
+
+Make more progress on #1070.
+
+Rename `collect_files()` to `collect_topdir_files()`. The function now checks
+for `prog.c`, `Makefile` and `remarks.md`, running the checks on them (like in
+the old command line interface), copying them to the work directory if all is
+okay. To do this it has to record the directory that the tool was run from as
+well as the topdir (as in file descriptor of it) as it has to switch back and
+forth between the directories. For the `check_prog_c()`, `check_Makefile()` and
+`check_remarks_md()` functions the filenames have to be faked: that is they have
+to be in the form: `topdir/prog.c`, `topdir/Makefile` and `topdir/remarks.md`.
+
+For now the code also allows one to specify extra filenames as optional args.
+This will change when this issue is resolved completely as only files under
+topdir will be copied over. Doing this for now does allow for extra files to be
+copied to the submission tarball, however, which is useful for testing.
+
+No lists are yet created so we do not show the user what directories/files were
+ignored. It is very likely that some (or possibly a lot) of this code will have
+to change but it should be possible to adapt it into new functions (which will
+be necessary).
+
+Added new functions to check if a string (or a `char const *`) matches a
+mandatory filename, a forbidden filename, an optional filename or an ignored
+directory name. These functions are used in the `test_extra_filename()` function
+(which now also checks for ignored directory names).
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.7 2025-01-28"`.
+Updated `SOUP_VERSION` to `"1.1.14 2025-01-28"`.
+
+
 ## Release 2.3.16 2025-01-26
 
 More work on #1070: the check on files being found now is done from the

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -155,6 +155,8 @@ static void warn_wordbuf(char const *prog_c);
 static void warn_ungetc(char const *prog_c);
 static void warn_rule_2b_size(struct info *infop, char const *prog_c);
 static RuleCount check_prog_c(struct info *infop, char const *submission_dir, char const *cp, char const *prog_c);
+static size_t collect_topdir_files(char * const *args, struct info *infop, char const *submission_dir,
+        char const *cp, RuleCount *size);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar, char const *cp,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry);
 static char *prompt(char const *str, size_t *lenp);

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -61,9 +61,18 @@
 #define PROG_ALT_C "prog.alt.c"                 /* alt code source file */
 #define TRY_ALT_SH "try.alt.sh"                 /* try.alt.sh for prog.alt.c */
 
+/*
+ * directory names that should be ignored
+ */
+#define CVS_DIRNAME "CVS"                       /* for CVS */
+#define GIT_DIRNAME ".git"                      /* for git */
+#define SVN_DIRNAME ".svn"                      /* for svn */
+#define RCCS_DIRNAME "RCCS"                     /* for RCCS */
+
 extern char *mandatory_filenames[];             /* filenames that MUST exist in the top level directory */
 extern char *forbidden_filenames[];             /* filenames that must NOT exist in the top level directory */
 extern char *optional_filenames[];              /* filenames that are OPTIONAL in top level directory */
+extern char *ignored_dirnames[];                /* directory names that should be ignored */
 
 /*
  * IOCCC author information
@@ -301,6 +310,11 @@ extern bool test_url(char const *str);
 extern bool test_alt_url(char const *str);
 extern bool test_wordbuf_warning(bool boolean);
 extern bool test_paths(char * const *args);
-extern size_t collect_files(char * const *args);
+extern bool is_mandatory_filename(char const *str);
+extern bool is_forbidden_filename(char const *str);
+extern bool is_optional_filename(char const *str);
+extern bool is_ignored_dirname(char const *str);
+
+
 
 #endif /* INCLUDE_ENTRY_UTIL_H */

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,13 +66,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.15 2025-01-24"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.17 2025-01-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.13 2025-01-26"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "1.1.14 2025-01-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.6 2025-01-26"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.7 2025-01-28"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
Rename collect_files() to collect_topdir_files(). The function now checks for prog.c, Makefile and remarks.md, running the checks on them (like in the old command line interface), copying them to the work directory if all is okay. To do this it has to record the directory that the tool was run from as well as the topdir (as in file descriptor of it) as it has to switch back and forth between the directories. For the check_prog_c(), check_Makefile() and check_remarks_md() functions the filenames have to be faked: that is they have to be in the form: topdir/prog.c, topdir/Makefile and topdir/remarks.md.

For now the code also allows one to specify extra filenames as optional args. This will change when this issue is resolved completely as only files under topdir will be copied over. Doing this for now does allow for extra files to be copied to the submission tarball, however, which is useful for testing.

No lists are yet created so we do not show the user what directories/files were ignored. It is very likely that some (or possibly a lot) of this code will have to change but it should be possible to adapt it into new functions (which will be necessary).

Added new functions to check if a string (or a char const *) matches a mandatory filename, a forbidden filename, an optional filename or an ignored directory name. These functions are used in the test_extra_filename() function (which now also checks for ignored directory names).

Updated MKIOCCCENTRY_VERSION to "1.2.7 2025-01-28". Updated SOUP_VERSION to "1.1.14 2025-01-28".