### PR TITLE
Multiple fixes and enhancements in jparse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.35 2025-02-16
+
+Multiple fixes and enhancements in some of the jparse util functions. Updated
+mkiocccentry for these fixes/enhancements. Note that `fts_open(3)` has to
+have either `FTS_PHYSICAL` or `FTS_LOGICAL` so the `read_fts()` function
+(prior to calling `fts_open(3)`) now removes both bits and then sets the
+right one based on the boolean. This is why it's no longer in the
+options to the function call - it would be removed anyway since we can't
+assume what is needed (for here we want `FTS_PHYSICAL` but in some cases
+it might not be desired and there was no way to be correct otherwise).
+
+There are other improvements and fixes as well.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.26 2025-02-16"`.
+
+
 ## Release 2.3.34 2025-02-15
 
 Added `-I path` option to `mkiocccentry(1)` to ignore a path. This option can be

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -429,14 +429,14 @@ count_comps(char const *str, char comp, bool remove_all)
 	not_reached();
     }
 
-    dbg(DBG_VVVHIGH, "#0: count_comps(\"%s\", %c, %s)", str, comp, booltostr(remove_all));
+    dbg(DBG_VVVHIGH, "#0: count_comps(\"%s\", %c, \"%s\")", str, comp, booltostr(remove_all));
 
     /*
      * case: empty string is 0
      */
     len = strlen(copy);
     if (len <= 0) {
-	dbg(DBG_VVHIGH, "#1: count_comps(\"%s\", %c, %s): \"%s\" is an empty string", str, comp, str,
+	dbg(DBG_VVHIGH, "#1: count_comps(\"%s\", %c, \"%s\"): \"%s\" is an empty string", str, comp, str,
                 booltostr(remove_all));
 	return 0;
     }
@@ -479,7 +479,7 @@ count_comps(char const *str, char comp, bool remove_all)
         /*
          * string is empty
          */
-	dbg(DBG_VHIGH, "#5: count_comps(\"%s\", '%c', %s) == 0", str, comp, booltostr(remove_all));
+	dbg(DBG_VHIGH, "#5: count_comps(\"%s\", '%c', \"%s\") == 0", str, comp, booltostr(remove_all));
         if (copy != NULL) {
             free(copy);
             copy = NULL;
@@ -502,7 +502,7 @@ count_comps(char const *str, char comp, bool remove_all)
              * We know this because we have removed all successive component chars
              * at the end of the string.
              */
-            dbg(DBG_VHIGH, "#6: count_comps(\"%s\", '%c', %s) == 1", str, comp, booltostr(remove_all));
+            dbg(DBG_VHIGH, "#6: count_comps(\"%s\", '%c', \"%s\") == 1", str, comp, booltostr(remove_all));
             return 1;
         } else {
             /*
@@ -526,7 +526,7 @@ count_comps(char const *str, char comp, bool remove_all)
 	/*
 	 * str does not have the component, return 1
 	 */
-	dbg(DBG_VVHIGH, "#3: count_comps(\"%s\", %c, %s) == 1", str, comp, booltostr(remove_all));
+	dbg(DBG_VVHIGH, "#3: count_comps(\"%s\", %c, \"%s\") == 1", str, comp, booltostr(remove_all));
         return 0;
     } else {
         while (p != NULL) {
@@ -556,7 +556,7 @@ count_comps(char const *str, char comp, bool remove_all)
     /*
      * return the total components
      */
-    dbg(DBG_VVHIGH, "#4: count_comps(\"%s\", %c, %s) == %ju", str, comp, booltostr(remove_all), (uintmax_t)count);
+    dbg(DBG_VVHIGH, "#4: count_comps(\"%s\", %c, \"%s\") == %ju", str, comp, booltostr(remove_all), (uintmax_t)count);
     return count;
 }
 
@@ -6580,14 +6580,14 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
      */
     if (found_unsafe == false) {
 	*posix_safe = true;
-	dbg(DBG_VVHIGH, "posix_safe_chk(\"%s\", %s, %s, %s, %s): string is NOT POSIX portable safe plus +/",
+	dbg(DBG_VVHIGH, "posix_safe_chk(\"%s\", \"%s\", \"%s\", \"%s\", \"%s\"): string is NOT POSIX portable safe plus +/",
 		str, booltostr(slash), booltostr(posix_safe), booltostr(first_alphanum), booltostr(upper));
 
     /*
      * report POSIX portable safe plus + safe with maybe /
      */
     } else {
-	dbg(DBG_VVHIGH, "posix_safe_chk(\"%s\", %s, %s, %s, %s): string is POSIX portable safe plus +/: \"%s\"",
+	dbg(DBG_VVHIGH, "posix_safe_chk(\"%s\", \"%s\", \"%s\", \"%s\", \"%s\"): string is POSIX portable safe plus +/: \"%s\"",
 		str, booltostr(slash), booltostr(posix_safe), booltostr(first_alphanum), booltostr(upper), str);
     }
     return;
@@ -7968,13 +7968,13 @@ main(int argc, char **argv)
     errno = 0; /* pre-clear errno for errp() */
     buf = calloc_path(dirname, filename);
     if (buf == NULL) {
-	errp(36, __func__, "calloc_path(\"%s\", %s) returned NULL", dirname, filename);
+	errp(36, __func__, "calloc_path(\"%s\", \"%s\") returned NULL", dirname, filename);
 	not_reached();
     } else if (strcmp(buf, "foo/bar") != 0) {
 	err(37, __func__, "buf: %s != %s/%s", buf, dirname, filename);
 	not_reached();
     } else {
-	fdbg(stderr, DBG_MED, "calloc_path(\"%s\", %s): returned %s", dirname, filename, buf);
+	fdbg(stderr, DBG_MED, "calloc_path(\"%s\", \"%s\"): returned %s", dirname, filename, buf);
     }
 
     /*
@@ -7992,13 +7992,13 @@ main(int argc, char **argv)
     errno = 0; /* pre-clear errno for errp() */
     buf = calloc_path(dirname, filename);
     if (buf == NULL) {
-	errp(38, __func__, "calloc_path(NULL, %s) returned NULL", filename);
+	errp(38, __func__, "calloc_path(NULL, \"%s\") returned NULL", filename);
 	not_reached();
     } else if (strcmp(buf, "bar") != 0) {
 	err(39, __func__, "buf: %s != %s", buf, filename);
 	not_reached();
     } else {
-	fdbg(stderr, DBG_MED, "calloc_path(NULL, %s): returned %s", filename, buf);
+	fdbg(stderr, DBG_MED, "calloc_path(NULL, \"%s\"): returned %s", filename, buf);
     }
 
     if (buf != NULL) {

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -204,17 +204,20 @@ extern bool is_mode(char const *path, mode_t mode);
 extern bool has_mode(char const *path, mode_t mode);
 extern mode_t filemode(char const *path);
 extern bool is_open_file_stream(FILE *stream);
+extern char *fts_path(FTSENT *ent);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);
-FTSENT *read_fts(char const *dir, int dirfd,
-        int *cwd, int options, FTS **fts, int (*cmp)(const FTSENT **, const FTSENT **));
+extern bool check_fts_info(FTS *fts, FTSENT *ent);
+FTSENT *read_fts(char const *dir, int dirfd, int *cwd, int options, FTS **fts,
+        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
+        bool logical);
 extern char const *find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
-        int (*cmp)(const FTSENT **, const FTSENT **), int options, int count,
-        short int depth, bool seedot);
+        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
+        int options, int count, short int depth, bool seedot, bool logical);
 extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped);
-extern struct dyn_array *find_paths(struct dyn_array *paths,
-        char const *dir, int dirfd, int *cwd, bool base, int (*cmp)(const FTSENT **, const FTSENT **),
-        int options, int count, short int depth, bool seedot);
+extern struct dyn_array *find_paths(struct dyn_array *paths, char const *dir, int dirfd, int *cwd, bool base,
+        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
+        int options, int count, short int depth, bool seedot, bool logical);
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.18 2025-02-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.19 2025-02-16"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.10 2025-02-15"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.11 2025-02-16"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -155,7 +155,7 @@ static void warn_wordbuf(void);
 static void warn_ungetc(void);
 static void warn_rule_2b_size(struct info *infop);
 static RuleCount check_prog_c(struct info *infop, char const *prog_c);
-static void check_ftsent(FTSENT *ent);
+static bool check_ent(FTS *fts, FTSENT *ent);
 static void scan_topdir(char *args, struct info *infop, char const *make, char const *submission_dir,
         RuleCount *size);
 static void copy_topdir(struct info *infop, char const *make, char const *submission_dir, char *topdir_path,

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.35 2025-02-15"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.36 2025-02-16"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.25 2025-02-15"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.26 2025-02-16"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
Multiple fixes and enhancements in some of the jparse util functions. Updated mkiocccentry for these fixes/enhancements. Note that fts_open(3) has to have either FTS_PHYSICAL or FTS_LOGICAL so the read_fts() function (prior to calling fts_open(3)) now removes both bits and then sets the right one based on the boolean. This is why it's no longer in the options to the function call - it would be removed anyway since we can't assume what is needed (for here we want FTS_PHYSICAL but in some cases it might not be desired and there was no way to be correct otherwise).

There are other improvements and fixes as well.

Updated MKIOCCCENTRY_VERSION to "1.2.26 2025-02-16".