### PR TITLE
Fix issue #1159 - -i answers always answers yes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,42 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.33 2025-02-14
+
+Fix issue #1159 - -i answers always answers yes.
+
+This is absolutely **ESSENTIAL** so that we don't have to worry about changes in
+file sets that would cause problems; if any file set (that we have to confirm is
+OK) changed the answers file would be **ENTIRELY** useless because the order of
+the answers would be different (i.e. we would need an **additional** line!). To
+be helpful if `answer_yes == true` (i.e. `-y` is used or implied) and `!quiet`)
+(i.e. `-q` not use) we will warn the user that we will answer yes to every
+question (at the beginning right after the `Welcome to mkiocccentry` message).
+We use the `print` macro from `jparse/` rather than `msg()` from `dbg` or
+`printf` with a single check because it performs many more checks which is very
+important when always answering yes (perhaps the function `pr()` that `print`
+uses should allow a string without having to have a format but that's another
+matter entirely).
+
+Improved the handling of user saying 'no' to a question: namely it suggests the
+user fix their topdir (giving the absolute path we determined earlier) and
+remove the submission directory (which is under the workdir) also giving the
+absolute path determined earlier on.
+
+Note that `mkiocccentry_test.sh` already uses `-q` so we don't need to update it
+(since it's not necessary to show this stuff for tests). The reason this issue
+was not detected earlier is because the script uses `-y`. Even so the code
+`copy_topdir()` and also `check_submission()` now do `if (!answer_yes &&
+!read_answers_flag_used)` instead of just `if (!answer_yes)` (not strictly
+necessary but this adds another layer of defence in case something goes wrong).
+
+A message was incorrect too (referred to the wrong type of file).
+
+Additionally an unnecessary arg to `get_contest_id()` was removed (it was a
+pointer to `read_answers_flag_used` but that is a global variable so it's
+unnecessary to have it in the function as we can just set read/set its value as
+necessary.
+
 ## Release 2.3.33 2025-02-13
 
 Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for new

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -160,12 +160,13 @@ static void scan_topdir(char *args, struct info *infop, char const *make, char c
         RuleCount *size);
 static void copy_topdir(struct info *infop, char const *make, char const *submission_dir, char *topdir_path,
         char *submit_path, int topdir, int cwd, RuleCount *size);
-static void check_submission(struct info *infop, char const *submission_dir, char const *make, RuleCount *size, int cwd);
+static void check_submission(struct info *infop, char const *submit_path, char const *topdir_path,
+        char const *make, RuleCount *size, int cwd);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);
 static char *prompt(char const *str, size_t *lenp);
-static char *get_contest_id(bool *testp, bool *read_answers_flag_used);
+static char *get_contest_id(bool *testp);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.33 2025-02-13"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.34 2025-02-14"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.23 2025-02-13"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.24 2025-02-14"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
This is absolutely ESSENTIAL so that we don't have to worry about changes in file sets that would cause problems; if any file set (that we have to confirm is OK) changed the answers file would be ENTIRELY useless because the order of the answers would be different (i.e. we would need an additional line!). To be helpful if answer_yes == true (i.e. -y is used or implied) and !quiet) (i.e. -q not use) we will warn the user that we will answer yes to every question (at the beginning right after the Welcome to mkiocccentry message). We use the print macro from jparse/ rather than msg() from dbg or printf with a single check because it performs many more checks which is very important when always answering yes (perhaps the function pr() that print uses should allow a string without having to have a format but that's another matter entirely).

Improved the handling of user saying 'no' to a question: namely it suggests the user fix their topdir (giving the absolute path we determined earlier) and remove the submission directory (which is under the workdir) also giving the absolute path determined earlier on.

Note that mkiocccentry_test.sh already uses -q so we don't need to update it (since it's not necessary to show this stuff for tests). The reason this issue was not detected earlier is because the script uses -y. Even so the code copy_topdir() and also check_submission() now do if (!answer_yes && !read_answers_flag_used) instead of just if (!answer_yes) (not strictly necessary but this adds another layer of defence in case something goes wrong).

A message was incorrect too (referred to the wrong type of file).

Additionally an unnecessary arg to get_contest_id() was removed (it was a pointer to read_answers_flag_used but that is a global variable so it's unnecessary to have it in the function as we can just set read/set its value as necessary.