### PR TITLE
Improve display of mkiocccentry_test.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,13 @@ single arg - the topdir - but this change allows it to be easier to do once
 `chkentry(1)` has been modified to do this (part of it was done - namely that
 the `topdir` arg is there and 'set' but it's not used yet).
 
+More fixes in `mkiocccentry_test.sh`. It no longer shows the commands of `make
+clobber` from the `mkiocccentry` function `check_submission()`. This is done by
+actually making the test Makefile have empty clobber and clean rules: they're
+not needed anyway. Also to help distinguish output after each mkiocccentry
+command is called it prints '--' and also it now shows the command that will be
+run (the mkiocccentry commands that is).
+
 
 ## Release 2.3.37 2025-02-19
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -137,7 +137,9 @@ static const char * const usage_msg3 =
     "\t-d\t\tAlias for -s %u\n"
     "\t\t\t    NOTE: implies -y -E -A random_answers.seed and -i random_answers.seed\n"
     "\t\t\t    NOTE: one cannot use -a/-A or -i with -s seed/-d.\n"
-    "\t\t\t    NOTE: this is the only time -a/-A can be used with -i answers.\n";
+    "\t\t\t    NOTE: this is the only time -a/-A can be used with -i answers.\n"
+    "\t-I path\t\tignore path (to file or directory) under topdir\n"
+    "\t\t\t    NOTE: you can ignore more than one file or directory with multiple -I args\n";
 static const char * const usage_msg4 =
     "\tworkdir\t\tdirectory where the submission directory and tarball are formed\n"
     "\ttopdir\t\tdirectory with required, optional and extra files and/or directories\n"

--- a/test_ioccc/Makefile.test
+++ b/test_ioccc/Makefile.test
@@ -212,18 +212,10 @@ everything: all alt
 ###############
 
 clean:
-	${RM} -f ${OBJ}
-	@-if [[ -f indent.c ]]; then \
-	    echo ${RM} -f indent.c; \
-	    ${RM} -f indent.c; \
-	fi
+	@:
 
 clobber: clean
-	${RM} -f ${TARGET} *.dSYM
-	@-if [[ -e sandwich ]]; then \
-	    ${RM} -f sandwich; \
-	    echo 'ate sandwich'; \
-	fi
+	@:
 
 
 ######################################

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -354,6 +354,7 @@ find "${workdir_esc}" -mindepth 1 -depth -delete
 rm -f "${src_dir}"/prog.c
 :> "${src_dir}"/prog.c
 # test empty prog.c, ignoring the warning about it
+echo "./mkiocccentry -y -q -W -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS  -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
@@ -446,6 +447,7 @@ answers >>answers.txt
 
 # run the test, looking for an exit
 #
+echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
@@ -534,6 +536,7 @@ test -f "${src_dir}"/bar || cat CODE_OF_CONDUCT.md >"${src_dir}"/bar
 
 # run the test, looking for an exit
 #
+echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
@@ -627,6 +630,7 @@ test -f "${src_dir}/$LONG_FILENAME" || touch "${src_dir}/$LONG_FILENAME"
 
 # run the test, looking for an exit
 #
+echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e  -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e  -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -eq 0 ]]; then
@@ -720,6 +724,7 @@ test -f "${src_src_dir}/foo" || touch "${src_src_dir}/foo"
 
 # run the test, looking for an exit
 #
+echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
@@ -815,6 +820,7 @@ test -f "${src_src_src_src_src_dir}/foo" || touch "${src_src_src_src_src_dir}/fo
 
 # run the test, looking for an exit
 #
+echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
 if [[ ${status} -eq 0 ]]; then

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -361,6 +361,8 @@ if [[ ${status} -ne 0 ]]; then
     exit "${status}"
 fi
 
+echo "--"
+
 # Form 'submissions' that are unlikely to win the IOCCC :-)
 #
 test -f "${src_dir}"/prog.c || {
@@ -451,6 +453,8 @@ if [[ ${status} -ne 0 ]]; then
     exit "${status}"
 fi
 
+echo "--"
+
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers() {
 cat <<"EOF"
@@ -536,6 +540,8 @@ if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
     exit "${status}"
 fi
+
+echo "--"
 
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers() {
@@ -631,6 +637,8 @@ else
     echo "$0: NOTE: length limit works." 1>&2
 fi
 
+echo "--"
+
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers() {
 cat <<"EOF"
@@ -718,6 +726,8 @@ if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
     exit "${status}"
 fi
+
+echo "--"
 
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers() {
@@ -815,6 +825,7 @@ else
     echo "$0: NOTE: limit works." 1>&2
 fi
 
+echo "--"
 
 # All Done!!! All Done!!! -- Jessica Noll, Age 2
 #


### PR DESCRIPTION
It can be a bit confusing with all the different tests that it runs (running it numerous times where it must fail and times where it must succeed) so I added a '--' between invocations.

Previously it looked weird in that it would show that all warnings are ignored and then immediately give an error (because the depth is too deep). But before that warning it would show that one (because of 'test' mode) could not use the tarball as a submission. So this should help separate it a bit.