### PR TITLE
New util functions for #1070 and #1152

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@
 /test_ioccc/test_JSON/
 /test_ioccc/test_ioccc.log
 /test_ioccc/test_iocccsize/
-/test_ioccc/test_src/
+/test_ioccc/topdir/
 /test_ioccc/workdir/
 /test_ioccc/txzchk_test.log
 /test_ioccc/utf8_test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,31 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.33 2025-02-13
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for new
+utility functions (FTS related as well as at least one other). These FTS related
+ones are useful for both #1070 (which it now uses) and also the new issue #1152.
+Most importantly (at this time) is that we no longer use the `fts_open()` and
+`fts_read()` functions directly: instead it is `read_fts()` which is a wrapper
+to it but one can call it multiple times to get the next entry in the tree.
+Using this has multiple advantages which will be more fully realised once issue
+#1152 is being worked on (that includes possibly the new function
+`find_file()`, though theoretically #1070 could also use it - it just does not
+need to). The function `find_file()` returns the path from the directory
+searched so one can `fopen(3)` it if they wish.
+
+As a special feature of `read_fts()`, one can switch back to the original
+directory, depending on the args (all NULL / -1 except for the `int *cwd` which
+must be not NULL and `*cwd` must be >= 0); this is useful because the function,
+if `dir` != NULL (or `dirfd` is a valid directory FD) will change the directory.
+This can be used after `find_file()` as well as long as you make sure that `cwd`
+is not NULL and `*cwd` is a valid FD (the feature will call `close(*cwd)` so it
+is no longer valid until it is obtained again perhaps by another call to the
+function).
+
+Added `/test_ioccc/topdir` to .gitignore.
+
 ## Release 2.3.32 2025-02-12
 
 Remove outdated man pages.
@@ -74,8 +99,6 @@ list but it does start with a `.` and it's not a required filename like
 `.auth.json` or `.info.json` it is a forbidden filename (it is true that
 the function `sane_relative_path()` would pick up on this but this is
 defence in depth).
-
-
 
 Updated `MKIOCCCENTRY_VERSION` to `"1.2.22 2025-02-12"`.
 Updated `TXZCHK_VERSION` to `"1.1.13 2025-02-12"`.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,98 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.16 2025-02-13
+
+New util function `read_fts()` which allows one to use `fts_open()` and
+`fts_read()` in a 're-entrant' way (not strictly true: one always has to pass to
+`fts_read()` the `FTS *`) an more importantly allowing one to not have to rely
+on using `fts_open()`, checking for NULL, then in a loop using `fts_read()` etc.
+The args are as follows:
+
+```c
+ /*
+ *  dir     -   char * which is the path to chdir(2) to before opening path but
+ *              only if != NULL && *fts == NULL
+ *  dirfd   -   if dir == NULL and dirfd > 0, fchdir(2) to it, else don't change
+ *              at all
+ *  cwd     -   if != NULL set *cwd PRIOR to chdir(dir)
+ *  options -   options to pass to fts_open()
+ *  fts     -   pointer to pointer to FTS to set to return value of fts_open()
+ *  compar  -   if != NULL use it for the compar() function in fts_open(), else
+ *              use fts_cmp() (see also fts_rcmp())
+ */
+```
+
+One can use the function like:
+
+```c
+    FTS *fts = NULL;                    /* FTS stream for fts_open() */
+    FTSENT *ent = NULL;                 /* FTSENT for each item from read_fts() */
+
+    ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_PHYSICAL, &fts, fts_cmp);
+    if (ent == NULL) {
+        /* handle error */
+    }  else {
+        do {
+            /* do stuff per entry */
+        } while ((ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_PHYSICAL, &fts, fts_cmp) != NULL);
+    }
+```
+
+or so, san typos.
+
+As a useful feature if you call `fts_read()` like:
+
+```c
+read_fts(NULL, -1, &cwd, -1, NULL, NULL);
+```
+
+and `*cwd` (an `int`) is `>= 0` it'll try doing `fchdir(*cwd)` to restore the
+directory to where it started, in case a change happened (as is quite likely).
+
+The function `fts_cmp()` is like `strcmp()` with the full path of a file (from
+the directory `.` - see below) and the function `fts_rcmp()` is the opposite of
+`strcmp()` on the full path.
+
+The function (`read_fts()`) does check for specific error conditions. For more
+details read the comments or the source (until eventually the functions in
+util.c are documented better).
+
+
+Added function `find_file()` which uses `read_fts()` to find file by name (base
+name or full path) from a directory (or current working directory if not
+requested) at a specified depth (if > 0). It is:
+
+```c
+extern char const *find_file(char const *filename, char const *dir, int dirfd, int *cwd, bool base,
+        int (*compar)(const FTSENT **, const FTSENT **), int options, int count, short int depth);
+```
+
+and the `filename` arg is the name to look for, the `dir` is the directory
+(name) to switch to (if not NULL), `dirfd` is the directory FD to switch to (if
+dir is NULL or `chdir(dir)` fails), `base` indicates whether to look by basename
+or full path (relative to directory, which if dir == NULL && dirfd < 0 we do not
+change directory at all), `compar()` is the same as in `read_fts()` (not
+required, one may simply use NULL just  like in `read_fts()`), options are the
+options to pass to `read_fts()` (if <= 0 it's set to `FTS_NOCHDIR`, otherwise we
+OR options with `FTS_NOCHDIR`), `count` allows one to control which number to
+match (that is if there are two files with the same match and you want the
+second one if you use count == 2 it'll not find the second one; if count <= 0
+this check is skipped) and `depth` allows one to find files at a specific depth
+(`<= 0` means skip this check). Before returning the FTS stream is closed and
+the original directory is restored. The `cwd` if not NULL will be set (in
+`read_fts()`) to the current working directory in case one needs to restore it.
+If it's not NULL this does mean the FD is left open until it is closed.
+
+Added function `has_mode()` which is similar to `is_mode()` but it checks that
+any of the bits are set (i.e. `stat.st_mode & mode`).
+
+`util_test` tests all of these functions.
+
+
+Updated `JPARSE_REPO_VERSION` to `"2.2.16 2025-02-13"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.11 2025-02-13"`.
+
+
 ## Release 2.2.15 2025-02-12
 
 New util functions to detect other file types (besides directories and regular
@@ -7,7 +100,7 @@ files) and to check if the path's mode (as in `stat.st_mode`) is an exact mode
 (based on the file type) as well as one to return the mode of a path. The
 following functions have been added:
 
