### PR TITLE
NetBSD fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,18 @@ requires more work).
 
 Fix `bug_report.sh` to check `test_ioccc/gen_test_JSON.sh`.
 
+Fix `test_ioccc/ioccc_test.sh` to have a `-m make` option for those who need to
+specify a path to a GNU `make(1)` tool. One can use this with `make test` by way
+of:
+
+```sh
+make MAKE=/path/to/gnumake test
+```
+
+for example.
+
+Fix `test_ioccc/gen_test_JSON.sh` to work for NetBSD (change in `grep` regexp).
+
 
 ## Release 2.3.30 2025-02-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Updated FAQ about installing the tools, giving better details on why it is
 **HIGHLY** recommend you do and also what you have to do if you do not (as it
 requires more work).
 
+Fix `bug_report.sh` to check `test_ioccc/gen_test_JSON.sh`.
+
 
 ## Release 2.3.30 2025-02-10
 

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -68,6 +68,7 @@ export TOOLS="
     ./soup/vermod.sh
     ./test_ioccc/chkentry_test.sh
     ./test_ioccc/fnamchk
+    ./test_ioccc/gen_test_JSON.sh
     ./test_ioccc/hostchk.sh
     ./test_ioccc/ioccc_test.sh
     ./test_ioccc/iocccsize_test.sh
@@ -96,7 +97,7 @@ if [[ -z "$MAKE" ]]; then
 	MAKE="$(type -P make)"
 fi
 export MAKE
-export BUG_REPORT_VERSION="1.0.7 2025-01-18"
+export BUG_REPORT_VERSION="1.0.8 2025-02-11"
 export FAILURE_SUMMARY=
 export NOTICE_SUMMARY=
 export DBG_LEVEL="0"

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -437,8 +437,8 @@ test: test_JSON
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
 	    exit 1; \
 	else \
-	    echo ./ioccc_test.sh; \
-	    ./ioccc_test.sh; \
+	    echo ./ioccc_test.sh -m${MAKE}; \
+	    ./ioccc_test.sh -m${MAKE}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "${OUR_NAME}: ERROR: ioccc_test.sh failed, error code: $$EXIT_CODE"; \

--- a/test_ioccc/gen_test_JSON.sh
+++ b/test_ioccc/gen_test_JSON.sh
@@ -31,7 +31,7 @@
 
 # setup
 #
-export VERSION="1.0.0 2025-01-19"
+export VERSION="1.0.1 2025-02-11"
 NAME=$(basename "$0")
 export NAME
 export V_FLAG=0
@@ -114,7 +114,7 @@ function get_value
 
     # fetch #define line from FILE
     #
-    VALUE=$(grep -E "#define\s+$TOKEN\s" "$FILE")
+    VALUE=$(grep "#define.*$TOKEN" "$FILE")
     status="$?"
     if [[ $status -ne 0 ]]; then
         echo "$0: ERROR: fetch $TOKEN from $FILE failed, status: $status" 1>&2

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -17,10 +17,11 @@
 
 # setup
 #
-export IOCCC_TEST_VERSION="1.0.3 2024-12-31"
+export IOCCC_TEST_VERSION="1.0.4 2025-0l-11"
 
 # attempt to fetch system specific path to the tools we need
 #
+
 # get tar path
 TAR="$(type -P tar 2>/dev/null)"
 # Make sure TAR is set:
@@ -40,13 +41,33 @@ if [[ -z "$TAR" ]]; then
     TAR="/usr/bin/tar"
 fi
 
+# get make path
+MAKE="$(type -P make 2>/dev/null)"
+# Make sure MAKE is set:
+#
+# It's possible that the path could not be obtained so we set it to the default
+# in this case.
+#
+# We could do it via parameter substitution but since it tries to execute the
+# command if for some reason the tool ever works without any args specified it
+# could make the script block (if we did it via parameter substitution we would
+# still have to redirect stderr to /dev/null). It would look like:
+#
+#   ${MAKE:=/usr/bin/make} 2>/dev/null
+#
+# but due to the reasons cited above we must rely on the more complicated form:
+if [[ -z "$MAKE" ]]; then
+    MAKE="/usr/bin/make"
+fi
 
-export USAGE="usage: $0 [-h] [-v level] [-J json_level] [-t tar] [-V] [-Z topdir]
+
+export USAGE="usage: $0 [-h] [-v level] [-J json_level] [-t tar] [-m make] [-V] [-Z topdir]
 
     -h              print help and exit
     -v level        set debug level (def: 0)
     -J json_level   set json debug level (def: 0)
     -t tar	    path to tar that accepts -J option (def: $TAR)
+    -m make         path to GNU compatible make (def: $MAKE)
     -V              print version and exit
     -Z topdir	    top level build directory (def: try . or ..)
 
