### PR TITLE
Add -I path to mkiocccentry to ignore a path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.34 2025-02-15
+
+Added `-I path` option to `mkiocccentry(1)` to ignore a path. This option can be
+specified more than once. The path is **under** the topdir (in other words if
+you have a file `topdir/foo` and you specify `topdir` as your `topdir` and you
+wish to ignore `topdir/foo` you would use `-I foo`, not `-I topdir/foo`). This
+was added because some people have files/directories in their submission
+directory that they do not want to submit (but do want in their directory) that
+would normally be included by `mkiocccentry(1)`. This has been added to help and
+the man page but not the FAQ, guidelines or rules (yet).
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for
+improvements (and fixes) to some utility functions (renamed due to the
+improvements) (one of which is used by the new feature).
+
+Update `MKIOCCCENTRY_VERSION` to `"1.2.25 2025-02-15"`.
+
+
+
 ## Release 2.3.33 2025-02-14
 
 Fix issue #1159 - -i answers always answers yes.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,32 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.18 2025-02-15
+
+Renamed and improved the `find_file*()` functions to `find_path*()` (i.e.
+`find_path()` and `find_paths()`).
+
+The functions now allow you to collect path name(s) of regular files,
+directories, symlinks and others that match `FTS_DEFAULT` rather than just
+files.
+
+The functions also have a new boolean which is an analogue to the `FTS_SEEDOT`
+flag to `fts_open()`: if it's true and the files are `.` or `..` then it will
+not be skipped; otherwise if it's false they will be (we search with a
+`path_argv` of `"."` so they are seen even without the `FTS_SEEDOT` option).
+
+There was a fix with the references to `fts_path` (in particular `fts_path + 2`)
+as not all path names are long enough. The function `append_path()` was renamed
+from `append_filename()` (this is where the problem was originally discovered).
+
+Additionally the functions (the two and also `read_fts()`) now remove the option
+`FTS_NOSTAT` as this is problematic to not have `stat(2)`.
+
+The `util_test` now adds to the list of paths a couple directories.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.10 2025-02-15"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.13 2025-02-15"`.
+
+
 ## Release 2.2.17 2025-02-14
 
 Make a new function like `find_file()` but which is more useful: it is now

--- a/jparse/test_jparse/is_available.sh
+++ b/jparse/test_jparse/is_available.sh
@@ -12,7 +12,7 @@
 #
 # "Because sometimes even the IOCCC Judges need some help." :-)
 #
-# "Because even the hard working helpers sometime need a helping hand." :-)
+# "Because even the hard working helpers sometimes need a helping hand." :-)
 #
 # Share and enjoy! :-)
 

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -100,7 +100,7 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-j 
     -s subdir		subdirectory under json_tree to find the good and bad subdirectories (def: $SUBDIR)
     -Z topdir		set path to top directory
     -k			keep temporary files on exit (def: remove temporary files before exiting)
-    -f			extra files specified must fail check, not pass (def: must $PASS_FAIL)
+    -f			extra files specified must FAIL check, not pass (def: must $PASS_FAIL)
     -L			skip the error location reporting (def: do not skip)
     -F			file args are files to test as files, not JSON documents per line (def: process as strings)
 
@@ -493,27 +493,27 @@ run_location_err_test()
     fi
 
     if [[ ! -e $jparse_err_file ]]; then
-	echo "$0: in run_location_err_test: jparse_err_file not found for test that must fail: $jparse_err_file"
+	echo "$0: in run_location_err_test: jparse_err_file not found for test that must FAIL: $jparse_err_file"
 	exit 41
     fi
     if [[ ! -f $jparse_err_file ]]; then
-	echo "$0: in run_location_err_test: jparse_err_file not a regular file for test that must fail: $jparse_err_file"
+	echo "$0: in run_location_err_test: jparse_err_file not a regular file for test that must FAIL: $jparse_err_file"
 	exit 42
     fi
     if [[ ! -r $jparse_err_file ]]; then
-	echo "$0: in run_location_err_test: jparse_err_file not readable for test that must fail: $jparse_err_file"
+	echo "$0: in run_location_err_test: jparse_err_file not readable for test that must FAIL: $jparse_err_file"
 	exit 43
     fi
     # debugging
     #
     if [[ $V_FLAG -ge 9 ]]; then
-	echo "$0: debug[9]: in run_location_err_test: test must fail"
+	echo "$0: debug[9]: in run_location_err_test: test must FAIL"
 	echo "$0: debug[9]: in run_location_err_test: jparse: $JPARSE" 1>&2
 	echo "$0: debug[9]: in run_location_err_test: jparse_test_file: $jparse_test_file" 1>&2
     fi
 
     if [[ $V_FLAG -ge 3 ]]; then
-	echo "$0: debug[3]: about to run test that must fail: $JPARSE -- $jparse_test_file >> ${LOGFILE} 2>$TMP_STDERR_FILE" 1>&2
+	echo "$0: debug[3]: about to run test that must FAIL: $JPARSE -- $jparse_test_file >> ${LOGFILE} 2>$TMP_STDERR_FILE" 1>&2
     fi
 
     "$JPARSE" -- "$jparse_test_file" 2>"$TMP_STDERR_FILE" | tee -a -- "${LOGFILE}"
@@ -608,13 +608,13 @@ run_file_test()
     #
     if [[ $status -eq 0 ]]; then
 	if [[ $pass_fail = pass ]]; then
-	    echo "$0: in test that must pass: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    echo "$0: in test that must PASS: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	    fi
 	else
 	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: in test that must fail: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		echo "$0: in test that must FAIL: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 		if [[ $V_FLAG -ge 3 ]]; then
 		    echo "$0: debug[3]: in run_file_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 		fi
@@ -628,7 +628,7 @@ run_file_test()
     else
 	if [[ $pass_fail = pass ]]; then
 	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: in test that must pass: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+		echo "$0: in test that must PASS: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 		if [[ $V_FLAG -ge 3 ]]; then
 		    echo "$0: debug[3]: in run_file_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 		fi
@@ -637,7 +637,7 @@ run_file_test()
 	    EXIT_CODE=1
 	else
 	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: in test that must fail: jparse OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+		echo "$0: in test that must FAIL: jparse OK, exit code: $status" 1>&2 >> "${LOGFILE}"
 		if [[ $V_FLAG -ge 3 ]]; then
 		    echo "$0: debug[3]: in run_file_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 		fi
@@ -684,15 +684,15 @@ run_print_test()
 
     if [[ -z $quiet_mode ]]; then
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must pass: $print_test -v $dbg_level >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must PASS: $print_test -v $dbg_level >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: debug[3]: about to run test that must pass: $print_test -v $dbg_level >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	echo "$0: debug[3]: about to run test that must PASS: $print_test -v $dbg_level >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
 	"$print_test" -v "$dbg_level" >> "${LOGFILE}" 2>&1
     else
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must pass: $print_test -v $dbg_level -q >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must PASS: $print_test -v $dbg_level -q >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: debug[3]: about to run test that must pass: $print_test -v $dbg_level -q >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	echo "$0: debug[3]: about to run test that must PASS: $print_test -v $dbg_level -q >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
 	"$print_test" -v "$dbg_level" -q >> "${LOGFILE}" 2>&1
     fi
     status="$?"
@@ -700,12 +700,12 @@ run_print_test()
     # examine test result
     #
     if [[ $status -eq 0 ]]; then
-	echo "$0: in test that must pass: print_test OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	echo "$0: in test that must PASS: print_test OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	if [[ $V_FLAG -ge 3 ]]; then
 	    echo "$0: debug[3]: print_test OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	fi
     else
-	echo "$0: in test that must pass: print_test FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	echo "$0: in test that must PASS: print_test FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 	PRINT_TEST_FAILURE="1"
 	EXIT_CODE=1
     fi
@@ -728,7 +728,7 @@ run_print_test()
 #	json_dbg_level		JSON parser debug level to use in: jparse -J json_dbg_level
 #	quiet_mode		quiet mode to use in: jparse -q
 #	json_doc_string		JSON document as a string to give to jparse
-#	pass_fail		if "pass" then tests must pass, otherwise if "fail" they must fail
+#	pass_fail		if "pass" then tests must PASS, otherwise if "fail" they must FAIL
 #
 run_string_test()
 {
@@ -778,12 +778,12 @@ run_string_test()
     #
     if [[ $status -eq 0 ]]; then
 	if [[ $pass_fail = pass ]]; then
-	    echo "$0: in test that must pass: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
+	    echo "$0: in test that must PASS: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: jparse OK, exit code 0" 1>&2 >> "${LOGFILE}"
 	    fi
 	else
-	    echo "$0: in test that must fail: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    echo "$0: in test that must FAIL: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 	    fi
@@ -792,14 +792,14 @@ run_string_test()
 	fi
     else
 	if [[ $pass_fail = pass ]]; then
-	    echo "$0: in test that must pass: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    echo "$0: in test that must PASS: jparse FAIL, exit code: $status" 1>&2 >> "${LOGFILE}"
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 	    fi
 	    update_string_summary "$json_doc_string"
 	    EXIT_CODE=1
 	else
-	    echo "$0: in test that must fail: jparse OK, exit code: $status" 1>&2 >> "${LOGFILE}"
+	    echo "$0: in test that must FAIL: jparse OK, exit code: $status" 1>&2 >> "${LOGFILE}"
 	    if [[ $V_FLAG -ge 3 ]]; then
 		echo "$0: debug[3]: in run_string_test: jparse exit code: $status" 1>&2 >> "${LOGFILE}"
 	    fi
@@ -914,25 +914,25 @@ fi
 #
 if [[ -n "$D_FLAG" ]]; then
     if [[ $V_FLAG -ge 3 ]]; then
-	echo "$0: debug[3]: about to run jparse tests that must pass: JSON files" 1>&2 >> "${LOGFILE}"
+	echo "$0: debug[3]: about to run jparse tests that must PASS: JSON files" 1>&2 >> "${LOGFILE}"
     fi
 
-    # run tests that must pass
+    # run tests that must PASS
     while read -r file; do
 	run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
     done < <(find "$JSON_GOOD_TREE" -type f -name '*.json' -print)
 
 
-    # run tests that must fail
+    # run tests that must FAIL
     #
     if [[ $V_FLAG -ge 3 ]]; then
-	echo "$0: debug[3]: about to run jparse tests that must fail: JSON files" 1>&2 >> "${LOGFILE}"
+	echo "$0: debug[3]: about to run jparse tests that must FAIL: JSON files" 1>&2 >> "${LOGFILE}"
     fi
     while read -r file; do
 	run_file_test "$JPARSE" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
     done < <(find "$JSON_BAD_TREE" -type f -name '*.json' -print)
 
-    # run tests that must fail with correct error locations, if -L not used
+    # run tests that must FAIL with correct error locations, if -L not used
     if [[ -z "$L_FLAG" ]]; then
 	while read -r file; do
 	    run_location_err_test "$file"

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1687,7 +1687,7 @@ read_fts(char const *dir, int dirfd, int *cwd, int options, FTS **fts,
             return ent;
         }
     } else {
-        err(139, __func__, "*fts is NULL when it shouldn't be");
+        err(138, __func__, "*fts is NULL when it shouldn't be");
         not_reached();
     }
     return NULL;
@@ -1800,14 +1800,14 @@ find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
      */
     ent = read_fts(dir, dirfd, cwd, options, &fts, cmp);
     if (ent == NULL){
-        err(140, __func__, "failed to open \".\"");
+        err(139, __func__, "failed to open \".\"");
         not_reached();
     } else {
         i = 0;
         do {
             if ((depth > 0 && ent->fts_level != depth) ||
-                    (ent->fts_info != FTS_D && ent->fts_info != FTS_F && ent->fts_info != FTS_DEFAULT) &&
-                    ent->fts_info != FTS_SL) {
+                    (ent->fts_info != FTS_D && ent->fts_info != FTS_F && ent->fts_info != FTS_DEFAULT &&
+                    ent->fts_info != FTS_SL)) {
                 continue;
             } else if (!seedot && (!strcmp(ent->fts_name, ".") || !strcmp(ent->fts_name, ".."))) {
                 continue;
@@ -1833,7 +1833,7 @@ find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
                         errno = 0; /* pre-clear errno for errp() */
                         path_found = strdup(ent->fts_path + offset);
                         if (path_found == NULL) {
-                            errp(141, __func__, "failed to strdup(\"%s\")", ent->fts_path + offset);
+                            errp(140, __func__, "failed to strdup(\"%s\")", ent->fts_path + offset);
                             not_reached();
                         }
                         /*
@@ -1862,7 +1862,7 @@ find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
                         errno = 0; /* pre-clear errno for errp() */
                         path_found = strdup(ent->fts_path + offset);
                         if (path_found == NULL) {
-                            errp(142, __func__, "failed to strdup(\"%s\")", ent->fts_path + offset);
+                            errp(141, __func__, "failed to strdup(\"%s\")", ent->fts_path + offset);
                             not_reached();
                         }
 
@@ -1927,11 +1927,11 @@ append_path(struct dyn_array **paths, char *str, bool unique, bool duped)
      * firewall
      */
     if (paths == NULL) {
-	err(143, __func__, "paths is NULL");
+	err(142, __func__, "paths is NULL");
 	not_reached();
     }
     if (str == NULL) {
-	err(144, __func__, "str is NULL");
+	err(143, __func__, "str is NULL");
 	not_reached();
     }
 
@@ -1941,7 +1941,7 @@ append_path(struct dyn_array **paths, char *str, bool unique, bool duped)
          */
         *paths  = dyn_array_create(sizeof(char *), 64, 64, true);
         if (*paths == NULL) {
-            err(145, __func__, "failed to create paths paths");
+            err(144, __func__, "failed to create paths paths");
             not_reached();
         }
     }
@@ -1965,7 +1965,7 @@ append_path(struct dyn_array **paths, char *str, bool unique, bool duped)
             /* get next string pointer */
             u = dyn_array_value(*paths, char *, i);
             if (u == NULL) {	/* paranoia */
-                err(146, __func__, "found NULL pointer in paths dynamic array element: %ju", (uintmax_t)i);
+                err(145, __func__, "found NULL pointer in paths dynamic array element: %ju", (uintmax_t)i);
                 not_reached();
             }
 
@@ -1985,7 +1985,7 @@ append_path(struct dyn_array **paths, char *str, bool unique, bool duped)
         errno = 0; /* pre-clear errno for errp() */
         u = strdup(str);
         if (u == NULL) {
-            errp(147, __func__, "failed to strdup(\"%s\")", str);
+            errp(146, __func__, "failed to strdup(\"%s\")", str);
             not_reached();
         }
     } else {
@@ -2084,7 +2084,7 @@ find_paths(struct dyn_array *paths, char const *dir, int dirfd, int *cwd, bool b
      * firewall
      */
     if (paths == NULL) {
-        err(148, __func__, "paths list is NULL");
+        err(147, __func__, "paths list is NULL");
         not_reached();
     }
 
@@ -2108,14 +2108,14 @@ find_paths(struct dyn_array *paths, char const *dir, int dirfd, int *cwd, bool b
      */
     ent = read_fts(dir, dirfd, cwd, options, &fts, cmp);
     if (ent == NULL){
-        err(149, __func__, "failed to open \".\"");
+        err(148, __func__, "failed to open \".\"");
         not_reached();
     } else {
         i = 0;
         do {
             if ((depth > 0 && ent->fts_level != depth) ||
-                    (ent->fts_info != FTS_D && ent->fts_info != FTS_F && ent->fts_info != FTS_DEFAULT) &&
-                    ent->fts_info != FTS_SL) {
+                    (ent->fts_info != FTS_D && ent->fts_info != FTS_F && ent->fts_info != FTS_DEFAULT &&
+                    ent->fts_info != FTS_SL)) {
                 continue;
             } else if (!seedot && (!strcmp(ent->fts_name, ".") || !strcmp(ent->fts_name, ".."))) {
                 continue;
@@ -2128,7 +2128,7 @@ find_paths(struct dyn_array *paths, char const *dir, int dirfd, int *cwd, bool b
                 for (j = 0; j < len; ++j) {
                     path = dyn_array_value(paths, char *, j);
                     if (path == NULL) {
-                        err(150, __func__, "paths[%ju] == NULL", j);
+                        err(149, __func__, "paths[%ju] == NULL", j);
                         not_reached();
                     }
 
@@ -2210,7 +2210,7 @@ filemode(char const *path)
      * firewall
      */
     if (path == NULL) {
-	err(151, __func__, "called with NULL path");
+	err(150, __func__, "called with NULL path");
 	not_reached();
     }
 
@@ -2624,7 +2624,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 	    if (ret < 0) {
 		/* exit or error return depending on abort_on_error */
 		if (abort_on_error) {
-		    errp(152, name, "fflush(stdin): error code: %d", ret);
+		    errp(151, name, "fflush(stdin): error code: %d", ret);
 		    not_reached();
 		} else {
 		    dbg(DBG_MED, "%s: called via %s: fflush(stdin) failed: %s", __func__, name, strerror(errno));
@@ -2649,7 +2649,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 	if (ret < 0) {
 	    /* exit or error return depending on abort_on_error */
 	    if (abort_on_error) {
-		errp(153, name, "fflush(stdout): error code: %d", ret);
+		errp(152, name, "fflush(stdout): error code: %d", ret);
 		not_reached();
 	    } else {
 		dbg(DBG_MED, "%s: called from %s: fflush(stdout) failed: %s", __func__, name, strerror(errno));
@@ -2673,7 +2673,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 	if (ret < 0) {
 	    /* exit or error return depending on abort_on_error */
 	    if (abort_on_error) {
-		errp(154, name, "fflush(stderr): error code: %d", ret);
+		errp(153, name, "fflush(stderr): error code: %d", ret);
 		not_reached();
 	    } else {
 		dbg(DBG_MED, "%s: called from %s: fflush(stderr) failed: %s", __func__, name, strerror(errno));
@@ -2709,7 +2709,7 @@ file_size(char const *path)
      * firewall
      */
     if (path == NULL) {
-	err(155, __func__, "called with NULL path");
+	err(154, __func__, "called with NULL path");
 	not_reached();
     }
 
@@ -3027,7 +3027,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
     if (name == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    err(156, __func__, "function name is not caller name because we were called with NULL name");
+	    err(155, __func__, "function name is not caller name because we were called with NULL name");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called with NULL name, returning: %d < 0", EXIT_NULL_ARGS);
@@ -3037,7 +3037,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
     if (format == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    err(157, name, "called with NULL format");
+	    err(156, name, "called with NULL format");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called with NULL format, returning: %d < 0", EXIT_NULL_ARGS);
@@ -3058,7 +3058,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
     if (cmd == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(158, name, "calloc failed in vcmdprintf()");
+	    errp(157, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s, returning: %d < 0",
@@ -3082,7 +3082,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
     if (exit_code < 0) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(159, __func__, "error calling system(%s)", cmd);
+	    errp(158, __func__, "error calling system(%s)", cmd);
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: error calling system(%s)", name, cmd);
@@ -3101,7 +3101,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
     } else if (exit_code == 127) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(160, __func__, "execution of the shell failed for system(%s)", cmd);
+	    errp(159, __func__, "execution of the shell failed for system(%s)", cmd);
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: execution of the shell failed for system(%s)", name, cmd);
@@ -3178,7 +3178,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
     if (name == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    err(161, __func__, "function name is not caller name because we were called with NULL name");
+	    err(160, __func__, "function name is not caller name because we were called with NULL name");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called with NULL name, returning NULL");
@@ -3188,7 +3188,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
     if (format == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    err(162, name, "called with NULL format");
+	    err(161, name, "called with NULL format");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called with NULL format, returning NULL");
@@ -3209,7 +3209,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
     if (cmd == NULL) {
 	/* exit or error return depending on abort */
 	if (abort_on_error) {
-	    errp(163, name, "calloc failed in vcmdprintf()");
+	    errp(162, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s returning: %d < 0",
@@ -3236,7 +3236,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
     if (stream == NULL) {
 	/* exit or error return depending on abort_on_error */
 	if (abort_on_error) {
-	    errp(164, name, "error calling popen(%s, \"%s\")", cmd, write_mode?"w":"r");
+	    errp(163, name, "error calling popen(%s, \"%s\")", cmd, write_mode?"w":"r");
 	    not_reached();
 	} else {
 	    dbg(DBG_MED, "called from %s: error calling popen(%s, \"%s\"): %s", name, cmd, write_mode?"w":"r", strerror(errno));
@@ -3312,7 +3312,7 @@ para(char const *line, ...)
      * firewall
      */
     if (stdout == NULL) {
-	err(165, __func__, "stdout is NULL");
+	err(164, __func__, "stdout is NULL");
 	not_reached();
     }
     clearerr(stdout);		/* pre-clear ferror() status */
@@ -3322,7 +3322,7 @@ para(char const *line, ...)
      */
     fd = fileno(stdout);
     if (fd < 0) {
-	errp(166, __func__, "fileno on stdout returned: %d < 0", fd);
+	errp(165, __func__, "fileno on stdout returned: %d < 0", fd);
 	not_reached();
     }
     clearerr(stdout);		/* paranoia */
@@ -3341,13 +3341,13 @@ para(char const *line, ...)
 	ret = fputs(line, stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(167, __func__, "error writing paragraph to a stdout");
+		errp(166, __func__, "error writing paragraph to a stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(168, __func__, "EOF while writing paragraph to a stdout");
+		err(167, __func__, "EOF while writing paragraph to a stdout");
 		not_reached();
 	    } else {
-		errp(169, __func__, "unexpected fputs error writing paragraph to stdout");
+		errp(168, __func__, "unexpected fputs error writing paragraph to stdout");
 		not_reached();
 	    }
 	}
@@ -3360,13 +3360,13 @@ para(char const *line, ...)
 	ret = fputc('\n', stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(170, __func__, "error writing newline to stdout");
+		errp(169, __func__, "error writing newline to stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(171, __func__, "EOF while writing newline to stdout");
+		err(170, __func__, "EOF while writing newline to stdout");
 		not_reached();
 	    } else {
-		errp(172, __func__, "unexpected fputc error writing newline to stdout");
+		errp(171, __func__, "unexpected fputc error writing newline to stdout");
 		not_reached();
 	    }
 	}
@@ -3391,13 +3391,13 @@ para(char const *line, ...)
     ret = fflush(stdout);
     if (ret == EOF) {
 	if (ferror(stdout)) {
-	    errp(173, __func__, "error flushing stdout");
+	    errp(172, __func__, "error flushing stdout");
 	    not_reached();
 	} else if (feof(stdout)) {
-	    err(174, __func__, "EOF while flushing stdout");
+	    err(173, __func__, "EOF while flushing stdout");
 	    not_reached();
 	} else {
-	    errp(175, __func__, "unexpected fflush error while flushing stdout");
+	    errp(174, __func__, "unexpected fflush error while flushing stdout");
 	    not_reached();
 	}
     }
@@ -3440,7 +3440,7 @@ fpara(FILE * stream, char const *line, ...)
      * firewall
      */
     if (stream == NULL) {
-	err(176, __func__, "stream is NULL");
+	err(175, __func__, "stream is NULL");
 	not_reached();
     }
 
@@ -3451,7 +3451,7 @@ fpara(FILE * stream, char const *line, ...)
     errno = 0;			/* pre-clear errno for errp() */
     fd = fileno(stream);
     if (fd < 0) {
-	errp(177, __func__, "fileno on stream returned: %d < 0", fd);
+	errp(176, __func__, "fileno on stream returned: %d < 0", fd);
 	not_reached();
     }
     clearerr(stream);		/* paranoia */
@@ -3470,13 +3470,13 @@ fpara(FILE * stream, char const *line, ...)
 	ret = fputs(line, stream);
 	if (ret == EOF) {
 	    if (ferror(stream)) {
-		errp(178, __func__, "error writing paragraph to stream");
+		errp(177, __func__, "error writing paragraph to stream");
 		not_reached();
 	    } else if (feof(stream)) {
-		err(179, __func__, "EOF while writing paragraph to stream");
+		err(178, __func__, "EOF while writing paragraph to stream");
 		not_reached();
 	    } else {
-		errp(180, __func__, "unexpected fputs error writing paragraph to stream");
+		errp(179, __func__, "unexpected fputs error writing paragraph to stream");
 		not_reached();
 	    }
 	}
@@ -3489,13 +3489,13 @@ fpara(FILE * stream, char const *line, ...)
 	ret = fputc('\n', stream);
 	if (ret == EOF) {
 	    if (ferror(stream)) {
-		errp(181, __func__, "error writing newline to stream");
+		errp(180, __func__, "error writing newline to stream");
 		not_reached();
 	    } else if (feof(stream)) {
-		err(182, __func__, "EOF while writing newline to stream");
+		err(181, __func__, "EOF while writing newline to stream");
 		not_reached();
 	    } else {
-		errp(183, __func__, "unexpected fputc error writing newline to stream");
+		errp(182, __func__, "unexpected fputc error writing newline to stream");
 		not_reached();
 	    }
 	}
@@ -3520,13 +3520,13 @@ fpara(FILE * stream, char const *line, ...)
     ret = fflush(stream);
     if (ret == EOF) {
 	if (ferror(stream)) {
-	    errp(184, __func__, "error flushing stream");
+	    errp(183, __func__, "error flushing stream");
 	    not_reached();
 	} else if (feof(stream)) {
-	    err(185, __func__, "EOF while flushing stream");
+	    err(184, __func__, "EOF while flushing stream");
 	    not_reached();
 	} else {
-	    errp(186, __func__, "unexpected fflush error while flushing stream");
+	    errp(185, __func__, "unexpected fflush error while flushing stream");
 	    not_reached();
 	}
     }
@@ -3720,7 +3720,7 @@ readline(char **linep, FILE * stream)
      * firewall
      */
     if (linep == NULL || stream == NULL) {
-	err(187, __func__, "called with NULL arg(s)");
+	err(186, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3735,10 +3735,10 @@ readline(char **linep, FILE * stream)
 	    dbg(DBG_VVHIGH, "EOF detected in getline");
 	    return -1; /* EOF found */
 	} else if (ferror(stream)) {
-	    errp(188, __func__, "getline() error");
+	    errp(187, __func__, "getline() error");
 	    not_reached();
 	} else {
-	    errp(189, __func__, "unexpected getline() error");
+	    errp(188, __func__, "unexpected getline() error");
 	    not_reached();
 	}
     }
@@ -3746,7 +3746,7 @@ readline(char **linep, FILE * stream)
      * paranoia
      */
     if (*linep == NULL) {
-	err(190, __func__, "*linep is NULL after getline()");
+	err(189, __func__, "*linep is NULL after getline()");
 	not_reached();
     }
 
@@ -3802,7 +3802,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
      * firewall
      */
     if (linep == NULL || stream == NULL) {
-	err(191, __func__, "called with NULL arg(s)");
+	err(190, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3824,7 +3824,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
     errno = 0;			/* pre-clear errno for errp() */
     ret = calloc((size_t)len+1+1, sizeof(char));
     if (ret == NULL) {
-	errp(192, __func__, "calloc of read line of %jd bytes failed", (intmax_t)len+1+1);
+	errp(191, __func__, "calloc of read line of %jd bytes failed", (intmax_t)len+1+1);
 	not_reached();
     }
     memcpy(ret, *linep, (size_t)len);
@@ -3927,7 +3927,7 @@ read_all(FILE *stream, size_t *psize)
      * firewall
      */
     if (stream == NULL) {
-	err(193, __func__, "called with NULL stream");
+	err(192, __func__, "called with NULL stream");
 	not_reached();
     }
 
@@ -4091,18 +4091,18 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      * firewall
      */
     if (src == NULL) {
-        err(194, __func__, "src path is NULL");
+        err(193, __func__, "src path is NULL");
         not_reached();
     } else if (*src == '\0') {
-        err(195, __func__, "src path is empty string");
+        err(194, __func__, "src path is empty string");
         not_reached();
     }
 
     if (dest == NULL) {
-        err(196, __func__, "dest path is NULL");
+        err(195, __func__, "dest path is NULL");
         not_reached();
     } else if (*dest == '\0') {
-        err(197, __func__, "dest path is empty string");
+        err(196, __func__, "dest path is empty string");
         not_reached();
     }
 
@@ -4110,13 +4110,13 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      * verify that src file exists
      */
     if (!exists(src)) {
-        err(198, __func__, "src file does not exist: %s", src);
+        err(197, __func__, "src file does not exist: %s", src);
         not_reached();
     } else if (!is_file(src)) {
-        err(199, __func__, "src file is not a regular file: %s", src);
+        err(198, __func__, "src file is not a regular file: %s", src);
         not_reached();
     } else if (!is_read(src)) {
-        err(200, __func__, "src file is not readable: %s", src);
+        err(199, __func__, "src file is not readable: %s", src);
         not_reached();
     }
 
@@ -4124,7 +4124,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      * verify dest path does NOT exist
      */
     if (exists(dest)) {
-        err(201, __func__, "dest file already exists: %s", dest);
+        err(200, __func__, "dest file already exists: %s", dest);
         not_reached();
     }
 
@@ -4134,7 +4134,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;      /* pre-clear errno for errp() */
     in_file = fopen(src, "rb");
     if (in_file == NULL) {
-        errp(202, __func__, "couldn't open src file %s for reading: %s", src, strerror(errno));
+        errp(201, __func__, "couldn't open src file %s for reading: %s", src, strerror(errno));
         not_reached();
     }
 
@@ -4144,7 +4144,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0; /* pre-clear errno for errp() */
     infd = open(src, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (infd < 0) {
-        errp(203, __func__, "failed to obtain file descriptor for %s: %s", src, strerror(errno));
+        errp(202, __func__, "failed to obtain file descriptor for %s: %s", src, strerror(errno));
         not_reached();
     }
 
@@ -4154,7 +4154,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;      /* pre-clear errno for errp() */
     ret = fstat(infd, &in_st);
     if (ret < 0) {
-	errp(204, __func__, "failed to get stat info for %s, stat returned: %s", src, strerror(errno));
+	errp(203, __func__, "failed to get stat info for %s, stat returned: %s", src, strerror(errno));
         not_reached();
     }
 
@@ -4168,7 +4168,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      */
     buf = read_all(in_file, &inbytes);
     if (buf == NULL) {
-        err(205, __func__, "couldn't read in src file: %s", src);
+        err(204, __func__, "couldn't read in src file: %s", src);
         not_reached();
     }
 
@@ -4180,7 +4180,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(in_file);
     if (ret < 0) {
-	errp(206, __func__, "fclose error for %s: %s", src, strerror(errno));
+	errp(205, __func__, "fclose error for %s: %s", src, strerror(errno));
 	not_reached();
     }
 
@@ -4194,7 +4194,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
             free(buf);
             buf = NULL;
         }
-        errp(207, __func__, "couldn't open dest file %s for writing: %s", dest, strerror(errno));
+        errp(206, __func__, "couldn't open dest file %s for writing: %s", dest, strerror(errno));
         not_reached();
     }
 
@@ -4204,7 +4204,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0; /* pre-clear errno for errp() */
     outfd = open(dest, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (outfd < 0) {
-        errp(208, __func__, "failed to obtain file descriptor for %s: %s", dest, strerror(errno));
+        errp(207, __func__, "failed to obtain file descriptor for %s: %s", dest, strerror(errno));
         not_reached();
     }
 
@@ -4215,7 +4215,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;		/* pre-clear errno for warnp() */
     outbytes = fwrite(buf, 1, inbytes, out_file);
     if (outbytes != inbytes) {
-        errp(209, __func__, "error: wrote %ju bytes out of expected %ju bytes",
+        errp(208, __func__, "error: wrote %ju bytes out of expected %ju bytes",
                     (uintmax_t)outbytes, (uintmax_t)inbytes);
         not_reached();
     } else {
@@ -4229,7 +4229,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(out_file);
     if (ret < 0) {
-	errp(210, __func__, "fclose error for %s: %s", dest, strerror(errno));
+	errp(209, __func__, "fclose error for %s: %s", dest, strerror(errno));
 	not_reached();
     }
 
@@ -4244,7 +4244,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
             free(buf);
             buf = NULL;
         }
-        err(211, __func__, "couldn't open dest file for reading: %s: %s", dest, strerror(errno));
+        err(210, __func__, "couldn't open dest file for reading: %s: %s", dest, strerror(errno));
         not_reached();
     }
 
@@ -4262,7 +4262,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      */
     copy = read_all(out_file, &inbytes);
     if (copy == NULL) {
-        err(212, __func__, "couldn't read in dest file: %s", dest);
+        err(211, __func__, "couldn't read in dest file: %s", dest);
         not_reached();
     }
 
@@ -4274,7 +4274,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(out_file);
     if (ret < 0) {
-	errp(213, __func__, "fclose error for %s: %s", dest, strerror(errno));
+	errp(212, __func__, "fclose error for %s: %s", dest, strerror(errno));
 	not_reached();
     }
 
@@ -4282,7 +4282,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      * first check that the bytes read in is the same as the bytes written
      */
     if (outbytes != inbytes) {
-        err(214, __func__, "error: read %ju bytes out of expected %ju bytes",
+        err(213, __func__, "error: read %ju bytes out of expected %ju bytes",
                     (uintmax_t)inbytes, (uintmax_t)outbytes);
         not_reached();
     } else {
@@ -4295,7 +4295,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
      * buffer from the dest file (copy of src file)
      */
     if (memcmp(copy, buf, inbytes) != 0) {
-        err(215, __func__, "copy of src file %s is not the same as the contents of the dest file %s", src, dest);
+        err(214, __func__, "copy of src file %s is not the same as the contents of the dest file %s", src, dest);
         not_reached();
     } else {
         dbg(DBG_HIGH, "copy of src file %s is identical to dest file %s", src, dest);
@@ -4324,7 +4324,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
         errno = 0;      /* pre-clear errno for errp() */
         ret = fchmod(outfd, in_st.st_mode);
         if (ret != 0) {
-            errp(216, __func__, "fchmod(2) failed to set source file %s mode %o on %s: %s", src, in_st.st_mode,
+            errp(215, __func__, "fchmod(2) failed to set source file %s mode %o on %s: %s", src, in_st.st_mode,
                     dest, strerror(errno));
             not_reached();
         }
@@ -4335,7 +4335,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
         errno = 0;      /* pre-clear errno for errp() */
         ret = fstat(outfd, &out_st);
         if (ret != 0) {
-            errp(217, __func__, "failed to get stat info for %s, stat returned: %s", dest, strerror(errno));
+            errp(216, __func__, "failed to get stat info for %s, stat returned: %s", dest, strerror(errno));
             not_reached();
         }
 
@@ -4343,7 +4343,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
          * we now need to verify that the modes are the same
          */
         if (in_st.st_mode != out_st.st_mode) {
-            err(218, __func__, "failed to copy st_mode %o from %s to %s: %o != %o", in_st.st_mode, src, dest, in_st.st_mode,
+            err(217, __func__, "failed to copy st_mode %o from %s to %s: %o != %o", in_st.st_mode, src, dest, in_st.st_mode,
                     out_st.st_mode);
             not_reached();
         }
@@ -4354,7 +4354,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
         errno = 0;      /* pre-clear errno for errp() */
         ret = fchmod(outfd, mode);
         if (ret != 0) {
-            errp(219, __func__, "fchmod(2) failed to set requested mode on %s: %s", dest, strerror(errno));
+            errp(218, __func__, "fchmod(2) failed to set requested mode on %s: %s", dest, strerror(errno));
             not_reached();
         }
 
@@ -4381,7 +4381,7 @@ copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode)
     errno = 0; /* pre-clear for errp() */
     ret = close(outfd);
     if (ret < 0) {
-        errp(220, __func__, "close(outfd) failed: %s", strerror(errno));
+        errp(219, __func__, "close(outfd) failed: %s", strerror(errno));
         not_reached();
     }
 
@@ -4424,20 +4424,20 @@ mkdirs(int dirfd, const char *str, mode_t mode)
      * firewall
      */
     if (str == NULL) {
-        err(221, __func__, "str (path) is NULL");
+        err(220, __func__, "str (path) is NULL");
         not_reached();
     }
 
     len = strlen(str);
     if (len <= 0) {
-        err(222, __func__, "str (path) is empty");
+        err(221, __func__, "str (path) is empty");
         not_reached();
     }
 
     errno = 0; /* pre-clear errno for errp() */
     dup = strdup(str);
     if (dup == NULL) {
-        errp(223, __func__, "duplicating \"%s\" failed", str);
+        errp(222, __func__, "duplicating \"%s\" failed", str);
         not_reached();
     }
 
@@ -4450,7 +4450,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
     errno = 0;                  /* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-        errp(224, __func__, "cannot open .");
+        errp(223, __func__, "cannot open .");
         not_reached();
     }
 
@@ -4466,7 +4466,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(dirfd) != 0) {
-        errp(225, __func__, "failed to change to parent directory");
+        errp(224, __func__, "failed to change to parent directory");
         not_reached();
     }
 
@@ -4481,7 +4481,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
         errno = 0; /* pre-clear errno for errp() */
         if (mkdir(dup, 0) != 0) {
             if (errno != EEXIST) {
-                errp(226, __func__, "mkdir() of %s failed with: %s", dup, strerror(errno));
+                errp(225, __func__, "mkdir() of %s failed with: %s", dup, strerror(errno));
                 not_reached();
             } else {
                 /*
@@ -4489,7 +4489,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                  */
                 errno = 0; /* pre-clear errno for errp */
                 if (chmod(dup, mode) != 0) {
-                    errp(227, __func__, "chmod(\"%s\", %o) failed", dup, mode);
+                    errp(226, __func__, "chmod(\"%s\", %o) failed", dup, mode);
                     not_reached();
                 } else {
                     dbg(DBG_HIGH, "set modes %o on %s", mode, dup);
@@ -4502,7 +4502,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
              */
             errno = 0; /* pre-clear errno for errp */
             if (chmod(dup, mode) != 0) {
-                errp(228, __func__, "chmod(\"%s\", %o) failed", dup, mode);
+                errp(227, __func__, "chmod(\"%s\", %o) failed", dup, mode);
                 not_reached();
             } else {
                 dbg(DBG_HIGH, "set modes %o on %s", mode, dup);
@@ -4519,7 +4519,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
         errno = 0; /* pre-clear errno for errp() */
         if (mkdir(p, 0) != 0) {
             if (errno != EEXIST) {
-                errp(229, __func__, "mkdir() of %s failed with: %s", p, strerror(errno));
+                errp(228, __func__, "mkdir() of %s failed with: %s", p, strerror(errno));
                 not_reached();
             } else {
                 /*
@@ -4527,7 +4527,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                  */
                 errno = 0; /* pre-clear errno for errp */
                 if (chmod(dup, mode) != 0) {
-                    errp(230, __func__, "chmod(\"%s\", %o) failed", dup, mode);
+                    errp(229, __func__, "chmod(\"%s\", %o) failed", dup, mode);
                     not_reached();
                 } else {
                     dbg(DBG_HIGH, "set mode %o on %s", mode, dup);
@@ -4540,7 +4540,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
              */
             errno = 0; /* pre-clear errno for errp */
             if (chmod(dup, mode) != 0) {
-                errp(231, __func__, "chmod(\"%s\", %o) failed", dup, mode);
+                errp(230, __func__, "chmod(\"%s\", %o) failed", dup, mode);
                 not_reached();
             } else {
                 dbg(DBG_HIGH, "set mode %o on %s", mode, dup);
@@ -4552,7 +4552,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
          */
         errno = 0; /* pre-clear errno for errp() */
         if (chdir(p) != 0) {
-            errp(232, __func__, "failed to change to %s", p);
+            errp(231, __func__, "failed to change to %s", p);
             not_reached();
         }
 
@@ -4563,7 +4563,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
             errno = 0; /* pre-clear errno for errp() */
             if (mkdir(p, 0) != 0) {
                 if (errno != EEXIST) {
-                    errp(233, __func__, "mkdir() of %s failed with: %s", p, strerror(errno));
+                    errp(232, __func__, "mkdir() of %s failed with: %s", p, strerror(errno));
                     not_reached();
                 } else {
                     /*
@@ -4571,7 +4571,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                      */
                     errno = 0; /* pre-clear errno for errp */
                     if (chmod(p, mode) != 0) {
-                        errp(234, __func__, "chmod(\"%s\", %o) failed", p, mode);
+                        errp(233, __func__, "chmod(\"%s\", %o) failed", p, mode);
                         not_reached();
                     } else {
                         dbg(DBG_HIGH, "set mode %o on %s", mode, p);
@@ -4583,7 +4583,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                  */
                 errno = 0; /* pre-clear errno for errp */
                 if (chmod(p, mode) != 0) {
-                    errp(235, __func__, "chmod(\"%s\", %o) failed", p, mode);
+                    errp(234, __func__, "chmod(\"%s\", %o) failed", p, mode);
                     not_reached();
                 } else {
                     dbg(DBG_HIGH, "set mode %o on %s", mode, p);
@@ -4592,7 +4592,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
             errno = 0; /* pre-clear errno for errp() */
             dir = chdir(p);
             if (dir < 0) {
-                errp(236, __func__, "failed to open directory %s", p);
+                errp(235, __func__, "failed to open directory %s", p);
                 not_reached();
             }
         }
@@ -4603,7 +4603,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(237, __func__, "failed to change back to previous directory");
+        errp(236, __func__, "failed to change back to previous directory");
         not_reached();
     }
 
@@ -4612,7 +4612,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(cwd) != 0) {
-        errp(238, __func__, "failed to close(cwd): %s", strerror(errno));
+        errp(237, __func__, "failed to close(cwd): %s", strerror(errno));
         not_reached();
     }
 
@@ -5771,7 +5771,7 @@ sane_relative_path(char const *str, uintmax_t max_path_len, uintmax_t max_filena
     errno = 0; /* pre-clear errno for errp() */
     dup = strdup(str);
     if (dup == NULL) {
-        errp(239, __func__, "duplicating \"%s\" failed", str);
+        errp(238, __func__, "duplicating \"%s\" failed", str);
         not_reached();
     }
 
@@ -6110,18 +6110,18 @@ path_has_component(char const *path, char const *name)
      * firewall
      */
     if (path == NULL) {
-        err(240, __func__, "path is NULL");
+        err(239, __func__, "path is NULL");
         not_reached();
     }
     if (name == NULL) {
-        err(241, __func__, "name is NULL");
+        err(240, __func__, "name is NULL");
         not_reached();
     }
 
     errno = 0;      /* pre-clear errno for errp() */
     path_dup = strdup(path);
     if (path_dup == NULL) {
-        errp(242, __func__, "duplicating %s failed", path);
+        errp(241, __func__, "duplicating %s failed", path);
         not_reached();
     }
 
@@ -6178,7 +6178,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
      * firewall
      */
     if (str == NULL || slash == NULL || posix_safe == NULL || first_alphanum == NULL || upper == NULL) {
-	err(243, __func__, "called with NULL arg(s)");
+	err(242, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -7267,7 +7267,7 @@ calloc_path(char const *dirname, char const *filename)
      * firewall
      */
     if (filename == NULL) {
-	err(244, __func__, "filename is NULL");
+	err(243, __func__, "filename is NULL");
 	not_reached();
     }
 
@@ -7284,7 +7284,7 @@ calloc_path(char const *dirname, char const *filename)
 	errno = 0;		/* pre-clear errno for errp() */
 	buf = strdup(filename);
 	if (buf == NULL) {
-	    errp(245, __func__, "strdup of filename failed: %s", filename);
+	    errp(244, __func__, "strdup of filename failed: %s", filename);
 	    not_reached();
 	}
 
@@ -7302,7 +7302,7 @@ calloc_path(char const *dirname, char const *filename)
 	buf = calloc(len+2, sizeof(char));	/* + 1 for paranoia padding */
 	errno = 0;		/* pre-clear errno for errp() */
 	if (buf == NULL) {
-	    errp(246, __func__, "calloc of %ju bytes failed", (uintmax_t)len);
+	    errp(245, __func__, "calloc of %ju bytes failed", (uintmax_t)len);
 	    not_reached();
 	}
 
@@ -7322,7 +7322,7 @@ calloc_path(char const *dirname, char const *filename)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = snprintf(buf, len, "%s/%s", dirname, filename);
 	if (ret < 0) {
-	    errp(247, __func__, "snprintf returned: %zu < 0", len);
+	    errp(246, __func__, "snprintf returned: %zu < 0", len);
 	    not_reached();
 	}
     }
@@ -7331,7 +7331,7 @@ calloc_path(char const *dirname, char const *filename)
      * return malloc path
      */
     if (buf == NULL) {
-	errp(248, __func__, "function attempted to return NULL");
+	errp(247, __func__, "function attempted to return NULL");
 	not_reached();
     }
     return buf;
@@ -7370,7 +7370,7 @@ open_dir_file(char const *dir, char const *file)
      * firewall
      */
     if (file == NULL) {
-	err(249, __func__, "called with NULL file");
+	err(248, __func__, "called with NULL file");
 	not_reached();
     }
 
@@ -7381,7 +7381,7 @@ open_dir_file(char const *dir, char const *file)
     errno = 0;                  /* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-        errp(10, __func__, "cannot open .");
+        errp(249, __func__, "cannot open .");
         not_reached();
     }
 
@@ -7394,15 +7394,15 @@ open_dir_file(char const *dir, char const *file)
 	 * check if we can search / work within the directory
 	 */
 	if (!exists(dir)) {
-	    err(11, __func__, "directory does not exist: %s", dir);
+	    err(10, __func__, "directory does not exist: %s", dir);
 	    not_reached();
 	}
 	if (!is_dir(dir)) {
-	    err(12, __func__, "is not a directory: %s", dir);
+	    err(11, __func__, "is not a directory: %s", dir);
 	    not_reached();
 	}
 	if (!is_exec(dir)) {
-	    err(13, __func__, "directory is not searchable: %s", dir);
+	    err(12, __func__, "directory is not searchable: %s", dir);
 	    not_reached();
 	}
 
@@ -7412,7 +7412,7 @@ open_dir_file(char const *dir, char const *file)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = chdir(dir);
 	if (ret < 0) {
-	    errp(14, __func__, "cannot cd %s", dir);
+	    errp(13, __func__, "cannot cd %s", dir);
 	    not_reached();
 	}
     }
@@ -7421,15 +7421,15 @@ open_dir_file(char const *dir, char const *file)
      * must be a readable file
      */
     if (!exists(file)) {
-	err(15, __func__, "file does not exist: %s", file);
+	err(14, __func__, "file does not exist: %s", file);
 	not_reached();
     }
     if (!is_file(file)) {
-	err(16, __func__, "file is not a regular file: %s", file);
+	err(15, __func__, "file is not a regular file: %s", file);
 	not_reached();
     }
     if (!is_read(file)) {
-	err(17, __func__, "file is not a readable file: %s", file);
+	err(16, __func__, "file is not a readable file: %s", file);
 	not_reached();
     }
 
@@ -7439,7 +7439,7 @@ open_dir_file(char const *dir, char const *file)
     errno = 0;		/* pre-clear errno for errp() */
     ret_stream = fopen(file, "r");
     if (ret_stream == NULL) {
-	errp(18, __func__, "cannot open file: %s", file);
+	errp(17, __func__, "cannot open file: %s", file);
 	not_reached();
     }
 
@@ -7454,13 +7454,13 @@ open_dir_file(char const *dir, char const *file)
 	errno = 0;                  /* pre-clear errno for errp() */
 	ret = fchdir(cwd);
 	if (ret < 0) {
-	    errp(19, __func__, "cannot fchdir to the previous current directory");
+	    errp(18, __func__, "cannot fchdir to the previous current directory");
 	    not_reached();
 	}
 	errno = 0;                  /* pre-clear errno for errp() */
 	ret = close(cwd);
 	if (ret < 0) {
-	    errp(20, __func__, "close of previous current directory failed");
+	    errp(19, __func__, "close of previous current directory failed");
 	    not_reached();
 	}
     }
@@ -7492,7 +7492,7 @@ count_char(char const *str, int ch)
      * firewall
      */
     if (str == NULL) {
-	err(21, __func__, "given NULL str");
+	err(20, __func__, "given NULL str");
 	not_reached();
     }
 
@@ -7608,7 +7608,7 @@ main(int argc, char **argv)
     while ((i = getopt(argc, argv, ":hv:J:Vqe:")) != -1) {
 	switch (i) {
 	case 'h':	/* -h - write help, to stderr and exit 0 */
-	    fprintf_usage(22, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
+	    fprintf_usage(21, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
                     JPARSE_LIBRARY_VERSION); /*ooo*/
 	    not_reached();
 	    break;
@@ -7654,19 +7654,19 @@ main(int argc, char **argv)
 	    break;
 	case ':':
 	    (void) fprintf(stderr, "%s: requires an argument -- %c\n\n", program, optopt);
-	    fprintf_usage(23, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
+	    fprintf_usage(22, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
                     JPARSE_LIBRARY_VERSION); /*ooo*/
 	    not_reached();
 	    break;
 	case '?':
 	    (void) fprintf(stderr, "%s: illegal option -- %c\n\n", program, optopt);
-	    fprintf_usage(24, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
+	    fprintf_usage(23, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION,
                     JPARSE_LIBRARY_VERSION); /*ooo*/
 	    not_reached();
 	    break;
 	default:
 	    fprintf_usage(DO_NOT_EXIT, stderr, "invalid -flag");
-	    fprintf_usage(25, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION,
+	    fprintf_usage(24, stderr, usage, program, UTIL_TEST_VERSION, JPARSE_UTILS_VERSION,
                     JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION); /*ooo*/
 	    not_reached();
 	}
@@ -7696,10 +7696,10 @@ main(int argc, char **argv)
     errno = 0; /* pre-clear errno for errp() */
     buf = calloc_path(dirname, filename);
     if (buf == NULL) {
-	errp(26, __func__, "calloc_path(%s, %s) returned NULL", dirname, filename);
+	errp(25, __func__, "calloc_path(%s, %s) returned NULL", dirname, filename);
 	not_reached();
     } else if (strcmp(buf, "foo/bar") != 0) {
-	err(27, __func__, "buf: %s != %s/%s", buf, dirname, filename);
+	err(26, __func__, "buf: %s != %s/%s", buf, dirname, filename);
 	not_reached();
     } else {
 	fdbg(stderr, DBG_MED, "calloc_path(%s, %s): returned %s", dirname, filename, buf);
@@ -7720,10 +7720,10 @@ main(int argc, char **argv)
     errno = 0; /* pre-clear errno for errp() */
     buf = calloc_path(dirname, filename);
     if (buf == NULL) {
-	errp(28, __func__, "calloc_path(NULL, %s) returned NULL", filename);
+	errp(27, __func__, "calloc_path(NULL, %s) returned NULL", filename);
 	not_reached();
     } else if (strcmp(buf, "bar") != 0) {
-	err(29, __func__, "buf: %s != %s", buf, filename);
+	err(28, __func__, "buf: %s != %s", buf, filename);
 	not_reached();
     } else {
 	fdbg(stderr, DBG_MED, "calloc_path(NULL, %s): returned %s", filename, buf);
@@ -7755,7 +7755,7 @@ main(int argc, char **argv)
      */
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_OK) {
-        err(30, __func__, "sane_relative_path(\"%s\", 99, 25, 4, fale): expected PATH_OK, got: %s",
+        err(29, __func__, "sane_relative_path(\"%s\", 99, 25, 4, fale): expected PATH_OK, got: %s",
                 relpath, path_sanity_name(sanity)); /*coo*/
         not_reached();
     } else {
@@ -7768,7 +7768,7 @@ main(int argc, char **argv)
     relpath = "foo/bar";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_OK) {
-        err(31, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_OK, got: %s",
+        err(30, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_OK, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7781,7 +7781,7 @@ main(int argc, char **argv)
     relpath = "";
     sanity = sane_relative_path(relpath, 99, 25, 2, false);
     if (sanity != PATH_ERR_PATH_EMPTY) {
-        err(32, __func__, "sane_relative_path(\"%s\", 99, 25, 2, false): expected PATH_ERR_PATH_EMPTY, got: %s",
+        err(31, __func__, "sane_relative_path(\"%s\", 99, 25, 2, false): expected PATH_ERR_PATH_EMPTY, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7794,7 +7794,7 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz";
     sanity =sane_relative_path(relpath, 2, 99, 2, false);
     if (sanity != PATH_ERR_PATH_TOO_LONG) {
-        err(33, __func__, "sane_relative_path(\"%s\", 2, 99, 2, false): expected PATH_ERR_PATH_TOO_LONG, got: %s",
+        err(32, __func__, "sane_relative_path(\"%s\", 2, 99, 2, false): expected PATH_ERR_PATH_TOO_LONG, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7807,7 +7807,7 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz";
     sanity =sane_relative_path(relpath, 0, 25, 2, false);
     if (sanity != PATH_ERR_MAX_PATH_LEN_0) {
-        err(34, __func__, "sane_relative_path(\"%s\", 0, 25, 2, false): expected PATH_ERR_MAX_PATH_LEN_0, got: %s",
+        err(33, __func__, "sane_relative_path(\"%s\", 0, 25, 2, false): expected PATH_ERR_MAX_PATH_LEN_0, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7820,7 +7820,7 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz";
     sanity = sane_relative_path(relpath, 99, 25, 0, false);
     if (sanity != PATH_ERR_MAX_DEPTH_0) {
-        err(35, __func__, "sane_relative_path(\"%s\", 99, 25, 0, false): expected PATH_ERR_MAX_DEPTH_0, got: %s",
+        err(34, __func__, "sane_relative_path(\"%s\", 99, 25, 0, false): expected PATH_ERR_MAX_DEPTH_0, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7833,7 +7833,7 @@ main(int argc, char **argv)
     relpath = "/foo";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_ERR_NOT_RELATIVE) {
-        err(36, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_RELATIVE, got: %s",
+        err(35, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_RELATIVE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7846,7 +7846,7 @@ main(int argc, char **argv)
     relpath = "aequeosalinocalcalinoceraceoaluminosocupreovitriolic"; /* 52 letter word recognised by some */
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_ERR_NAME_TOO_LONG) {
-        err(37, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NAME_TOO_LONG, got: %s",
+        err(36, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NAME_TOO_LONG, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7859,7 +7859,7 @@ main(int argc, char **argv)
     relpath = "foo";
     sanity = sane_relative_path(relpath, 99, 0, 2, false);
     if (sanity != PATH_ERR_MAX_NAME_LEN_0) {
-        err(38, __func__, "sane_relative_path(\"%s\", 99, 0, 2, false): expected PATH_ERR_MAX_NAME_LEN_0, got: %s",
+        err(37, __func__, "sane_relative_path(\"%s\", 99, 0, 2, false): expected PATH_ERR_MAX_NAME_LEN_0, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7872,7 +7872,7 @@ main(int argc, char **argv)
     relpath = "foo/bar";
     sanity = sane_relative_path(relpath, 99, 25, 1, false);
     if (sanity != PATH_ERR_PATH_TOO_DEEP) {
-        err(39, __func__, "sane_relative_path(\"%s\", 99, 25, 1, false): expected PATH_ERR_PATH_TOO_DEEP, got: %s",
+        err(38, __func__, "sane_relative_path(\"%s\", 99, 25, 1, false): expected PATH_ERR_PATH_TOO_DEEP, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7885,7 +7885,7 @@ main(int argc, char **argv)
     relpath = "foo/../";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
-        err(40, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
+        err(39, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7898,7 +7898,7 @@ main(int argc, char **argv)
     relpath = "foo/./";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
-        err(41, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
+        err(40, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7911,7 +7911,7 @@ main(int argc, char **argv)
     relpath = "./foo/";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
-        err(42, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
+        err(41, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7924,7 +7924,7 @@ main(int argc, char **argv)
     relpath = "foo1";
     sanity = sane_relative_path(relpath, 99, 25, 4, false);
     if (sanity != PATH_OK) {
-        err(43, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_OK, got: %s",
+        err(42, __func__, "sane_relative_path(\"%s\", 99, 25, 4, false): expected PATH_OK, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7937,7 +7937,7 @@ main(int argc, char **argv)
     relpath = "a/b/c/d";
     sanity = sane_relative_path(relpath, 99, 25, 3, false);
     if (sanity != PATH_ERR_PATH_TOO_DEEP) {
-        err(44, __func__, "sane_relative_path(\"%s\", 99, 25, 3, false): expected PATH_ERR_PATH_TOO_DEEP, got: %s",
+        err(43, __func__, "sane_relative_path(\"%s\", 99, 25, 3, false): expected PATH_ERR_PATH_TOO_DEEP, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7950,7 +7950,7 @@ main(int argc, char **argv)
     relpath = "./foo";
     sanity = sane_relative_path(relpath, 99, 25, 3, true);
     if (sanity != PATH_OK) {
-        err(45, __func__, "sane_relative_path(\"%s\", 99, 25, 3, true): expected PATH_OK, got: %s",
+        err(44, __func__, "sane_relative_path(\"%s\", 99, 25, 3, true): expected PATH_OK, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7963,7 +7963,7 @@ main(int argc, char **argv)
     relpath = "./foo";
     sanity = sane_relative_path(relpath, 99, 25, 3, false);
     if (sanity != PATH_ERR_NOT_POSIX_SAFE) {
-        err(46, __func__, "sane_relative_path(\"%s\", 99, 25, 3, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
+        err(45, __func__, "sane_relative_path(\"%s\", 99, 25, 3, false): expected PATH_ERR_NOT_POSIX_SAFE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7977,7 +7977,7 @@ main(int argc, char **argv)
     relpath = ".//foo";
     sanity = sane_relative_path(relpath, 99, 25, 3, true);
     if (sanity != PATH_ERR_NOT_RELATIVE) {
-        err(47, __func__, "sane_relative_path(\"%s\", 99, 25, 3, true): expected PATH_ERR_NOT_RELATIVE, got: %s",
+        err(46, __func__, "sane_relative_path(\"%s\", 99, 25, 3, true): expected PATH_ERR_NOT_RELATIVE, got: %s",
                 relpath, path_sanity_name(sanity));
         not_reached();
     } else {
@@ -7994,10 +7994,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 0);
     if (name == NULL) {
-        err(48, __func__, "dir_name(\"%s\", 0): returned NULL", relpath);
+        err(47, __func__, "dir_name(\"%s\", 0): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, relpath) != 0) {
-        err(49, __func__, "dir_name(\"%s\", 0): returned %s, expected: %s", relpath, name, relpath);
+        err(48, __func__, "dir_name(\"%s\", 0): returned %s, expected: %s", relpath, name, relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 0) == %s", relpath, relpath);
@@ -8009,10 +8009,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 1);
     if (name == NULL) {
-        err(50, __func__, "dir_name(\"%s\", 1): returned NULL", relpath);
+        err(49, __func__, "dir_name(\"%s\", 1): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo/bar/baz/zab/rab") != 0) {
-        err(51, __func__, "dir_name(\"%s\", 1): returned %s, expected: foo/bar/baz/zab/rab", relpath, name);
+        err(50, __func__, "dir_name(\"%s\", 1): returned %s, expected: foo/bar/baz/zab/rab", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 1) == foo/bar/baz/zab/rab", relpath);
@@ -8028,10 +8028,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 2);
     if (name == NULL) {
-        err(52, __func__, "dir_name(\"%s\", 2): returned NULL", relpath);
+        err(51, __func__, "dir_name(\"%s\", 2): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo/bar/baz/zab") != 0) {
-        err(53, __func__, "dir_name(\"%s\", 2): returned %s, expected: foo/bar/baz/zab", relpath, name);
+        err(52, __func__, "dir_name(\"%s\", 2): returned %s, expected: foo/bar/baz/zab", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 2) == foo/bar/baz/zab", relpath);
@@ -8047,10 +8047,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 3);
     if (name == NULL) {
-        err(54, __func__, "dir_name(\"%s\", 3): returned NULL", relpath);
+        err(53, __func__, "dir_name(\"%s\", 3): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo/bar/baz") != 0) {
-        err(55, __func__, "dir_name(\"%s\", 3): returned %s, expected: foo/bar/baz", relpath, name);
+        err(54, __func__, "dir_name(\"%s\", 3): returned %s, expected: foo/bar/baz", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 3) == foo/bar/baz", relpath);
@@ -8066,10 +8066,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 4);
     if (name == NULL) {
-        err(56, __func__, "dir_name(\"%s\", 4): returned NULL", relpath);
+        err(55, __func__, "dir_name(\"%s\", 4): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo/bar") != 0) {
-        err(57, __func__, "dir_name(\"%s\", 4): returned %s, expected: foo/bar", relpath, name);
+        err(56, __func__, "dir_name(\"%s\", 4): returned %s, expected: foo/bar", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 4) == foo/bar", relpath);
@@ -8085,10 +8085,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 5);
     if (name == NULL) {
-        err(58, __func__, "dir_name(\"%s\", 5): returned NULL", relpath);
+        err(57, __func__, "dir_name(\"%s\", 5): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo") != 0) {
-        err(59, __func__, "dir_name(\"%s\", 5): returned %s, expected: foo", relpath, name);
+        err(58, __func__, "dir_name(\"%s\", 5): returned %s, expected: foo", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 5) == foo", relpath);
@@ -8110,10 +8110,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, 6);
     if (name == NULL) {
-        err(60, __func__, "dir_name(\"%s\", 6): returned NULL", relpath);
+        err(59, __func__, "dir_name(\"%s\", 6): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo") != 0) {
-        err(61, __func__, "dir_name(\"%s\", 6): returned %s, expected: foo", relpath, name);
+        err(60, __func__, "dir_name(\"%s\", 6): returned %s, expected: foo", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", 6) == foo", relpath);
@@ -8129,10 +8129,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = dir_name(relpath, -1);
     if (name == NULL) {
-        err(62, __func__, "dir_name(\"%s\", -1): returned NULL", relpath);
+        err(61, __func__, "dir_name(\"%s\", -1): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "foo") != 0) {
-        err(63, __func__, "dir_name(\"%s\", -1): returned %s, expected: foo", relpath, name);
+        err(62, __func__, "dir_name(\"%s\", -1): returned %s, expected: foo", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "dir_name(\"%s\", -1) == foo", relpath);
@@ -8148,10 +8148,10 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz/zab/rab/oof";
     name = base_name(relpath);
     if (name == NULL) {
-        err(64, __func__, "base_name(\"%s\"): returned NULL", relpath);
+        err(63, __func__, "base_name(\"%s\"): returned NULL", relpath);
         not_reached();
     } else if (strcmp(name, "oof") != 0) {
-        err(65, __func__, "base_name(\"%s\"): returned %s, expected: oof", relpath, name);
+        err(64, __func__, "base_name(\"%s\"): returned %s, expected: oof", relpath, name);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "base_name(\"%s\") == oof", relpath);
@@ -8168,7 +8168,7 @@ main(int argc, char **argv)
     relpath = "foo/bar/baz";
     comps = count_dirs(relpath);
     if (comps != 2) {
-        err(66, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
+        err(65, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 2", relpath);
@@ -8180,7 +8180,7 @@ main(int argc, char **argv)
     relpath = "foo//baz";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(67, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(66, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8192,7 +8192,7 @@ main(int argc, char **argv)
     relpath = "///";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(68, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(67, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8204,7 +8204,7 @@ main(int argc, char **argv)
     relpath = "/";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(69, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(68, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8216,7 +8216,7 @@ main(int argc, char **argv)
     relpath = "foo///";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(70, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(69, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8228,7 +8228,7 @@ main(int argc, char **argv)
     relpath = "";
     comps = count_dirs(relpath);
     if (comps != 0) {
-        err(71, __func__, "count_dirs(\"%s\"): %ju != 0", relpath, comps);
+        err(70, __func__, "count_dirs(\"%s\"): %ju != 0", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 0", relpath);
@@ -8240,7 +8240,7 @@ main(int argc, char **argv)
     relpath = "foo/..//foo";
     comps = count_dirs(relpath);
     if (comps != 2) {
-        err(72, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
+        err(71, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 2", relpath);
@@ -8252,7 +8252,7 @@ main(int argc, char **argv)
     relpath = "foo/..//foo/3/";
     comps = count_dirs(relpath);
     if (comps != 4) {
-        err(73, __func__, "count_dirs(\"%s\"): %ju != 4", relpath, comps);
+        err(72, __func__, "count_dirs(\"%s\"): %ju != 4", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 4", relpath);
@@ -8264,7 +8264,7 @@ main(int argc, char **argv)
     relpath = "foo/../foo";
     comps = count_dirs(relpath);
     if (comps != 2) {
-        err(74, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
+        err(73, __func__, "count_dirs(\"%s\"): %ju != 2", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 2", relpath);
@@ -8276,7 +8276,7 @@ main(int argc, char **argv)
     relpath = "foo/../foo/3/";
     comps = count_dirs(relpath);
     if (comps != 4) {
-        err(75, __func__, "count_dirs(\"%s\"): %ju != 4", relpath, comps);
+        err(74, __func__, "count_dirs(\"%s\"): %ju != 4", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 4", relpath);
@@ -8288,7 +8288,7 @@ main(int argc, char **argv)
     relpath = "foo//foo";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(76, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(75, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8300,7 +8300,7 @@ main(int argc, char **argv)
     relpath = "foo//foo/3/";
     comps = count_dirs(relpath);
     if (comps != 3) {
-        err(77, __func__, "count_dirs(\"%s\"): %ju != 3", relpath, comps);
+        err(76, __func__, "count_dirs(\"%s\"): %ju != 3", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 3", relpath);
@@ -8312,7 +8312,7 @@ main(int argc, char **argv)
     relpath = "foo/foo";
     comps = count_dirs(relpath);
     if (comps != 1) {
-        err(78, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
+        err(77, __func__, "count_dirs(\"%s\"): %ju != 1", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 1", relpath);
@@ -8324,7 +8324,7 @@ main(int argc, char **argv)
     relpath = "foo/foo/3/";
     comps = count_dirs(relpath);
     if (comps != 3) {
-        err(79, __func__, "count_dirs(\"%s\"): %ju != 3", relpath, comps);
+        err(78, __func__, "count_dirs(\"%s\"): %ju != 3", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_dirs(\"%s\") == 3", relpath);
@@ -8340,7 +8340,7 @@ main(int argc, char **argv)
     relpath = "foo,bar,,,";
     comps = count_comps(relpath, ',', true);
     if (comps != 2) {
-        err(80, __func__, "count_comps(\"%s\", ',', true): %ju != 2", relpath, comps);
+        err(79, __func__, "count_comps(\"%s\", ',', true): %ju != 2", relpath, comps);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "count_comps(\"%s\", ',', true) == 2", relpath);
@@ -8351,7 +8351,7 @@ main(int argc, char **argv)
      */
     relpath = "foo/bar/baz";
     if (!path_has_component(relpath, "baz")) {
-        err(81, __func__, "path_has_component(\"%s\", \"baz\") returned false: expected true", relpath);
+        err(80, __func__, "path_has_component(\"%s\", \"baz\") returned false: expected true", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "path_has_component(\"%s\", \"baz\") == true", relpath);
@@ -8362,7 +8362,7 @@ main(int argc, char **argv)
      */
     relpath = "foo/bar/baz";
     if (!path_has_component(relpath, "bar")) {
-        err(82, __func__, "path_has_component(\"%s\", \"bar\") returned false: expected true", relpath);
+        err(81, __func__, "path_has_component(\"%s\", \"bar\") returned false: expected true", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "path_has_component(\"%s\", \"bar\") == true", relpath);
@@ -8373,7 +8373,7 @@ main(int argc, char **argv)
      */
     relpath = "foo//bar/baz";
     if (!path_has_component(relpath, "bar")) {
-        err(83, __func__, "path_has_component(\"%s\", \"bar\") returned false: expected true", relpath);
+        err(82, __func__, "path_has_component(\"%s\", \"bar\") returned false: expected true", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "path_has_component(\"%s\", \"bar\") == true", relpath);
@@ -8384,7 +8384,7 @@ main(int argc, char **argv)
      */
     relpath = "foo//bar/baz";
     if (!path_has_component(relpath, "baz")) {
-        err(84, __func__, "path_has_component(\"%s\", \"baz\") returned false: expected true", relpath);
+        err(83, __func__, "path_has_component(\"%s\", \"baz\") returned false: expected true", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "path_has_component(\"%s\", \"baz\") == true", relpath);
@@ -8395,7 +8395,7 @@ main(int argc, char **argv)
      */
     relpath = "foo//bar/.git//";
     if (!path_has_component(relpath, ".git")) {
-        err(85, __func__, "path_has_component(\"%s\", \".git\") returned false: expected true", relpath);
+        err(84, __func__, "path_has_component(\"%s\", \".git\") returned false: expected true", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "path_has_component(\"%s\", \".git\") == true", relpath);
@@ -8405,19 +8405,19 @@ main(int argc, char **argv)
     if (relpath != NULL) {
         errno = 0;  /* pre-clear errno for errp() */
         if (stat(relpath, &in_st) != 0) {
-            errp(86, __func__, "couldn't stat file %s", relpath);
+            errp(85, __func__, "couldn't stat file %s", relpath);
             not_reached();
         }
         bytes = copyfile(relpath, "util_test.copy.c", true, 0);
         fdbg(stderr, DBG_MED, "copyfile(\"%s\", \"util_test.copy.c\", true, 0): %ju bytes", relpath, (uintmax_t)bytes);
         errno = 0; /* pre-clear errno for errp() */
         if (stat("util_test.copy.c", &out_st) != 0) {
-            errp(87, __func__, "couldn't stat file util_test.copy.c");
+            errp(86, __func__, "couldn't stat file util_test.copy.c");
             not_reached();
         }
 
         if (!is_mode("util_test.copy.c", in_st.st_mode)) {
-            err(88, __func__, "copyfile() failed to copy st_mode of file %s", relpath);
+            err(87, __func__, "copyfile() failed to copy st_mode of file %s", relpath);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "copyfile() successfully copied st_mode of file %s: %o == %o", relpath,
@@ -8429,7 +8429,7 @@ main(int argc, char **argv)
          */
         errno = 0;      /* pre-clear errno for errp() */
         if (unlink("util_test.copy.c") != 0) {
-            errp(89, __func__, "unable to delete file util_test.copy.c");
+            errp(88, __func__, "unable to delete file util_test.copy.c");
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "successfully deleted copied file util_test.copy.c");
@@ -8456,12 +8456,12 @@ main(int argc, char **argv)
          */
         errno = 0;  /* pre-clear errno for errp() */
         if (stat("util_test.copy.c", &out_st) != 0) {
-            errp(90, __func__, "failed to stat util_test.copy.c");
+            errp(89, __func__, "failed to stat util_test.copy.c");
             not_reached();
         }
 
         if ((out_st.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO)) != (S_IRUSR|S_IWUSR)) {
-            err(91, __func__, "copyfile() failed to set S_IRUSR|S_IWUSR on util_test.copy.c");
+            err(90, __func__, "copyfile() failed to set S_IRUSR|S_IWUSR on util_test.copy.c");
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "copyfile() successfully set S_IRUSR|S_IWUSR on util_test.copy.c");
@@ -8471,7 +8471,7 @@ main(int argc, char **argv)
          */
         errno = 0;      /* pre-clear errno for errp() */
         if (unlink("util_test.copy.c") != 0) {
-            errp(92, __func__, "unable to delete file util_test.copy.c");
+            errp(91, __func__, "unable to delete file util_test.copy.c");
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "successfully deleted copied file util_test.copy.c");
@@ -8496,7 +8496,7 @@ main(int argc, char **argv)
      */
     errno = 0; /* pre-clear errno for errp() */
     if (stat("util.o", &in_st) != 0) {
-        errp(93, __func__, "failed to stat util.o");
+        errp(92, __func__, "failed to stat util.o");
         not_reached();
     }
     /*
@@ -8504,12 +8504,12 @@ main(int argc, char **argv)
      */
     errno = 0;  /* pre-clear errno for errp() */
     if (stat("util.copy.o", &out_st) != 0) {
-        errp(94, __func__, "failed to stat util.copy.o");
+        errp(93, __func__, "failed to stat util.copy.o");
         not_reached();
     }
 
     if (!is_mode("util.copy.o", in_st.st_mode)) {
-        err(95, __func__, "util.o st_mode != util.copy.o st_mode: %o != %o", in_st.st_mode, out_st.st_mode);
+        err(94, __func__, "util.o st_mode != util.copy.o st_mode: %o != %o", in_st.st_mode, out_st.st_mode);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "copyfile() successfully copied st_mode to dest file: %o == %o", in_st.st_mode, out_st.st_mode);
@@ -8519,7 +8519,7 @@ main(int argc, char **argv)
      */
     errno = 0;      /* pre-clear errno for errp() */
     if (unlink("util.copy.o") != 0) {
-        errp(96, __func__, "unable to delete file util.copy.o");
+        errp(95, __func__, "unable to delete file util.copy.o");
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "successfully deleted copied file util_test.copy.c");
@@ -8539,10 +8539,10 @@ main(int argc, char **argv)
     dir_exists = is_dir(relpath);
     mkdirs(-1, relpath, 0755);
     if (!exists(relpath)) {
-        err(97, __func__, "%s does not exist", relpath);
+        err(96, __func__, "%s does not exist", relpath);
         not_reached();
     } else if (!is_dir(relpath)) {
-        err(98, __func__, "%s is not a directory", relpath);
+        err(97, __func__, "%s is not a directory", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "%s is a directory", relpath);
@@ -8553,7 +8553,7 @@ main(int argc, char **argv)
      */
     if (!dir_exists) {
         if (!is_mode(relpath, 0755)) {
-            err(99, __func__, "failed to set mode of %s to %o", relpath, 0755);
+            err(98, __func__, "failed to set mode of %s to %o", relpath, 0755);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "%s is mode 07555", relpath);
@@ -8571,10 +8571,10 @@ main(int argc, char **argv)
     dir_exists = is_dir(relpath);
     mkdirs(-1, relpath, 0755);
     if (!exists(relpath)) {
-        err(100, __func__, "%s does not exist", relpath);
+        err(99, __func__, "%s does not exist", relpath);
         not_reached();
     } else if (!is_dir(relpath)) {
-        err(101, __func__, "%s is not a directory", relpath);
+        err(100, __func__, "%s is not a directory", relpath);
         not_reached();
     } else {
         fdbg(stderr, DBG_MED, "%s is a directory", relpath);
@@ -8585,7 +8585,7 @@ main(int argc, char **argv)
      */
     if (!dir_exists) {
         if (!is_mode(relpath, 0755)) {
-            err(102, __func__, "failed to set mode of %s to %o", relpath, 0755);
+            err(101, __func__, "failed to set mode of %s to %o", relpath, 0755);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "%s is mode 07555", relpath);
@@ -8595,7 +8595,7 @@ main(int argc, char **argv)
          * also check that has_mode() works with the 0755 mode we set
          */
         if (!has_mode(relpath, 0755)){
-            err(103, __func__, "%s does not have bits %0o set", relpath, 0755);
+            err(102, __func__, "%s does not have bits %0o set", relpath, 0755);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "%s has bits %0o in stat.st_mode",
@@ -8606,7 +8606,7 @@ main(int argc, char **argv)
          * also check specific bits
          */
         if (!has_mode(relpath, S_IRWXU)) {
-            err(104, __func__, "%s does not have bits %0o set", relpath, S_IRWXU);
+            err(103, __func__, "%s does not have bits %0o set", relpath, S_IRWXU);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "%s has bits %0o in stat.st_mode", relpath, S_IRWXU);
@@ -8616,7 +8616,7 @@ main(int argc, char **argv)
          * check bits not set
          */
         if (has_mode(relpath, S_ISUID)) {
-            err(105, __func__, "%s has set user id on execution", relpath);
+            err(104, __func__, "%s has set user id on execution", relpath);
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "%s does not have set user id on execution", relpath);
@@ -8654,7 +8654,7 @@ main(int argc, char **argv)
      */
     ent = read_fts("test_jparse", -1, &cwd, -1, &fts, fts_cmp);
     if (ent == NULL) {
-        err(106, __func__, "read_fts() returned a NULL pointer on \"test_jparse\"");
+        err(105, __func__, "read_fts() returned a NULL pointer on \"test_jparse\"");
         not_reached();
     } else {
         do {
@@ -8782,7 +8782,7 @@ main(int argc, char **argv)
      */
     paths_found = find_paths(paths, NULL, -1, &cwd, true, NULL, FTS_NOCHDIR, 0, 0, false);
     if (paths_found == NULL) {
-        err(107, __func__, "didn't find any paths in the paths array");
+        err(106, __func__, "didn't find any paths in the paths array");
         not_reached();
     }
 
@@ -8795,7 +8795,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(108, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(107, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -8838,7 +8838,7 @@ main(int argc, char **argv)
      */
     paths_found = find_paths(paths, NULL, -1, &cwd, true, NULL, FTS_NOCHDIR, 0, 0, true);
     if (paths_found == NULL) {
-        err(109, __func__, "didn't find any paths in the paths array");
+        err(106, __func__, "didn't find any paths in the paths array");
         not_reached();
     }
 
@@ -8851,7 +8851,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(110, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(107, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -8895,7 +8895,7 @@ main(int argc, char **argv)
      */
     paths_found = find_paths(paths, NULL, -1, &cwd, false, NULL, FTS_NOCHDIR, 0, 0, false);
     if (paths_found == NULL) {
-        err(111, __func__, "didn't find any files in the paths array");
+        err(108, __func__, "didn't find any files in the paths array");
         not_reached();
     }
 
@@ -8908,7 +8908,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(112, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(109, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -8951,7 +8951,7 @@ main(int argc, char **argv)
      */
     paths_found = find_paths(paths, NULL, -1, &cwd, true, NULL, FTS_NOCHDIR, 0, 2, false);
     if (paths_found == NULL) {
-        err(113, __func__, "didn't find any files in the paths array");
+        err(110, __func__, "didn't find any files in the paths array");
         not_reached();
     }
 
@@ -8964,7 +8964,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(114, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(111, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -9007,7 +9007,7 @@ main(int argc, char **argv)
      */
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, true, NULL, FTS_NOCHDIR, 0, 1, false);
     if (paths_found == NULL) {
-        err(115, __func__, "didn't find any files in the paths array");
+        err(112, __func__, "didn't find any files in the paths array");
         not_reached();
     }
 
@@ -9028,7 +9028,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(116, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(113, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -206,13 +206,15 @@ extern mode_t filemode(char const *path);
 extern bool is_open_file_stream(FILE *stream);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);
-FTSENT *read_fts(char const *dir, int dirfd, int *cwd, int options, FTS **fts,
-        int (*compar)(const FTSENT **, const FTSENT **));
-extern char const *find_file(char const *filename, char const *dir, int dirfd, int *cwd, bool base,
-        int (*compar)(const FTSENT **, const FTSENT **), int options, int count, short int depth);
-extern bool append_filename(struct dyn_array **array, char *str, bool unique, bool duped);
-extern struct dyn_array *find_files(struct dyn_array *filenames, char const *dir, int dirfd, int *cwd, bool base,
-        int (*compar)(const FTSENT **, const FTSENT **), int options, int count, short int depth);
+FTSENT *read_fts(char const *dir, int dirfd,
+        int *cwd, int options, FTS **fts, int (*cmp)(const FTSENT **, const FTSENT **));
+extern char const *find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
+        int (*cmp)(const FTSENT **, const FTSENT **), int options, int count,
+        short int depth, bool seedot);
+extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped);
+extern struct dyn_array *find_paths(struct dyn_array *paths,
+        char const *dir, int dirfd, int *cwd, bool base, int (*cmp)(const FTSENT **, const FTSENT **),
+        int options, int count, short int depth, bool seedot);
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.17 2025-02-14"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.18 2025-02-15"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.9 2025-02-14"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.10 2025-02-15"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -160,7 +160,7 @@ static void scan_topdir(char *args, struct info *infop, char const *make, char c
         RuleCount *size);
 static void copy_topdir(struct info *infop, char const *make, char const *submission_dir, char *topdir_path,
         char *submit_path, int topdir, int cwd, RuleCount *size);
-static void check_submission(struct info *infop, char const *submit_path, char const *topdir_path,
+static void check_submission(struct info *infop, char *submit_path, char *topdir_path,
         char const *make, RuleCount *size, int cwd);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -400,6 +400,22 @@ free_info(struct info *infop)
         infop->unsafe_dirs = NULL;
     }
 
+   /*
+     * user requested ignored files
+     */
+    if (infop->ignore_paths != NULL) {
+        len = dyn_array_tell(infop->ignore_paths);
+        for (i = 0; i < len; ++i) {
+            p = dyn_array_value(infop->ignore_paths, char *, i);
+            if (p != NULL) {
+                free(p);
+                p = NULL;
+            }
+        }
+        dyn_array_free(infop->ignore_paths);
+        infop->ignore_paths = NULL;
+    }
+
     /*
      * zeroize the info structure
      */

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -218,10 +218,10 @@ struct info
     struct dyn_array *forbidden_files;  /* forbidden files */
     struct dyn_array *unsafe_files;     /* unsafe files */
     struct dyn_array *unsafe_dirs;      /* unsafe directories */
-
+    struct dyn_array *ignore_paths;     /* list of paths user requested we ignore (-I foo -I bar) */
 
     /*
-     * file name array
+     * JSON stuff
      */
     char const *info_file;	/* .info.json filename */
     char const *auth_file;	/* .auth.json filename */

--- a/soup/is_available.sh
+++ b/soup/is_available.sh
@@ -12,7 +12,7 @@
 #
 # "Because sometimes even the IOCCC Judges need some help." :-)
 #
-# "Because even the hard working helpers sometime need a helping hand." :-)
+# "Because even the hard working helpers sometimes need a helping hand." :-)
 #
 # Share and enjoy! :-)
 

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "10 February 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "15 February 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -92,6 +92,24 @@ There are many rules and checks done in the above process that you may find in m
 \<https://www.ioccc.org/faq.html#mkiocccentry_process\>.
 .PP
 Because some might want or need to update an entry there is functionality to write your answers to a file so that you can feed the program the answers quickly; see below.
+Because some might want some files or directories in their topdir that they don't want to submit but would normally be included in the tarball by
+.BR mkiocccentry (1),
+the
+option
+.BI \-I\  path
+was added to ignore a path.
+This option can be used more than once and the
+.I path
+is the path under the topdir (in other words, if the topdir has a file called
+.BR foo ,
+you would use
+.BI \-I\  foo
+instead of
+.BI \-I\  topdir/foo\c
+\&).
+See the
+.B EXAMPLES
+section below for an example.
 .SH OPTIONS
 .TP
 .B \-h
@@ -251,6 +269,10 @@ This option cannot be used with
 or
 .B \-A\
 \&.
+This option implies
+.B \-y
+and disables some messages as well.
+Thus if you do have a file set change you should inspect your tarball after it has been formed to make sure it is still OK.
 .TP
 .BI \-s\  seed
 Generate pseudo-random answers to the questions
@@ -297,6 +319,19 @@ and
 .B \-d
 Alias for
 .BR \-s\  21701\ .
+.TP
+.BI \-I\  path
+Ignores a path from in the
+.BR topdir .
+This option can be specified multiple times.
+If used
+.BR mkiocccentry (1)
+will present you with a list of ignored paths to confirm everything is OK, unless you have used the
+.B \-i
+option.
+If the path is a directory
+.BR mkiocccentry (1)
+will not traverse it.
 .SH EXIT STATUS
 .TP
 0
@@ -390,7 +425,7 @@ If you have an issue with the tool you can open an issue at
 as a bug report or feature request.
 .SH EXAMPLES
 .PP
-Run test script:
+Run test script from the repo directory:
 .sp
 .RS
 .ft B
@@ -412,7 +447,7 @@ for future updates:
 .RS
 .ft B
  mkdir workdir
- ./mkiocccentry \-a answers workdir topdir
+ mkiocccentry \-a answers workdir topdir
 .ft R
 .RE
 .PP
@@ -420,7 +455,7 @@ Use the answers file from the previous invocation to quickly update the entry, a
 .sp
 .RS
 .ft B
- ./mkiocccentry \-i answers workdir topdir
+ mkiocccentry \-i answers workdir topdir
 .ft R
 .RE
 .PP
@@ -431,9 +466,45 @@ and
 .sp
 .RS
 .ft B
- ./mkiocccentry \-t /path/to/tar \-T /path/to/txzchk \.\.\.
+ mkiocccentry \-t /path/to/tar \-T /path/to/txzchk workdir topdir
 .ft R
 .RE
+.PP
+Assuming your topdir has the directories
+.BR little ,
+.BR little/bunny ,
+.BR little/bunny/foo ,
+.BR little/bunny/foo/foo ,
+.BR little/ham
+and the files
+.BR little/bunny/foo/foo/mouse ,
+.B little/ham/spam
+and your required files
+.BR prog.c ,
+.B Makefile
+and
+.BR remarks.md ,
+ignore directory
+.BR little/bunny/foo/foo :
+.sp
+.RS
+.ft B
+ mkiocccentry -I little/bunny/foo/foo workdir topdir
+.ft R
+.RE
+.PP
+Alternatively you could do:
+.sp
+.RS
+.ft B
+ mkiocccentry -I little/bunny/foo workdir topdir
+.ft R
+.RE
+because ignoring the path
+.B little/bunny/foo
+makes
+.BR mkiocccentry (1)
+not traverse it.
 .SH SEE ALSO
 .BR iocccsize (1),
 .BR chkentry (1),

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.34 2025-02-14"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.35 2025-02-15"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.24 2025-02-14"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.25 2025-02-15"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
    
Added -I path option to mkiocccentry(1) to ignore a path. This option can be specified more than once. The path is **under** the topdir (in other words if you have a file topdir/foo and you specify topdir as your topdir and you wish to ignore topdir/foo you would use -I foo, not -I topdir/foo). This was added because some people have files/directories in their submission directory that they do not want to submit (but do want in their directory) that would normally be included by mkiocccentry(1). This has been added to help and the man page but not the FAQ, guidelines or rules (yet).

Sync jparse repo (https://github.com/xexyl/jparse/) to jparse/ for improvements (and fixes) to some utility functions (renamed due to the improvements) (one of which is used by the new feature).

Update MKIOCCCENTRY_VERSION to "1.2.25 2025-02-15".