### PR TITLE
Fix and improve warning of -y and -Y

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.45 2025-02-28
+
+Fix and improve warning of `-y` and `-Y` in `mkiocccentry`.
+
+The code did not explicitly check for `-Y`; it just used the implicit `-y` from
+`-Y`. That is fixed and now if not `-q` show a simple summary but always show
+the longer warning to be sure that they know. As for `-Y` it really ought to be
+used only for the test script but even `-y` should be used with **EXTREME**
+caution.
+
+It is hoped this is the last update to `mkiocccentry(1)` prior to the soft code
+freeze today.
+
+TODO: finish work on the `chkentry_test.sh` script.
+
+
+
 ## Release 2.3.44 2025-02-27
 
 Prepare for code freeze (28 February 2025) with some final changes, some

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -567,20 +567,45 @@ main(int argc, char *argv[])
 	print("Welcome to mkiocccentry version: %s\n", MKIOCCCENTRY_VERSION);
     }
 
-    /*
-     * warn (if not -q/quiet mode) user that with -i answers (or -y) we will
-     * always answer yes. This is especially important (in fact absolutely
-     * essential for -i answers) because if there was a change in file set(s)
-     * then the answers file would be entirely useless!
-     */
-    if (answer_yes && !quiet) {
-        /*
-         * we could use msg() but this performs more checks which is very
-         * important for this
-         */
-        print("%s", "Notice: we will always answer yes to questions.");
-    }
 
+    /*
+     * warn about -Y option
+     */
+    if (force_yes) {
+        para("",
+             "WARNING: you've chosen to answer YES to ALL prompts. If this was",
+             "unintentional, run the program again without specifying -Y. We cannot",
+             "stress the importance of this enough! Well OK, we can overstress most things",
+             "but you get the point; do not use the -Y option without EXTREME caution!",
+             "",
+             "Hint: this option is mostly useful for mkiocccentry_test.sh; if you REALLY",
+             "want to answer yes you should use -y instead which will allow you to still",
+             "verify certain things.",
+             "",
+             NULL);
+
+        /*
+         * if not quiet give a shorter warning as well
+         */
+        if (!quiet) {
+            print("%s", "Notice: we will ALWAYS answer YES to questions.\n");
+        }
+    } else if (answer_yes) {
+        /* warn about -y option */
+        para("",
+             "WARNING: you've chosen to answer yes to ALMOST ALL prompts. If this was",
+             "unintentional, run the program again without specifying -y. We cannot",
+             "stress the importance of this enough! Well OK, we can overstress most things",
+             "but you get the point; do not use the -y option without EXTREME caution!",
+             "",
+             NULL);
+        /*
+         * if not quiet give a shorter warning as well
+         */
+        if (!quiet) {
+            print("%s", "Notice: we will answer YES to MOST questions.\n");
+        }
+    }
 
 
     /*
@@ -588,18 +613,6 @@ main(int argc, char *argv[])
      */
     info.mkiocccentry_ver = MKIOCCCENTRY_VERSION;
     dbg(DBG_HIGH, "info.mkiocccentry_ver: %s", info.mkiocccentry_ver);
-
-    /* warn about -y option */
-    if (answer_yes) {
-	para("",
-	     "WARNING: you've chosen to answer yes to almost all prompts. If this was",
-	     "unintentional, run the program again without specifying -y. We cannot",
-	     "stress the importance of this enough! Well OK, we can overstress most things",
-	     "but you get the point; do not use the -y option without EXTREME caution!",
-	     "",
-	     NULL);
-    }
-
     /* if the user requested to ignore warnings, and now -E, then ignore this once and warn them :) */
     if (ignore_warnings) {
 	para("",

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.45 2025-02-27"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.46 2025-02-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -99,7 +99,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.35 2025-02-27"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.36 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 


### PR DESCRIPTION
The code did not explicitly check for -Y; it just used the implicit -y from -Y. That is fixed and now if not -q show a simple summary but always show the longer warning to be sure that they know. As for -Y it really ought to be used only for the test script but even -y should be used with EXTREME caution.

It is hoped this is the last update to mkiocccentry(1) prior to the soft code freeze today.

TODO: finish work on the chkentry_test.sh script.