### PR TITLE
Plug more holes in

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,7 +59,26 @@ its use.
 
 Cleaned up warning in `check_submission()`.
 
+More sanity checks in `scan_topdir()` and `check_submission()`: make sure that a
+directory name is not the same as a required or optional filename. That does not
+mean that one couldn't have a subdirectory with that name but it cannot be in
+the top level of the submission directory.
+
+Plug some holes in txzchk. This includes not checking the max depth of a
+directory (only total number of directories was checked), checking that a
+directory is not named a required/mandatory filename, certain other directory
+name checks and other such things. Rebuilt the test error files.
+
+Improved `is_forbidden_filename()`: if it's not in the forbidden filenames
+list but it does start with a `.` and it's not a required filename like
+`.auth.json` or `.info.json` it is a forbidden filename (it is true that
+the function `sane_relative_path()` would pick up on this but this is
+defence in depth).
+
+
+
 Updated `MKIOCCCENTRY_VERSION` to `"1.2.22 2025-02-12"`.
+Updated `TXZCHK_VERSION` to `"1.1.13 2025-02-12"`.
 Updated `SOUP_VERSION` to `"1.1.20 2025-02-12"`.
 Updated `MKIOCCCENTRY_TEST_VERSION` to` "1.0.11 2025-02-12"`.
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1397,6 +1397,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
             bool ignored_dirname = false;
             bool forbidden_filename = false;
             bool optional = false;
+            bool mandatory_filename = false;
 
             /*
              * skip '.'
@@ -1417,6 +1418,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
             ignored_dirname = has_ignored_dirname(ent->fts_path + 2);
             forbidden_filename = is_forbidden_filename(ent->fts_path + 2);
             optional = is_optional_filename(ent->fts_path + 2);
+            mandatory_filename = is_mandatory_filename(ent->fts_path + 2);
 
             /*
              * NOTE: when traversing the directory "." the filenames found under
@@ -1589,13 +1591,33 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
                 case FTS_D: /* directory */
                     /*
                      * we know this is an okay path because all error conditions
-                     * have been accounted for above
+                     * have been accounted for above.
                      */
