### PR TITLE
New jparse util function for mkiocccentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,17 @@ files. Added a good test file and a bad test file. Rebuilt error files.
 
 Updated `TXZCHK_VERSION` to `"1.1.9 2025-01-31"`.
 
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for new
+utility function to check for ignored (or if desired forbidden) path components.
+This will be useful when traversing directories. It is currently used for this
+but ignored paths are still not processed (just skipped). (A new function was
+added to mkiocccentry.c for this too.)
+
+Fixed bug in mkiocccentry where the max depth error was reporting the wrong
+depth.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.10 2025-01-31"`.
+
 
 ## Release 2.3.19 2025-01-30
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,17 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.11 2025-01-31
+
+Add new util function `path_has_component()` which takes two `char *`s: a full
+path and a name to check against. This function will allow one to check a full
+path to see if it has a specific component. This can be used along with
+`sane_relative_path()` should one need to skip specific components such as
+`.git`.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.3 2025-01-31"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.6 2025-01-31"`.
+
+
 ## Release 2.2.10 2025-01-26
 
 Fix memory error in `count_comps()` (in `util.c`).

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -231,6 +231,7 @@ extern enum path_sanity sane_relative_path(char const *str, uintmax_t max_path_l
         uintmax_t max_depth, bool dot_slash_okay);
 extern char const *path_sanity_name(enum path_sanity sanity);
 extern char const *path_sanity_error(enum path_sanity sanity);
+extern bool path_has_component(char const *path, char const *name);
 extern void clearerr_or_fclose(FILE *stream);
 extern ssize_t fprint_line_buf(FILE *stream, const void *buf, size_t len, int start, int end);
 extern ssize_t fprint_line_str(FILE *stream, char *str, size_t *retlen, int start, int end);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.10 2025-01-26"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.11 2025-01-31"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.2 2025-01-26"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.3 2025-01-31"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -3034,11 +3034,11 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 
 	    /*
 	     * free storage
+             *
+             * We can't check for != NULL because of GitHub.
 	     */
-	    if (line != NULL) {
-		free(line);
-		line = NULL;
-	    }
+            free(line);
+            line = NULL;
 
 	    /*
 	     * non-: line
@@ -3111,11 +3111,11 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 
 	/*
 	 * free storage
+         *
+         * We can't check for != NULL because of GitHub.
 	 */
-	if (line != NULL) {
-	    free(line);
-	    line = NULL;
-	}
+        free(line);
+        line = NULL;
 
     } while (!infop->first_rule_is_all || !infop->found_all_rule || !infop->found_clean_rule ||
 	     !infop->found_clobber_rule || !infop->found_try_rule);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -155,6 +155,7 @@ static void warn_wordbuf(void);
 static void warn_ungetc(void);
 static void warn_rule_2b_size(struct info *infop);
 static RuleCount check_prog_c(struct info *infop, char const *submission_dir, char const *cp, char const *prog_c);
+static bool has_ignored_dirname(char const *path);
 static size_t collect_topdir_files(char * const *args, struct info *infop, char const *submission_dir,
         char const *cp, RuleCount *size);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar, char const *cp,


### PR DESCRIPTION
Sync jparse repo (https://github.com/xexyl/jparse/) to jparse/ for new utility function to check for ignored (or if desired forbidden) path components. This will be useful when traversing directories. It is currently used for this but ignored paths are still not processed (just skipped). (A new function was added to mkiocccentry.c for this too.)

Fixed bug in mkiocccentry where the max depth error was reporting the wrong depth.

Updated MKIOCCCENTRY_VERSION to "1.2.10 2025-01-31".