### PR TITLE
Fix #1181 and other issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,24 @@ able to find it (and Landon is one of the very few who know about it).
 Okay so there's some fun totally unrelated to the changes but it's fun so why
 not? :-)
 
+Fix bug in `mkiocccentry` where a submission topdir which only had the three
+required files would abort with an error (due to list being not NULL but empty
+due to a typo).
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for some
+upcoming fixes to `chkentry` (I thought of a loophole in a new option that was
+being finalised and more was discovered after this).
+
+`chkentry` has had a partial fix but more needs to be done (for the loophole I
+thought of with the `-w` option). Unfortunately the other things took more time
+than I hoped and I cannot get it in today - and fixes and improvements to the
+FTS functions requires a minor update to chkentry (both in `chkentry.c` and
+`soup/entry_util.c`)  minor change or else it will not compile and also will
+likely segfault.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.33 2025-02-34"`.
+Updated `CHKENTRY_VERSION` to `"1.1.4 2025-02-24"`.
+
 
 ## Release 2.3.41 2025-02-23
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,49 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.27 2025-02-24
+
+Enhance and make more sane the FTS functions even more.
+
+The `struct fts` now holds a `struct dyn_array *ignore` list of paths to ignore.
+The function `read_fts()` checks for ignored paths and if one is encountered it
+is skipped. This uses the same logic as that of `find_path()` and `find_paths()`
+when looking for matches of filenames (not to be ignored).
+
+The `read_fts()` function handles the ignored files based on the booleans (in
+the `struct fts`) `base` and `match_case` (in the `struct fts`).
+
+The `read_fts()` function now checks the depth (instead of the `find_path()` and
+`find_paths()` functions that use it).
+
+In order to make the `reset_fts()` function saner it now requires another arg
+and one also should `memset()` it to 0 prior to calling `reset_fts()`. Doing
+this (with the new `bool` in `struct fts` called `initialised`) allows one to
+close the stream if it's not NULL (say because they used `read_fts()` without
+finishing the loop, leaving the stream in a bad state). It also allows to check
+the ignored list - deciding to free it or not based on the new bool
+(`free_ignored`). Having these updates is a trade-off (having to now use
+`memset(3)` prior to calling `reset_fts()` for the first time) but one that is
+worth it and good practice anyway.
+
+Fixed some comments in the functions (or above them) and removed some duplicate
+comments as well.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.24 2025-02-24"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.21 2025-02-24"`.
+
+## Release 2.2.26 2025-02-23
+
+Updated `jsemtblgen.c` for recent change to `json_sem.[ch]`.
+
+Internal improvement to `find_path()` and `find_paths()` functions: don't
+repeatedly call `lstat(2)`/`stat(2)` per file for the `FTS_DEFAULT`
+case: instead use the function `type_of_file()` once which will at most
+call `lstat(2)` once and if that is not used it will call `stat(2)` once. We
+can then check the file type as a simple comparison.
+
+Updated `JSEMTBLGEN_VERSION` to `"1.2.2 2025-02-23"`.
+Updated `JPARSE_UTILS_VERSION` to `"1.0.23 2025-02-23"`.
+
 ## Release 2.2.25 2025-02-22
 
 Significantly simplify use of FTS functions.

--- a/jparse/jsemtblgen.h
+++ b/jparse/jsemtblgen.h
@@ -76,7 +76,7 @@
 /*
  * official jsemtblgen version
  */
-#define JSEMTBLGEN_VERSION "1.2.1 2025-01-18"		/* format: major.minor YYYY-MM-DD */
+#define JSEMTBLGEN_VERSION "1.2.2 2025-02-23"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jsemtblgen tool basename

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -246,8 +246,10 @@ struct fts
     bool base;              /* true ==> basename match */
     bool seedot;            /* true ==> analogous to FTS_SEEDOT */
     bool match_case;        /* true ==> case-sensitive match */
+    struct dyn_array *ignore;   /* paths to ignore */
     int (*cmp)(const FTSENT **, const FTSENT **);   /* function pointer to use when traversing (NULL ==> fts_cmp()) */
     bool(*check)(FTS *, FTSENT *);  /* function pointer to use to check an FTSENT * (NULL ==> check_fts_info()) */
+    bool initialised;       /* internal use: after first call we can safely check pointers */
 };
 
 /*
@@ -273,7 +275,7 @@ extern bool is_read(char const *path);
 extern bool is_write(char const *path);
 extern mode_t filemode(char const *path);
 extern bool is_open_file_stream(FILE *stream);
-extern void reset_fts(struct fts *fts);
+extern void reset_fts(struct fts *fts, bool free_ignored);
 extern char *fts_path(FTSENT *ent);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.25 2025-02-22"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.27 2025-02-24"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.22 2025-02-22"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.24 2025-02-24"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1334,8 +1334,11 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
     /*
      * before we do anything else we must reset fts structure and set the
      * variables we need
+     *
+     * IMPORTANT: make SURE to use memset(&fts, 0, sizeof(struct fts)) first!
      */
-    reset_fts(&fts);
+    memset(&fts, 0, sizeof(struct fts));
+    reset_fts(&fts, false); /* false means do not clear out ignored list */
     fts.logical = false;
     fts.options = FTS_NOCHDIR | FTS_NOSTAT;
     /*
@@ -1344,7 +1347,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
      */
     ent = read_fts(NULL, -1, NULL, &fts);
     if (ent == NULL){
-        err(49, __func__, "failed to read \".\"");
+        err(49, __func__, "failed to find any files in \".\"");
         not_reached();
     } else {
         do {
@@ -2653,8 +2656,10 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
     /*
      * before we can do anything else we must reset the fts struct and then set
      * our options
+     * IMPORTANT: make SURE to use memset(&fts, 0, sizeof(struct fts)) first!
      */
-    reset_fts(&fts);
+    memset(&fts, 0, sizeof(struct fts));
+    reset_fts(&fts, false); /* false means do not clear out ignored list */
     fts.logical = false;
     fts.options = FTS_NOCHDIR | FTS_NOSTAT;
 
@@ -2665,7 +2670,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     ent = read_fts(NULL, -1, NULL, &fts);
     if (ent == NULL){
-        err(92, __func__, "failed to open \".\"");
+        err(92, __func__, "failed to find any files in \".\"");
         not_reached();
     } else {
         do {
@@ -3465,19 +3470,19 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
 
     /* required files list */
-    free_paths_array(&required_files, false);
+    free_paths_array(&required_files, true);
     required_files = NULL; /* extra sanity */
     /* extra files list */
-    free_paths_array(&extra_files, false);
+    free_paths_array(&extra_files, true);
     extra_files = NULL; /* extra sanity*/
     /* missing files list */
-    free_paths_array(&missing_files, false);
+    free_paths_array(&missing_files, true);
     missing_files = NULL; /* extra sanity */
     /* directories list */
-    free_paths_array(&directories, false);
+    free_paths_array(&directories, true);
     directories = NULL; /* extra sanity */
     /* missing directories list */
-    free_paths_array(&missing_dirs, false);
+    free_paths_array(&missing_dirs, true);
     missing_dirs = NULL; /* extra sanity */
 
     /*

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -3826,8 +3826,13 @@ test_manifest(struct manifest *manp, char *topdir)
 
     /*
      * first reset fts struct
+     *
+     * IMPORTANT: make sure to memset(&fts, 0, sizeof(struct fts)) before the
+     * first use of reset_fts()! This is needed here AND chkentry because we do
+     * not pass a struct fts * here nor should we.
      */
-    reset_fts(&fts);
+    memset(&fts, 0, sizeof(struct fts));
+    reset_fts(&fts, false); /* false means do not clear out ignored list */
     /*
      * Below we will have to check that the files in the manifest actually exist
      * in the topdir. To do this we have to use the find_path() or find_paths()

--- a/soup/version.h
+++ b/soup/version.h
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.32 2025-02-23"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.33 2025-02-34"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -109,7 +109,7 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "1.1.3 2025-02-23"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "1.1.4 2025-02-24"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * Version of info for JSON the .entry.json files.


### PR DESCRIPTION
Fix bug in mkiocccentry where a submission topdir which only had the three required files would abort with an error (due to list being not NULL but empty due to a typo).

Sync [jparse repo](https://github.com/xexyl/jparse/) to jparse/ for some upcoming fixes to chkentry (I thought of a loophole in a new option that was being finalised and more was discovered after this).

chkentry has had a partial fix but more needs to be done (for the loophole I thought of with the -w option). Unfortunately the other things took more time than I hoped and I cannot get it in today - and fixes and improvements to the FTS functions requires a minor update to chkentry (both in chkentry.c and soup/entry_util.c)  minor change or else it will not compile and also will likely segfault.

Updated MKIOCCCENTRY_VERSION to "1.2.33 2025-02-34". Updated CHKENTRY_VERSION to "1.1.4 2025-02-24".