+
+                    /*
+                     * Even so we have extra checks to do.
+                     */
+                    if (optional) {
+                        /*
+                         * you're not allowed to have directory names that are
+                         * actually optional filenames
+                         */
+                        err(67, __func__, "directory name matches optional filename: %s", ent->fts_path + 2);
+                        not_reached();
+                    }
+                    if (mandatory_filename) {
+                        /*
+                         * you're not allowed to have directory names that are
+                         * actually required filenames either
+                         */
+                        err(68, __func__, "directory name matches required filename: %s", ent->fts_path + 2);
+                        not_reached();
+                    }
                     dbg(DBG_MED, "found sane relative directory name topdir: %s", ent->fts_path + 2);
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(67, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(69, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1612,7 +1634,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(68, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(70, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1662,7 +1684,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(69, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(71, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1688,7 +1710,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
      * check that there are not too many non-optional non-required files
      */
     if (count > MAX_EXTRA_FILE_COUNT) {
-        err(70, __func__, "too many files: %ju > %ju", (uintmax_t)count, (uintmax_t)MAX_FILE_COUNT);
+        err(72, __func__, "too many files: %ju > %ju", (uintmax_t)count, (uintmax_t)MAX_FILE_COUNT);
         not_reached();
     }
 
@@ -1698,7 +1720,7 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
     dirs = dyn_array_tell(infop->directories);
     unsafe_dirs = dyn_array_tell(infop->unsafe_dirs);
     if (MAX_EXTRA_DIR_COUNT > 0 && dirs + unsafe_dirs > MAX_EXTRA_DIR_COUNT) {
-        err(71, __func__, "too many extra directories: %ju > %ju", (uintmax_t)(dirs + unsafe_dirs),
+        err(73, __func__, "too many extra directories: %ju > %ju", (uintmax_t)(dirs + unsafe_dirs),
                 (uintmax_t)MAX_EXTRA_DIR_COUNT);
         not_reached();
     }
@@ -1707,13 +1729,13 @@ scan_topdir(char * const *args, struct info *infop, char const *make, char const
      * verify prog.c, Makefile and remarks.md have been found
      */
     if (!found_prog_c) {
-        err(72, __func__, "prog.c not found in topdir %s", args[0]);
+        err(74, __func__, "prog.c not found in topdir %s", args[0]);
         not_reached();
     } else if (!found_Makefile) {
-        err(73, __func__, "Makefile not found in topdir %s", args[0]);
+        err(75, __func__, "Makefile not found in topdir %s", args[0]);
         not_reached();
     } else if (!found_remarks_md) {
-        err(74, __func__, "remarks.md not found in topdir %s", args[0]);
+        err(76, __func__, "remarks.md not found in topdir %s", args[0]);
         not_reached();
     }
 
@@ -1768,15 +1790,15 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      * firewall
      */
     if (infop == NULL || make == NULL || submission_dir == NULL || topdir_path == NULL || submit_path == NULL || size == NULL) {
-        err(75, __func__, "passed NULL pointer(s)");
+        err(77, __func__, "passed NULL pointer(s)");
         not_reached();
     }
     if (topdir < 0) {
-        err(76, __func__, "passed invalid topdir file descriptors");
+        err(78, __func__, "passed invalid topdir file descriptors");
         not_reached();
     }
     if (cwd < 0) {
-        err(77, __func__, "passed invalid cwd file descriptors");
+        err(79, __func__, "passed invalid cwd file descriptors");
         not_reached();
     }
 
@@ -1784,35 +1806,35 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      * the arrays in struct info must exist from scan_topdir()
      */
     if (infop->ignored_symlinks == NULL) {
-        err(78, __func__, "NULL ignored symlinks list array");
+        err(80, __func__, "NULL ignored symlinks list array");
         not_reached();
     }
     if (infop->extra_files == NULL) {
-        err(79, __func__, "NULL files list array");
+        err(81, __func__, "NULL files list array");
         not_reached();
     }
     if (infop->required_files == NULL) {
-        err(80, __func__, "NULL required files list array");
+        err(82, __func__, "NULL required files list array");
         not_reached();
     }
     if (infop->directories == NULL) {
-        err(81, __func__, "NULL directories list array");
+        err(83, __func__, "NULL directories list array");
         not_reached();
     }
     if (infop->ignored_dirs == NULL) {
-        err(82, __func__, "NULL ignored directories list array");
+        err(84, __func__, "NULL ignored directories list array");
         not_reached();
     }
     if (infop->forbidden_files == NULL) {
-        err(83, __func__, "NULL forbidden filenames list array");
+        err(85, __func__, "NULL forbidden filenames list array");
         not_reached();
     }
     if (infop->unsafe_files == NULL) {
-        err(84, __func__, "NULL unsafe filenames list array");
+        err(86, __func__, "NULL unsafe filenames list array");
         not_reached();
     }
     if (infop->unsafe_dirs == NULL) {
-        err(85, __func__, "NULL unsafe directory names list array");
+        err(87, __func__, "NULL unsafe directory names list array");
         not_reached();
     }
 
@@ -1822,33 +1844,33 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      * NOTE: more will be done in check_submission()
      */
     if (array_has_path(infop->extra_files, PROG_C_FILENAME)) {
-        err(86, __func__, "extra files list has required file prog.c");
+        err(88, __func__, "extra files list has required file prog.c");
         not_reached();
     } else if (array_has_path(infop->directories, PROG_C_FILENAME)) {
-        err(87, __func__, "directories list has required file prog.c");
+        err(89, __func__, "directories list has required file prog.c");
         not_reached();
     } else if (array_has_path(infop->ignored_symlinks, PROG_C_FILENAME)) {
-        err(88, __func__, "ignored symlinks list has required file prog.c");
+        err(90, __func__, "ignored symlinks list has required file prog.c");
         not_reached();
     }
     if (array_has_path(infop->extra_files, MAKEFILE_FILENAME)) {
-        err(89, __func__, "extra files list has required file Makefile");
+        err(91, __func__, "extra files list has required file Makefile");
         not_reached();
     } else if (array_has_path(infop->directories, MAKEFILE_FILENAME)) {
-        err(90, __func__, "directories list has required file Makefile");
+        err(92, __func__, "directories list has required file Makefile");
         not_reached();
     } else if (array_has_path(infop->ignored_symlinks, MAKEFILE_FILENAME)) {
-        err(91, __func__, "ignored symlinks list has required file Makefile");
+        err(93, __func__, "ignored symlinks list has required file Makefile");
         not_reached();
     }
     if (array_has_path(infop->extra_files, REMARKS_FILENAME)) {
-        err(92, __func__, "extra files list has required file remarks.md");
+        err(94, __func__, "extra files list has required file remarks.md");
         not_reached();
     } else if (array_has_path(infop->directories, REMARKS_FILENAME)) {
-        err(93, __func__, "directories list has required file remarks.md");
+        err(95, __func__, "directories list has required file remarks.md");
         not_reached();
     } else if (array_has_path(infop->ignored_symlinks, REMARKS_FILENAME)) {
-        err(94, __func__, "ignored symlinks list has required file remarks.md");
+        err(96, __func__, "ignored symlinks list has required file remarks.md");
         not_reached();
     }
 
@@ -1859,7 +1881,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
     errno = 0;          /* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-        errp(95, __func__, "unable to fchdir(cwd)");
+        errp(97, __func__, "unable to fchdir(cwd)");
         not_reached();
     }
 
@@ -1878,7 +1900,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0;
                 ret = printf("\t%10s%s", ignored_dirnames[i], !((i+1)%3)||ignored_dirnames[i+1]==NULL?"\n":"   ");
                 if (ret <= 0) {
-                    errp(96, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
+                    errp(98, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
                     not_reached();
                 }
             }
@@ -1894,7 +1916,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->ignored_dirs, char *, i);
             if (p == NULL) {
-                err(97, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
+                err(99, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -1902,7 +1924,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(98, __func__, "aborting because user said ignored directories list is not OK");
+                err(100, __func__, "aborting because user said ignored directories list is not OK");
                 not_reached();
             }
         }
@@ -1929,7 +1951,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->unsafe_dirs, char *, i);
             if (p == NULL) {
-                err(99, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
+                err(101, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -1937,7 +1959,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(100, __func__, "aborting because user said unsafe directory names list is not OK");
+                err(102, __func__, "aborting because user said unsafe directory names list is not OK");
                 not_reached();
             }
         }
@@ -1958,7 +1980,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0;
                 ret = printf("\t%10s%s", forbidden_filenames[i], !((i+1)%3)||forbidden_filenames[i+1]==NULL?"\n":"   ");
                 if (ret <= 0) {
-                    errp(101, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
+                    errp(103, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
                     not_reached();
                 }
             }
@@ -1975,7 +1997,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->forbidden_files, char *, i);
             if (p == NULL) {
-                err(102, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
+                err(104, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -1983,7 +2005,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(103, __func__, "aborting because user said forbidden files list is not OK");
+                err(105, __func__, "aborting because user said forbidden files list is not OK");
                 not_reached();
             }
         }
@@ -2009,7 +2031,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->unsafe_files, char *, i);
             if (p == NULL) {
-                err(104, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
+                err(106, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -2017,7 +2039,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(105, __func__, "aborting because user said unsafe filenames list is not OK");
+                err(107, __func__, "aborting because user said unsafe filenames list is not OK");
                 not_reached();
             }
         }
@@ -2042,7 +2064,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->ignored_symlinks, char *, i);
             if (p == NULL) {
-                err(106, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
+                err(108, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -2050,7 +2072,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(107, __func__, "aborting because user said ignored symlinks list is not OK");
+                err(109, __func__, "aborting because user said ignored symlinks list is not OK");
                 not_reached();
             }
         }
@@ -2072,7 +2094,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->directories, char *, i);
             if (p == NULL) {
-                err(108, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                err(110, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -2080,7 +2102,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(109, __func__, "aborting because user said directories list is not OK");
+                err(111, __func__, "aborting because user said directories list is not OK");
                 not_reached();
             }
         }
@@ -2091,7 +2113,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      */
     len = dyn_array_tell(infop->required_files);
     if (len <= 0) {
-        err(110, __func__, "list of required files is empty");
+        err(112, __func__, "list of required files is empty");
         not_reached();
     }
     if (len > 0) {
@@ -2106,7 +2128,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->required_files, char *, i);
             if (p == NULL) {
-                err(111, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                err(113, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -2124,7 +2146,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->extra_files, char *, i);
                 if (p == NULL) {
-                    err(112, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                    err(114, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2133,7 +2155,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(113, __func__, "aborting because user said files list is not OK");
+                err(115, __func__, "aborting because user said files list is not OK");
                 not_reached();
             }
         }
@@ -2149,7 +2171,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             errno = 0;      /* pre-clear errno for errp() */
             if (chdir(submission_dir) != 0) {
-                errp(114, __func__, "chdir(\"%s\") failed", submission_dir);
+                errp(116, __func__, "chdir(\"%s\") failed", submission_dir);
                 not_reached();
             }
 
@@ -2159,7 +2181,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                  */
                 p = dyn_array_value(infop->directories, char *, i);
                 if (p == NULL) {
-                    err(115, __func__, "found NULL pointer in infop->directories list");
+                    err(117, __func__, "found NULL pointer in infop->directories list");
                     not_reached();
                 }
                 /*
@@ -2175,7 +2197,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
          */
         errno = 0;
         if (fchdir(topdir) != 0) {
-            errp(116, __func__, "cannot change to topdir");
+            errp(118, __func__, "cannot change to topdir");
             not_reached();
         }
 
@@ -2184,13 +2206,13 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
          */
         len = dyn_array_tell(infop->required_files);
         if (len <= 0) {
-            err(117, __func__, "list of required files is empty");
+            err(119, __func__, "list of required files is empty");
             not_reached();
         }
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->required_files, char *, i);
             if (p == NULL) {
-                err(118, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                err(120, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             /*
@@ -2201,7 +2223,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             fname = calloc_path(topdir_path, p);
             if (fname == NULL) {
-                err(119, __func__, "couldn't allocate path to copy");
+                err(121, __func__, "couldn't allocate path to copy");
                 not_reached();
             }
             if (target_path != NULL) {
@@ -2219,7 +2241,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             errno = 0; /* pre-clear errno for errp() */
             target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
             if (target_path == NULL) {
-                errp(120, __func__, "failed to allocate target path for %s", p);
+                errp(122, __func__, "failed to allocate target path for %s", p);
                 not_reached();
             }
             /*
@@ -2228,7 +2250,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             errno = 0; /* pre-clear errno for errp() */
             ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
             if (ret <= 0) {
-                errp(121, __func__, "snprintf to form target path for %s failed", fname);
+                errp(123, __func__, "snprintf to form target path for %s failed", fname);
                 not_reached();
             }
 
@@ -2262,7 +2284,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->extra_files, char *, i);
             if (p == NULL) {
-                err(122, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                err(124, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             /*
@@ -2273,7 +2295,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             fname = calloc_path(topdir_path, p);
             if (fname == NULL) {
-                err(123, __func__, "couldn't allocate path to copy");
+                err(125, __func__, "couldn't allocate path to copy");
                 not_reached();
             }
             if (target_path != NULL) {
@@ -2291,7 +2313,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             errno = 0; /* pre-clear errno for errp() */
             target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
             if (target_path == NULL) {
-                errp(124, __func__, "failed to allocate target path for %s", p);
+                errp(126, __func__, "failed to allocate target path for %s", p);
                 not_reached();
             }
             /*
@@ -2299,7 +2321,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             errno = 0; /* pre-clear errno for errp() */
             ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
             if (ret <= 0) {
-                errp(125, __func__, "snprintf to form target path for %s failed", fname);
+                errp(128, __func__, "snprintf to form target path for %s failed", fname);
                 not_reached();
             } else if (!strcmp(p, TRY_SH) || !strcmp(p, TRY_ALT_SH)) {
                 /*
@@ -2344,7 +2366,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(topdir) != 0) {
-        errp(126, __func__, "failed to close(topdir)");
+        errp(129, __func__, "failed to close(topdir)");
         not_reached();
     }
 
@@ -2410,14 +2432,14 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * firewall
      */
     if (infop == NULL || submission_dir == NULL || make == NULL || size == NULL) {
-        err(128, __func__, "passed NULL arg(s)");
+        err(130, __func__, "passed NULL arg(s)");
         not_reached();
     }
     /*
      * cwd must be >= 0
      */
     if (cwd < 0) {
-        err(129, __func__, "original directory file descriptor < 0");
+        err(131, __func__, "original directory file descriptor < 0");
         not_reached();
     }
 
@@ -2428,7 +2450,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(130, __func__, "failed to change to original directory");
+        errp(132, __func__, "failed to change to original directory");
         not_reached();
     }
 
@@ -2439,35 +2461,35 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * insist they exist at this point).
      */
     if (infop->ignored_symlinks == NULL) {
-        err(131, __func__, "NULL ignored symlinks list array");
+        err(133, __func__, "NULL ignored symlinks list array");
         not_reached();
     }
     if (infop->extra_files == NULL) {
-        err(132, __func__, "NULL files list array");
+        err(134, __func__, "NULL files list array");
         not_reached();
     }
     if (infop->required_files == NULL) {
-        err(133, __func__, "NULL required files list array");
+        err(135, __func__, "NULL required files list array");
         not_reached();
     }
     if (infop->directories == NULL) {
-        err(134, __func__, "NULL directories list array");
+        err(136, __func__, "NULL directories list array");
         not_reached();
     }
     if (infop->ignored_dirs == NULL) {
-        err(135, __func__, "NULL ignored directories list array");
+        err(137, __func__, "NULL ignored directories list array");
         not_reached();
     }
     if (infop->forbidden_files == NULL) {
-        err(136, __func__, "NULL forbidden filenames list array");
+        err(138, __func__, "NULL forbidden filenames list array");
         not_reached();
     }
     if (infop->unsafe_files == NULL) {
-        err(137, __func__, "NULL unsafe filenames list array");
+        err(139, __func__, "NULL unsafe filenames list array");
         not_reached();
     }
     if (infop->unsafe_dirs == NULL) {
-        err(138, __func__, "NULL unsafe directory names list array");
+        err(140, __func__, "NULL unsafe directory names list array");
         not_reached();
     }
 
@@ -2478,27 +2500,27 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     required_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (required_files == NULL) {
-        err(139, __func__, "couldn't create required files list array");
+        err(141, __func__, "couldn't create required files list array");
         not_reached();
     }
     extra_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (extra_files == NULL) {
-        err(140, __func__, "couldn't create extra files list array");
+        err(142, __func__, "couldn't create extra files list array");
         not_reached();
     }
     missing_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_files == NULL) {
-        err(141, __func__, "couldn't create missing files list array");
+        err(143, __func__, "couldn't create missing files list array");
         not_reached();
     }
     directories = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (directories == NULL) {
-        err(142, __func__, "couldn't create directories list array");
+        err(144, __func__, "couldn't create directories list array");
         not_reached();
     }
     missing_dirs = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_dirs == NULL) {
-        err(143, __func__, "couldn't create missing directories list array");
+        err(145, __func__, "couldn't create missing directories list array");
         not_reached();
     }
 
@@ -2507,7 +2529,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     errno = 0; /* pre-clear errno for errp() */
     if (chdir(submission_dir) != 0) {
-        errp(144, __func__, "unable to change to submission directory: %s", submission_dir);
+        errp(146, __func__, "unable to change to submission directory: %s", submission_dir);
         not_reached();
     }
 
@@ -2521,7 +2543,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * an error too but that's flagged by check_Makefile()).
      */
     if (!is_read("Makefile")) {
-        err(145, __func__, "Makefile not a regular readable file in submission directory %s", submission_dir);
+        err(147, __func__, "Makefile not a regular readable file in submission directory %s", submission_dir);
         not_reached();
     }
     /*
@@ -2542,13 +2564,14 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
     errno = 0;      /* pre-clear errno for errp() */
     fts = fts_open(path, FTS_NOCHDIR | FTS_PHYSICAL, fts_cmp);
     if (fts == NULL) {
-        errp(146, __func__, "fts_open() returned NULL for: %s", submission_dir);
+        errp(148, __func__, "fts_open() returned NULL for: %s", submission_dir);
         not_reached();
     } else {
         while ((ent = fts_read(fts)) != NULL) {
             bool ignored_dirname = false;
             bool forbidden_filename = false;
             bool optional = false;
+            bool mandatory_filename = false;
 
             /*
              * skip '.'
@@ -2569,12 +2592,13 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
             ignored_dirname = has_ignored_dirname(ent->fts_path + 2);
             forbidden_filename = is_forbidden_filename(ent->fts_path + 2);
             optional = is_optional_filename(ent->fts_path + 2);
+            mandatory_filename = is_mandatory_filename(ent->fts_path + 2);
 
             if (ignored_dirname) {
-                err(147, __func__, "found ignored directory in submission directory");
+                err(149, __func__, "found ignored directory in submission directory");
                 not_reached();
             } else if (forbidden_filename) {
-                err(148, __func__, "found forbidden file in submission directory");
+                err(150, __func__, "found forbidden file in submission directory");
                 not_reached();
             }
             /*
@@ -2589,26 +2613,26 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
             sanity = sane_relative_path(ent->fts_path, MAX_PATH_LEN, MAX_FILENAME_LEN, MAX_PATH_DEPTH, true);
             switch (sanity) {
                 case PATH_ERR_NAME_TOO_LONG: /* last component too long */
-                    err(149, __func__, "%s: name too long: strlen(\"%s\"): %ju > %ju", ent->fts_name, ent->fts_name,
+                    err(151, __func__, "%s: name too long: strlen(\"%s\"): %ju > %ju", ent->fts_name, ent->fts_name,
                             (uintmax_t)strlen(ent->fts_name), (uintmax_t)MAX_FILENAME_LEN);
                     not_reached();
                     break;
                 case PATH_ERR_PATH_TOO_LONG: /* entire path too long */
-                    err(150, __func__, "%s: path too long: strlen(\"%s\"): %ju > %ju", ent->fts_path + 2, ent->fts_path,
+                    err(152, __func__, "%s: path too long: strlen(\"%s\"): %ju > %ju", ent->fts_path + 2, ent->fts_path,
                             (uintmax_t)strlen(ent->fts_path), (uintmax_t)MAX_FILENAME_LEN);
                     not_reached();
                     break;
                 case PATH_ERR_PATH_TOO_DEEP: /* too many subdirectories */
-                    err(151, __func__, "%s: path too deep: depth %ju > %ju", ent->fts_path + 2,
+                    err(153, __func__, "%s: path too deep: depth %ju > %ju", ent->fts_path + 2,
                             (uintmax_t)count_dirs(ent->fts_path), (uintmax_t)MAX_PATH_DEPTH);
                     not_reached();
                     break;
                 case PATH_ERR_NOT_POSIX_SAFE: /* not sane relative path */
-                    err(152, __func__, "%s: path not POSIX plus + safe", ent->fts_path + 2);
+                    err(154, __func__, "%s: path not POSIX plus + safe", ent->fts_path + 2);
                     not_reached();
                     break;
                 case PATH_ERR_NOT_RELATIVE: /* path not relative: starts with '/' */
-                    err(153, __func__, "%s: path not relative", ent->fts_path + 2);
+                    err(155, __func__, "%s: path not relative", ent->fts_path + 2);
                     not_reached();
                     break;
                 case PATH_ERR_UNKNOWN: /* unknown error */
@@ -2617,7 +2641,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                 case PATH_ERR_MAX_PATH_LEN_0: /* max path length <= 0 (should never happen) */
                 case PATH_ERR_MAX_DEPTH_0: /* max depth <= 0 (should never happen) */
                 case PATH_ERR_MAX_NAME_LEN_0: /* max name length <= 0 (should never happen) */
-                    err(154, __func__, "%s: %s", ent->fts_path + 2, path_sanity_error(sanity));
+                    err(156, __func__, "%s: %s", ent->fts_path + 2, path_sanity_error(sanity));
                     not_reached();
                     break;
                 case PATH_OK: /* sane relative path */
@@ -2626,7 +2650,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                     /*
                      * something is quite wrong here
                      */
-                    err(155, __func__, "unknown status for %s", ent->fts_path);
+                    err(157, __func__, "unknown status for %s", ent->fts_path);
                     not_reached();
                     break;
             }
@@ -2637,38 +2661,57 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                      * we know this is an okay path because all error conditions
                      * have been accounted for above
                      */
-                    dbg(DBG_MED, "found sane relative directory name in submission directory: %s", ent->fts_path + 2);
+                    /*
+                     * Even so we have extra checks to do.
+                     */
+                    if (optional) {
+                        /*
+                         * you're not allowed to have directory names that are
+                         * actually optional filenames
+                         */
+                        err(158, __func__, "directory name matches optional filename: %s", ent->fts_path + 2);
+                        not_reached();
+                    }
+                    if (mandatory_filename) {
+                        /*
+                         * you're not allowed to have directory names that are
+                         * actually required filenames either
+                         */
+                        err(159, __func__, "directory name matches required filename: %s", ent->fts_path + 2);
+                        not_reached();
+                    }
                     /*
                      * if this directory does not exist in the topdir it is an
                      * error
                      */
                     if (!array_has_path(infop->directories, ent->fts_path + 2)) {
-                        err(156, __func__, "directory in submission directory not found in topdir: %s", ent->fts_path + 2);
+                        err(160, __func__, "directory in submission directory not found in topdir: %s", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
                      * extra sanity checks
                      */
                     if (!is_dir(ent->fts_path + 2)) {
-                        err(157, __func__, "fts_read() found %s as directory but is_dir() returned false", ent->fts_path + 2);
+                        err(161, __func__, "fts_read() found %s as directory but is_dir() returned false", ent->fts_path + 2);
                         not_reached();
                     } else if (!is_mode(ent->fts_path + 2, 0755)) {
-                        err(158, __func__, "directory %s: mode %o != 0755", ent->fts_path + 2, filemode(ent->fts_path + 2));
+                        err(162, __func__, "directory %s: mode %o != 0755", ent->fts_path + 2, filemode(ent->fts_path + 2));
                         not_reached();
                     }
                     /*
                      * directories MUST be mode 0755!
                      */
                     if (!is_mode(ent->fts_path + 2, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) {
-                        err(159, __func__, "directory %s must be mode 0444: %o != 0444", ent->fts_path + 2,
+                        err(163, __func__, "directory %s must be mode 0444: %o != 0444", ent->fts_path + 2,
                                 filemode(ent->fts_path + 2));
                         not_reached();
                     }
 
+                    dbg(DBG_MED, "found sane relative directory name in submission directory: %s", ent->fts_path + 2);
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(160, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(164, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -2682,7 +2725,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                      * extra sanity check
                      */
                     if (!is_file(ent->fts_path + 2)) {
-                        err(161, __func__, "fts_read() found %s as file but is_file() returned false", ent->fts_path + 2);
+                        err(165, __func__, "fts_read() found %s as file but is_file() returned false", ent->fts_path + 2);
                         not_reached();
                     }
 
@@ -2692,7 +2735,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(162, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(166, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
 
@@ -2708,7 +2751,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                     if (strcmp(filename, PROG_C_FILENAME) && strcmp(filename, MAKEFILE_FILENAME) &&
                         strcmp(filename, REMARKS_FILENAME)) {
                             if (!array_has_path(infop->extra_files, filename)) {
-                                err(163, __func__, "file in submission directory not in topdir: %s", filename);
+                                err(167, __func__, "file in submission directory not in topdir: %s", filename);
                                 not_reached();
                             }
                             if (!strcmp(filename, TRY_SH) || !strcmp(filename, TRY_ALT_SH)) {
@@ -2716,7 +2759,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                                     /*
                                      * these MUST be mode 0555!
                                      */
-                                    err(164, __func__, "file %s must be mode 0555: %o != 0555",
+                                    err(168, __func__, "file %s must be mode 0555: %o != 0555",
                                             filename, filemode(filename));
                                     not_reached();
                                 }
@@ -2725,7 +2768,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                                  * these MUST be mode 0444!
                                  */
                                 if (!is_mode(filename, S_IRUSR | S_IRGRP | S_IROTH)) {
-                                    err(165, __func__, "file %s must be mode 0444: %o != 0444",
+                                    err(169, __func__, "file %s must be mode 0444: %o != 0444",
                                             filename, filemode(filename));
                                     not_reached();
                                 }
@@ -2733,14 +2776,14 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                             append_unique_str(extra_files, filename);
                     } else {
                         if (!array_has_path(infop->required_files, filename)) {
-                            err(166, __func__, "file in submission directory not in topdir: %s", filename);
+                            err(170, __func__, "file in submission directory not in topdir: %s", filename);
                             not_reached();
                         }
                         /*
                          * these files MUST be mode 0444!
                          */
                         if (!is_mode(filename, S_IRUSR | S_IRGRP | S_IROTH)) {
-                            err(167, __func__, "file %s must be mode 0444: %o != 0444", filename,
+                            err(171, __func__, "file %s must be mode 0444: %o != 0444", filename,
                                     filemode(filename));
                             not_reached();
                         }
@@ -2778,7 +2821,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                     break;
                 case FTS_SL: /* symlink */
                 case FTS_SLNONE: /* symlink with non-existing target */
-                    err(168, __func__, "found symlink in submission directory");
+                    err(172, __func__, "found symlink in submission directory");
                     not_reached();
                     break;
                 default:
@@ -2798,13 +2841,13 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * directory
      */
     if (!found_prog_c) {
-        err(169, __func__, "prog.c not found in submission directory %s", submission_dir);
+        err(173, __func__, "prog.c not found in submission directory %s", submission_dir);
         not_reached();
     } else if (!found_Makefile) {
-        err(170, __func__, "Makefile not found in submission directory %s", submission_dir);
+        err(174, __func__, "Makefile not found in submission directory %s", submission_dir);
         not_reached();
     } else if (!found_remarks_md) {
-        err(171, __func__, "remarks.md not found in submission directory %s", submission_dir);
+        err(175, __func__, "remarks.md not found in submission directory %s", submission_dir);
         not_reached();
     }
 
@@ -2812,7 +2855,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * check that there are not too many extra files
      */
     if (count > MAX_EXTRA_FILE_COUNT) {
-        err(172, __func__, "too many files: %ju > %ju", (uintmax_t)count, (uintmax_t)MAX_FILE_COUNT);
+        err(176, __func__, "too many files: %ju > %ju", (uintmax_t)count, (uintmax_t)MAX_FILE_COUNT);
         not_reached();
     }
     /*
@@ -2820,7 +2863,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     len = dyn_array_tell(directories);
     if (MAX_EXTRA_DIR_COUNT > 0 && len > MAX_EXTRA_DIR_COUNT) {
-        err(173, __func__, "too many extra directories in submission directory: %ju > %ju", (uintmax_t)len,
+        err(177, __func__, "too many extra directories in submission directory: %ju > %ju", (uintmax_t)len,
                 (uintmax_t)MAX_EXTRA_DIR_COUNT);
         not_reached();
     }
@@ -2833,19 +2876,19 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     len = dyn_array_tell(infop->required_files);
     if (len <= 0) {
-        err(174, __func__, "list of required files list is empty");
+        err(178, __func__, "list of required files list is empty");
         not_reached();
     }
     len2 = dyn_array_tell(required_files);
     if (len2 <= 0) {
-        err(175, __func__, "list of required files in submission directory is empty");
+        err(179, __func__, "list of required files in submission directory is empty");
         not_reached();
     }
     /*
      * the required files lists must be the same length
      */
     if (len != len2) {
-        err(176, __func__, "size of required files list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
+        err(180, __func__, "size of required files list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
                 (uintmax_t)len);
         not_reached();
     }
@@ -2855,7 +2898,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
          */
         p = dyn_array_value(infop->required_files, char *, i);
         if (p == NULL) {
-            err(177, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+            err(181, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
             not_reached();
         }
         /*
@@ -2863,7 +2906,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
          */
         fname = dyn_array_value(required_files, char *, i);
         if (fname == NULL) {
-            err(178, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
+            err(182, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
             not_reached();
         }
 
@@ -2890,7 +2933,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
             errno = 0; /* pre-clear errno for errp() */
             filename = strdup(p);
             if (filename == NULL) {
-                errp(179, __func__, "strdup(\"%s\") failed", p);
+                errp(183, __func__, "strdup(\"%s\") failed", p);
                 not_reached();
             }
             append_unique_str(missing_files, filename);
@@ -2900,11 +2943,11 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
          * we also check that these files are not in another list
          */
         if (array_has_path(directories, p)) {
-            err(180, __func__, "required file %s in directories list", p);
+            err(184, __func__, "required file %s in directories list", p);
             not_reached();
         }
         if (array_has_path(extra_files, p)) {
-            err(181, __func__, "required file %s in extra files list", p);
+            err(185, __func__, "required file %s in extra files list", p);
             not_reached();
         }
 
@@ -2949,7 +2992,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
              * if there is any file other than the three required files that are
              * in the required files list it is an error (and a bug)
              */
-            err(182, __func__, "BUG: non-required file found in required files list: %s, please report", fname);
+            err(186, __func__, "BUG: non-required file found in required files list: %s, please report", fname);
             not_reached();
         }
     }
@@ -2958,15 +3001,15 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * extra sanity check on the three required files
      */
     if (array_has_path(missing_files, PROG_C_FILENAME)) {
-        err(183, __func__, "prog.c in missing files list!");
+        err(187, __func__, "prog.c in missing files list!");
         not_reached();
     }
     if (array_has_path(missing_files, MAKEFILE_FILENAME)) {
-        err(184, __func__, "Makefile in missing files list!");
+        err(188, __func__, "Makefile in missing files list!");
         not_reached();
     }
     if (array_has_path(missing_files, REMARKS_FILENAME)) {
-        err(185, __func__, "remarks.md in missing files list!");
+        err(189, __func__, "remarks.md in missing files list!");
         not_reached();
     }
 
@@ -2983,7 +3026,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * (topdir list size) it is an error
      */
     if (len != len2) {
-        err(186, __func__, "size of extra files list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
+        err(190, __func__, "size of extra files list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
                 (uintmax_t)len);
         not_reached();
     }
@@ -2994,7 +3037,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
              */
             p = dyn_array_value(infop->extra_files, char *, i);
             if (p == NULL) {
-                err(187, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                err(191, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             /*
@@ -3002,7 +3045,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
              */
             fname = dyn_array_value(extra_files, char *, i);
             if (p == NULL) {
-                err(188, __func__, "found NULL pointer in extra files list in submission directory, element: %ju", (uintmax_t)i);
+                err(192, __func__, "found NULL pointer in extra files list in submission directory, element: %ju", (uintmax_t)i);
                 not_reached();
             }
 
@@ -3029,7 +3072,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                 errno = 0; /* pre-clear errno for errp() */
                 filename = strdup(p);
                 if (filename == NULL) {
-                    errp(189, __func__, "strdup(\"%s\") failed", p);
+                    errp(193, __func__, "strdup(\"%s\") failed", p);
                     not_reached();
                 }
                 append_unique_str(missing_files, filename);
@@ -3046,7 +3089,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         ret = fprintf(stderr, "The following file%s %s missing:\n\n",
                 len == 1 ? "" : "s", len == 1 ? "is" : "are");
         if (ret <= 0) {
-            errp(190, __func__, "error writing missing files list title");
+            errp(194, __func__, "error writing missing files list title");
             not_reached();
         }
         for (i = 0; i < len; i++) {
@@ -3055,12 +3098,12 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
              */
             fname = dyn_array_value(missing_files, char *, i);
             if (fname == NULL) {
-                err(191, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
+                err(195, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", fname);
         }
-        err(192, __func__, "aborting due to missing files");
+        err(196, __func__, "aborting due to missing files");
         not_reached();
     }
 
@@ -3076,7 +3119,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      * (topdir list size) it is an error
      */
     if (len != len2) {
-        err(193, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
+        err(197, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
                 (uintmax_t)len);
         not_reached();
     }
@@ -3084,12 +3127,12 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(infop->directories, char *, i);
             if (p == NULL) {
-                err(194, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                err(198, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             fname = dyn_array_value(directories, char *, i);
             if (fname == NULL) {
-                err(195, __func__, "found NULL pointer in directories list in submission directory, element: %ju", (uintmax_t)i);
+                err(199, __func__, "found NULL pointer in directories list in submission directory, element: %ju", (uintmax_t)i);
                 not_reached();
             }
 
@@ -3116,7 +3159,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
                 errno = 0; /* pre-clear errno for errp() */
                 filename = strdup(p);
                 if (filename == NULL) {
-                    errp(196, __func__, "strdup(\"%s\") failed", p);
+                    errp(200, __func__, "strdup(\"%s\") failed", p);
                     not_reached();
                 }
                 append_unique_str(missing_dirs, filename);
@@ -3130,7 +3173,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         ret = fprintf(stderr, "The following director%s %s missing:\n\n",
                 len == 1 ? "y" : "ies", len == 1 ? "is" : "are");
         if (ret <= 0) {
-            errp(197, __func__, "error writing missing directories list title");
+            errp(201, __func__, "error writing missing directories list title");
             not_reached();
         }
         for (i = 0; i < len; i++) {
@@ -3139,14 +3182,14 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
              */
             fname = dyn_array_value(missing_dirs, char *, i);
             if (fname == NULL) {
-                err(198, __func__,
+                err(202, __func__,
                         "found NULL pointer in missing directories list in submission directory, element: %ju",
                         (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", fname);
         }
-        err(199, __func__, "aborting due to missing directories");
+        err(203, __func__, "aborting due to missing directories");
         not_reached();
     }
 
@@ -3166,7 +3209,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(directories, char *, i);
             if (p == NULL) {
-                err(200, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                err(204, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -3175,7 +3218,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(201, __func__, "aborting because user said files list is not OK");
+                err(205, __func__, "aborting because user said files list is not OK");
                 not_reached();
             }
         }
@@ -3187,7 +3230,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     len = dyn_array_tell(required_files);
     if (len <= 0) {
-        err(202, __func__, "list of required files is empty");
+        err(206, __func__, "list of required files is empty");
         not_reached();
     }
     if (len > 0) {
@@ -3202,7 +3245,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(required_files, char *, i);
             if (p == NULL) {
-                err(203, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                err(207, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -3217,7 +3260,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(extra_files, char *, i);
                 if (p == NULL) {
-                    err(204, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                    err(208, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -3226,7 +3269,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
         if (!answer_yes) {
             yorn = yes_or_no("Is this OK? [yn]");
             if (!yorn) {
-                err(205, __func__, "aborting because user said files list is not OK");
+                err(209, __func__, "aborting because user said files list is not OK");
                 not_reached();
             }
         }
@@ -3305,7 +3348,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(206, __func__, "unable to change to previous directory");
+        errp(210, __func__, "unable to change to previous directory");
         not_reached();
     }
 
@@ -3314,7 +3357,7 @@ check_submission(struct info *infop, char const *submission_dir, char const *mak
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(cwd) != 0) {
-        errp(207, __func__, "failed to close(cwd)");
+        errp(211, __func__, "failed to close(cwd)");
         not_reached();
     }
 }
@@ -3399,7 +3442,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
      */
     if (infop == NULL || workdir == NULL || tar == NULL || ls == NULL ||
 	txzchk == NULL || fnamchk == NULL || chkentry == NULL || make == NULL) {
-	err(208, __func__, "called with NULL arg(s)");
+	err(212, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3421,7 +3464,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(209, __func__, "tar does not exist: %s", tar);
+	err(213, __func__, "tar does not exist: %s", tar);
 	not_reached();
     }
     if (!is_file(tar)) {
@@ -3438,7 +3481,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(210, __func__, "tar is not a regular file: %s", tar);
+	err(214, __func__, "tar is not a regular file: %s", tar);
 	not_reached();
     }
     if (!is_exec(tar)) {
@@ -3455,7 +3498,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(211, __func__, "tar is not an executable program: %s", tar);
+	err(215, __func__, "tar is not an executable program: %s", tar);
 	not_reached();
     }
 
@@ -3477,7 +3520,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(212, __func__, "ls does not exist: %s", ls);
+	err(216, __func__, "ls does not exist: %s", ls);
 	not_reached();
     }
     if (!is_file(ls)) {
@@ -3494,7 +3537,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(213, __func__, "ls is not a regular file: %s", ls);
+	err(217, __func__, "ls is not a regular file: %s", ls);
 	not_reached();
     }
     if (!is_exec(ls)) {
@@ -3511,7 +3554,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(214, __func__, "ls is not an executable program: %s", ls);
+	err(218, __func__, "ls is not an executable program: %s", ls);
 	not_reached();
     }
 
@@ -3533,7 +3576,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(215, __func__, "txzchk does not exist: %s", txzchk);
+	err(219, __func__, "txzchk does not exist: %s", txzchk);
 	not_reached();
     }
     if (!is_file(txzchk)) {
@@ -3550,7 +3593,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(216, __func__, "txzchk is not a regular file: %s", txzchk);
+	err(220, __func__, "txzchk is not a regular file: %s", txzchk);
 	not_reached();
     }
     if (!is_exec(txzchk)) {
@@ -3567,7 +3610,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(217, __func__, "txzchk is not an executable program: %s", txzchk);
+	err(221, __func__, "txzchk is not an executable program: %s", txzchk);
 	not_reached();
     }
 
@@ -3589,7 +3632,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(218, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(222, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -3606,7 +3649,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(219, __func__, "fnamchk is not a regular file: %s", fnamchk);
+	err(223, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -3623,7 +3666,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(220, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(224, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -3645,7 +3688,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(221, __func__, "chkentry does not exist: %s", chkentry);
+	err(225, __func__, "chkentry does not exist: %s", chkentry);
 	not_reached();
     }
     if (!is_file(chkentry)) {
@@ -3662,7 +3705,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(222, __func__, "chkentry is not a regular file: %s", chkentry);
+	err(226, __func__, "chkentry is not a regular file: %s", chkentry);
 	not_reached();
     }
     if (!is_exec(chkentry)) {
@@ -3679,7 +3722,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(223, __func__, "chkentry is not an executable program: %s", chkentry);
+	err(227, __func__, "chkentry is not an executable program: %s", chkentry);
 	not_reached();
     }
 
@@ -3701,7 +3744,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(224, __func__, "make does not exist: %s", make);
+	err(228, __func__, "make does not exist: %s", make);
 	not_reached();
     }
     if (!is_file(make)) {
@@ -3718,7 +3761,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(225, __func__, "make is not a regular file: %s", make);
+	err(229, __func__, "make is not a regular file: %s", make);
 	not_reached();
     }
     if (!is_exec(make)) {
@@ -3735,7 +3778,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(226, __func__, "make is not an executable program: %s", make);
+	err(230, __func__, "make is not an executable program: %s", make);
 	not_reached();
     }
 
@@ -3752,7 +3795,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "You should either create workdir, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(227, __func__, "workdir does not exist: %s", workdir);
+	err(231, __func__, "workdir does not exist: %s", workdir);
 	not_reached();
     }
     if (!is_dir(workdir)) {
@@ -3764,7 +3807,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(228, __func__, "workdir is not a directory: %s", workdir);
+	err(232, __func__, "workdir is not a directory: %s", workdir);
 	not_reached();
     }
     if (!is_write(workdir)) {
@@ -3776,7 +3819,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "create a new writable directory, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(229, __func__, "workdir is not a writable directory: %s", workdir);
+	err(233, __func__, "workdir is not a writable directory: %s", workdir);
 	not_reached();
     }
 
@@ -3826,7 +3869,7 @@ prompt(char const *str, size_t *lenp)
      * NOTE: As noted above, lenp can be NULL.
      */
     if (str == NULL) {
-	err(230, __func__, "called with NULL str");
+	err(234, __func__, "called with NULL str");
 	not_reached();
     }
 
@@ -3839,13 +3882,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(str, stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(231, __func__, "error printing prompt string");
+		errp(235, __func__, "error printing prompt string");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(232, __func__, "EOF while printing prompt string");
+		err(236, __func__, "EOF while printing prompt string");
 		not_reached();
 	    } else {
-		errp(233, __func__, "unexpected fputs error printing prompt string");
+		errp(237, __func__, "unexpected fputs error printing prompt string");
 		not_reached();
 	    }
 	}
@@ -3854,13 +3897,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(": ", stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(234, __func__, "error printing :<space>");
+		errp(238, __func__, "error printing :<space>");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(235, __func__, "EOF while writing :<space>");
+		err(239, __func__, "EOF while writing :<space>");
 		not_reached();
 	    } else {
-		errp(236, __func__, "unexpected fputs error printing :<space>");
+		errp(240, __func__, "unexpected fputs error printing :<space>");
 		not_reached();
 	    }
 	}
@@ -3869,13 +3912,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fflush(stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(237, __func__, "error flushing prompt to stdout");
+		errp(241, __func__, "error flushing prompt to stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(238, __func__, "EOF while flushing prompt to stdout");
+		err(242, __func__, "EOF while flushing prompt to stdout");
 		not_reached();
 	    } else {
-		errp(239, __func__, "unexpected fflush error while flushing prompt to stdout");
+		errp(243, __func__, "unexpected fflush error while flushing prompt to stdout");
 		not_reached();
 	    }
 	}
@@ -3886,7 +3929,7 @@ prompt(char const *str, size_t *lenp)
      */
     buf = readline_dup(&linep, true, &len, input_stream);
     if (buf == NULL) {
-	err(240, __func__, "EOF while reading prompt input");
+	err(244, __func__, "EOF while reading prompt input");
 	not_reached();
     }
     dbg(DBG_VHIGH, "received a %ju byte response", (uintmax_t)len);
@@ -3942,10 +3985,10 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
      * firewall
      */
     if (testp == NULL) {
-	err(241, __func__, "called with NULL testp");
+	err(245, __func__, "called with NULL testp");
 	not_reached();
     } else if (read_answers_flag_used == NULL) {
-	err(242, __func__, "called with NULL read_answers_flag_used");
+	err(246, __func__, "called with NULL read_answers_flag_used");
 	not_reached();
     }
 
@@ -3985,7 +4028,7 @@ get_contest_id(bool *testp, bool *read_answers_flag_used)
 	    malloc_ret = prompt("", &len);
 	}
 	if (*read_answers_flag_used && !seen_answers_header) {
-	    err(243, __func__, "didn't find the correct answers file header");
+	    err(247, __func__, "didn't find the correct answers file header");
 	    not_reached();
 	}
 
@@ -4083,7 +4126,7 @@ get_submit_slot(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(244, __func__, "called with NULL arg(s)");
+	err(248, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4094,7 +4137,7 @@ get_submit_slot(struct info *infop)
         errno = 0;		/* pre-clear errno for errp() */
         ret = printf("\nYou are allowed to submit up to %d submissions to a given IOCCC.\n", MAX_SUBMIT_SLOT + 1);
         if (ret <= 0) {
-            errp(245, __func__, "printf error printing number of submissions allowed");
+            errp(249, __func__, "printf error printing number of submissions allowed");
             not_reached();
         }
         para("",
@@ -4128,7 +4171,7 @@ get_submit_slot(struct info *infop)
 	    ret = fprintf(stderr, "\nThe submit slot number must be a number from 0 through %d; please re-enter.\n",
 		    MAX_SUBMIT_SLOT);
 	    if (ret <= 0) {
-		errp(246, __func__, "fprintf error while informing about the valid submit slot number range");
+		errp(10, __func__, "fprintf error while informing about the valid submit slot number range");
                 not_reached();
 	    }
             /*
@@ -4148,7 +4191,7 @@ get_submit_slot(struct info *infop)
                 ret = printf("The slot number you entered is: %d\n",
                              submit_slot);
                 if (ret <= 0) {
-                    errp(247, __func__, "fprintf error writing slot number");
+                    errp(11, __func__, "fprintf error writing slot number");
                     not_reached();
                 }
                 yorn = yes_or_no("Is that slot number correct? [yn]");
@@ -4209,12 +4252,12 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      * firewall
      */
     if (workdir == NULL || ioccc_id == NULL || tarball_path == NULL) {
-	err(248, __func__, "called with NULL arg(s)");
+	err(12, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     test = test_submit_slot(submit_slot);
     if (test == false) {
-	err(249, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
+	err(13, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
 	not_reached();
     }
 
@@ -4228,13 +4271,13 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
     errno = 0;			/* pre-clear errno for errp() */
     submission_dir = (char *)malloc(submission_dir_len + 1);
     if (submission_dir == NULL) {
-	errp(10, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
+	errp(14, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(submission_dir, submission_dir_len + 1, "%s/%s-%d", workdir, ioccc_id, submit_slot);
     if (ret <= 0) {
-	errp(11, __func__, "snprintf to form submission directory failed");
+	errp(15, __func__, "snprintf to form submission directory failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "submission directory path: %s", submission_dir);
@@ -4246,7 +4289,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nsubmission directory already exists: %s\n", submission_dir);
 	if (ret <= 0) {
-	    errp(12, __func__, "fprintf error while informing that the submission directory already exists");
+	    errp(16, __func__, "fprintf error while informing that the submission directory already exists");
             not_reached();
 	}
 	fpara(stderr,
@@ -4254,7 +4297,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 	      "You need to move that directory, or remove it, or use a different workdir.",
 	      "",
 	      NULL);
-	err(13, __func__, "submission directory exists: %s", submission_dir);
+	err(17, __func__, "submission directory exists: %s", submission_dir);
 	not_reached();
     }
     dbg(DBG_HIGH, "submission directory path: %s", submission_dir);
@@ -4271,13 +4314,13 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     ret = mkdir(submission_dir, 0);
     if (ret < 0) {
-	errp(14, __func__, "cannot mkdir %s", submission_dir);
+	errp(18, __func__, "cannot mkdir %s", submission_dir);
 	not_reached();
     }
     errno = 0; /* pre-clear errno for errp() */
     ret = chmod(submission_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
     if (ret < 0) {
-        errp(15, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
+        errp(19, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
         not_reached();
     }
 
@@ -4288,7 +4331,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     *tarball_path = form_tar_filename(ioccc_id, submit_slot, test_mode, tstamp);
     if (*tarball_path == NULL) {
-	errp(16, __func__, "failed to form compressed tarball path");
+	errp(20, __func__, "failed to form compressed tarball path");
 	not_reached();
     }
     dbg(DBG_HIGH, "compressed tarball path: %s", *tarball_path);
@@ -4333,7 +4376,7 @@ warn_empty_prog(void)
 	}
 	yorn = yes_or_no("Are you sure you want to submit an empty prog.c file? [yn]");
 	if (!yorn) {
-	    err(17, __func__, "please fix your prog.c file");
+	    err(21, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their empty prog.c is OK");
@@ -4362,7 +4405,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * firewall
      */
     if (infop == NULL) {
-	err(18, __func__, "called with NULL infop");
+	err(22, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -4376,7 +4419,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %jd > Rule 2a maximum: %jd\n",
 		      (intmax_t)infop->rule_2a_size, (intmax_t)RULE_2A_SIZE);
 	if (ret <= 0) {
-	    errp(19, __func__, "fprintf error when printing prog.c Rule 2a warning");
+	    errp(23, __func__, "fprintf error when printing prog.c Rule 2a warning");
             not_reached();
 	}
 	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
@@ -4393,7 +4436,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	    if (!yorn) {
-		err(20, __func__, "please fix your prog.c file");
+		err(24, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that their prog.c size: %jd > Rule 2a max size: %jd is OK",
@@ -4411,7 +4454,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 				  "YOUR remarks.md FILE!\n\n",
 				  (intmax_t)infop->rule_2a_size, (intmax_t)size.rule_2a_size);
 	    if (ret <= 0) {
-		errp(21, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
+		errp(25, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -4419,7 +4462,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	    if (!yorn) {
-		err(22, __func__, "please fix your prog.c file");
+		err(26, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that prog.c size: %jd != rule_count function size: %jd is OK",
@@ -4430,7 +4473,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * invalid mode
      */
     } else {
-	err(23, __func__, "invalid mode passed to function: %d", mode);
+	err(27, __func__, "invalid mode passed to function: %d", mode);
 	not_reached();
     }
     return;
@@ -4458,7 +4501,7 @@ warn_nul_chars(void)
 	ret = fprintf(stderr, "\nprog.c has NUL character(s)!\n"
 			      "Be careful you don't violate rule 13!\n\n");
 	if (ret <= 0) {
-	    errp(24, __func__, "fprintf error when printing prog.c nul_warning");
+	    errp(28, __func__, "fprintf error when printing prog.c nul_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4467,7 +4510,7 @@ warn_nul_chars(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(25, __func__, "please fix your prog.c file");
+	    err(29, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having NUL character(s) is OK");
@@ -4496,7 +4539,7 @@ warn_trigraph(void)
 	ret = fprintf(stderr, "\nprog.c has unknown or invalid trigraph(s) found!\n"
 			      "Is that a bug in, or a feature of your code?\n\n");
 	if (ret <= 0) {
-	    errp(26, __func__, "fprintf error when printing prog.c trigraph_warning");
+	    errp(30, __func__, "fprintf error when printing prog.c trigraph_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4505,7 +4548,7 @@ warn_trigraph(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(27, __func__, "please fix your prog.c file");
+	    err(31, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having unknown or invalid trigraph(s) is OK");
@@ -4534,7 +4577,7 @@ warn_wordbuf(void)
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
 			      "YOUR remarks.md FILE!\n\n");
 	if (ret <= 0) {
-	    errp(28, __func__, "fprintf error when printing prog.c wordbuf_warning");
+	    errp(32, __func__, "fprintf error when printing prog.c wordbuf_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4543,7 +4586,7 @@ warn_wordbuf(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(29, __func__, "please fix your prog.c file");
+	    err(33, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c triggering a word buffer overflow is OK");
@@ -4573,7 +4616,7 @@ warn_ungetc(void)
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
 			      "YOUR remarks.md FILE!\n\n");
 	if (ret <= 0) {
-	    errp(30, __func__, "fprintf error when printing prog.c ungetc_warning");
+	    errp(34, __func__, "fprintf error when printing prog.c ungetc_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4582,7 +4625,7 @@ warn_ungetc(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [yn]");
 	if (!yorn) {
-	    err(31, __func__, "please fix your prog.c file");
+	    err(35, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c triggering an ungetc warning OK");
@@ -4606,7 +4649,7 @@ warn_rule_2b_size(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(32, __func__, "called with NULL infop");
+	err(36, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -4618,7 +4661,7 @@ warn_rule_2b_size(struct info *infop)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %ju > Rule 2b maximum: %ju\n",
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
 	if (ret <= 0) {
-	    errp(33, __func__, "printf error printing prog.c size > Rule 2b maximum");
+	    errp(37, __func__, "printf error printing prog.c size > Rule 2b maximum");
 	    not_reached();
 	}
 
@@ -4635,7 +4678,7 @@ warn_rule_2b_size(struct info *infop)
 	}
 	yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [yn]");
 	if (!yorn) {
-	    err(34, __func__, "please fix your prog.c file");
+	    err(38, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their prog.c size: %ju > Rule 2B max size: %ju is OK",
@@ -4672,7 +4715,7 @@ check_prog_c(struct info *infop, char const *prog_c)
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(35, __func__, "called with NULL arg(s)");
+	err(39, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     /*
@@ -4684,7 +4727,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(36, __func__, "prog.c does not exist: %s", prog_c);
+	err(40, __func__, "prog.c does not exist: %s", prog_c);
 	not_reached();
     }
     if (!is_file(prog_c)) {
@@ -4693,7 +4736,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(37, __func__, "prog.c is not a regular file: %s", prog_c);
+	err(41, __func__, "prog.c is not a regular file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -4702,7 +4745,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(38, __func__, "prog.c is not a readable file: %s", prog_c);
+	err(42, __func__, "prog.c is not a readable file: %s", prog_c);
 	not_reached();
     }
 
@@ -4716,7 +4759,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     prog_stream = fopen(prog_c, "r");
     if (prog_stream == NULL) {
-	errp(39, __func__, "failed to fopen: %s", prog_c);
+	errp(43, __func__, "failed to fopen: %s", prog_c);
 	not_reached();
     }
     size = rule_count(prog_stream);
@@ -4725,7 +4768,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(prog_stream);
     if (ret != 0) {
-	errp(40, __func__, "failed to fclose: %s", prog_c);
+	errp(44, __func__, "failed to fclose: %s", prog_c);
 	not_reached();
     }
 
@@ -4735,7 +4778,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     infop->rule_2a_size = file_size(prog_c);
     dbg(DBG_MED, "Rule 2a size: %jd", (intmax_t)infop->rule_2a_size);
     if (infop->rule_2a_size < 0) {
-	err(41, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
+	err(45, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
 	not_reached();
     } else if (infop->rule_2a_size == 0 || infop->rule_2b_size == 0) {
 	warn_empty_prog();
@@ -4862,7 +4905,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(42, __func__, "called with NULL arg(s)");
+	err(46, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4872,7 +4915,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     stream = fopen(Makefile, "r");
     if (stream == NULL) {
-	errp(43, __func__, "cannot open Makefile: %s", Makefile);
+	errp(47, __func__, "cannot open Makefile: %s", Makefile);
 	not_reached();
     }
 
@@ -5071,7 +5114,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(stream);
     if (ret < 0) {
-	errp(44, __func__, "fclose error");
+	errp(48, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5114,7 +5157,7 @@ warn_Makefile(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(45, __func__, "called with NULL infop");
+	err(49, __func__, "called with NULL infop");
 	not_reached();
     }
     if (need_confirm && (!answer_yes || seed_used)) {
@@ -5194,7 +5237,7 @@ warn_Makefile(struct info *infop)
 	if (!answer_yes) {
 	    yorn = yes_or_no("Do you still want to submit this Makefile in the hopes that it is OK? [yn]");
 	    if (!yorn) {
-		err(46, __func__, "Use a different Makefile or modify your Makefile");
+		err(50, __func__, "Use a different Makefile or modify your Makefile");
 		not_reached();
 	    }
 	}
@@ -5223,7 +5266,7 @@ check_Makefile(struct info *infop, char const *Makefile)
      * firewall
      */
     if (infop == NULL || Makefile == NULL) {
-	err(47, __func__, "called with NULL arg(s)");
+	err(51, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5236,7 +5279,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "We cannot find the Makefile.",
 	      "",
 	      NULL);
-	err(48, __func__, "Makefile does not exist: %s", Makefile);
+	err(52, __func__, "Makefile does not exist: %s", Makefile);
 	not_reached();
     }
     if (!is_file(Makefile)) {
@@ -5245,7 +5288,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	       "The Makefile path, while it exists, is not a regular file.",
 	       "",
 	       NULL);
-	err(49, __func__, "Makefile is not a regular file: %s", Makefile);
+	err(53, __func__, "Makefile is not a regular file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -5254,15 +5297,15 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "The Makefile path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(50, __func__, "Makefile is not readable file: %s", Makefile);
+	err(54, __func__, "Makefile is not readable file: %s", Makefile);
 	not_reached();
     }
     filesize = file_size(Makefile);
     if (filesize < 0) {
-	err(51, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
+	err(55, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
 	not_reached();
     } else if (filesize == 0) {
-	err(52, __func__, "Makefile cannot be empty: %s", Makefile);
+	err(56, __func__, "Makefile cannot be empty: %s", Makefile);
 	not_reached();
     }
 
@@ -5300,7 +5343,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
      * firewall
      */
     if (infop == NULL || remarks_md == NULL) {
-	err(53, __func__, "called with NULL arg(s)");
+	err(57, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5313,7 +5356,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	       "We cannot find the remarks.md file.",
 	       "",
 	       NULL);
-	err(54, __func__, "remarks.md does not exist: %s", remarks_md);
+	err(58, __func__, "remarks.md does not exist: %s", remarks_md);
 	not_reached();
     }
     if (!is_file(remarks_md)) {
@@ -5321,7 +5364,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(55, __func__, "remarks.md is not a regular file: %s", remarks_md);
+	err(59, __func__, "remarks.md is not a regular file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -5330,15 +5373,15 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(56, __func__, "remarks.md is not readable file: %s", remarks_md);
+	err(60, __func__, "remarks.md is not readable file: %s", remarks_md);
 	not_reached();
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(57, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
+	err(61, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
-	err(58, __func__, "remarks.md cannot be empty: %s", remarks_md);
+	err(62, __func__, "remarks.md cannot be empty: %s", remarks_md);
 	not_reached();
     }
 
@@ -5366,7 +5409,7 @@ yes_or_no(char const *question)
      * firewall
      */
     if (question == NULL) {
-	err(59, __func__, "called with NULL question");
+	err(63, __func__, "called with NULL question");
 	not_reached();
     }
 
@@ -5485,7 +5528,7 @@ get_title(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(60, __func__, "called with NULL infop");
+	err(64, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -5505,7 +5548,7 @@ get_title(struct info *infop)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	if (ret <= 0) {
-	    errp(61, __func__, "fprintf #0 error: %d", ret);
+	    errp(65, __func__, "fprintf #0 error: %d", ret);
             not_reached();
 	}
     }
@@ -5563,7 +5606,7 @@ get_title(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	    if (ret <= 0) {
-		errp(62, __func__, "fprintf #1 error: %d", ret);
+		errp(66, __func__, "fprintf #1 error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -5622,7 +5665,7 @@ get_title(struct info *infop)
             ret = printf("The title you entered is: %s\n",
                          title);
             if (ret <= 0) {
-                errp(63, __func__, "fprintf title");
+                errp(67, __func__, "fprintf title");
                 not_reached();
             }
             yorn = yes_or_no("Is that title correct? [yn]");
@@ -5673,7 +5716,7 @@ get_abstract(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(64, __func__, "called with NULL infp");
+	err(68, __func__, "called with NULL infp");
 	not_reached();
     }
 
@@ -5740,7 +5783,7 @@ get_abstract(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your abstract must be between 1 and %d characters long.\n\n", MAX_ABSTRACT_LEN);
 	    if (ret <= 0) {
-		errp(65, __func__, "fprintf error: %d", ret);
+		errp(69, __func__, "fprintf error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -5766,7 +5809,7 @@ get_abstract(struct info *infop)
             ret = printf("The abstract you entered is: %s\n",
                          abstract);
             if (ret <= 0) {
-                errp(66, __func__, "fprintf abstract");
+                errp(70, __func__, "fprintf abstract");
                 not_reached();
             }
             yorn = yes_or_no("Is that abstract correct? [yn]");
@@ -5963,7 +6006,7 @@ get_author_info(struct author **author_set_p)
      * firewall
      */
     if (author_set_p == NULL) {
-	err(67, __func__, "called with NULL author_set_p");
+	err(71, __func__, "called with NULL author_set_p");
 	not_reached();
     }
 
@@ -5985,20 +6028,20 @@ get_author_info(struct author **author_set_p)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nThe number of authors must be a number from 1 through %d;\nplease re-enter.\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(68, __func__, "fprintf error #0 while printing author number range");
+		errp(72, __func__, "fprintf error #0 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nIf you happen to have more than %d authors, we ask that you pick\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(69, __func__, "fprintf error #1 while printing author number range");
+		errp(73, __func__, "fprintf error #1 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "just %d authors and mention the remaining NUMBER of the authors in\nthe remarks file.\n",
                     MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(70, __func__, "fprintf error #2 while printing author number range");
+		errp(74, __func__, "fprintf error #2 while printing author number range");
                 not_reached();
 	    }
 	    author_count = -1;	/* invalidate input */
@@ -6026,7 +6069,7 @@ get_author_info(struct author **author_set_p)
     errno = 0;			/* pre-clear errno for errp() */
     author_set = (struct author *) malloc(sizeof(struct author) * (size_t)author_count);
     if (author_set == NULL) {
-	errp(71, __func__, "malloc a struct author array of length: %d failed", author_count);
+	errp(75, __func__, "malloc a struct author array of length: %d failed", author_count);
 	not_reached();
     }
 
@@ -6062,31 +6105,31 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL0);
 	if (ret < 0) {
-	    errp(72, __func__, "puts error printing ISO 3166-1 URL0");
+	    errp(76, __func__, "puts error printing ISO 3166-1 URL0");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL1);
 	if (ret < 0) {
-	    errp(73, __func__, "puts error printing ISO 3166-1 URL1");
+	    errp(77, __func__, "puts error printing ISO 3166-1 URL1");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL2);
 	if (ret < 0) {
-	    errp(74, __func__, "puts error printing ISO 3166-1 URL2");
+	    errp(78, __func__, "puts error printing ISO 3166-1 URL2");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL3);
 	if (ret < 0) {
-	    errp(75, __func__, "puts error printing ISO 3166-1 URL3");
+	    errp(79, __func__, "puts error printing ISO 3166-1 URL3");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL4);
 	if (ret < 0) {
-	    errp(76, __func__, "puts error printing ISO 3166-1 URL4");
+	    errp(80, __func__, "puts error printing ISO 3166-1 URL4");
             not_reached();
 	}
 	para("",
@@ -6118,7 +6161,7 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = printf("\nEnter information for author #%d\n\n", i);
 	if (ret <= 0) {
-	    errp(77, __func__, "printf error printing author number");
+	    errp(81, __func__, "printf error printing author number");
             not_reached();
 	}
 	author_set[i].author_num = i;
@@ -6171,7 +6214,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit names to %d characters\n\n", MAX_NAME_LEN);
 		if (ret <= 0) {
-		    errp(78, __func__, "fprintf error while reject name that is too long");
+		    errp(82, __func__, "fprintf error while reject name that is too long");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6200,7 +6243,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d name duplicates previous author #%d name", i, j);
 			if (ret <= 0) {
-			    errp(79, __func__, "fprintf error while reject duplicate name");
+			    errp(83, __func__, "fprintf error while reject duplicate name");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -6254,7 +6297,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(80, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
+		    errp(84, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6264,19 +6307,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(81, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
+		    errp(85, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(82, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
+		    errp(86, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(83, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
+		    errp(87, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6325,7 +6368,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(84, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
+		    errp(88, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6335,19 +6378,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(85, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
+		    errp(89, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(86, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
+		    errp(90, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(87, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
+		    errp(91, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6382,7 +6425,7 @@ get_author_info(struct author **author_set_p)
 		ret = printf("The location/country code you entered is assigned to: %s (%s)\n",
 			     author_set[i].location_name, author_set[i].common_name);
 		if (ret <= 0) {
-		    errp(88, __func__, "fprintf location/country code assignment");
+		    errp(92, __func__, "fprintf location/country code assignment");
                     not_reached();
 		}
 		yorn = yes_or_no("Is that location/country code correct? [yn]");
@@ -6437,7 +6480,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit email address to %d characters\n", MAX_EMAIL_LEN);
 		if (ret <= 0) {
-		    errp(89, __func__, "fprintf error while printing Email address length limit");
+		    errp(93, __func__, "fprintf error while printing Email address length limit");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6495,7 +6538,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters.\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(90, __func__, "fprintf error while printing URL length limit");
+		    errp(94, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6591,7 +6634,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(91, __func__, "fprintf error while printing URL length limit");
+		    errp(95, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6687,7 +6730,7 @@ get_author_info(struct author **author_set_p)
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit Mastodon handles to %d "
 			"characters, starting with the @\n\n", MAX_MASTODON_LEN);
 		if (ret <= 0) {
-		    errp(92, __func__, "fprintf error while printing mastodon handle length limit");
+		    errp(96, __func__, "fprintf error while printing mastodon handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6777,7 +6820,7 @@ get_author_info(struct author **author_set_p)
 			    "\nSorry ( tm Canada :-) ), we limit GitHub account names to %d characters after the 1st @.\n\n",
 			    MAX_GITHUB_LEN);
 		if (ret <= 0) {
-		    errp(93, __func__, "fprintf error while printing GitHub user length limit");
+		    errp(97, __func__, "fprintf error while printing GitHub user length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6864,7 +6907,7 @@ get_author_info(struct author **author_set_p)
 		    fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit affiliation names to %d characters\n\n",
 			    MAX_AFFILIATION_LEN);
 		if (ret <= 0) {
-		    errp(94, __func__, "fprintf error while printing affiliation length limit");
+		    errp(98, __func__, "fprintf error while printing affiliation length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6941,7 +6984,7 @@ get_author_info(struct author **author_set_p)
 	     */
 	    def_handle = default_handle(author_set[i].name);
 	    if (def_handle == NULL) {
-		err(95, __func__, "default_handle() returned NULL!");
+		err(99, __func__, "default_handle() returned NULL!");
 		not_reached();
 	    }
 	    dbg(DBG_VHIGH, "default IOCCC author handle: <%s>", def_handle);
@@ -6949,7 +6992,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = printf("\nThe default IOCCC author handle for author #%d is:\n\n    %s\n\n", i, def_handle);
 		if (ret <= 0) {
-		    errp(96, __func__, "fprintf error while printing default IOCCC author handle");
+		    errp(100, __func__, "fprintf error while printing default IOCCC author handle");
                     not_reached();
 		}
 	    }
@@ -7012,7 +7055,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nThe IOCCC author handle is limited to %d characters\n\n", MAX_HANDLE);
 		if (ret <= 0) {
-		    errp(97, __func__, "fprintf error while printing IOCCC author handle length limit");
+		    errp(101, __func__, "fprintf error while printing IOCCC author handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7043,7 +7086,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d author_handle duplicates previous author #%d author_handle", i, j);
 			if (ret <= 0) {
-			    errp(98, __func__, "fprintf error while printing duplicate author_handle error");
+			    errp(102, __func__, "fprintf error while printing duplicate author_handle error");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -7090,7 +7133,7 @@ get_author_info(struct author **author_set_p)
 						      printf("IOCCC author handle was manually entered\n"))  <= 0 ||
 	    ((author_set[i].author_handle[0] == '\0') ? printf("IOCCC author handle\n\n") :
 						        printf("IOCCC author handle: %s\n\n", author_set[i].author_handle)) <= 0) {
-	    errp(99, __func__, "error while printing author #%d information\n", i);
+	    errp(103, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -7144,7 +7187,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * firewall
      */
     if (submission_dir == NULL || ls == NULL) {
-	err(100, __func__, "called with NULL arg(s)");
+	err(104, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -7157,7 +7200,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", submission_dir);
     if (ret <= 0) {
-	errp(101, __func__, "printf error code: %d", ret);
+	errp(105, __func__, "printf error code: %d", ret);
         not_reached();
     }
     para("",
@@ -7167,7 +7210,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to perform: cd -- %s && %s -lakR .", submission_dir, ls);
     exit_code = shell_cmd(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (exit_code != 0) {
-	err(102, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
+	err(106, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
 			   submission_dir, ls, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7178,7 +7221,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to popen: cd -- %s && %s -lakR .", submission_dir, ls);
     ls_stream = pipe_open(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (ls_stream == NULL) {
-	err(103, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
+	err(107, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
 	not_reached();
     }
 
@@ -7210,18 +7253,18 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * no line was read at all
      */
     if (readline_len < 0 && i == 0) {
-	err(104, __func__, "EOF while reading output of ls: %s", ls);
+	err(108, __func__, "EOF while reading output of ls: %s", ls);
 	not_reached();
     }
     /*
      * lines were read from ls but nothing correct was found
      */
     if (i == 0) {
-        err(105, __func__, "found no k-block line in ls output");
+        err(109, __func__, "found no k-block line in ls output");
         not_reached();
     }
     if (kdirsize <= 0) {
-	err(106, __func__, "ls k-block value: %d <= 0", kdirsize);
+	err(110, __func__, "ls k-block value: %d <= 0", kdirsize);
 	not_reached();
     }
     dbg(DBG_MED, "Directory %s size in kibibyte (1024 byte blocks): %d", submission_dir, kdirsize);
@@ -7265,7 +7308,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
                   "not the topdir where your submission files are) and then rerun this tool",
                   "again.",
 		  NULL);
-	    err(107, __func__, "user rejected listing of submission directory: %s", submission_dir);
+	    err(111, __func__, "user rejected listing of submission directory: %s", submission_dir);
 	    not_reached();
 	}
     }
@@ -7329,11 +7372,11 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
      * firewall
      */
     if (infop == NULL || submission_dir == NULL || chkentry == NULL || fnamchk == NULL) {
-	err(108, __func__, "called with NULL arg(s)");
+	err(112, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->extra_files == NULL) {
-        err(109, __func__, "called with NULL files list");
+        err(113, __func__, "called with NULL files list");
         not_reached();
     }
 
@@ -7353,13 +7396,13 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(110, __func__, "cannot set TZ=UTC");
+	errp(114, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = gmtime(&(infop->tstamp));
     if (timeptr == NULL) {
-	errp(111, __func__, "gmtime returned NULL");
+	errp(115, __func__, "gmtime returned NULL");
 	not_reached();
     }
 
@@ -7370,7 +7413,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     infop->utctime = (char *)calloc(utctime_len + 1, sizeof(char)); /* + 1 for paranoia padding */
     if (infop->utctime == NULL) {
-	errp(112, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
+	errp(116, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
 	not_reached();
     }
 
@@ -7385,7 +7428,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     strftime_ret = strftime(infop->utctime, utctime_len, "%a %b %d %H:%M:%S %Y UTC", timeptr);
     if (strftime_ret == 0) {
-	errp(113, __func__, "strftime returned 0");
+	errp(117, __func__, "strftime returned 0");
 	not_reached();
     }
     dbg(DBG_VHIGH, "infop->utctime: %s", infop->utctime);
@@ -7397,20 +7440,20 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(114, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
+	errp(118, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/%s", submission_dir, INFO_JSON_FILENAME);
     if (ret <= 0) {
-	errp(115, __func__, "snprintf #0 error: %d", ret);
+	errp(119, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(116, __func__, "failed to open for writing: %s", info_path);
+	errp(120, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -7420,7 +7463,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0; /* pre-clear errno for errp() */
     fd = open(info_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        errp(117, __func__, "failed to obtain file descriptor for: %s", info_path);
+        errp(121, __func__, "failed to obtain file descriptor for: %s", info_path);
         not_reached();
     }
 
@@ -7463,7 +7506,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
 	json_fprintf_value_bool(info_stream, "    ", "test_mode", " : ", infop->test_mode, ",\n") &&
 	fprintf(info_stream, "    \"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(118, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(122, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -7492,7 +7535,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
 	  json_fprintf_value_string(info_stream, "            ", "remarks", " : ", "remarks.md", "\n") &&
 			    fprintf(info_stream, "        }%s\n", (infop->extra_count > 0) ?  "," : "") > 0;
     if (!ret) {
-	errp(119, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(123, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -7503,14 +7546,14 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
         for (i = 0; i < infop->extra_count; ++i) {
             p = dyn_array_value(infop->extra_files, char *, i);
             if (p == NULL) {
-                err(120, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)i);
+                err(124, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             ret =                   fprintf(info_stream, "        {\n") > 0 &&
                   json_fprintf_value_string(info_stream, "            ", "extra_file", " : ", p, "\n") &&
                                     fprintf(info_stream, "        }%s\n", ((i+1) < infop->extra_count) ?  "," : "") > 0;
             if (!ret) {
-                errp(121, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)i, info_path);
+                errp(125, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)i, info_path);
                 not_reached();
             }
         }
@@ -7526,7 +7569,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
 	json_fprintf_value_long(info_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(122, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(126, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -7536,7 +7579,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(123, __func__, "fclose error");
+	errp(128, __func__, "fclose error");
 	not_reached();
     }
 
@@ -7551,7 +7594,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     dbg(DBG_HIGH, "about to perform: %s -q -- . %s", chkentry, info_path);
     exit_code = shell_cmd(__func__, false, true, "% -q -- . %", chkentry, info_path);
     if (exit_code != 0) {
-	err(124, __func__, "%s -q -- . %s failed with exit code: %d",
+	err(129, __func__, "%s -q -- . %s failed with exit code: %d",
 			   chkentry, info_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7565,7 +7608,7 @@ write_info(struct info *infop, char const *submission_dir, char const *chkentry,
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(125, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
+        err(130, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
         not_reached();
     }
 
@@ -7598,19 +7641,19 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
      * firewall
      */
     if (authp == NULL || infop == NULL || authorp == NULL) {
-	err(126, __func__, "called with NULL arg(s)");
+	err(131, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->ioccc_id == NULL) {
-	err(128, __func__, "infop->ioccc_id is NULL");
+	err(132, __func__, "infop->ioccc_id is NULL");
 	not_reached();
     }
     if (infop->tarball == NULL) {
-	err(129, __func__, "infop->tarball is NULL");
+	err(133, __func__, "infop->tarball is NULL");
 	not_reached();
     }
     if (infop->utctime == NULL) {
-	err(130, __func__, "infop->utctime is NULL");
+	err(134, __func__, "infop->utctime is NULL");
 	not_reached();
     }
     memset(authp, 0, sizeof(*authp));
@@ -7634,14 +7677,14 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->ioccc_id = strdup(infop->ioccc_id);
     if (authp->ioccc_id == NULL) {
-	errp(131, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
+	errp(135, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
 	not_reached();
     }
     authp->submit_slot = infop->submit_slot;
     errno = 0;			/* pre-clear errno for errp() */
     authp->tarball = strdup(infop->tarball);
     if (authp->tarball == NULL) {
-	errp(132, __func__, "strdup() tarball path %s failed", infop->tarball);
+	errp(136, __func__, "strdup() tarball path %s failed", infop->tarball);
 	not_reached();
     }
     /* copy over test or non-test mode */
@@ -7663,7 +7706,7 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->utctime = strdup(infop->utctime);
     if (authp->utctime == NULL) {
-	errp(133, __func__, "strdup() utctime path %s failed", infop->utctime);
+	errp(137, __func__, "strdup() utctime path %s failed", infop->utctime);
 	not_reached();
     }
     return;
@@ -7698,14 +7741,14 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
      * firewall
      */
     if (authp == NULL || submission_dir == NULL || chkentry == NULL || fnamchk == NULL) {
-	err(134, __func__, "called with NULL arg(s)");
+	err(138, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (authp->author_count <= 0) {
-	err(135, __func__, "author_count %d <= 0", authp->author_count);
+	err(139, __func__, "author_count %d <= 0", authp->author_count);
 	not_reached();
     } else if (authp->author_count > MAX_AUTHORS) {
-	err(136, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
+	err(140, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -7717,27 +7760,27 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     auth_path = (char *)malloc(auth_path_len + 1);
     if (auth_path == NULL) {
-	errp(137, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
+	errp(141, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(auth_path, auth_path_len, "%s/%s", submission_dir, AUTH_JSON_FILENAME);
     if (ret <= 0) {
-	errp(138, __func__, "snprintf #0 error: %d", ret);
+	errp(142, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".auth.json path: %s", auth_path);
     errno = 0;			/* pre-clear errno for errp() */
     auth_stream = fopen(auth_path, "w");
     if (auth_stream == NULL) {
-	errp(139, __func__, "failed to open for writing: %s", auth_path);
+	errp(143, __func__, "failed to open for writing: %s", auth_path);
 	not_reached();
     }
 
     errno = 0; /* pre-clear errno for errp() */
     fd = open(auth_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        err(140, __func__, "failed to obtain file descriptor for: %s", auth_path);
+        err(144, __func__, "failed to obtain file descriptor for: %s", auth_path);
         not_reached();
     }
 
@@ -7760,7 +7803,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
 	json_fprintf_value_bool(auth_stream, "    ", "test_mode", " : ", authp->test_mode, ",\n") &&
 	fprintf(auth_stream, "    \"authors\" : [\n") > 0;
     if (!ret) {
-	errp(141, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
+	errp(145, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -7787,7 +7830,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
 	    json_fprintf_value_long(auth_stream, "            ", "author_number", " : ", ap->author_num, "\n") &&
 	    fprintf(auth_stream, "        }%s\n", (((i + 1) < authp->author_count) ? "," : "")) > 0;
 	if (ret == false) {
-	    errp(142, __func__, "fprintf error writing author %d info to %s", i, auth_path);
+	    errp(146, __func__, "fprintf error writing author %d info to %s", i, auth_path);
 	    not_reached();
 	}
     }
@@ -7803,7 +7846,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
 	json_fprintf_value_long(auth_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(auth_stream, "}\n") > 0;
     if (!ret) {
-	errp(143, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
+	errp(147, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -7813,7 +7856,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(auth_stream);
     if (ret < 0) {
-	errp(144, __func__, "fclose error");
+	errp(148, __func__, "fclose error");
 	not_reached();
     }
 
@@ -7829,7 +7872,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
     dbg(DBG_HIGH, "about to perform: %s -q -- %s .", chkentry, auth_path);
     exit_code = shell_cmd(__func__, false, true, "% -q -- % .", chkentry, auth_path);
     if (exit_code != 0) {
-	err(145, __func__, "%s -q -- %s . failed with exit code: %d",
+	err(149, __func__, "%s -q -- %s . failed with exit code: %d",
 			   chkentry, auth_path, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7843,7 +7886,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(146, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
+        err(150, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
         not_reached();
     }
 
@@ -7853,7 +7896,7 @@ write_auth(struct auth *authp, char const *submission_dir, char const *chkentry,
     errno = 0; /* pre-clear for errp() */
     ret = close(fd);
     if (ret < 0) {
-        errp(147, __func__, "close(fd) failed");
+        errp(151, __func__, "close(fd) failed");
         not_reached();
     }
 
@@ -7903,7 +7946,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
      */
     if (workdir == NULL || submission_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(148, __func__, "called with NULL arg(s)");
+	err(152, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -7919,7 +7962,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(149, __func__, "cannot open .");
+	errp(153, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -7929,7 +7972,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(workdir);
     if (ret < 0) {
-	errp(150, __func__, "cannot cd %s", workdir);
+	errp(154, __func__, "cannot cd %s", workdir);
 	not_reached();
     }
 
@@ -7957,7 +8000,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     exit_code = shell_cmd(__func__, false, true, "% --format=v7 -cJf % -- %",
 				    tar, basename_tarball_path, basename_submission_dir);
     if (exit_code != 0) {
-	err(151, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
+	err(155, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
 			   tar, basename_tarball_path, basename_submission_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7968,7 +8011,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(152, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(156, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -7977,7 +8020,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(153, __func__, "The compressed tarball: %s size: %ju > %jd",
+	err(157, __func__, "The compressed tarball: %s size: %ju > %jd",
 		 basename_tarball_path, (uintmax_t)buf.st_size, (intmax_t)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -7988,13 +8031,13 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(154, __func__, "cannot fchdir to the previous current directory");
+	errp(158, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(155, __func__, "close of previous current directory failed");
+	errp(159, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -8007,7 +8050,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         exit_code = shell_cmd(__func__, false, true, "% -e -w -v 1 -F % -- %/../%",
                                               txzchk, fnamchk, submission_dir, basename_tarball_path);
         if (exit_code != 0) {
-            err(156, __func__, "%s -e -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+            err(160, __func__, "%s -e -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             not_reached();
         }
@@ -8018,7 +8061,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         exit_code = shell_cmd(__func__, false, true, "% -w -v 1 -F % -- %/../%",
                                               txzchk, fnamchk, submission_dir, basename_tarball_path);
         if (exit_code != 0) {
-            err(157, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+            err(161, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             not_reached();
         }
@@ -8068,13 +8111,13 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
      * firewall
      */
     if (workdir == NULL || submission_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(158, __func__, "called with NULL arg(s)");
+	err(162, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     submission_dir_esc = cmdprintf("%", submission_dir);
     if (submission_dir_esc == NULL) {
-	err(159, __func__, "failed to cmdprintf: submission_dir");
+	err(163, __func__, "failed to cmdprintf: submission_dir");
 	not_reached();
     }
 
@@ -8087,14 +8130,14 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    rm -rf %s%s\n", submission_dir[0] == '-' ? "-- " : "", submission_dir_esc);
     if (ret <= 0) {
-	errp(160, __func__, "printf #0 error");
+	errp(164, __func__, "printf #0 error");
 	not_reached();
     }
     free(submission_dir_esc);
 
     workdir_esc = cmdprintf("%", workdir);
     if (workdir_esc == NULL) {
-	err(161, __func__, "failed to cmdprintf: workdir");
+	err(165, __func__, "failed to cmdprintf: workdir");
 	not_reached();
     }
 
@@ -8105,7 +8148,7 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, workdir[0] == '-' ? "./" : "", workdir_esc, tarball_path);
     if (ret <= 0) {
-	errp(162, __func__, "printf #2 error");
+	errp(166, __func__, "printf #2 error");
 	not_reached();
     }
     free(workdir_esc);
@@ -8177,7 +8220,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_URL);
     if (ret <= 0) {
-	errp(163, __func__, "printf error printing IOCCC_REGISTER_URL");
+	errp(167, __func__, "printf error printing IOCCC_REGISTER_URL");
 	not_reached();
     }
     para("",
@@ -8187,7 +8230,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_FAQ_URL);
     if (ret <= 0) {
-	errp(164, __func__, "printf error printing IOCCC register FAQ URL");
+	errp(168, __func__, "printf error printing IOCCC register FAQ URL");
 	not_reached();
     }
     para("",
@@ -8197,7 +8240,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n    %s\n    %s\n", IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL, IOCCC_SUBMIT_INFO_URL);
     if (ret <= 0) {
-	errp(165, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
+	errp(169, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
 	not_reached();
     }
 
@@ -8209,7 +8252,7 @@ show_registration_url(void)
     errno = 0;      /* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_STATUS_URL);
     if (ret < 0) {
-	errp(166, __func__, "printf error printing IOCCC status URL");
+	errp(170, __func__, "printf error printing IOCCC status URL");
 	not_reached();
     }
 
@@ -8246,7 +8289,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
         "after you have registered, you must upload into slot %d:\n\n\t%s/%s\n", slot_number,
         workdir, tarball_path);
     if (ret <= 0) {
-	errp(167, __func__, "printf error printing tarball path and slot number");
+	errp(171, __func__, "printf error printing tarball path and slot number");
 	not_reached();
     }
     para("",
@@ -8256,7 +8299,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
     ret = printf("    %s\n", IOCCC_SUBMIT_URL);
     if (ret < 0) {
-	errp(168, __func__, "printf error printing IOCCC submit URL");
+	errp(172, __func__, "printf error printing IOCCC submit URL");
 	not_reached();
     }
 
@@ -8267,7 +8310,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
      ret = printf("    %s\n", IOCCC_ENTER_FAQ_URL);
     if (ret < 0) {
-	errp(169, __func__, "printf error printing IOCCC enter FAQ URL");
+	errp(173, __func__, "printf error printing IOCCC enter FAQ URL");
 	not_reached();
     }
 }

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -4948,6 +4948,15 @@ is_forbidden_filename(char const *str)
         }
     }
 
+    /*
+     * also if it starts with '.' and it's not a required file that starts with
+     * a dot it is also forbidden
+     */
+    if (!is_mandatory_filename(str) && *str == '.') {
+        dbg(DBG_MED, "%s is a forbidden filename", str);
+        return true;
+    }
+
     dbg(DBG_MED, "%s is not a forbidden filename", str);
     return false;
 }
@@ -4983,6 +4992,7 @@ is_optional_filename(char const *str)
     dbg(DBG_MED, "%s is not an optional filename", str);
     return false;
 }
+
 
 /*
  * is_ignored_dirname  - check if str is an ignored directory name

--- a/soup/version.h
+++ b/soup/version.h
@@ -104,7 +104,7 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "1.1.12 2025-02-09"	/* format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "1.1.13 2025-02-12"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official chkentry version

--- a/test_ioccc/test_txzchk/bad/submit.test-1.1922598666.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-1.1922598666.txt.err
@@ -10,5 +10,7 @@ Warning: txzchk: found non-executable non-directory file test-1/.auth.json with 
 Warning: txzchk: found non-executable non-directory file test-1/prog.c with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-1/extra2 with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-1/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
+Warning: txzchk: test-1/extra1/extra2//.. (basename ..) is a forbidden filename
+Warning: txzchk: test-1/extra1/extra2/extra3/extra4: depth too deep: 5 > 4
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-1.1922598666.txt: found a total of 1 invalidly named dot file
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-1.1922598666.txt: found 12 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-1.1922598666.txt: found 14 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-1.1927515344.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-1.1927515344.txt.err
@@ -8,5 +8,6 @@ Warning: txzchk: found non-executable non-directory file test-1/.auth.json with 
 Warning: txzchk: found non-executable non-directory file test-1/prog.c with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-1/extra2 with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-1/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
+Warning: txzchk: test-1/foo/.auth.json (basename .auth.json) is an invalid dot file
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-1.1927515344.txt: found a total of 2 invalidly named dot files
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-1.1927515344.txt: found 11 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt.err
@@ -8,5 +8,6 @@ Warning: check_txz_file: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.t
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt: found non .auth.json and .info.json dot file .foo
 Warning: txzchk: found non-executable non-directory file test-4/extra2 with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-4/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt: filename test-4/.foo (basename .foo) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt: found a total of 1 invalidly named dot file
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt: found 10 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-4.9876543210.txt: found 11 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt.err
@@ -17,6 +17,8 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: foun
 Warning: txzchk: found non-executable non-directory file var/tmp/test-5/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: found incorrect top level directory in filename var/tmp/test-5/Makefile
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: found incorrect top level directory in filename var/tmp/test-5/
+Warning: txzchk: var/tmp/test-5/.auth.json (basename .auth.json) is an invalid dot file
+Warning: txzchk: var/tmp/test-5/.info.json (basename .info.json) is an invalid dot file
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: no .info.json found
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: no .auth.json found
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-5.9876543210.txt: no prog.c found

--- a/test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt.err
@@ -27,7 +27,11 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: fou
 Warning: txzchk: found non-executable non-directory file test-6//.info.json with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/Makefile with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/prog.c with wrong permissions: -rw-rw-r-- != -r--r--r--
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: filename test-6//.test.json (basename .test.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: filename test-6//.file.json (basename .file.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: found a total of 2 files with the name . in the same directory
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: filename test-6/. (basename .) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: found a total of 2 files with the name prog.c in the same directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: not all files in correct directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: found a total of 6 invalidly named dot files
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: found 31 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.16444111149.txt: found 37 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt.err
@@ -27,7 +27,11 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: foun
 Warning: txzchk: found non-executable non-directory file test-6//.info.json with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/Makefile with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/prog.c with wrong permissions: -rw-rw-r-- != -r--r--r--
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: filename test-6//.test.json (basename .test.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: filename test-6//.file.json (basename .file.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: found a total of 2 files with the name . in the same directory
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: filename test-6/. (basename .) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: found a total of 2 files with the name prog.c in the same directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: not all files in correct directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: found a total of 6 invalidly named dot files
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: found 31 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598666.txt: found 37 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt.err
@@ -27,7 +27,11 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: foun
 Warning: txzchk: found non-executable non-directory file test-6//.info.json with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/Makefile with wrong permissions: -rw-rw-r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-6/prog.c with wrong permissions: -rw-rw-r-- != -r--r--r--
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: filename test-6//.test.json (basename .test.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: filename test-6//.file.json (basename .file.json) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: found a total of 2 files with the name . in the same directory
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: filename test-6/. (basename .) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: found a total of 2 files with the name prog.c in the same directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: not all files in correct directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: found a total of 6 invalidly named dot files
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: found 31 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-6.1922598667.txt: found 37 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-7.9876543210.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-7.9876543210.txt.err
@@ -8,5 +8,6 @@ Warning: txzchk: found non-executable non-directory file test-7/.auth.json with 
 Warning: txzchk: found non-executable non-directory file test-7/prog.c with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-7/extra2 with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-7/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
+Warning: txzchk: ../../../../etc/passwd: depth too deep: 6 > 4
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-7.9876543210.txt: not all files in correct directory
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-7.9876543210.txt: found 11 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-7.9876543210.txt: found 12 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt.err
@@ -16,10 +16,10 @@ Warning: txzchk: found non-executable non-directory file test-9/prog.c with wron
 Warning: txzchk: found non-executable non-directory file test-9/extra2 with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: found empty Makefile
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename prog.orig not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename prog.orig.c not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/prog.orig (basename prog.orig) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/prog.orig.c (basename prog.orig.c) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543211.txt: found 24 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt.err
@@ -27,13 +27,14 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: foun
 Warning: txzchk: found non-executable non-directory file Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: found incorrect top level directory in filename Makefile
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: found a total of 2 files with the name . in the same directory
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename prog.orig not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename prog.orig.c not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/. (basename .) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/prog.orig (basename prog.orig) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/prog.orig.c (basename prog.orig.c) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: no Makefile found
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: not all files in correct directory
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: found a total of 2 invalidly named dot files
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: found 37 feathers stuck in the tarball
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543212.txt: found 40 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt.err
@@ -49,8 +49,8 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: fou
 Warning: txzchk: found non-executable non-directory file test-9/extra2 with wrong permissions: srw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: too many files: 39 > 31
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.98765432128.txt: found 55 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt.err
@@ -17,10 +17,10 @@ Warning: txzchk: found non-executable non-directory file test-9/extra2 with wron
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: found a non-directory non-regular non-hard-linked item: srw-r--r--  0 501    20          0 Feb  6 02:28 test-9/Makefile
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: found empty Makefile
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: srw-r--r-- != -r--r--r--
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename prog.orig not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename prog.orig.c not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/prog.orig (basename prog.orig) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/prog.orig.c (basename prog.orig.c) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543213.txt: found 25 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt.err
@@ -18,10 +18,10 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: foun
 Warning: txzchk: found non-executable non-directory file test-9/extra2 with wrong permissions: srw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: found a total of 2 files with the name extra2 in the same directory
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename prog.orig not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename prog.orig.c not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/prog.orig (basename prog.orig) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/prog.orig.c (basename prog.orig.c) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543214.txt: found 26 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt.err
@@ -15,8 +15,8 @@ Warning: txzchk: found non-executable non-directory file test-9/prog.c with wron
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: found a non-directory non-regular non-hard-linked item: srw-r--r--  0 501    20          4 Feb  6 02:28 test-9/extra2
 Warning: txzchk: found non-executable non-directory file test-9/extra2 with wrong permissions: srw-r--r-- != -r--r--r--
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543215.txt: found 21 feathers stuck in the tarball

--- a/test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt.err
+++ b/test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt.err
@@ -46,8 +46,8 @@ Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: foun
 Warning: txzchk: found non-executable non-directory file test-9/extra2 with wrong permissions: srw-r--r-- != -r--r--r--
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: too many files: 37 > 31
 Warning: txzchk: found non-executable non-directory file test-9/Makefile with wrong permissions: -rw-r--r-- != -r--r--r--
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename prog not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename README.md not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename GNUmakefile not allowed
-Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename index.html not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename test-9/prog (basename prog) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename test-9/README.md (basename README.md) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename test-9/GNUmakefile (basename GNUmakefile) not allowed
+Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: filename test-9/index.html (basename index.html) not allowed
 Warning: txzchk: ./test_ioccc/test_txzchk/bad/submit.test-9.9876543219.txt: found 52 feathers stuck in the tarball

--- a/txzchk.h
+++ b/txzchk.h
@@ -125,6 +125,9 @@ struct tarball
     uintmax_t directories;                  /* total number of subdirectories counting the required top level directory */
     uintmax_t invalid_perms;                /* total number of files with invalid permissions */
     uintmax_t total_exec_files;             /* total number of executable FILES */
+    uintmax_t invalid_dirnames;             /* number of invalid directory names */
+    uintmax_t invalid_directories;          /* invalid directory */
+    uintmax_t depth_errors;                 /* number of directories > max depth */
     uintmax_t total_feathers;		    /* number of total feathers stuck in tarball (i.e. issues found) */
 };
 


### PR DESCRIPTION
More sanity checks in `scan_topdir()` and `check_submission()`: make sure that a directory name is not the same as a required or optional filename. That does not mean that one couldn't have a subdirectory with that name but it cannot be in the top level of the submission directory.

Plug some holes in txzchk. This includes not checking the max depth of a directory (only total number of directories was checked), checking that a directory is not named a required/mandatory filename, certain other directory name checks and other such things. Rebuilt the test error files.

Improved is_forbidden_filename(): if it's not in the forbidden filenames list but it does start with a '.' and it's not a required filename like '.auth.json' or '.info.json' it is a forbidden filename (it is true that the function sane_relative_path() would pick up on this but this is defence in depth).