### PR TITLE
Resequence exit codes in jparse/util

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.3.45 2025-02-28
+
+Fix and improve warning of `-y` and `-Y` in `mkiocccentry`.
+
+The code did not explicitly check for `-Y`; it just used the implicit `-y` from
+`-Y`. That is fixed and now if not `-q` show a simple summary but always show
+the longer warning to be sure that they know. As for `-Y` it really ought to be
+used only for the test script but even `-y` should be used with **EXTREME**
+caution.
+
+It is hoped this is the last update to `mkiocccentry(1)` prior to the soft code
+freeze today.
+
+TODO: finish work on the `chkentry_test.sh` script.
+
+
+
 ## Release 2.3.44 2025-02-27
 
 Prepare for code freeze (28 February 2025) with some final changes, some

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,14 @@ caution.
 It is hoped this is the last update to `mkiocccentry(1)` prior to the soft code
 freeze today.
 
+Update `MKIOCCCENTRY_VERSION` to `"1.2.36 2025-02-28"`.
+
 TODO: finish work on the `chkentry_test.sh` script.
 
+Resequence exit codes in `jparse/util.c`. It appears that this was not done or
+something went wrong when doing so (as running `make seqcexit` updated the exit
+codes and this comes from after running it in `jparse/` and committing and then
+syncing from `jparse` to `jparse/`).
 
 
 ## Release 2.3.44 2025-02-27

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -11271,7 +11271,7 @@ main(int argc, char **argv)
     fts.max_depth = 5;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found == NULL) {
-        err(208, __func__, "didn't find any paths in the paths array");
+        err(210, __func__, "didn't find any paths in the paths array");
         not_reached();
     }
 
@@ -11285,7 +11285,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(209, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(211, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -11332,7 +11332,7 @@ main(int argc, char **argv)
     fts.max_depth = 3;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found == NULL) {
-        err(208, __func__, "didn't find any paths in the paths array");
+        err(212, __func__, "didn't find any paths in the paths array");
         not_reached();
     }
 
@@ -11346,7 +11346,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(209, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(213, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -11395,7 +11395,7 @@ main(int argc, char **argv)
     fts.max_depth = 0;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found == NULL) {
-        err(208, __func__, "didn't find any paths in the paths array");
+        err(214, __func__, "didn't find any paths in the paths array");
         not_reached();
     }
 
@@ -11409,7 +11409,7 @@ main(int argc, char **argv)
             /* get next string pointer */
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {	/* paranoia */
-                err(209, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
+                err(215, __func__, "found NULL pointer at paths_found[%ju]", (uintmax_t)j);
                 not_reached();
             }
 
@@ -11460,7 +11460,7 @@ main(int argc, char **argv)
     fts.max_depth = 3;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found != NULL) {
-        err(208, __func__, "bogus range of min/max directories found directories");
+        err(216, __func__, "bogus range of min/max directories found directories");
         not_reached();
     }
 
@@ -11489,7 +11489,7 @@ main(int argc, char **argv)
     fts.match_case = true;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found != NULL) {
-        err(210, __func__, "found unexpected socket under test_jparse/");
+        err(217, __func__, "found unexpected socket under test_jparse/");
         not_reached();
     }
 
@@ -11521,7 +11521,7 @@ main(int argc, char **argv)
     fts.match_case = true;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found != NULL) {
-        err(211, __func__, "found unexpected character device under test_jparse/");
+        err(218, __func__, "found unexpected character device under test_jparse/");
         not_reached();
     }
 
@@ -11554,7 +11554,7 @@ main(int argc, char **argv)
     fts.match_case = true;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found != NULL) {
-        err(212, __func__, "found unexpected block device under test_jparse/");
+        err(219, __func__, "found unexpected block device under test_jparse/");
         not_reached();
     }
 
@@ -11581,7 +11581,7 @@ main(int argc, char **argv)
     fts.match_case = false;
     paths_found = find_paths(paths, "test_jparse", -1, &cwd, false, &fts);
     if (paths_found != NULL) {
-        err(213, __func__, "found unexpected FIFO under test_jparse/");
+        err(220, __func__, "found unexpected FIFO under test_jparse/");
         not_reached();
     }
 
