### PR TITLE
Improve topdir checks in chkentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,8 +35,13 @@ handling the arrays).
 The function `free_info()` now uses the recent function `free_paths_array()` for
 the dynamic arrays of paths.
 
+Better checks on `topdir` in `chkentry` (as in even though the pointers were
+checked for NULL they are now only done if topdir is a directory that can be
+searched).
+
 Updated `MKIOCCCENTRY_VERSION` `"1.2.30 2025-02-21"`.
 Updated `SOUP_VERSION` to `"1.1.22 2025-02-21"`
+Updated `CHKENTRY_VERSION` to `"1.1.2 2025-02-21"`.
 
 
 ## Release 2.3.38 2025-02-20

--- a/chkentry.c
+++ b/chkentry.c
@@ -133,6 +133,7 @@ main(int argc, char *argv[])
 {
     char const *program = NULL;		/* our name */
     char **topdir = NULL;               /* directory from which files are to be checked */
+    char *dir = NULL;                   /* *topdir */
     extern char *optarg;		/* option argument */
     extern int optind;			/* argv index of the next arg */
     char const *auth_filename = ".";	/* .auth.json file to process, or NULL ==> no .auth.json to process */
@@ -244,335 +245,350 @@ main(int argc, char *argv[])
 	break;
     }
 
