### PR TITLE
Improve -i answers to prompt for y/n questions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,16 @@ tool - which is quite useful to know that the user is using the most recent
 version of the script. This was also done in `jparse/` but that doesn't matter
 here; it's only mentioned due to the sync.
 
+Enhance `mkiocccentry` prompting with `-i answers` used. Instead of always
+answering yes even when an issue is found, unless the new option `-Y` is used,
+give the user a chance to confirm things are okay (in particular, it allows one
+to answer no to a question; it does not prompt you for everything as that would
+defeat the purpose of the answers file). The use of `-Y` is highly discouraged
+unless you are **certain** you're good to go and it is mostly used for
+`mkiocccentry_test.sh` which needs to be non-interactive.
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.35 2025-02-27"`.
+Updated `MKIOCCCENTRY_TEST_VERSION` to` "1.0.15 2025-02-26"`.
 
 
 ## Release 2.3.44 2025-02-26

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "21 February 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "27 February 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -172,6 +172,11 @@ See:
 \<https://www.ioccc.org/next/index.html\>
 .ft R
 for information on the IOCCC rules and guidelines.
+.TP
+.B \-Y
+Force answer yes to questions even when you would otherwise be prompted.
+This is mostly for the test-suite and in particular for the reading of answers from a file.
+That is because when scanning the topdir and making directories and copying files from the topdir to the submission directory and checking that the directory ended up okay, we do prompt the user again.
 .TP
 .BI \-t\  tar
 Set path to

--- a/soup/version.h
+++ b/soup/version.h
@@ -99,7 +99,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.34 2025-02-26"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.35 2025-02-27"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -76,7 +76,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="1.0.14 2025-02-25"
+export MKIOCCCENTRY_TEST_VERSION="1.0.15 2025-02-26"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit
@@ -348,8 +348,8 @@ test -f "${topdir}"/prog.c || echo "int main(){}" >"${topdir}"/prog.c
 # delete the work directory for next test
 find "${workdir_esc}" -mindepth 1 -depth -delete
 # test empty prog.c, ignoring the warning about it
-echo "./mkiocccentry -y -q -W -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS  -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -W -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS  -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -446,8 +446,8 @@ test -f "${topdir}"/prog.alt.c || touch "${topdir}"/prog.alt.c
 rm -f "${topdir}"/prog.c
 :> "${topdir}"/prog.c
 # test empty prog.c, ignoring the warning about it
-echo "./mkiocccentry -y -q -W -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS  -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -W -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS  -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -W -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS"  -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -540,8 +540,8 @@ answers >>answers.txt
 
 # run the test, looking for an exit
 #
-echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -630,8 +630,8 @@ test -f "${topdir}"/bar || cat CODE_OF_CONDUCT.md >"${topdir}"/bar
 
 # run the test, looking for an exit
 #
-echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -724,8 +724,8 @@ test -f "${topdir}/$LONG_FILENAME" || touch "${topdir}/$LONG_FILENAME"
 
 # run the test, looking for an exit
 #
-echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e  -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e  -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e  -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e  -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 4 ]]; then
     echo "$0: ERROR: mkiocccentry exit code not 4: $status" 1>&2
@@ -819,8 +819,8 @@ test -f "${topdir_topdir}/foo" || touch "${topdir_topdir}/foo"
 
 # run the test, looking for an exit
 #
-echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 0 ]]; then
     echo "$0: ERROR: mkiocccentry non-zero exit code: $status" 1>&2
@@ -916,8 +916,8 @@ test -f "${topdir_topdir_topdir_topdir_topdir}/foo" || touch "${topdir_topdir_to
 
 # run the test, looking for an exit
 #
-echo "./mkiocccentry -y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
-./mkiocccentry -y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
+echo "./mkiocccentry -y -Y -q -i answers.txt -m $MAKE -F $FNAMCHK -t $TAR -T $TXZCHK -e -l $LS -v $V_FLAG -J $J_FLAG -- ${workdir} ${topdir}"
+./mkiocccentry -y -Y -q -i answers.txt -m "$MAKE" -F "$FNAMCHK" -t "$TAR" -T "$TXZCHK" -e -l "$LS" -v "$V_FLAG" -J "$J_FLAG" -- "${workdir}" "${topdir}"
 status=$?
 if [[ ${status} -ne 4 ]]; then
     echo "$0: ERROR: mkiocccentry zero exit code not 4: $status" 1>&2


### PR DESCRIPTION
With -i answers used, unless -Y is used, mkiocccentry now will ask you to confirm things are okay (in other words if something goes wrong that would normally be warned about, you'll get to see it).

If you need to not have this you can use the new -Y option which forces -y. This is not usually a good idea but it's required for the test script (mkiocccentry_test.sh) as it is not interactive and shouldn't be.

Updated MKIOCCCENTRY_VERSION to "1.2.35 2025-02-27". Updated MKIOCCCENTRY_TEST_VERSION to "1.0.15 2025-02-26".