### PR TITLE
Bug fixes in mkiocccentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,15 @@ the documentation on the website too.
 Clean up some usage messages to be shorter (in some ways) especially the length
 of lines (some formatting fixes were also made).
 
+Bug fix in `mkiocccentry` - check for NULL or empty workdir and topdir.
+
+Change mkiocccentry arg count check to be exact as we no longer use extra args
+(though it didn't hurt to have them it might be better to be clear to the user).
+This required updating `mkiocccentry_test.sh` as well.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.29 2025-02-20"`.
+Updated `MKIOCCCENTRY_TEST_VERSION` to `"1.0.12 2025-02-20"`.
+
 
 ## Release 2.3.37 2025-02-19
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -387,8 +387,9 @@ main(int argc, char *argv[])
 	    break;
 	}
     }
-    /* must have at least the required number of args */
-    if (argc - optind < REQUIRED_ARGS) {
+
+    /* must have the required number of args */
+    if (argc - optind != REQUIRED_ARGS) {
 	usage(3, program, "wrong number of arguments"); /*ooo*/
 	not_reached();
     }
@@ -495,12 +496,17 @@ main(int argc, char *argv[])
     dbg(DBG_MED, "tar: %s", tar);
     dbg(DBG_MED, "ls: %s", ls);
     workdir = argv[optind];
-    dbg(DBG_MED, "workdir: %s", workdir);
     topdir = argv + optind + REQUIRED_ARGS - 1;
-    if (topdir == NULL) {
-        err(245, __func__, "topdir is NULL");
+    if (workdir == NULL || *workdir == '\0') {
+        err(3, __func__, "workdir is NULL or empty string");/*ooo*/
         not_reached();
     }
+    dbg(DBG_MED, "workdir: %s", workdir);
+    if (topdir == NULL || *topdir == NULL || **topdir == '\0') {
+        err(3, __func__, "topdir is NULL or empty string");/*ooo*/
+        not_reached();
+    }
+    dbg(DBG_MED, "topdir: %s", *topdir);
     if (answers != NULL) {
         dbg(DBG_MED, "answers file: %s", answers);
     }

--- a/soup/version.h
+++ b/soup/version.h
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.28 2025-02-19"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.29 2025-02-20"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -76,7 +76,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="1.0.11 2025-02-12"
+export MKIOCCCENTRY_TEST_VERSION="1.0.12 2025-02-20"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit
@@ -354,7 +354,7 @@ find "${workdir_esc}" -mindepth 1 -depth -delete
 rm -f "${src_dir}"/prog.c
 :> "${src_dir}"/prog.c
 # test empty prog.c, ignoring the warning about it
-./mkiocccentry -y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}" "${src_dir}"/{extra1,extra2}
+./mkiocccentry -y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -444,7 +444,7 @@ answers >>answers.txt
 
 # run the test, looking for an exit
 #
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}" "${src_dir}"/{extra1,extra2}
+./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -530,7 +530,7 @@ test -f "${src_dir}"/bar || cat CODE_OF_CONDUCT.md >"${src_dir}"/bar
 
 # run the test, looking for an exit
 #
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}" "${src_dir}"/{extra1,extra2,foo,bar}
+./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -712,7 +712,7 @@ test -f "${src_src_dir}/foo" || touch "${src_src_dir}/foo"
 
 # run the test, looking for an exit
 #
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}" "${src_dir}"/{extra1,extra2,foo,bar} "${src_src_dir}"
+./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2


### PR DESCRIPTION
Check for NULL or empty workdir and topdir prior to doing anything.

Change mkiocccentry arg count check to be exact as we no longer use extra args (though it didn't hurt to have them it might be better to be clear to the user). This required updating mkiocccentry_test.sh as well.

Updated MKIOCCCENTRY_VERSION to "1.2.29 2025-02-20". Updated MKIOCCCENTRY_TEST_VERSION to "1.0.12 2025-02-20".