@@ -11621,7 +11621,7 @@ main(int argc, char **argv)
         for (j = 0; j < len; ++j) {
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {
-                err(214, __func__, "found NULL pointer in paths_found (not file, directory or symlink) array");
+                err(221, __func__, "found NULL pointer in paths_found (not file, directory or symlink) array");
                 not_reached();
             }
             warn(__func__, "path is not a file, directory or symlink: %s", name);
@@ -11629,7 +11629,7 @@ main(int argc, char **argv)
         /*
          * make it an error
          */
-        err(215, __func__, "found unexpected file type under test_jparse/");
+        err(222, __func__, "found unexpected file type under test_jparse/");
         not_reached();
     }
 
@@ -11669,7 +11669,7 @@ main(int argc, char **argv)
     relpath = "foobar";
     touch(relpath, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     if (!exists(relpath)) {
-        err(216, __func__, "file %s does not exist after touch()", relpath);
+        err(223, __func__, "file %s does not exist after touch()", relpath);
         not_reached();
     }
 
@@ -11693,17 +11693,17 @@ main(int argc, char **argv)
         for (j = 0; j < len; ++j) {
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {
-                err(217, __func__, "found NULL pointer in paths_found (any) array");
+                err(224, __func__, "found NULL pointer in paths_found (any) array");
                 not_reached();
             }
             if (strcmp(relpath, name) != 0) {
-                err(218, __func__, "found non-matching file in list: %s != %s", name, relpath);
+                err(225, __func__, "found non-matching file in list: %s != %s", name, relpath);
                 not_reached();
             }
             fdbg(stderr, DBG_MED, "found file %s as case-sensitive search", name);
         }
     } else {
-        err(219, __func__, "couldn't find any file called \"%s\" as case-sensitive search", relpath);
+        err(226, __func__, "couldn't find any file called \"%s\" as case-sensitive search", relpath);
         not_reached();
     }
 
@@ -11742,18 +11742,18 @@ main(int argc, char **argv)
         for (j = 0; j < len; ++j) {
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {
-                err(220, __func__, "found NULL pointer in paths_found (any) array");
+                err(227, __func__, "found NULL pointer in paths_found (any) array");
                 not_reached();
             }
             if (strcasecmp(relpath, name) != 0) {
-                err(221, __func__, "found non-matching file in list: %s != %s", name, relpath);
+                err(228, __func__, "found non-matching file in list: %s != %s", name, relpath);
                 not_reached();
             }
 
             fdbg(stderr, DBG_MED, "found %s by case-insensitive search", name);
         }
     } else {
-        err(222, __func__, "couldn't find any file called \"%s\" by case-insensitive search", relpath);
+        err(229, __func__, "couldn't find any file called \"%s\" by case-insensitive search", relpath);
         not_reached();
     }
 
