### PR TITLE
Various improvements with mkiocccentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,37 @@ Fix many debug calls in `soup/entry_util.c` at level medium to not reveal
 information about the submission. This includes GitHub handle and country code,
 amongst others.
 
+Due to what will be needed with chkentry (and also in mkiocccentry - which has
+been updated) some of the jparse util functions were updated and new ones were
+added. It cannot always be assumed that finding files should be done in a
+case-insensitive manner so there is a new boolean in those functions (and in one
+or two of the new functions). The `mkiocccentry` had a function that is based on
+one of them (`array_has_path()`).
+
+The arrays in the info struct in mkiocccentry now are freed and set to NULL IFF
+(if and only if) they are empty. This not only allows for not checking them for
+NULL (except before showing the contents) but it also allows for more checks
+that were not previously done (some were thought of in the process of this and
+the below change).
+
+Update exit codes in mkiocccentry, allocating `4` for any issue (and there are a
+lot, even more now due to more checks (as above) and `5` for when the user says
+something is not okay. Updated the man page for this though the
+guidelines/rules/FAQ and quick start guide do need to be updated as well (for
+this change possibly and other more recent changes as well). This also lets the
+`mkiocccentry_test.sh` script verify that the exact error code is encountered
+(when testing errors) and not just not 0. Besides additional testing (after code
+freeze and of course before) this should, with the exception of documentation,
+complete the `workdir topdir` model, unless something else useful or important
+is thought of (like the allocation of exit codes and the new approach to
+handling the arrays).
+
+The function `free_info()` now uses the recent function `free_paths_array()` for
+the dynamic arrays of paths.
+
+Updated `MKIOCCCENTRY_VERSION` `"1.2.30 2025-02-21"`.
+Updated `SOUP_VERSION` to `"1.1.22 2025-02-21"`
+
 
 ## Release 2.3.38 2025-02-20
 

--- a/chkentry.c
+++ b/chkentry.c
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
 	    msg_warn_silent = true;
 	    break;
         case 'i':
-            append_path(&ignored_filenames, optarg, true, false);
+            append_path(&ignored_filenames, optarg, true, false, false);
             break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */

--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -44,3 +44,6 @@ build.log
 /test_jparse/util_test.o
 util_test.c
 /verge
+foobar
+util_test.copy.c
+util.copy.o

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,40 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.24 2025-02-21
+
+Update and add utils.
+
+Yes I am afraid that more things were thought of, particularly when using some
+of the functions. Unfortunately making the assumption of using `strcmp()` or
+`strcasecmp()` when looking for files is wrong as some file systems (like the
+default here - macOS) are case insensitive and sometimes one might or might not
+want to have better control (like the use case). Thus the functions ought to
+have an option to specify if you want to make a case-sensitive or
+case-insensitive search (if the boolean is false it means case insensitive).
+This applies to `find_path()`, `find_path_in_array()`, `find_paths()`,
+`append_path()` and the new function `array_has_path()` (which takes a `intmax_t
+*` which if not NULL will be set to either `-1` or the index in the array). Yes
+the `find_path*()` functions have **way too many** args and it would be good if
+they can be refactored but that will have to happen another time.
+
+As I needed an easier way to test the above searching I added the functions
+`touch()` and `touchat()` which are analogous to the `touch(1)` command (except
+it does not do anything if the file does already exists) and `openat(2)`. That
+means that `touchat(2)` uses `touch()` which uses `open(2)` with the flag
+`O_CREAT`. Importantly it is not like `creat(2)` which will truncate the file if
+it already exists. It takes a `mode_t mode` to set the mode.
+
+Updated .gitignore with some paths that the test code makes or copies (and now
+`make clobber` also removes those).
+
+New function `paths_in_array()` which counts the number of paths in the array
+(if not NULL) - i.e. it uses `dyn_array_tell()` but only if not NULL; if the
+array is NULL it simply returns 0.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.21 2025-02-21"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.19 2025-02-21"`.
+
+
 ## Release 2.2.23 2025-02-20
 
 New util function to find a path in an array.

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -1133,7 +1133,7 @@ clobber: legacy_clobber clean
 	${Q} ${RM} ${RM_V} -f ${BUILD_LOG} jparse_test.log
 	${Q} ${RM} ${RM_V} -f Makefile.orig
 	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
-	${Q} ${RM} ${RM_V} -f util_test.copy.c util.copy.o
+	${Q} ${RM} ${RM_V} -f util_test.copy.c util.copy.o foobar
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -259,14 +259,16 @@ FTSENT *read_fts(char *dir, int dirfd, int *cwd, int options, bool logical, FTS 
         int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *));
 extern char const *find_path(char const *path, char *dir, int dirfd, int *cwd,
         int options, bool logical, enum fts_type type, int count, int depth,
-        bool base, bool seedot, int (*cmp)(const FTSENT **, const FTSENT **),
+        bool base, bool seedot, bool match_case, int (*cmp)(const FTSENT **, const FTSENT **),
         bool(*check)(FTS *, FTSENT *));
-extern char *find_path_in_array(char *path, struct dyn_array *paths, bool empty, intmax_t *idx);
-extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped);
+extern bool array_has_path(struct dyn_array *array, char *path, bool match_case, intmax_t *idx);
+extern uintmax_t paths_in_array(struct dyn_array *array);
+extern char *find_path_in_array(char *path, struct dyn_array *paths, bool match_case, intmax_t *idx);
+extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped, bool match_case);
 extern void free_paths_array(struct dyn_array **paths, bool only_empty);
 extern struct dyn_array *find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd,
         int options, bool logical, enum fts_type type, int count, int depth,
-        bool base, bool seedot, int (*cmp)(const FTSENT **, const FTSENT **),
+        bool base, bool seedot, bool match_case, int (*cmp)(const FTSENT **, const FTSENT **),
         bool(*check)(FTS *, FTSENT *));
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
@@ -288,6 +290,8 @@ extern char *readline_dup(char **linep, bool strip, size_t *lenp, FILE * stream)
 extern void chkbyte2asciistr(void);
 extern void *read_all(FILE *stream, size_t *psize);
 extern size_t copyfile(char const *src, char const *dest, bool copy_mode, mode_t mode);
+extern void touch(char const *path, mode_t mode);
+extern void touchat(char const *path, mode_t mode, char const *dir, int dirfd);
 extern int mkdirs(int dirfd, const char *str, mode_t mode);
 extern bool is_string(char const * const ptr, size_t len);
 extern char const *strnull(char const * const str);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.23 2025-02-20"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.24 2025-02-21"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.20 2025-02-20"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.21 2025-02-21"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -160,7 +160,7 @@ static void scan_topdir(char *args, struct info *infop, char const *make, char c
         RuleCount *size);
 static void copy_topdir(struct info *infop, char const *make, char const *submission_dir, char *topdir_path,
         char *submit_path, int topdir, int cwd, RuleCount *size);
-static void check_submission(struct info *infop, char *submit_path, char *topdir_path,
+static void check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         char const *make, RuleCount *size, int cwd);
 static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar,
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -222,10 +222,6 @@ free_auth(struct auth *authp)
 void
 free_info(struct info *infop)
 {
-    char *p = NULL;
-    size_t i = 0;
-    size_t len = 0;
-
     /*
      * firewall
      */
@@ -289,142 +285,50 @@ free_info(struct info *infop)
     /*
      * required files (prog.c, Makefile, remarks.md)
      */
-    if (infop->required_files != NULL) {
-        len = dyn_array_tell(infop->required_files);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->required_files, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->required_files);
-        infop->required_files = NULL;
-    }
+    free_paths_array(&infop->required_files, false);
+    infop->required_files = NULL;
     /*
      * extra files (anything not a required file)
      */
-    if (infop->extra_files != NULL) {
-        len = dyn_array_tell(infop->extra_files);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->extra_files, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->extra_files);
-        infop->extra_files = NULL;
-    }
+    free_paths_array(&infop->extra_files, false);
+    infop->extra_files = NULL;
     /*
      * directories found in topdir
      */
-    if (infop->directories != NULL) {
-        len = dyn_array_tell(infop->directories);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->directories, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->directories);
-        infop->directories = NULL;
-    }
+    free_paths_array(&infop->directories, false);
+    infop->directories = NULL;
     /*
      * ignored directories (.git, CVS etc.)
      */
-    if (infop->ignored_dirs != NULL) {
-        len = dyn_array_tell(infop->ignored_dirs);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->ignored_dirs, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->ignored_dirs);
-        infop->ignored_dirs = NULL;
-    }
+    free_paths_array(&infop->ignored_dirs, false);
+    infop->ignored_dirs = NULL;
     /*
      * forbidden files (prog, prog.alt, GNUMakefile, README.md etc.)
      */
-    if (infop->forbidden_files != NULL) {
-        len = dyn_array_tell(infop->forbidden_files);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->forbidden_files, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->forbidden_files);
-        infop->forbidden_files = NULL;
-    }
+    free_paths_array(&infop->forbidden_files, false);
+    infop->forbidden_files = NULL;
     /*
      * unsafe files (those that sane_relative_path() returns
      * PATH_ERR_NOT_POSIX_SAFE)
      */
-    if (infop->unsafe_files != NULL) {
-        len = dyn_array_tell(infop->unsafe_files);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->unsafe_files, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->unsafe_files);
-        infop->unsafe_files = NULL;
-    }
+    free_paths_array(&infop->unsafe_files, false);
+    infop->unsafe_files = NULL;
     /*
      * unsafe directories (those that sane_relative_path() returns
      * PATH_ERR_NOT_POSIX_SAFE)
      */
-    if (infop->unsafe_dirs != NULL) {
-        len = dyn_array_tell(infop->unsafe_dirs);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->unsafe_dirs, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->unsafe_dirs);
-        infop->unsafe_dirs = NULL;
-    }
-
-
+    free_paths_array(&infop->unsafe_dirs, false);
+    infop->unsafe_dirs = NULL;
     /*
      * ignored symlinks (any symlinks found in topdir)
      */
-    if (infop->ignored_symlinks != NULL) {
-        len = dyn_array_tell(infop->ignored_symlinks);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->ignored_symlinks, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->ignored_symlinks);
-        infop->ignored_symlinks = NULL;
-    }
+    free_paths_array(&infop->ignored_symlinks, false);
+    infop->ignored_symlinks = NULL;
    /*
      * user requested ignored files
      */
-    if (infop->ignore_paths != NULL) {
-        len = dyn_array_tell(infop->ignore_paths);
-        for (i = 0; i < len; ++i) {
-            p = dyn_array_value(infop->ignore_paths, char *, i);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
-            }
-        }
-        dyn_array_free(infop->ignore_paths);
-        infop->ignore_paths = NULL;
-    }
+    free_paths_array(&infop->ignore_paths, false);
+    infop->ignore_paths = NULL;
 
     /*
      * zeroize the info structure

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "20 February 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "21 February 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -366,6 +366,19 @@ and version string printed
 .TQ
 3
 invalid command line, invalid option or option missing an argument
+.TQ
+4
+something went wrong in scanning, copying or verifying
+.I topdir
+and
+.I workdir
+.TQ
+5
+user says something about the
+.I topdir
+or
+.I workdir
+is not okay
 .TQ
 >= 10
 internal error

--- a/soup/version.h
+++ b/soup/version.h
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.29 2025-02-20"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.30 2025-02-21"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -76,7 +76,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="1.0.12 2025-02-20"
+export MKIOCCCENTRY_TEST_VERSION="1.0.13 2025-02-21"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit
@@ -633,8 +633,8 @@ test -f "${src_dir}/$LONG_FILENAME" || touch "${src_dir}/$LONG_FILENAME"
 echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e  -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e  -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
-if [[ ${status} -eq 0 ]]; then
-    echo "$0: ERROR: mkiocccentry zero exit code when it should be non-zero: $status" 1>&2
+if [[ ${status} -ne 4 ]]; then
+    echo "$0: ERROR: mkiocccentry exit code not 4: $status" 1>&2
     exit 1
 else
     echo "$0: NOTE: the above error is expected as we were testing that the filename" 1>&2
@@ -823,8 +823,8 @@ test -f "${src_src_src_src_src_dir}/foo" || touch "${src_src_src_src_src_dir}/fo
 echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${src_dir}"
 ./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${src_dir}"
 status=$?
-if [[ ${status} -eq 0 ]]; then
-    echo "$0: ERROR: mkiocccentry zero exit code when it should be non-zero: $status" 1>&2
+if [[ ${status} -ne 4 ]]; then
+    echo "$0: ERROR: mkiocccentry zero exit code not 4: $status" 1>&2
     exit 1
 else
     echo "$0: NOTE: the above error is expected as we were testing that the max depth" 1>&2


### PR DESCRIPTION
Due to what will be needed with chkentry (and also in mkiocccentry - which has been updated) some of the jparse util functions were updated and new ones were added. It cannot always be assumed that finding files should be done in a case-insensitive manner so there is a new boolean in those functions (and in one or two of the new functions). The mkiocccentry had a function that is based on one of them (array_has_path()).

The arrays in the info struct in mkiocccentry now are freed and set to NULL IFF (if and only if) they are empty. This not only allows for not checking them for NULL (except before showing the contents) but it also allows for more checks that were not previously done (some were thought of in the process of this and the below change).

Update exit codes in mkiocccentry, allocating 4 for any issue (and there are a lot, even more now due to more checks (as above) and 5 for when the user says something is not okay. Updated the man page for this though the guidelines/rules/FAQ and quick start guide do need to be updated as well (for this change possibly and other more recent changes as well). This also lets the mkiocccentry_test.sh script verify that the exact error code is encountered (when testing errors) and not just not 0. Besides additional testing (after code freeze and of course before) this should, with the exception of documentation, complete the workdir topdir model, unless something else useful or important is thought of (like the allocation of exit codes and the new approach to handling the arrays).

The function free_info() now uses the recent function free_paths_array() for the dynamic arrays of paths.

Updated MKIOCCCENTRY_VERSION "1.2.30 2025-02-21".
Updated SOUP_VERSION to "1.1.22 2025-02-21"