### PR TITLE
Various fixes and enhancements to find_path*()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.3.36 2025-02-17
+
+Various fixes and further enhancements to the `find_path*()` functions in
+jparse. One in particular will very possibly be very useful for the
+`chkentry(1)` updates but it's a useful update anyway (allows filtering file
+types by an enum of bits). These were synced from the [jparse
+repo](https://github.com/xexyl/jparse/) to `jparse/`.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.27 2025-02-17"`.
+
 
 ## Release 2.3.35 2025-02-16
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -167,7 +167,8 @@ typedef unsigned char bool;
 /*
  * for the path sanity functions
  */
-enum path_sanity {
+enum path_sanity
+{
     PATH_ERR_UNKNOWN = 0,               /* unknown error code (default in switch) */
     PATH_OK,                            /* path (str) is a sane relative path */
     PATH_ERR_PATH_IS_NULL,              /* path string (str) is NULL */
@@ -180,6 +181,21 @@ enum path_sanity {
     PATH_ERR_MAX_NAME_LEN_0,            /* max filename length <= 0 */
     PATH_ERR_PATH_TOO_DEEP,             /* current depth > max_depth */
     PATH_ERR_NOT_POSIX_SAFE             /* invalid/not sane path component */
+};
+
+/*
+ * enum for the find_path() functions (bits to be ORed)
+ */
+enum fts_type
+{
+    FTS_TYPE_ANY        = 0,        /* all types of files allowed */
+    FTS_TYPE_FILE       = 1,        /* regular files type allowed */
+    FTS_TYPE_DIR        = 2,        /* directories allowed */
+    FTS_TYPE_SYMLINK    = 4,        /* symlinks allowed */
+    FTS_TYPE_SOCK       = 8,        /* sockets allowed */
+    FTS_TYPE_CHAR       = 16,       /* character devices allowed */
+    FTS_TYPE_BLOCK      = 32,       /* block devices allowed */
+    FTS_TYPE_FIFO       = 64        /* FIFO allowed */
 };
 
 /*
@@ -208,16 +224,18 @@ extern char *fts_path(FTSENT *ent);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);
 extern bool check_fts_info(FTS *fts, FTSENT *ent);
-FTSENT *read_fts(char const *dir, int dirfd, int *cwd, int options, FTS **fts,
-        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
-        bool logical);
-extern char const *find_path(char const *path, char const *dir, int dirfd, int *cwd, bool base,
-        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
-        int options, int count, short int depth, bool seedot, bool logical);
+FTSENT *read_fts(char *dir, int dirfd, int *cwd, int options, bool logical, FTS **fts,
+        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *));
+extern char const *find_path(char const *path, char *dir, int dirfd, int *cwd,
+        int options, bool logical, enum fts_type type, int count, int depth,
+        bool base, bool seedot, int (*cmp)(const FTSENT **, const FTSENT **),
+        bool(*check)(FTS *, FTSENT *));
 extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped);
-extern struct dyn_array *find_paths(struct dyn_array *paths, char const *dir, int dirfd, int *cwd, bool base,
-        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *),
-        int options, int count, short int depth, bool seedot, bool logical);
+extern void free_paths_array(struct dyn_array **paths, bool only_empty);
+extern struct dyn_array *find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd,
+        int options, bool logical, enum fts_type type, int count, int depth,
+        bool base, bool seedot, int (*cmp)(const FTSENT **, const FTSENT **),
+        bool(*check)(FTS *, FTSENT *));
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.19 2025-02-16"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.20 2025-02-17"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.11 2025-02-16"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.12 2025-02-17"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1374,7 +1374,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
      * now that we have changed to the correct directory and gathered everything
      * we need to scan for files and directories, we can traverse the tree.
      */
-    ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, &fts, fts_cmp, check_ent, false);
+    ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, false, &fts, fts_cmp, check_ent);
     if (ent == NULL){
         err(50, __func__, "failed to open \".\"");
         not_reached();
@@ -1710,7 +1710,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     break;
             }
         }
-        while ((ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, &fts, fts_cmp, check_ent, false)) != NULL);
+        while ((ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, false, &fts, fts_cmp, check_ent)) != NULL);
     }
 
     /*
@@ -2623,7 +2623,7 @@ check_submission(struct info *infop, char *submit_path, char *topdir_path,
      * clobber, we need to verify that the topdir matches what is in the
      * submission directory. If anything is out of order it is an error.
      */
-    ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR, &fts, fts_cmp, check_ent, false);
+    ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR, false, &fts, fts_cmp, check_ent);
     if (ent == NULL){
         err(147, __func__, "failed to open \".\"");
         not_reached();
@@ -2890,7 +2890,7 @@ check_submission(struct info *infop, char *submit_path, char *topdir_path,
                 default:
                     break;
             }
-        } while ((ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, &fts, fts_cmp, check_ent, false)) != NULL);
+        } while ((ent = read_fts(NULL, -1, NULL, FTS_NOCHDIR | FTS_NOSTAT, false, &fts, fts_cmp, check_ent)) != NULL);
     }
 
     /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.36 2025-02-16"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.37 2025-02-17"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.26 2025-02-16"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.27 2025-02-17"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
Various fixes and further enhancements to the find_path*() functions in jparse. One in particular will very possibly be very useful for the chkentry(1) updates but it's a useful update anyway (allows filtering file types by an enum of bits). These were synced from the jparse repo (https://github.com/xexyl/jparse/) to jparse/.

Updated MKIOCCCENTRY_VERSION to "1.2.27 2025-02-17".