@@ -11763,7 +11763,7 @@ main(int argc, char **argv)
     errno = 0;      /* pre-clear errno for errp() */
     if (unlink(relpath) != 0) {
         if (errno != ENOENT) {
-            errp(223, __func__, "unable to delete file %s", relpath);
+            errp(230, __func__, "unable to delete file %s", relpath);
             not_reached();
         }
     } else {
@@ -11805,7 +11805,7 @@ main(int argc, char **argv)
      * make sure it exists
      */
     if (!exists(relpath)) {
-        err(224, __func__, "file %s does not exist", relpath);
+        err(231, __func__, "file %s does not exist", relpath);
         not_reached();
     }
 
@@ -11843,7 +11843,7 @@ main(int argc, char **argv)
         for (j = 0; j < len; ++j) {
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {
-                err(225, __func__, "found NULL pointer in paths_found (any) array");
+                err(232, __func__, "found NULL pointer in paths_found (any) array");
                 not_reached();
             }
             fdbg(stderr, DBG_MED, "found file %s as case-sensitive search", name);
@@ -11892,11 +11892,11 @@ main(int argc, char **argv)
         for (j = 0; j < len; ++j) {
             name = dyn_array_value(paths_found, char *, j);
             if (name == NULL) {
-                err(226, __func__, "found NULL pointer in paths_found array");
+                err(233, __func__, "found NULL pointer in paths_found array");
                 not_reached();
             }
             if (strcasecmp(relpath, name) != 0) {
-                err(227, __func__, "found non-matching file: %s != %s", name, relpath);
+                err(234, __func__, "found non-matching file: %s != %s", name, relpath);
                 not_reached();
             }
             fdbg(stderr, DBG_MED, "found %s by case-insensitive search", name);
@@ -11905,7 +11905,7 @@ main(int argc, char **argv)
         /*
          * as it is a case-insensitive it should always succeed
          */
-        err(228, __func__, "couldn't find any file called %s by case-insensitive search", relpath);
+        err(235, __func__, "couldn't find any file called %s by case-insensitive search", relpath);
         not_reached();
     }
 
@@ -11935,7 +11935,7 @@ main(int argc, char **argv)
         free(fname);
         fname = NULL;
     } else {
-        err(229, __func__, "couldn't find %s in tree", relpath);
+        err(236, __func__, "couldn't find %s in tree", relpath);
         not_reached();
     }
 
@@ -11946,7 +11946,7 @@ main(int argc, char **argv)
     errno = 0;      /* pre-clear errno for errp() */
     if (unlink(relpath) != 0) {
         if (errno != ENOENT) {
-            errp(230, __func__, "unable to delete file %s", relpath);
+            errp(237, __func__, "unable to delete file %s", relpath);
             not_reached();
         }
     } else {

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -567,20 +567,45 @@ main(int argc, char *argv[])
 	print("Welcome to mkiocccentry version: %s\n", MKIOCCCENTRY_VERSION);
     }
 
-    /*
-     * warn (if not -q/quiet mode) user that with -i answers (or -y) we will
-     * always answer yes. This is especially important (in fact absolutely
-     * essential for -i answers) because if there was a change in file set(s)
-     * then the answers file would be entirely useless!
-     */
-    if (answer_yes && !quiet) {
-        /*
-         * we could use msg() but this performs more checks which is very
-         * important for this
-         */
-        print("%s", "Notice: we will always answer yes to questions.");
-    }
 
+    /*
+     * warn about -Y option
+     */
+    if (force_yes) {
+        para("",
+             "WARNING: you've chosen to answer YES to ALL prompts. If this was",
+             "unintentional, run the program again without specifying -Y. We cannot",
+             "stress the importance of this enough! Well OK, we can overstress most things",
+             "but you get the point; do not use the -Y option without EXTREME caution!",
+             "",
+             "Hint: this option is mostly useful for mkiocccentry_test.sh; if you REALLY",
+             "want to answer yes you should use -y instead which will allow you to still",
+             "verify certain things.",
+             "",
+             NULL);
+
+        /*
+         * if not quiet give a shorter warning as well
+         */
+        if (!quiet) {
+            print("%s", "Notice: we will ALWAYS answer YES to questions.\n");
+        }
+    } else if (answer_yes) {
+        /* warn about -y option */
+        para("",
+             "WARNING: you've chosen to answer yes to ALMOST ALL prompts. If this was",
+             "unintentional, run the program again without specifying -y. We cannot",
+             "stress the importance of this enough! Well OK, we can overstress most things",
+             "but you get the point; do not use the -y option without EXTREME caution!",
+             "",
+             NULL);
+        /*
+         * if not quiet give a shorter warning as well
+         */
+        if (!quiet) {
+            print("%s", "Notice: we will answer YES to MOST questions.\n");
+        }
+    }
 
 
     /*
@@ -588,18 +613,6 @@ main(int argc, char *argv[])
      */
     info.mkiocccentry_ver = MKIOCCCENTRY_VERSION;
     dbg(DBG_HIGH, "info.mkiocccentry_ver: %s", info.mkiocccentry_ver);
-
-    /* warn about -y option */
-    if (answer_yes) {
-	para("",
-	     "WARNING: you've chosen to answer yes to almost all prompts. If this was",
-	     "unintentional, run the program again without specifying -y. We cannot",
-	     "stress the importance of this enough! Well OK, we can overstress most things",
-	     "but you get the point; do not use the -y option without EXTREME caution!",
-	     "",
-	     NULL);
-    }
-
     /* if the user requested to ignore warnings, and now -E, then ignore this once and warn them :) */
     if (ignore_warnings) {
 	para("",

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.45 2025-02-27"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.3.46 2025-02-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -99,7 +99,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.35 2025-02-27"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "1.2.36 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 

--- a/test_ioccc/chkentry_test.sh
+++ b/test_ioccc/chkentry_test.sh
@@ -2,6 +2,8 @@
 #
 # chkentry_test.sh - chkentry test on good and bad files under a directory
 #
+# "Because grammar and syntax alone do not make a complete language." :-)
+#
 # Use chkentry to test all the files under test_JSON{info,auth}.json/good/ and
 # verify there are no JSON semantic errors.  If any JSON semantic errors are
 # detected, this script will exit non-zero.
@@ -10,20 +12,40 @@
 # verify there are JSON semantic errors.  If any file is found to be free of
 # JSON semantic errors, this script will exit non-zero.
 #
-# IMPORTANT NOTE: All JSON files (under both good and bad) MUST to be valid JSON.
-#		  This script focuses testing JSON semantic errors only.
+# Copyright (c) 2022-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
-# This script was written in 2022 by:
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
 #
-#	@xexyl
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# This script and the JSON parser were co-developed in 2022-2025 by Cody Boone
+# Ferguson and Landon Curt Noll:
+#
+#  @xexyl
 #	https://xexyl.net		Cody Boone Ferguson
 #	https://ioccc.xexyl.net
-#
-# with some minor improvements by:
-#
+# and:
 #	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
 #
 # "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# "Share and Enjoy!"
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+
 #
 # setup
 #
@@ -37,11 +59,11 @@ export EXIT_CODE=0
 export INVALID_JSON_FOUND=""
 export UNEXPECTED_SEMANTIC_ERROR=""
 export SEMANTIC_ERROR_MISSED=""
-export JSON_TREE="./test_ioccc/test_JSON"
+export SLOT_TREE="./test_ioccc/slot"
 
-export CHKENTRY_TEST_VERSION="1.1.0 2025-01-18"
+export CHKENTRY_TEST_VERSION="1.1.1 2025-02-28"
 
-export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-c chkentry] [-d json_tree]
+export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-c chkentry] [-d slot_tree]
 
     -h			print help and exit
     -V			print version and exit
@@ -50,15 +72,12 @@ export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-c 
     -J level		set JSON parser verbosity level (def level: 0)
     -q			quiet mode: silence msg(), warn(), warnp() if -v 0 (def: loud :-) )
     -c chkentry		path to chkentry tool (def: $CHKENTRY)
