### PR TITLE
Rename topdir -> submission_dir in chkentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.44 2025-02-26
+
+Remove unused arg in `write_json_files()`.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.34 2025-02-26"`.
+
+
 ## Release 2.3.43 2025-02-25
 
 Improve `mkiocccentry_test.sh` - add only required files test.
@@ -59,8 +66,12 @@ FTS functions requires a minor update to chkentry (both in `chkentry.c` and
 `soup/entry_util.c`)  minor change or else it will not compile and also will
 likely segfault.
 
-Updated `MKIOCCCENTRY_VERSION` to `"1.2.33 2025-02-34"`.
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.33 2025-02-24"`.
 Updated `CHKENTRY_VERSION` to `"1.1.4 2025-02-24"`.
+
+**NOTE**: the `MKIOCCCENTRY_VERSION` in this commit was by accident `"1.2.33
+2025-02-34"` but we have retroactively fixed it. Thus if you check out this
+specific commit you would see that the version is a mismatch here.
 
 
 ## Release 2.3.41 2025-02-23

--- a/chkentry.c
+++ b/chkentry.c
@@ -65,7 +65,7 @@ static bool ignore_remarks_md = false;         /* true ==> skip remarks.md check
  * Use the usage() function to print the usage_msg([0-9]?)+ strings.
  */
 static const char * const usage_msg =
-    "usage: %s [-h] [-v level] [-J level] [-V] [-q] [-i file] topdir\n"
+    "usage: %s [-h] [-v level] [-J level] [-V] [-q] [-i file] submission_dir\n"
     "\n"
     "\t-h\t\tprint help message and exit\n"
     "\t-v level\tset verbosity level (def level: %d)\n"
@@ -174,21 +174,22 @@ usage(int exitcode, char const *prog, char const *str)
  * to know all the possible paths in a submission/entry, in those cases it must
  * be the exact path.
  *
- * NOTE: these paths are from UNDER the topdir. So if one has the file:
+ * NOTE: these paths are from UNDER the submission directory. So if one has the
+ * file:
  *
- *      topdir/foo/bar/baz
+ *      submission_dir/foo/bar/baz
  *
  * and they run the command:
  *
- *      chkentry topdir
+ *      chkentry submission_dir
  *
  * and want to ignore the path baz they should NOT do:
  *
- *      chkentry -i topdir/foo/bar/baz topdir
+ *      chkentry -i submission_dir/foo/bar/baz submission_dir
  *
  * Rather they should do:
  *
- *      chkentry -i foo/bar/baz topdir
+ *      chkentry -i foo/bar/baz submission_dir
  *
  * NOTE: this function uses the static char *abbrevs[][2]  to find abbreviations.
  * In the case nothing is found then the path will be added to the list as is.
@@ -196,7 +197,7 @@ usage(int exitcode, char const *prog, char const *str)
  * NOTE: this function will not add a path to the array more than once so if you
  * were to do:
  *
- *      chkentry -i foo -i foo topdir
+ *      chkentry -i foo -i foo submission_dir
  *
  * the ignored list would only have the path 'foo' once.
  *
