### PR TITLE
Removed MKIOCCCENTRY_DEV macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.18 2025-01-29
+
+More work on #1070.
+
+The `collect_topdir_files()` now verifies that all three required files
+(`prog.c`, `Makefile` and `remarks.md`) are found.
+
+The `collect_topdir_files()` also only records extra files if it's not an
+optional file or a required file.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.8 2025-01-29"`.
+
+
 ## Release 2.3.17 2025-01-28
 
 Make more progress on #1070.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,17 @@ The `collect_topdir_files()` now verifies that all three required files
 The `collect_topdir_files()` also only records extra files if it's not an
 optional file or a required file.
 
+Removed the `MKIOCCENTRY_DEV` macro. Instead it now defaults to the new way but
+with the ability to (for now) specify extra files as additional args. This is
+not how it will remain but this change allows for easier development. The
+`mkiocccentry_test.sh` script was updated to account for this. The `warn_*()`
+functions no longer take a `char const *` of the file they are warning against
+as it's required to be the specific names so there is no need to repeat it (plus
+it's called in multiple locations and we do not always have the path).
+
+This means that `make test` can work in the new way though later the script will
+have to be changed again.
+
 Updated `MKIOCCCENTRY_VERSION` to `"1.2.8 2025-01-29"`.
 
 

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -147,13 +147,13 @@
 /*
  * forward declarations
  */
-static void warn_empty_prog(char const *prog_c);
-static void warn_rule_2a_size(struct info *infop, char const *prog_c, int mode, RuleCount size);
-static void warn_nul_chars(char const *prog_c);
-static void warn_trigraph(char const *prog_c);
-static void warn_wordbuf(char const *prog_c);
-static void warn_ungetc(char const *prog_c);
-static void warn_rule_2b_size(struct info *infop, char const *prog_c);
+static void warn_empty_prog(void);
+static void warn_rule_2a_size(struct info *infop, int mode, RuleCount size);
+static void warn_nul_chars(void);
+static void warn_trigraph(void);
+static void warn_wordbuf(void);
+static void warn_ungetc(void);
+static void warn_rule_2b_size(struct info *infop);
 static RuleCount check_prog_c(struct info *infop, char const *submission_dir, char const *cp, char const *prog_c);
 static size_t collect_topdir_files(char * const *args, struct info *infop, char const *submission_dir,
         char const *cp, RuleCount *size);
@@ -165,7 +165,7 @@ static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);
 static bool inspect_Makefile(char const *Makefile, struct info *infop);
-static void warn_Makefile(char const *Makefile, struct info *infop);
+static void warn_Makefile(struct info *infop);
 static void check_Makefile(struct info *infop, char const *submission_dir, char const *cp, char const *Makefile);
 static void check_remarks_md(struct info *infop, char const *submission_dir, char const *cp, char const *remarks_md);
 static void check_extra_data_files(struct info *infop, char const *submission_dir, char const *cp, int count, char **args);

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.17 2025-01-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.18 2025-01-29"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.7 2025-01-28"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.8 2025-01-29"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION

Instead it now defaults to the new way but with the ability to (for now) 
specify extra files as additional args. This is not how it will remain 
but this change allows for easier development. The mkiocccentry_test.sh
script was updated to account for this. The warn_*() functions no longer
take a char const * of the file they are warning against as it's
required to be the specific names so there is no need to repeat it (plus
it's called in multiple locations and we do not always have the path).

This means that make test can work in the new way though later the script will
have to be changed again.