-    /*
-     * case: 1 arg - directory
-     */
     if (topdir != NULL && *topdir != NULL) {
+        dir = *topdir;
 	/*
-	 * open the .auth.json file under topdir
+	 * check if we can search / work within the directory
 	 */
-	auth_filename = ".auth.json";
-	auth_stream = open_dir_file(*topdir, auth_filename);
-	if (auth_stream == NULL) { /* paranoia */
-	    err(27, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", *topdir, auth_filename);
+	if (!exists(dir)) {
+	    err(39, __func__, "directory does not exist: %s", dir);
+	    not_reached();
+	}
+	if (!is_dir(dir)) {
+	    err(40, __func__, "is not a directory: %s", dir);
+	    not_reached();
+	}
+	if (!is_exec(dir)) {
+	    err(41, __func__, "directory is not searchable: %s", dir);
 	    not_reached();
 	}
 
-	/*
-	 * open the .info.json file under topdir
-	 */
-	info_filename = ".info.json";
-	info_stream = open_dir_file(*topdir, info_filename);
-	if (info_stream == NULL) { /* paranoia */
-	    err(28, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", *topdir, info_filename);
-	    not_reached();
-	}
-    }
+        /*
+         * open the .auth.json file under topdir
+         */
+        auth_filename = ".auth.json";
+        auth_stream = open_dir_file(dir, auth_filename);
+        if (auth_stream == NULL) { /* paranoia */
+            err(42, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", dir, auth_filename);
+            not_reached();
+        }
 
-    auth_path = calloc_path(*topdir, auth_filename);
-    if (auth_path == NULL) {
-	err(29, __func__, "auth_path is NULL");
-	not_reached();
-    }
-    info_path = calloc_path(*topdir, info_filename);
-    if (info_path == NULL) {
-	err(30, __func__, "info_path is NULL");
-	not_reached();
-    }
+        /*
+         * open the .info.json file under topdir
+         */
+        info_filename = ".info.json";
+        info_stream = open_dir_file(dir, info_filename);
+        if (info_stream == NULL) { /* paranoia */
+            err(43, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", dir, info_filename);
+            not_reached();
+        }
 
-    /*
-     * parse .auth.json if it is open
-     */
-    if (auth_stream != NULL) {
-	auth_tree = parse_json_stream(auth_stream, auth_path, &auth_valid);
-	if (auth_valid == false || auth_tree == NULL) {
-	    err(4, __func__, "failed to parse JSON in .auth.json file: %s", auth_path); /*ooo*/
-	    not_reached();
-	}
-	dbg(DBG_LOW, "successful parse of JSON in .auth.json file: %s", auth_path);
-    }
+        auth_path = calloc_path(dir, auth_filename);
+        if (auth_path == NULL) {
+            err(44, __func__, "auth_path is NULL");
+            not_reached();
+        }
+        info_path = calloc_path(dir, info_filename);
+        if (info_path == NULL) {
+            err(45, __func__, "info_path is NULL");
+            not_reached();
+        }
 
-    /*
-     * parse .info.json if it is open
-     */
-    if (info_stream != NULL) {
-	info_tree = parse_json_stream(info_stream, info_path, &info_valid);
-	if (info_valid == false || info_tree == NULL) {
-	    err(4, __func__, "failed to parse JSON in .info.json file: %s", info_path); /*ooo*/
-	    not_reached();
-	}
-	dbg(DBG_LOW, "successful parse of JSON in .info.json file: %s", info_path);
-    }
+        /*
+         * parse .auth.json if it is open
+         */
+        if (auth_stream != NULL) {
+            auth_tree = parse_json_stream(auth_stream, auth_path, &auth_valid);
+            if (auth_valid == false || auth_tree == NULL) {
+                err(4, __func__, "failed to parse JSON in .auth.json file: %s", auth_path); /*ooo*/
+                not_reached();
+            }
+            dbg(DBG_LOW, "successful parse of JSON in .auth.json file: %s", auth_path);
+        }
 
-    /*
-     * check a JSON parse tree against a JSON semantic table for .auth.json, if open
-     */
-    if (auth_stream != NULL) {
+        /*
+         * parse .info.json if it is open
+         */
+        if (info_stream != NULL) {
+            info_tree = parse_json_stream(info_stream, info_path, &info_valid);
+            if (info_valid == false || info_tree == NULL) {
+                err(4, __func__, "failed to parse JSON in .info.json file: %s", info_path); /*ooo*/
+                not_reached();
+            }
+            dbg(DBG_LOW, "successful parse of JSON in .info.json file: %s", info_path);
+        }
 
-	/*
-	 * perform JSON semantic analysis on the .auth.json JSON parse tree
-	 */
-	dbg(DBG_HIGH, "about to perform JSON semantic check for .auth.json file: %s", auth_path);
-	auth_all_err_count = json_sem_check(auth_tree, JSON_DEFAULT_MAX_DEPTH, sem_auth,
-					  &auth_count_err, &auth_val_err);
+        /*
+         * check a JSON parse tree against a JSON semantic table for .auth.json, if open
+         */
+        if (auth_stream != NULL) {
 
-	/*
-	 * firewall on json_sem_check() results AND count errors for .auth.json
-	 */
-	if (auth_count_err == NULL) {
-	    err(31, __func__, "json_sem_check() left auth_count_err as NULL for .auth.json file: %s", auth_path);
-	    not_reached();
-	}
-	if (dyn_array_tell(auth_count_err) < 0) {
-	    err(32, __func__, "dyn_array_tell(auth_count_err): %jd < 0 "
-		   "for .auth.json file: %s", dyn_array_tell(auth_count_err), auth_path);
-	    not_reached();
-	}
-	auth_count_err_count = (uintmax_t) dyn_array_tell(auth_count_err);
-	if (auth_val_err == NULL) {
-	    err(33, __func__, "json_sem_check() left auth_val_err as NULL for .auth.json file: %s", auth_path);
-	    not_reached();
-	}
-	if (dyn_array_tell(auth_val_err) < 0) {
-	    err(34, __func__, "dyn_array_tell(auth_val_err): %jd < 0 "
-		   "for .auth.json file: %s", dyn_array_tell(auth_val_err), auth_path);
-	    not_reached();
-	}
-	auth_val_err_count = (uintmax_t)dyn_array_tell(auth_val_err);
-	if (auth_all_err_count < auth_count_err_count+auth_val_err_count) {
-	    err(35, __func__, "auth_all_err_count: %ju < auth_count_err_count: %ju + auth_val_err_count: %ju "
-		   "for .auth.json file: %s",
-		   auth_all_err_count, auth_count_err_count, auth_val_err_count, auth_path);
-	    not_reached();
-	}
-	auth_int_err_count = auth_all_err_count - (auth_count_err_count+auth_val_err_count);
-    }
+            /*
+             * perform JSON semantic analysis on the .auth.json JSON parse tree
+             */
+            dbg(DBG_HIGH, "about to perform JSON semantic check for .auth.json file: %s", auth_path);
+            auth_all_err_count = json_sem_check(auth_tree, JSON_DEFAULT_MAX_DEPTH, sem_auth,
+                                              &auth_count_err, &auth_val_err);
 
-    /*
-     * check a JSON parse tree against a JSON semantic table for .info.json, if open
-     */
-    if (info_stream != NULL) {
+            /*
+             * firewall on json_sem_check() results AND count errors for .auth.json
+             */
+            if (auth_count_err == NULL) {
+                err(46, __func__, "json_sem_check() left auth_count_err as NULL for .auth.json file: %s", auth_path);
+                not_reached();
+            }
+            if (dyn_array_tell(auth_count_err) < 0) {
+                err(47, __func__, "dyn_array_tell(auth_count_err): %jd < 0 "
+                       "for .auth.json file: %s", dyn_array_tell(auth_count_err), auth_path);
+                not_reached();
+            }
+            auth_count_err_count = (uintmax_t) dyn_array_tell(auth_count_err);
+            if (auth_val_err == NULL) {
+                err(48, __func__, "json_sem_check() left auth_val_err as NULL for .auth.json file: %s", auth_path);
+                not_reached();
+            }
+            if (dyn_array_tell(auth_val_err) < 0) {
+                err(49, __func__, "dyn_array_tell(auth_val_err): %jd < 0 "
+                       "for .auth.json file: %s", dyn_array_tell(auth_val_err), auth_path);
+                not_reached();
+            }
+            auth_val_err_count = (uintmax_t)dyn_array_tell(auth_val_err);
+            if (auth_all_err_count < auth_count_err_count+auth_val_err_count) {
+                err(50, __func__, "auth_all_err_count: %ju < auth_count_err_count: %ju + auth_val_err_count: %ju "
+                       "for .auth.json file: %s",
+                       auth_all_err_count, auth_count_err_count, auth_val_err_count, auth_path);
+                not_reached();
+            }
+            auth_int_err_count = auth_all_err_count - (auth_count_err_count+auth_val_err_count);
+        }
 
-	/*
-	 * perform JSON semantic analysis on the .info.json JSON parse tree
-	 */
-	dbg(DBG_HIGH, "about to perform JSON semantic check for .info.json file: %s", info_path);
-	info_all_err_count = json_sem_check(info_tree, JSON_DEFAULT_MAX_DEPTH, sem_info,
-					  &info_count_err, &info_val_err);
+        /*
+         * check a JSON parse tree against a JSON semantic table for .info.json, if open
+         */
+        if (info_stream != NULL) {
 
-	/*
-	 * firewall on json_sem_check() results AND count errors for .info.json
-	 */
-	if (info_count_err == NULL) {
-	    err(36, __func__, "json_sem_check() left info_count_err as NULL for .info.json file: %s", info_path);
-	    not_reached();
-	}
-	if (dyn_array_tell(info_count_err) < 0) {
-	    err(37, __func__, "dyn_array_tell(info_count_err): %jd < 0 "
-		   "for .info.json file: %s",
-		   dyn_array_tell(info_count_err), info_path);
-	    not_reached();
-	}
-	info_count_err_count = (uintmax_t)dyn_array_tell(info_count_err);
-	if (info_val_err == NULL) {
-	    err(38, __func__, "json_sem_check() left info_val_err as NULL for .info.json file: %s", info_path);
-	    not_reached();
-	}
-	if (dyn_array_tell(info_val_err) < 0) {
-	    err(39, __func__, "dyn_array_tell(info_val_err): %jd < 0 "
-		   "for .info.json file: %ss",
-		   dyn_array_tell(info_val_err), info_path);
-	    not_reached();
-	}
-	info_val_err_count = (uintmax_t)dyn_array_tell(info_val_err);
-	if (info_all_err_count < info_count_err_count+info_val_err_count) {
-	    err(40, __func__, "info_all_err_count: %ju < info_count_err_count: %ju + info_val_err_count: %ju "
-		   "for .info.json file: %s",
-		   info_all_err_count, info_count_err_count, info_val_err_count, info_path);
-	    not_reached();
-	}
-	info_int_err_count = info_all_err_count - (info_count_err_count+info_val_err_count);
-    }
+            /*
+             * perform JSON semantic analysis on the .info.json JSON parse tree
+             */
+            dbg(DBG_HIGH, "about to perform JSON semantic check for .info.json file: %s", info_path);
+            info_all_err_count = json_sem_check(info_tree, JSON_DEFAULT_MAX_DEPTH, sem_info,
+                                              &info_count_err, &info_val_err);
 
-    /*
-     * count all errors
-     */
-    all_count_err_count = info_count_err_count + auth_count_err_count;
-    all_val_err_count = info_val_err_count + auth_val_err_count;
-    all_int_err_count = info_int_err_count + auth_int_err_count;
-    all_all_err_count = info_all_err_count + auth_all_err_count;
+            /*
+             * firewall on json_sem_check() results AND count errors for .info.json
+             */
+            if (info_count_err == NULL) {
+                err(51, __func__, "json_sem_check() left info_count_err as NULL for .info.json file: %s", info_path);
+                not_reached();
+            }
+            if (dyn_array_tell(info_count_err) < 0) {
+                err(52, __func__, "dyn_array_tell(info_count_err): %jd < 0 "
+                       "for .info.json file: %s",
+                       dyn_array_tell(info_count_err), info_path);
+                not_reached();
+            }
+            info_count_err_count = (uintmax_t)dyn_array_tell(info_count_err);
+            if (info_val_err == NULL) {
+                err(53, __func__, "json_sem_check() left info_val_err as NULL for .info.json file: %s", info_path);
+                not_reached();
+            }
+            if (dyn_array_tell(info_val_err) < 0) {
+                err(54, __func__, "dyn_array_tell(info_val_err): %jd < 0 "
+                       "for .info.json file: %ss",
+                       dyn_array_tell(info_val_err), info_path);
+                not_reached();
+            }
+            info_val_err_count = (uintmax_t)dyn_array_tell(info_val_err);
+            if (info_all_err_count < info_count_err_count+info_val_err_count) {
+                err(55, __func__, "info_all_err_count: %ju < info_count_err_count: %ju + info_val_err_count: %ju "
+                       "for .info.json file: %s",
+                       info_all_err_count, info_count_err_count, info_val_err_count, info_path);
+                not_reached();
+            }
+            info_int_err_count = info_all_err_count - (info_count_err_count+info_val_err_count);
+        }
 
-    /*
-     * report details of any .auth.json semantic errors
-     */
-    if (auth_all_err_count > 0) {
-	fpr(stderr, __func__, "What follows are semantic errors for .auth.json file: %s\n", auth_path);
-	if (auth_count_err == NULL) {
-	    fpr(stderr, __func__, "auth_count_err is NULL!!!\n");
-	} else {
-	    for (c=0; c < auth_count_err_count; ++c) {
-		sem_count_err = dyn_array_addr(auth_count_err, struct json_sem_count_err, c);
-		fprint_count_err(stderr, ".auth.json count error ", sem_count_err, "\n");
-	    }
-	    for (c=0; c < auth_val_err_count; ++c) {
-		sem_val_err = dyn_array_addr(auth_val_err, struct json_sem_val_err, c);
-		fprint_val_err(stderr, ".auth.json validation error ", sem_val_err, "\n");
-	    }
-	}
-	if (auth_int_err_count > 0) {
-	    fpr(stderr, __func__, ".auth.json internal errors found: %ju", auth_int_err_count);
-	}
-    }
+        /*
+         * count all errors
+         */
+        all_count_err_count = info_count_err_count + auth_count_err_count;
+        all_val_err_count = info_val_err_count + auth_val_err_count;
+        all_int_err_count = info_int_err_count + auth_int_err_count;
+        all_all_err_count = info_all_err_count + auth_all_err_count;
 
-    /*
-     * report details of any .info.json semantic errors
-     */
-    if (info_all_err_count > 0) {
-	fpr(stderr, __func__, "What follows are semantic errors for .info.json file: %s\n", info_path);
-	if (info_count_err == NULL) {
-	    fpr(stderr, __func__, "info_count_err is NULL!!!\n");
-	} else {
-	    for (c=0; c < info_count_err_count; ++c) {
-		sem_count_err = dyn_array_addr(info_count_err, struct json_sem_count_err, c);
-		fprint_count_err(stderr, ".info.json count error ", sem_count_err, "\n");
-	    }
-	    for (c=0; c < info_val_err_count; ++c) {
-		sem_val_err = dyn_array_addr(info_val_err, struct json_sem_val_err, c);
-		fprint_val_err(stderr, ".info.json validation error ", sem_val_err, "\n");
-	    }
-	}
-	if (info_int_err_count > 0) {
-	    fpr(stderr, __func__, ".info.json internal errors found: %ju", info_int_err_count);
-	}
-    }
-
-    /*
-     * report on semantic count errors
-     */
-    if (all_count_err_count > 0) {
-	if (auth_count_err_count > 0) {
-	    dbg(DBG_LOW, "count errors for .auth.json: %ju", auth_count_err_count);
-	}
-	if (info_count_err_count > 0) {
-	    dbg(DBG_LOW, "count errors for .info.json: %ju", info_count_err_count);
-	}
-	dbg(DBG_LOW, "count errors for both files: %ju", all_count_err_count);
-    }
-
-    /*
-     * report on semantic validation errors
-     */
-    if (all_val_err_count > 0) {
-	if (auth_val_err_count > 0) {
-	    dbg(DBG_LOW, "validation errors for .auth.json: %ju", auth_val_err_count);
-	}
-	if (info_val_err_count > 0) {
-	    dbg(DBG_LOW, "validation errors for .info.json: %ju", info_val_err_count);
-	}
-	dbg(DBG_LOW, "validation errors for both files: %ju", all_val_err_count);
-    }
-
-    /*
-     * report on internal errors
-     */
-    if (all_int_err_count > 0) {
-	if (auth_int_err_count > 0) {
-	    dbg(DBG_LOW, "internal errors for .auth.json: %ju", auth_int_err_count);
-	}
-	if (info_int_err_count > 0) {
-	    dbg(DBG_LOW, "internal errors for .info.json: %ju", info_int_err_count);
-	}
-	dbg(DBG_LOW, "internal errors for both files: %ju", all_int_err_count);
-    }
-
-    /*
-     * report on total error counts
-     */
-    if (all_all_err_count > 0) {
-	if (auth_all_err_count > 0) {
-	    dbg(DBG_LOW, "total semantic errors for .auth.json: %ju", auth_all_err_count);
-	}
-	if (info_all_err_count > 0) {
-	    dbg(DBG_LOW, "total semantic errors for .info.json: %ju", info_all_err_count);
-	}
-	dbg(DBG_LOW, "total semantic errors for both files: %ju", all_all_err_count);
-    }
-
-    /*
-     * summarize the JSON semantic check status
-     */
-    if (auth_all_err_count > 0) {
-	if (auth_path == NULL) {
-	    werr(1, __func__, "JSON semantic check failed for .auth.json file: ((NULL))"); /*ooo*/
-	} else {
-	    werr(1, __func__, "JSON semantic check failed for .auth.json file: %s", auth_path); /*ooo*/
-	}
-    }
-    if (info_all_err_count > 0) {
-	if (info_path == NULL) {
-	    werr(1, __func__, "JSON semantic check failed for .info.json file: ((NULL))"); /*ooo*/
-	} else {
-	    werr(1, __func__, "JSON semantic check failed for .info.json file: %s", info_path); /*ooo*/
-	}
-    }
-    if (all_all_err_count == 0) {
-	dbg(DBG_LOW, "JSON semantic check OK");
-    }
-
-    /*
-     * cleanup - except for info_stream and auth_stream.
-     *
-     * We don't try closing info_stream or auth_stream because the json parser
-     * already does that at this point. This is because we no longer use yyin
-     * due to complications introduced when making the lexer re-entrant. This is
-     * not a problem under macOS but it is under linux.
-     */
-    if (auth_tree != NULL) {
-	json_tree_free(auth_tree, JSON_DEFAULT_MAX_DEPTH);
-	auth_tree = NULL;
-    }
-    if (info_tree != NULL) {
-	json_tree_free(info_tree, JSON_DEFAULT_MAX_DEPTH);
-	info_tree = NULL;
-    }
-    if (auth_count_err != NULL) {
-	free_count_err(auth_count_err);
-	auth_count_err = NULL;
-    }
-    if (auth_val_err != NULL) {
-	free_val_err(auth_val_err);
-	auth_val_err = NULL;
-    }
-    if (info_count_err != NULL) {
-	free_count_err(info_count_err);
-	info_count_err = NULL;
-    }
-    if (info_val_err != NULL) {
-	free_val_err(info_val_err);
-	info_val_err = NULL;
-    }
-    if (auth_path != NULL) {
-	free(auth_path);
-	auth_path = NULL;
-    }
-    if (info_path != NULL) {
-	free(info_path);
-	info_path = NULL;
-    }
-
-    if (ignored_filenames != NULL) {
-        len = dyn_array_tell(ignored_filenames);
-        for (j = 0; j < len; ++j) {
-            p = dyn_array_value(ignored_filenames, char *, j);
-            if (p != NULL) {
-                free(p);
-                p = NULL;
+        /*
+         * report details of any .auth.json semantic errors
+         */
+        if (auth_all_err_count > 0) {
+            fpr(stderr, __func__, "What follows are semantic errors for .auth.json file: %s\n", auth_path);
+            if (auth_count_err == NULL) {
+                fpr(stderr, __func__, "auth_count_err is NULL!!!\n");
+            } else {
+                for (c=0; c < auth_count_err_count; ++c) {
+                    sem_count_err = dyn_array_addr(auth_count_err, struct json_sem_count_err, c);
+                    fprint_count_err(stderr, ".auth.json count error ", sem_count_err, "\n");
+                }
+                for (c=0; c < auth_val_err_count; ++c) {
+                    sem_val_err = dyn_array_addr(auth_val_err, struct json_sem_val_err, c);
+                    fprint_val_err(stderr, ".auth.json validation error ", sem_val_err, "\n");
+                }
+            }
+            if (auth_int_err_count > 0) {
+                fpr(stderr, __func__, ".auth.json internal errors found: %ju", auth_int_err_count);
             }
         }
-        dyn_array_free(ignored_filenames);
-        ignored_filenames = NULL;
-    }
 
+        /*
+         * report details of any .info.json semantic errors
+         */
+        if (info_all_err_count > 0) {
+            fpr(stderr, __func__, "What follows are semantic errors for .info.json file: %s\n", info_path);
+            if (info_count_err == NULL) {
+                fpr(stderr, __func__, "info_count_err is NULL!!!\n");
+            } else {
+                for (c=0; c < info_count_err_count; ++c) {
+                    sem_count_err = dyn_array_addr(info_count_err, struct json_sem_count_err, c);
+                    fprint_count_err(stderr, ".info.json count error ", sem_count_err, "\n");
+                }
+                for (c=0; c < info_val_err_count; ++c) {
+                    sem_val_err = dyn_array_addr(info_val_err, struct json_sem_val_err, c);
+                    fprint_val_err(stderr, ".info.json validation error ", sem_val_err, "\n");
+                }
+            }
+            if (info_int_err_count > 0) {
+                fpr(stderr, __func__, ".info.json internal errors found: %ju", info_int_err_count);
+            }
+        }
+
+        /*
+         * report on semantic count errors
+         */
+        if (all_count_err_count > 0) {
+            if (auth_count_err_count > 0) {
+                dbg(DBG_LOW, "count errors for .auth.json: %ju", auth_count_err_count);
+            }
+            if (info_count_err_count > 0) {
+                dbg(DBG_LOW, "count errors for .info.json: %ju", info_count_err_count);
+            }
+            dbg(DBG_LOW, "count errors for both files: %ju", all_count_err_count);
+        }
+
+        /*
+         * report on semantic validation errors
+         */
+        if (all_val_err_count > 0) {
+            if (auth_val_err_count > 0) {
+                dbg(DBG_LOW, "validation errors for .auth.json: %ju", auth_val_err_count);
+            }
+            if (info_val_err_count > 0) {
+                dbg(DBG_LOW, "validation errors for .info.json: %ju", info_val_err_count);
+            }
+            dbg(DBG_LOW, "validation errors for both files: %ju", all_val_err_count);
+        }
+
+        /*
+         * report on internal errors
+         */
+        if (all_int_err_count > 0) {
+            if (auth_int_err_count > 0) {
+                dbg(DBG_LOW, "internal errors for .auth.json: %ju", auth_int_err_count);
+            }
+            if (info_int_err_count > 0) {
+                dbg(DBG_LOW, "internal errors for .info.json: %ju", info_int_err_count);
+            }
+            dbg(DBG_LOW, "internal errors for both files: %ju", all_int_err_count);
+        }
+
+        /*
+         * report on total error counts
+         */
+        if (all_all_err_count > 0) {
+            if (auth_all_err_count > 0) {
+                dbg(DBG_LOW, "total semantic errors for .auth.json: %ju", auth_all_err_count);
+            }
+            if (info_all_err_count > 0) {
+                dbg(DBG_LOW, "total semantic errors for .info.json: %ju", info_all_err_count);
+            }
+            dbg(DBG_LOW, "total semantic errors for both files: %ju", all_all_err_count);
+        }
+
+        /*
+         * summarize the JSON semantic check status
+         */
+        if (auth_all_err_count > 0) {
+            if (auth_path == NULL) {
+                werr(1, __func__, "JSON semantic check failed for .auth.json file: ((NULL))"); /*ooo*/
+            } else {
+                werr(1, __func__, "JSON semantic check failed for .auth.json file: %s", auth_path); /*ooo*/
+            }
+        }
+        if (info_all_err_count > 0) {
+            if (info_path == NULL) {
+                werr(1, __func__, "JSON semantic check failed for .info.json file: ((NULL))"); /*ooo*/
+            } else {
+                werr(1, __func__, "JSON semantic check failed for .info.json file: %s", info_path); /*ooo*/
+            }
+        }
+        if (all_all_err_count == 0) {
+            dbg(DBG_LOW, "JSON semantic check OK");
+        }
+
+        /*
+         * cleanup - except for info_stream and auth_stream.
+         *
+         * We don't try closing info_stream or auth_stream because the json parser
+         * already does that at this point. This is because we no longer use yyin
+         * due to complications introduced when making the lexer re-entrant. This is
+         * not a problem under macOS but it is under linux.
+         */
+        if (auth_tree != NULL) {
+            json_tree_free(auth_tree, JSON_DEFAULT_MAX_DEPTH);
+            auth_tree = NULL;
+        }
+        if (info_tree != NULL) {
+            json_tree_free(info_tree, JSON_DEFAULT_MAX_DEPTH);
+            info_tree = NULL;
+        }
+        if (auth_count_err != NULL) {
+            free_count_err(auth_count_err);
+            auth_count_err = NULL;
+        }
+        if (auth_val_err != NULL) {
+            free_val_err(auth_val_err);
+            auth_val_err = NULL;
+        }
+        if (info_count_err != NULL) {
+            free_count_err(info_count_err);
+            info_count_err = NULL;
+        }
+        if (info_val_err != NULL) {
+            free_val_err(info_val_err);
+            info_val_err = NULL;
+        }
+        if (auth_path != NULL) {
+            free(auth_path);
+            auth_path = NULL;
+        }
+        if (info_path != NULL) {
+            free(info_path);
+            info_path = NULL;
+        }
+
+        if (ignored_filenames != NULL) {
+            len = dyn_array_tell(ignored_filenames);
+            for (j = 0; j < len; ++j) {
+                p = dyn_array_value(ignored_filenames, char *, j);
+                if (p != NULL) {
+                    free(p);
+                    p = NULL;
+                }
+            }
+            dyn_array_free(ignored_filenames);
+            ignored_filenames = NULL;
+        }
+    } else {
+	usage(3, program, "invalid command line");/*ooo*/
+    }
 
     /*
      * All Done!!! All Done!!! -- Jessica Noll, Age 2

--- a/soup/version.h
+++ b/soup/version.h
@@ -109,7 +109,7 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "1.1.1 2025-02-20"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "1.1.2 2025-02-21"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * Version of info for JSON the .entry.json files.


### PR DESCRIPTION
Better checks on topdir in chkentry (as in even though the pointers were checked for NULL they are now only done if topdir is a directory that can be searched).

Updated CHKENTRY_VERSION to "1.1.2 2025-02-21".