-    -d json_tree	test files json_tree/{info,auth}.json/{good,bad}/*.json (def: $JSON_TREE)
+    -d slot_tree	test files slot_tree/{info,auth}.json/{good,bad}/*.json (def: $SLOT_TREE)
 
-			NOTE: these subdirectories are required under json_tree:
+			NOTE: these subdirectories are required under slot_tree:
 
-			json_tree/auth.json/good/	valid JSON syntax that is a proper .auth.json semantic file
-			json_tree/auth.json/bad/	valid JSON syntax that has 1 or more .auth.json semantic errors
-
-			json_tree/info.json/good/	valid JSON syntax that is a proper .info.json semantic file
-			json_tree/info.json/bad/	valid JSON syntax that has 1 or more .info.json semantic errors
+			    slot_tree/good/	valid submission directories
+			    slot_tree/bad/	invalid submission directories
 
 Exit codes:
      0   all OK
@@ -66,7 +85,7 @@ Exit codes:
      2   -h and help string printed or -V and version string printed
      3   invalid command line
      4	 missing or non-executable chkentry
-     5	 missing or non-readable json_tree directory or subdirectory
+     5	 missing or non-readable slot_tree directory or subdirectory
      6	 some files were invalid JSON; chkentry correctly tested all other files
      7	 some files were invalid JSON and some chkentry tests failed
  >= 10   internal error
@@ -93,7 +112,7 @@ while getopts :hVv:D:J:qc:d: flag; do
 	;;
     c)	CHKENTRY="$OPTARG";
 	;;
-    d)	JSON_TREE="$OPTARG"
+    d)	SLOT_TREE="$OPTARG"
 	;;
     \?) echo "$0: ERROR: invalid option: -$OPTARG" 1>&2
 	echo 1>&2
@@ -129,10 +148,8 @@ if [[ $# -ne 0 ]]; then
     echo "$USAGE" 1>&2
     exit 3
 fi
-export AUTH_GOOD_TREE="$JSON_TREE/auth.json/good"
-export AUTH_BAD_TREE="$JSON_TREE/auth.json/bad"
-export INFO_GOOD_TREE="$JSON_TREE/info.json/good"
-export INFO_BAD_TREE="$JSON_TREE/info.json/bad"
+export GOOD_TREE="$SLOT_TREE/good"
+export BAD_TREE="$SLOT_TREE/bad"
 
 # firewall
 #
@@ -149,80 +166,51 @@ if [[ ! -x $CHKENTRY ]]; then
     exit 4
 fi
 
-# check that json_tree is a readable directory
+# check that slot_tree is a readable directory
 #
-if [[ ! -e $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not found: $JSON_TREE" 1>&2
+if [[ ! -e $SLOT_TREE ]]; then
+    echo "$0: ERROR: slot_tree not found: $SLOT_TREE" 1>&2
     exit 5
 fi
-if [[ ! -d $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not a directory: $JSON_TREE" 1>&2
+if [[ ! -d $SLOT_TREE ]]; then
+    echo "$0: ERROR: slot_tree not a directory: $SLOT_TREE" 1>&2
     exit 5
 fi
-if [[ ! -r $JSON_TREE ]]; then
-    echo "$0: ERROR: json_tree not readable directory: $JSON_TREE" 1>&2
+if [[ ! -r $SLOT_TREE ]]; then
+    echo "$0: ERROR: slot_tree not readable directory: $SLOT_TREE" 1>&2
     exit 5
 fi
 
-# good tree for auth.json
+# good tree
 #
-if [[ ! -e $AUTH_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/good for chkentry directory not found: $AUTH_GOOD_TREE" 1>&2
+if [[ ! -e $GOOD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/good for chkentry directory not found: $GOOD_TREE" 1>&2
     exit 5
 fi
-if [[ ! -d $AUTH_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/good for chkentry not a directory: $AUTH_GOOD_TREE" 1>&2
+if [[ ! -d $GOOD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/good for chkentry not a directory: $GOOD_TREE" 1>&2
     exit 5
 fi
-if [[ ! -r $AUTH_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/good for chkentry not readable directory: $AUTH_GOOD_TREE" 1>&2
+if [[ ! -r $GOOD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/good for chkentry not readable directory: $GOOD_TREE" 1>&2
     exit 5
 fi
 
-# bad tree for auth.json
+# bad tree
 #
-if [[ ! -e $AUTH_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/bad for chkentry directory not found: $AUTH_BAD_TREE" 1>&2
+if [[ ! -e $BAD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/bad for chkentry directory not found: $BAD_TREE" 1>&2
     exit 5
 fi
-if [[ ! -d $AUTH_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/bad for chkentry not a directory: $AUTH_BAD_TREE" 1>&2
+if [[ ! -d $BAD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/bad for chkentry not a directory: $BAD_TREE" 1>&2
     exit 5
 fi
-if [[ ! -r $AUTH_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/auth.json/bad for chkentry not readable directory: $AUTH_BAD_TREE" 1>&2
+if [[ ! -r $BAD_TREE ]]; then
+    echo "$0: ERROR: slot_tree/bad for chkentry not readable directory: $BAD_TREE" 1>&2
     exit 5
 fi
 
-# good tree for info.json
-#
-if [[ ! -e $INFO_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/good for chkentry directory not found: $INFO_GOOD_TREE" 1>&2
-    exit 5
-fi
-if [[ ! -d $INFO_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/good for chkentry not a directory: $INFO_GOOD_TREE" 1>&2
-    exit 5
-fi
-if [[ ! -r $INFO_GOOD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/good for chkentry not readable directory: $INFO_GOOD_TREE" 1>&2
-    exit 5
-fi
-
-# bad tree for info.json
-#
-if [[ ! -e $INFO_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/bad for chkentry directory not found: $INFO_BAD_TREE" 1>&2
-    exit 5
-fi
-if [[ ! -d $INFO_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/bad for chkentry not a directory: $INFO_BAD_TREE" 1>&2
-    exit 5
-fi
-if [[ ! -r $INFO_BAD_TREE ]]; then
-    echo "$0: ERROR: json_tree/info.json/bad for chkentry not readable directory: $INFO_BAD_TREE" 1>&2
-    exit 5
-fi
 
 # remove logfile so that each run starts out with an empty file
 #
@@ -237,105 +225,83 @@ if [[ ! -w "${LOGFILE}" ]]; then
     exit 11
 fi
 
-# run_auth_test - run a single chkentry test on a file
+# run_good_test - run a single chkentry test on a directory that must pass
 #
 # usage:
-#	run_auth_test chkentry dbg_level json_dbg_level quiet_mode auth_json pass|fail
+#	run_good_test chkentry dbg_level json_dbg_level quiet_mode directory
 #
 #	chkentry		path to the chkentry program
 #	dbg_level		internal test debugging level to use as in: chkentry -v dbg_level
 #	json_dbg_level		JSON parser debug level to use in: chkentry -J json_dbg_level
 #	quiet_mode		quiet mode to use in: chkentry -q
-#	auth_json		auth.json file to check with chkentry
-#	pass|fail		string saying if chkentry must return valid json or invalid json
+#	directory		directory to check
 #
-run_auth_test()
+# The return code of this function is non-zero if an internal error occurs OR if
+# the return value of chkentry is not 0.
+#
+run_good_test()
 {
     # parse args
     #
-    if [[ $# -ne 6 ]]; then
-	echo "$0: ERROR: expected 6 args to run_auth_test, found $#" 1>&2
+    if [[ $# -ne 5 ]]; then
+	echo "$0: ERROR: expected 5 args to run_good_test, found $#" 1>&2
 	exit 12
     fi
     declare chkentry="$1"
     declare dbg_level="$2"
     declare json_dbg_level="$3"
     declare quiet_mode="$4"
-    declare auth_json="$5"
-    declare pass_fail="$6"
-
-    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
-	echo "$0: ERROR: in run_auth_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	exit 13
-    fi
+    declare directory="$5"
 
     # debugging
     #
     if [[ $V_FLAG -ge 9 ]]; then
-	echo "$0: debug[9]: in run_auth_test: chkentry: $chkentry" 1>&2
-	echo "$0: debug[9]: in run_auth_test: dbg_level: $dbg_level" 1>&2
-	echo "$0: debug[9]: in run_auth_test: json_dbg_level: $json_dbg_level" 1>&2
-	echo "$0: debug[9]: in run_auth_test: quiet_mode: $quiet_mode" 1>&2
-	echo "$0: debug[9]: in run_auth_test: auth_json: $auth_json" 1>&2
-	echo "$0: debug[9]: in run_auth_test: pass_fail: $pass_fail" 1>&2
+	echo "$0: debug[9]: in run_good_test: chkentry: $chkentry" 1>&2
+	echo "$0: debug[9]: in run_good_test: dbg_level: $dbg_level" 1>&2
+	echo "$0: debug[9]: in run_good_test: json_dbg_level: $json_dbg_level" 1>&2
+	echo "$0: debug[9]: in run_good_test: quiet_mode: $quiet_mode" 1>&2
+	echo "$0: debug[9]: in run_good_test: directory: $directory" 1>&2
+    fi
+
+    # directory must exist
+    #
+    if [[ ! -d "$directory" ]] || [[ ! -r "$directory" ]]; then
+        echo "$0: ERROR: directory is not a directory or unreadable: $directory"
+        exit 13
     fi
 
     # perform the test
     #
     if [[ -z $quiet_mode ]]; then
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -- $auth_json . >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must pass: $chkentry -v $dbg_level -J $json_dbg_level -- $directory >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -- $auth_json . >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
-	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -- "$auth_json" . >> "${LOGFILE}" 2>&1
+	echo "$0: about to run test that must pass: $chkentry -v $dbg_level -J $json_dbg_level -- $directory >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -- "$directory" >> "${LOGFILE}" 2>&1
 	status="$?"
     else
 	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -q -- $auth_json . >> ${LOGFILE} 2>&1" 1>&2
+	    echo "$0: debug[3]: about to run test that must pass: $chkentry -v $dbg_level -J $json_dbg_level -q -- $directory >> ${LOGFILE} 2>&1" 1>&2
 	fi
-	echo "$0: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -q -- $auth_json . >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
-	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -q -- "$auth_json" . >> "${LOGFILE}" 2>&1
+	echo "$0: about to run test that must pass: $chkentry -v $dbg_level -J $json_dbg_level -q -- $directory >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
+	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -q -- "$directory" >> "${LOGFILE}" 2>&1
 	status="$?"
     fi
 
     # examine test result
     #
-    if [[ $status -eq 4 ]]; then
-	echo "$0: ERROR: file is not a valid JSON file for chkentry to test: $auth_json" >> "${LOGFILE}"
-	if [[ $V_FLAG -ge 1 ]]; then
-	    echo "$0: debug[1]: ERROR: file is not a valid JSON file for chkentry to test: $auth_json" 1>&2
-	fi
-	INVALID_JSON_FOUND="true"
-    elif [[ $status -eq 0 ]]; then
-	if [[ $pass_fail = pass ]]; then
-	    echo "$0: test $auth_json should PASS: chkentry PASS with exit code 0" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 3 ]]; then
-		echo "$0: debug[3]: test $auth_json should PASS: chkentry passed with exit code 0" 1>&2
-	    fi
-	else
-	    echo "$0: ERROR: test $auth_json should FAIL: chkentry incorrectly exited code 0" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: debug[1]: ERROR: test $auth_json should FAIL: chkentry incorrectly exited code 0" 1>&2
-	    fi
-	    SEMANTIC_ERROR_MISSED="true"
-	fi
+    if [[ $status -eq 0 ]]; then
+        echo "$0: test $directory should PASS: chkentry PASS with exit code 0" 1>&2 >> "${LOGFILE}"
+        if [[ $V_FLAG -ge 3 ]]; then
+            echo "$0: debug[3]: test $directory should PASS: chkentry passed with exit code 0" 1>&2
+        fi
     else
-	if [[ $pass_fail = pass ]]; then
-	    echo "$0: ERROR: test $auth_json should PASS: chkentry FAIL with exit code: $status" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		if [[ $V_FLAG -ge 1 ]]; then
-		    echo "$0: debug[1]: ERROR: test $auth_json should pass: chkentry FAIL with exit code: $status" 1>&2
-		fi
-	    fi
-	    UNEXPECTED_SEMANTIC_ERROR="true"
-	else
-	    echo "$0: test $auth_json should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		if [[ $V_FLAG -ge 3 ]]; then
-		    echo "$0: debug[3]: debug[3]: test $auth_json should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2
-		fi
-	    fi
-	fi
+        echo "$0: test $directory should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2 >> "${LOGFILE}"
+        if [[ $V_FLAG -ge 1 ]]; then
+            if [[ $V_FLAG -ge 3 ]]; then
+                echo "$0: debug[3]: debug[3]: test $directory should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2
+            fi
+        fi
     fi
     echo >> "${LOGFILE}"
 
@@ -344,151 +310,27 @@ run_auth_test()
     return
 }
 
-# run_info_test - run a single chkentry test on a file
-#
-# usage:
-#	run_info_test chkentry dbg_level json_dbg_level quiet_mode info_json pass|fail
-#
-#	chkentry		path to the chkentry program
-#	dbg_level		internal test debugging level to use as in: chkentry -v dbg_level
-#	json_dbg_level		JSON parser debug level to use in: chkentry -J json_dbg_level
-#	quiet_mode		quiet mode to use in: chkentry -q
-#	info_json		info.json file to check with chkentry
-#	pass|fail		string saying if chkentry must return valid json or invalid json
-#
-run_info_test()
-{
-    # parse args
-    #
-    if [[ $# -ne 6 ]]; then
-	echo "$0: ERROR: expected 6 args to run_info_test, found $#" 1>&2
-	exit 13
-    fi
-    declare chkentry="$1"
-    declare dbg_level="$2"
-    declare json_dbg_level="$3"
-    declare quiet_mode="$4"
-    declare info_json="$5"
-    declare pass_fail="$6"
 
-    if [[ "$pass_fail" != "pass" && "$pass_fail" != "fail" ]]; then
-	echo "$0: ERROR: in run_info_test: pass_fail neither 'pass' nor 'fail'" 1>&2
-	EXIT_CODE=14
-	return
-    fi
 
-    # debugging
-    #
-    if [[ $V_FLAG -ge 9 ]]; then
-	echo "$0: debug[9]: in run_info_test: chkentry: $chkentry" 1>&2
-	echo "$0: debug[9]: in run_info_test: dbg_level: $dbg_level" 1>&2
-	echo "$0: debug[9]: in run_info_test: json_dbg_level: $json_dbg_level" 1>&2
-	echo "$0: debug[9]: in run_info_test: quiet_mode: $quiet_mode" 1>&2
-	echo "$0: debug[9]: in run_info_test: info_json: $info_json" 1>&2
-	echo "$0: debug[9]: in run_info_test: pass_fail: $pass_fail" 1>&2
-    fi
 
-    # perform the test
-    #
-    if [[ -z $quiet_mode ]]; then
-	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -- . $info_json >> ${LOGFILE} 2>&1" 1>&2
-	fi
-	echo "$0: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -- . $info_json >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
-	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -- . "$info_json" >> "${LOGFILE}" 2>&1
-	status="$?"
-    else
-	if [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -q -- . $info_json >> ${LOGFILE} 2>&1" 1>&2
-	fi
-	echo "$0: about to run test that must $pass_fail: $chkentry -v $dbg_level -J $json_dbg_level -q -- . $info_json >> ${LOGFILE} 2>&1" >> "${LOGFILE}"
-	"$chkentry" -v "$dbg_level" -J "$json_dbg_level" -q -- . "$info_json" >> "${LOGFILE}" 2>&1
-	status="$?"
-    fi
-
-    # examine test result
-    #
-    if [[ $status -eq 4 ]]; then
-	echo "$0: ERROR: file is not a valid JSON file for chkentry to test: $info_json" >> "${LOGFILE}"
-	if [[ $V_FLAG -ge 1 ]]; then
-	    echo "$0: debug[1]: ERROR: file is not a valid JSON file for chkentry to test: $info_json" 1>&2
-	fi
-	INVALID_JSON_FOUND="true"
-    elif [[ $status -eq 0 ]]; then
-	if [[ $pass_fail = pass ]]; then
-	    echo "$0: test $info_json should PASS: chkentry PASS with exit code 0" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 3 ]]; then
-		echo "$0: debug[3]: test $info_json should PASS: chkentry passed with exit code 0" 1>&2
-	    fi
-	else
-	    echo "$0: ERROR: test $info_json should FAIL: chkentry incorrectly exited code 0" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: debug[1]: ERROR: test $info_json should FAIL: chkentry incorrectly exited code 0" 1>&2
-	    fi
-	    SEMANTIC_ERROR_MISSED="true"
-	fi
-    else
-	if [[ $pass_fail = pass ]]; then
-	    echo "$0: ERROR: test $info_json should PASS: chkentry FAIL with exit code: $status" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		if [[ $V_FLAG -ge 1 ]]; then
-		    echo "$0: debug[1]: ERROR: test $info_json should pass: chkentry FAIL with exit code: $status" 1>&2
-		fi
-	    fi
-	    UNEXPECTED_SEMANTIC_ERROR="true"
-	else
-	    echo "$0: test $info_json should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2 >> "${LOGFILE}"
-	    if [[ $V_FLAG -ge 1 ]]; then
-		if [[ $V_FLAG -ge 3 ]]; then
-		    echo "$0: debug[3]: debug[3]: test $info_json should FAIL: chkentry FAIL correctly with exit code: $status" 1>&2
-		fi
-	    fi
-	fi
-    fi
-    echo >> "${LOGFILE}"
-
-    # return
-    #
-    return
-}
-
-# run tests that must pass: auth.json
+# run tests that must pass: good
 #
 if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run chkentry tests that must pass: auth.json files" 1>&2
+    echo "$0: debug[3]: about to run chkentry tests that must pass: good/ files" 1>&2
 fi
 while read -r file; do
-    run_auth_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
-done < <(find "$AUTH_GOOD_TREE" -type f -name '*.json' -print)
+    run_good_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file"
+done < <(find "$GOOD_TREE" -mindepth 2 -maxdepth 2 -type d -print)
 
 
-# run tests that must fail: auth.json
+# run tests that must fail: bad
 #
-if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run chkentry tests that must fail: auth.json files" 1>&2
-fi
-while read -r file; do
-    run_auth_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
-done < <(find "$AUTH_BAD_TREE" -type f -name '*.json' -print)
-
-
-# run tests that must pass: info.json
-#
-if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run chkentry tests that must pass: info.json files" 1>&2
-fi
-while read -r file; do
-    run_info_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" pass
-done < <(find "$INFO_GOOD_TREE" -type f -name '*.json' -print)
-
-# run tests that must fail: info.json
-#
-if [[ $V_FLAG -ge 3 ]]; then
-    echo "$0: debug[3]: about to run chkentry tests that must fail: info.json files" 1>&2
-fi
-while read -r file; do
-    run_info_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file" fail
-done < <(find "$INFO_BAD_TREE" -type f -name '*.json' -print)
+#if [[ $V_FLAG -ge 3 ]]; then
+#    echo "$0: debug[3]: about to run chkentry tests that must fail: bad/ files" 1>&2
+#fi
+#while read -r file; do
+#    run_bad_test "$CHKENTRY" "$DBG_LEVEL" "$JSON_DBG_LEVEL" "$Q_FLAG" "$file"
+#done < <(find "$BAD_TREE" -type d -print)
 
 # determine exit code
 #


### PR DESCRIPTION

It appears that this was not done or something went wrong when doing so
(as running make seqcexit updated the exit codes and this comes from
after running it in jparse/ and committing and then syncing from
jparse to jparse/).

Also as an update to the previous commit with the minor fix and
improvement to mkiocccentry -y and -Y warnings, I meant to update the
MKIOCCCENTRY_VERSION in the CHANGES.md; it is now "1.2.36 2025-02-28". 