@@ -577,7 +578,7 @@ int
 main(int argc, char *argv[])
 {
     char const *program = NULL;		/* our name */
-    char **topdir = NULL;               /* directory from which files are to be checked */
+    char **submission_dir = NULL;       /* directory from which files are to be checked */
     extern char *optarg;		/* option argument */
     extern int optind;			/* argv index of the next arg */
     char const *auth_filename = ".";	/* .auth.json file to process, or NULL ==> no .auth.json to process */
@@ -694,7 +695,7 @@ main(int argc, char *argv[])
     argv += optind;
     switch (argc) {
     case 1:
-        topdir = argv;
+        submission_dir = argv;
 	break;
     case 2:
         if (!strcmp(argv[0], ".") && !strcmp(argv[1], ".")) {
@@ -708,20 +709,20 @@ main(int argc, char *argv[])
 	break;
     }
 
-    if (topdir != NULL && *topdir != NULL) {
+    if (submission_dir != NULL && *submission_dir != NULL) {
 	/*
 	 * check if we can search / work within the directory
 	 */
-	if (!exists(*topdir)) {
-	    err(56, __func__, "directory does not exist: %s", *topdir);
+	if (!exists(*submission_dir)) {
+	    err(56, __func__, "directory does not exist: %s", *submission_dir);
 	    not_reached();
 	}
-	if (!is_dir(*topdir)) {
-	    err(57, __func__, "is not a directory: %s", *topdir);
+	if (!is_dir(*submission_dir)) {
+	    err(57, __func__, "is not a directory: %s", *submission_dir);
 	    not_reached();
 	}
-	if (!is_exec(*topdir)) {
-	    err(58, __func__, "directory is not searchable: %s", *topdir);
+	if (!is_exec(*submission_dir)) {
+	    err(58, __func__, "directory is not searchable: %s", *submission_dir);
 	    not_reached();
 	}
 
@@ -743,7 +744,7 @@ main(int argc, char *argv[])
              * make sure .entry.json exists unless -i entry
              */
             if (!ignore_entry) {
-                path = find_path(ENTRY_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(ENTRY_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "file does NOT exist and -w USED and -i entry NOT used: %s", ENTRY_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -769,7 +770,7 @@ main(int argc, char *argv[])
              * unless -i auth .auth.json must NOT exist
              */
             if (!ignore_auth) {
-                path = find_path(AUTH_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(AUTH_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "file EXISTS and -w USED and -i auth NOT used: %s", AUTH_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -789,7 +790,7 @@ main(int argc, char *argv[])
                 /*
                  * .info.json
                  */
-                path = find_path(INFO_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(INFO_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "file EXISTS and -w USED and -i info NOT used: %s", INFO_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -809,7 +810,7 @@ main(int argc, char *argv[])
                 /*
                  * README.md
                  */
-                path = find_path(README_MD_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(README_MD_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "file does NOT exist and -w USED and -i README NOT used: %s", README_MD_FILENAME);
                     ++all_extra_err_count;
@@ -837,7 +838,7 @@ main(int argc, char *argv[])
                 /*
                  * index.html
                  */
-                path = find_path(INDEX_HTML_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(INDEX_HTML_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "file does NOT exist and -w USED and -i index NOT used: %s", INDEX_HTML_FILENAME);
                     ++all_extra_err_count;
@@ -866,7 +867,7 @@ main(int argc, char *argv[])
                 /*
                  * Makefile
                  */
-                path = find_path(MAKEFILE_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(MAKEFILE_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -w used and -i Makefile not used", MAKEFILE_FILENAME);
                     ++all_extra_err_count;
@@ -894,7 +895,7 @@ main(int argc, char *argv[])
                 /*
                  * prog.c
                  */
-                path = find_path(PROG_C_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(PROG_C_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -w used and -i prog.c not used", PROG_C_FILENAME);
                     ++all_extra_err_count;
@@ -922,7 +923,7 @@ main(int argc, char *argv[])
                 /*
                  * prog
                  */
-                path = find_path(PROG_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(PROG_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -w used and -i prog not used", PROG_FILENAME);
                     ++all_extra_err_count;
@@ -942,7 +943,7 @@ main(int argc, char *argv[])
                 /*
                  * remarks.md
                  */
-                path = find_path(REMARKS_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(REMARKS_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -w used and -i remarks not used", REMARKS_FILENAME);
                     ++all_extra_err_count;
@@ -968,7 +969,7 @@ main(int argc, char *argv[])
              * list of paths to ignore is already in the fts->ignore list we
              * don't need to do anything special.
              */
-            found = find_paths(paths, *topdir, -1, &cwd, false, &fts);
+            found = find_paths(paths, *submission_dir, -1, &cwd, false, &fts);
             if (found != NULL) {
                 /*
                  * case: files were found, check that they are both allowed and
@@ -1051,7 +1052,7 @@ main(int argc, char *argv[])
              * make sure .entry.json does NOT exist unless -i entry
              */
             if (!ignore_entry) {
-                path = find_path(ENTRY_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(ENTRY_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -w and -i entry not used and ", ENTRY_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -1069,7 +1070,7 @@ main(int argc, char *argv[])
              * unless -i auth .auth.json MUST exist
              */
             if (!ignore_auth) {
-                path = find_path(AUTH_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(AUTH_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -i auth not used", AUTH_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -1097,7 +1098,7 @@ main(int argc, char *argv[])
                 /*
                  * .info.json
                  */
-                path = find_path(INFO_JSON_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(INFO_JSON_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -i info not used", INFO_JSON_FILENAME);
                     ++all_extra_err_count;
@@ -1125,7 +1126,7 @@ main(int argc, char *argv[])
                 /*
                  * README.md
                  */
-                path = find_path(README_MD_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(README_MD_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -i README not used", README_MD_FILENAME);
                     ++all_extra_err_count;
@@ -1145,7 +1146,7 @@ main(int argc, char *argv[])
                 /*
                  * index.html
                  */
-                path = find_path(INDEX_HTML_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(INDEX_HTML_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -i index not used", INDEX_HTML_FILENAME);
                     ++all_extra_err_count;
@@ -1166,7 +1167,7 @@ main(int argc, char *argv[])
                 /*
                  * Makefile
                  */
-                path = find_path(MAKEFILE_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(MAKEFILE_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -i Makefile not used", MAKEFILE_FILENAME);
                     ++all_extra_err_count;
@@ -1194,7 +1195,7 @@ main(int argc, char *argv[])
                 /*
                  * prog.c
                  */
-                path = find_path(PROG_C_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(PROG_C_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -i prog.c not used", PROG_C_FILENAME);
                     ++all_extra_err_count;
@@ -1222,7 +1223,7 @@ main(int argc, char *argv[])
                 /*
                  * prog
                  */
-                path = find_path(PROG_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(PROG_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path != NULL) {
                     dbg(DBG_LOW, "%s exists and -i prog not used", PROG_FILENAME);
                     ++all_extra_err_count;
@@ -1242,7 +1243,7 @@ main(int argc, char *argv[])
                 /*
                  * remarks.md
                  */
-                path = find_path(REMARKS_FILENAME, *topdir, -1, &cwd, false, &fts);
+                path = find_path(REMARKS_FILENAME, *submission_dir, -1, &cwd, false, &fts);
                 if (path == NULL) {
                     dbg(DBG_LOW, "%s does not exist and -i remarks not used", REMARKS_FILENAME);
                     ++all_extra_err_count;
@@ -1275,7 +1276,7 @@ main(int argc, char *argv[])
              * list of paths to ignore is already in the fts->ignore list we
              * don't need to do anything special.
              */
-            found = find_paths(paths, *topdir, -1, &cwd, false, &fts);
+            found = find_paths(paths, *submission_dir, -1, &cwd, false, &fts);
             if (found != NULL) {
                 /*
                  * case: files were found, check that they are both allowed and
@@ -1350,16 +1351,16 @@ main(int argc, char *argv[])
         }
 
         /*
-         * open the .auth.json file under topdir if !ignore_auth && -w not used
+         * open the .auth.json file under submission_dir if !ignore_auth && -w not used
          */
         if (!ignore_auth && !winning_entry_mode) {
             auth_filename = ".auth.json";
-            auth_stream = open_dir_file(*topdir, auth_filename);
+            auth_stream = open_dir_file(*submission_dir, auth_filename);
             if (auth_stream == NULL) { /* paranoia */
-                err(63, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", *topdir, auth_filename);
+                err(63, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, auth_filename);
                 not_reached();
             }
-            auth_path = calloc_path(*topdir, auth_filename);
+            auth_path = calloc_path(*submission_dir, auth_filename);
             if (auth_path == NULL) {
                 err(64, __func__, "auth_path is NULL");
                 not_reached();
@@ -1367,16 +1368,16 @@ main(int argc, char *argv[])
         }
 
         /*
-         * open the .info.json file under topdir if !ignore_info and -w not used
+         * open the .info.json file under submission_dir if !ignore_info and -w not used
          */
         if (!ignore_info && !winning_entry_mode) {
             info_filename = ".info.json";
-            info_stream = open_dir_file(*topdir, info_filename);
+            info_stream = open_dir_file(*submission_dir, info_filename);
             if (info_stream == NULL) { /* paranoia */
-                err(65, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", *topdir, info_filename);
+                err(65, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, info_filename);
                 not_reached();
             }
-            info_path = calloc_path(*topdir, info_filename);
+            info_path = calloc_path(*submission_dir, info_filename);
             if (info_path == NULL) {
                 err(66, __func__, "info_path is NULL");
                 not_reached();
@@ -1461,7 +1462,7 @@ main(int argc, char *argv[])
              */
             dbg(DBG_HIGH, "about to perform JSON semantic check for .info.json file: %s", info_path);
             info_all_err_count = json_sem_check(info_tree, JSON_DEFAULT_MAX_DEPTH, sem_info,
-                                              &info_count_err, &info_val_err, *topdir);
+                                              &info_count_err, &info_val_err, *submission_dir);
 
             /*
              * firewall on json_sem_check() results AND count errors for .info.json

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -805,7 +805,7 @@ main(int argc, char *argv[])
     if (!quiet) {
 	para("", "Forming the .auth.json file and .info json file ...", NULL);
     }
-    write_json_files(&auth, &info, submission_dir, chkentry, fnamchk);
+    write_json_files(&auth, &info, submission_dir, chkentry);
     if (!quiet) {
 	para("... completed .auth.json and .info.json files.", "", NULL);
     }
@@ -7530,21 +7530,19 @@ form_info(struct info *infop)
  * write_json_files
  *
  * Create the .auth.json and .info.json files and then verify them by running
- * chkentry(1) on them.
+ * chkentry(1) on the submission directory.
  *
  * given:
  *      authp           -   pointer to auth structure
  *      infop           -   pointer to info structure
  *      submission_dir  -   submission directory
  *      chkentry        -   path to chkentry(1) tool
- *      fnamchk         -   path to fnamchk(1) tool
  *
  * This function does not return if a NULL pointer is encountered, if certain
  * variables are not in the right range or if chkentry(1) fails.
  */
 static void
-write_json_files(struct auth *authp, struct info *infop, char const *submission_dir, char const *chkentry,
-        char const *fnamchk)
+write_json_files(struct auth *authp, struct info *infop, char const *submission_dir, char const *chkentry)
 {
     char *info_path;		/* path to .info.json file */
     size_t info_path_len;	/* length of path to .info.json */
@@ -7562,7 +7560,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     /*
      * firewall
      */
-    if (infop == NULL || authp == NULL || submission_dir == NULL || chkentry == NULL || fnamchk == NULL) {
+    if (infop == NULL || authp == NULL || submission_dir == NULL || chkentry == NULL) {
         err(20, __func__, "called with NULL arg(s)");
         not_reached();
     }
@@ -7883,7 +7881,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      */
     if (!quiet) {
 	para("",
-	    "Checking the format of .auth.json and .info.json ...", NULL);
+	    "Checking your submission directory for various issues ...", NULL);
     }
     dbg(DBG_HIGH, "about to perform: %s -q -- %s", chkentry, submission_dir);
     exit_code = shell_cmd(__func__, false, true, "% -q -- %", chkentry, submission_dir);
@@ -7893,7 +7891,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	not_reached();
     }
     if (!quiet) {
-	para("... all appears well with the .auth.json and .info.json files.", NULL);
+	para("... all appears well with your submission directory.", NULL);
     }
 
     /*

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -179,8 +179,7 @@ static char *get_title(struct info *infop);
 static char *get_abstract(struct info *infop);
 static int get_author_info(struct author **author_set_p);
 static void verify_submission_dir(char const *submission_dir, char const *ls);
-static void write_json_files(struct auth *authp, struct info *infop, char const *submission_dir, char const *chkentry,
-        char const *fnamchk);
+static void write_json_files(struct auth *authp, struct info *infop, char const *submission_dir, char const *chkentry);
 static void form_auth(struct auth *authp, struct info *infop, int author_count, struct author *authorp);
 static void form_info(struct info *infop);
 static void form_tarball(char const *workdir, char const *submission_dir, char const *tarball_path, char const *tar,

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -341,7 +341,7 @@ extern bool test_IOCCC_contest(char const *str);
 extern bool test_IOCCC_year(int IOCCC_year);
 extern bool test_iocccsize_version(char const *str);
 extern bool test_location_code(char const *str);
-extern bool test_manifest(struct manifest *manp, char *topdir);
+extern bool test_manifest(struct manifest *manp, char *submission_dir);
 enum manifest_path check_manifest_path(char *path, char const *name, mode_t mode);
 void test_manifest_path(char *path, char const *name, enum manifest_path error, mode_t mode);
 extern bool test_min_timestamp(time_t tstamp);

--- a/soup/man/man1/chkentry.1
+++ b/soup/man/man1/chkentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH chkentry 1 "25 February 2025" "chkentry" "IOCCC tools"
+.TH chkentry 1 "26 February 2025" "chkentry" "IOCCC tools"
 .SH NAME
 .B chkentry
 \- check JSON files in an IOCCC entry
@@ -24,7 +24,7 @@
 .RB [\| \-i
 .IR path \|]
 .RB [\| \-w \|]
-.I topdir
+.I submission_dir
 .SH DESCRIPTION
 .PP
 .BR chkentry (1)

--- a/soup/version.h
+++ b/soup/version.h
@@ -66,7 +66,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.43 2025-02-25"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.44 2025-02-26"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -82,7 +82,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.33 2025-02-34"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.34 2025-02-26"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION

The tool is run on the submission directory that has the files that came  
from the topdir, not the topdir itself. 