@@ -69,7 +90,7 @@ export TOPDIR=
 
 # parse args
 #
-while getopts :hv:J:VZ:t: flag; do
+while getopts :hv:J:VZ:t:m: flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -85,6 +106,8 @@ while getopts :hv:J:VZ:t: flag; do
         ;;
     t)	TAR="$OPTARG";
 	;;
+    m)  MAKE="$OPTARG";
+        ;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
 	echo 1>&2
 	echo "$USAGE" 1>&2
@@ -321,6 +344,18 @@ elif [[ ! -x "$TAR" ]]; then
     echo "$0: ERROR: tar is not executable: $TAR" | tee -a -- "$LOGFILE"
     EXIT_CODE="5"
 fi
+# make
+if [[ ! -e "$MAKE" ]]; then
+    echo "$0: ERROR: make file not found: $MAKE" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+elif [[ ! -f "$MAKE" ]]; then
+    echo "$0: ERROR: make is not a regular file: $MAKE" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+elif [[ ! -x "$MAKE" ]]; then
+    echo "$0: ERROR: make is not executable: $MAKE" | tee -a -- "$LOGFILE"
+    EXIT_CODE="5"
+fi
+
 
 # test_txzchk
 if [[ ! -e test_ioccc/test_txzchk ]]; then
@@ -411,8 +446,8 @@ fi
 echo | tee -a -- "$LOGFILE"
 echo "RUNNING: test_ioccc/mkiocccentry_test.sh" | tee -a -- "$LOGFILE"
 echo | tee -a -- "$LOGFILE"
-echo "test_ioccc/mkiocccentry_test.sh -Z $TOPDIR -t $TAR" | tee -a -- "$LOGFILE"
-test_ioccc/mkiocccentry_test.sh -Z "$TOPDIR" -t "$TAR" | tee -a -- "$LOGFILE"
+echo "test_ioccc/mkiocccentry_test.sh -m $MAKE -Z $TOPDIR -t $TAR" | tee -a -- "$LOGFILE"
+test_ioccc/mkiocccentry_test.sh -m "$MAKE" -Z "$TOPDIR" -t "$TAR" | tee -a -- "$LOGFILE"
 status="${PIPESTATUS[0]}"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: test_ioccc/mkiocccentry_test.sh non-zero exit code: $status" 1>&2 | tee -a -- "$LOGFILE"

--- a/test_ioccc/man/man8/ioccc_test.8
+++ b/test_ioccc/man/man8/ioccc_test.8
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH ioccc_test.sh 8 "05 February 2023" "ioccc_test.sh" "IOCCC tools"
+.TH ioccc_test.sh 8 "11 February 2025" "ioccc_test.sh" "IOCCC tools"
 .SH NAME
 .B ioccc_test.sh
 \- perform the complete suite of tests for the mkiocccentry repo
@@ -23,6 +23,8 @@
 .RB [\| \-V \|]
 .RB [\| \-t
 .IR tar \|]
+.RB [\| \-m
+.IR make \|]
 .RB [\| \-Z
 .IR topdir \|]
 .SH DESCRIPTION
@@ -42,6 +44,16 @@ make test
 .RE
 .sp
 to help report bugs or other problems.
+If your default
+.BR make (1)
+tool path is not a GNU make program you will have to instead do:
+.sp
+.RS
+.ft B
+make MAKE=/path/to/gnumake test
+.fr R
+.RE
+.sp
 .SH OPTIONS
 .TP
 .B \-h
@@ -72,6 +84,15 @@ command must support the
 option and the
 .B v7
 format.
+.TP
+.BI \-m\  make
+Set
+.B make
+path to
+.IR make .
+The
+.BR make (1)
+command must be GNU Make compatible.
 .TP
 .BI \-Z\  topdir
 Declare the top level directory of this repository.
@@ -186,6 +207,25 @@ Run the test script directly:
 .RS
 .ft B
 make clobber all && ./test_ioccc/ioccc_test.sh
+.ft R
+.RE
+.PP
+Run the test suite the preferred way with a different
+.BR make (1):
+.sp
+.RS
+.ft B
+make MAKE=/path/to/gnumake clobber all test
+.ft R
+.RE
+.PP
+Run the test script directly with a different
+.BR make (1)
+path:
+.sp
+.RS
+.ft B
+make clobber all && ./test_ioccc/ioccc_test.sh -m /path/to/gnumake
 .ft R
 .RE
 .SH SEE ALSO


### PR DESCRIPTION

Fix test_ioccc/ioccc_test.sh to have a -m make option for those who need to
specify a path to a GNU make(1) tool. One can use this with make test by way
of:

    make MAKE=/path/to/gnumake test

for example.

Fix test_ioccc/gen_test_JSON.sh to work for NetBSD (change in grep regexp).

