### PR TITLE
Significantly simplify the FTS util functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.40 2025-02-22
+
+Significantly simplify and refactor the FTS functions in jparse/util.c. A great
+deal of thought and effort was put into this and when the `topdir` is passed to
+`chk_manifest()` (which is being worked on) it will be far easier. The benefit
+of these changes, besides being much cleaner, simpler and it being modularised,
+is that if some issue is discovered or some new feature is needed (as has
+already happened numerous times) function calls do not have to be updated.
+
+`mkiocccentry` has been updated to use the simplified interface as well.
+
+A note: `jparse/` has not been fully synced because of a change in `json_sem`
+for `chkentry` that is not yet complete (this was done prior to deciding to
+rework the FTS functions). So the CHANGES.md file and the `json_sem.[ch]` files
+committed to the jparse repo are not yet here.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.31 2025-02-22"`
+
+
 ## Release 2.3.39 2025-02-21
 
 Fix many debug calls in `soup/entry_util.c` at level medium to not reveal

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -177,7 +177,7 @@ C_OPT= -O3
 
 # Compiler warnings
 #
-WARN_FLAGS= -pedantic -Wall -Wextra -Wformat -Wno-unused-but-set-variable -Wno-char-subscripts -Wno-sign-compare
+WARN_FLAGS= -pedantic -Wall -Wextra -Wformat -Wno-char-subscripts -Wno-sign-compare
 	    
 #WARN_FLAGS= -pedantic -Wall -Wextra -Werror
 
@@ -489,7 +489,7 @@ json_util.o: json_util.c json_util.h
 	${CC} ${CFLAGS} json_util.c -c
 
 jparse.tab.o: jparse.tab.c
-	${CC} ${CFLAGS} jparse.tab.c -c
+	${CC} ${CFLAGS} -Wno-unused-but-set-variable jparse.tab.c -c
 
 jparse_main.o: jparse_main.c version.h
 	${CC} ${CFLAGS} jparse_main.c -c

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -229,6 +229,28 @@ enum file_type
 };
 
 /*
+ * structures
+ */
+
+/*
+ * struct fts - for the FTS related functions
+ */
+struct fts
+{
+    FTS *tree;              /* tree from fts_open() */
+    int options;            /* options for fts_read() */
+    bool logical;           /* true ==> set FTS_LOGICAL, false ==> set FTS_PHYSICAL */
+    enum fts_type type;     /* types of files desired (bitwise OR) */
+    int count;              /* > 0 - if more than one match, return count-th match */
+    int depth;              /* > 0 - make sure that the FTS level matches this depth */
+    bool base;              /* true ==> basename match */
+    bool seedot;            /* true ==> analogous to FTS_SEEDOT */
+    bool match_case;        /* true ==> case-sensitive match */
+    int (*cmp)(const FTSENT **, const FTSENT **);   /* function pointer to use when traversing (NULL ==> fts_cmp()) */
+    bool(*check)(FTS *, FTSENT *);  /* function pointer to use to check an FTSENT * (NULL ==> check_fts_info()) */
+};
+
+/*
  * external function declarations
  */
 extern char *base_name(char const *path);
@@ -251,25 +273,19 @@ extern bool is_read(char const *path);
 extern bool is_write(char const *path);
 extern mode_t filemode(char const *path);
 extern bool is_open_file_stream(FILE *stream);
+extern void reset_fts(struct fts *fts);
 extern char *fts_path(FTSENT *ent);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);
 extern bool check_fts_info(FTS *fts, FTSENT *ent);
-FTSENT *read_fts(char *dir, int dirfd, int *cwd, int options, bool logical, FTS **fts,
-        int (*cmp)(const FTSENT **, const FTSENT **), bool(*check)(FTS *, FTSENT *));
-extern char const *find_path(char const *path, char *dir, int dirfd, int *cwd,
-        int options, bool logical, enum fts_type type, int count, int depth,
-        bool base, bool seedot, bool match_case, int (*cmp)(const FTSENT **, const FTSENT **),
-        bool(*check)(FTS *, FTSENT *));
+extern FTSENT *read_fts(char *dir, int dirfd, int *cwd, struct fts *fts);
 extern bool array_has_path(struct dyn_array *array, char *path, bool match_case, intmax_t *idx);
 extern uintmax_t paths_in_array(struct dyn_array *array);
 extern char *find_path_in_array(char *path, struct dyn_array *paths, bool match_case, intmax_t *idx);
 extern bool append_path(struct dyn_array **paths, char *str, bool unique, bool duped, bool match_case);
 extern void free_paths_array(struct dyn_array **paths, bool only_empty);
-extern struct dyn_array *find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd,
-        int options, bool logical, enum fts_type type, int count, int depth,
-        bool base, bool seedot, bool match_case, int (*cmp)(const FTSENT **, const FTSENT **),
-        bool(*check)(FTS *, FTSENT *));
+extern char *find_path(char const *path, char *dir, int dirfd, int *cwd, bool abspath, struct fts *fts);
+extern struct dyn_array *find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd, bool abspath, struct fts *fts);
 extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.24 2025-02-21"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.25 2025-02-22"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.21 2025-02-21"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.22 2025-02-22"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.39 2025-02-21"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.40 2025-02-22"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.30 2025-02-21"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.31 2025-02-22"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
By refactoring the FTS functions in jparse/util.c the functions are far easier to use now. A great deal of thought and effort was put into this and when the topdir is passed to chk_manifest() (which is being worked on) it will be far easier. The benefit of these changes, besides being much cleaner, simpler and it being modularised, is that if some issue is discovered or some new feature is needed (as has already happened numerous times) function calls do not have to be updated.

mkiocccentry has been updated to use the simplified interface as well.

A note: jparse/ has not been fully synced because of a change in json_sem for chkentry that is not yet complete (this was done prior to deciding to rework the FTS functions). So the CHANGES.md file and the json_sem.[ch] files committed to the jparse repo are not yet here.

Updated MKIOCCCENTRY_VERSION to "1.2.31 2025-02-22"