-```
+```c
 extern bool is_socket(char const *path);
 extern bool is_symlink(char const *path);
 extern bool is_chardev(char const *path);

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -20,11 +20,12 @@
 #if !defined(INCLUDE_UTIL_H)
 #    define  INCLUDE_UTIL_H
 
-
-#include <sys/types.h>
-#include <float.h> /* for long doubles */
-#include <inttypes.h> /* uintmax_t and intmax_t and perhaps SIZE_MAX */
-#include <string.h> /* for strcmp */
+#include <float.h>      /* for long doubles */
+#include <inttypes.h>   /* uintmax_t and intmax_t and perhaps SIZE_MAX */
+#include <string.h>     /* for strcmp */
+#include <sys/types.h>  /* various things */
+#include <sys/stat.h>   /* for stat(2) and others */
+#include <fts.h>        /* FTS and FTSENT */
 
 
 /*
@@ -200,8 +201,15 @@ extern bool is_dir(char const *path);
 extern bool is_read(char const *path);
 extern bool is_write(char const *path);
 extern bool is_mode(char const *path, mode_t mode);
+extern bool has_mode(char const *path, mode_t mode);
 extern mode_t filemode(char const *path);
 extern bool is_open_file_stream(FILE *stream);
+extern int fts_cmp(const FTSENT **a, const FTSENT **b);
+extern int fts_rcmp(const FTSENT **a, const FTSENT **b);
+FTSENT *read_fts(char const *dir, int dirfd, int *cwd, int options, FTS **fts,
+        int (*compar)(const FTSENT **, const FTSENT **));
+extern char const *find_file(char const *filename, char const *dir, int dirfd, int *cwd, bool base,
+        int (*compar)(const FTSENT **, const FTSENT **), int options, int count, short int depth);
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.15 2025-02-12"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.16 2025-02-13"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.7 2025-02-12"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.8 2025-02-13"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -156,12 +156,11 @@ static void warn_ungetc(void);
 static void warn_rule_2b_size(struct info *infop);
 static RuleCount check_prog_c(struct info *infop, char const *prog_c);
 static void check_ftsent(FTSENT *ent);
-static void scan_topdir(char * const *args, struct info *infop, char const *make, char const *submission_dir,
+static void scan_topdir(char *args, struct info *infop, char const *make, char const *submission_dir,
         RuleCount *size);
 static void copy_topdir(struct info *infop, char const *make, char const *submission_dir, char *topdir_path,
         char *submit_path, int topdir, int cwd, RuleCount *size);
 static void check_submission(struct info *infop, char const *submission_dir, char const *make, RuleCount *size, int cwd);
-static int fts_cmp(const FTSENT **a, const FTSENT **b);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.32 2025-02-12"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.33 2025-02-13"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.22 2025-02-12"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.23 2025-02-13"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
Sync jparse repo (https://github.com/xexyl/jparse/) to jparse/ for new utility functions (FTS related as well as at least one other). These FTS related ones are useful for both #1070 (which it now uses) and also the new issue #1152.  Most importantly (at this time) is that we no longer use the fts_open() and fts_read() functions directly: instead it is read_fts() which is a wrapper to it but one can call it multiple times to get the next entry in the tree.  Using this has multiple advantages which will be more fully realised once issue #1152 is being worked on (that includes possibly the new function find_file(), though theoretically #1070 could also use it - it just does not need to). The function find_file() returns the path from the directory searched so one can fopen(3) it if they wish.

As a special feature of read_fts(), one can switch back to the original directory, depending on the args (all NULL / -1 except for the int *cwd which must be not NULL and *cwd must be >= 0); this is useful because the function, if dir != NULL (or dirfd is a valid directory FD) will change the directory. This can be used after find_file() as well as long as you make sure that cwd is not NULL and *cwd is a valid FD (the feature will call close(*cwd) so it is no longer valid until it is obtained again perhaps by another call to the function).

Added /test_ioccc/topdir to .gitignore.