### PR TITLE
Additional fixes and updates to various tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ random_answers.*
 /test_ioccc/fnamchk
 /test_ioccc/.hostchk.*.work/
 /test_ioccc/.local.dir.tags
-test_ioccc/slot/good/workdir/
 /test_ioccc/tags
 /test_ioccc/test_JSON/
 /test_ioccc/test_ioccc.log

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,37 @@ the longer warning to be sure that they know. As for `-Y` it really ought to be
 used only for the test script but even `-y` should be used with **EXTREME**
 caution.
 
-It is hoped this is the last update to `mkiocccentry(1)` prior to the soft code
-freeze today.
+Add extra sanity checks in `check_submission_dir()`: it now checks towards the
+beginning if the required files exist (that is, the three user submitted files,
+not the JSON file as those don't exist yet, though it does check that they do
+not exist as dot files here would be an error) and are readable and if they are
+not size 0 (for Makefile and remarks.md - prog.c may be empty).
 
-Update `MKIOCCCENTRY_VERSION` to `"1.2.36 2025-02-28"`.
+Updated some literal strings of the three required filenames (as above) to their
+macros in both mkiocccentry and txzchk.
 
-TODO: finish work on the `chkentry_test.sh` script.
+Fixes in `chkentry` with checking if files exist or do not exist (depending on
+options) and also add checks for file sizes for certain files, namely Makefile,
+remarks.md (in non-winning mode) as well as index.html (in winning mode) and
+README.md (in winning mode).
+
+Error messages were improved in `chkentry` as well though there are some places
+(the manifest check) where they could be improved (this would require lower
+level changes that we do not have time for before the freeze later today).
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` for new util
+function (that uses its `file_size()` function) `is_empty()`. This is used in
+the update to `chkentry`.
+
+More work on the `chkentry_test.sh` script. The script is in better shape so
+that when the directories are generated (they cannot be static due to version
+changes - at least without a new option) the script should hopefully be easily
+updated (though it depends maybe on how the new directories are generated).
+
+Updated `MKIOCCCENTRY_VERSION` to `"1.2.36 2025-02-28"`.
+Updated `TXZCHK_VERSION` to `"1.1.15 2025-02-28"`.
+Updated `CHKENTRY_VERSION` to `"1.1.6 2025-02-28"`.
+Updated `CHKENTRY_TEST_VERSION` to `"1.1.1 2025-02-28"`.
 
 Resequence exit codes in `jparse/util.c`. It appears that this was not done or
 something went wrong when doing so (as running `make seqcexit` updated the exit

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 #
 # mkiocccentry and related tools - how to form an IOCCC submission
 #
-# For the mkiocccentry utility:
+# For mkiocccentry:
 #
-# Copyright (c) 2021-2025 by Landon Curt Noll.  All Rights Reserved.
+# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -16,17 +17,26 @@
 #       source works derived from this source
 #       binaries derived from this source or from derived source
 #
-# LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
-# EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
-# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
-# USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-# PERFORMANCE OF THIS SOFTWARE.
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+# This tool was co-developed in 2021-2025 by Cody Boone Ferguson and Landon
+# Curt Noll:
+#
+#  @xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 ####
 
 ####

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,13 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.30 2025-02-28
+
+Add util function that uses `file_size()` called `is_empty()`.
+
+Updated `JPARSE_UTILS_VERSION` to `"1.0.26 2025-02-28"`.
+Updated `UTIL_TEST_VERSION` to `"1.0.24 2025-02-28"`.
+
+
 ## Release 2.2.29 2025-02-27
 
 The script `jparse_bug_report.sh` actually can have the script in the `TOOLS`

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -3847,6 +3847,52 @@ file_size(char const *path)
     return buf.st_size;
 }
 
+/*
+ * is_empty - determine if the file is empty
+ *
+ * Return if a file is empty (size 0).
+ *
+ * given:
+ *      path    - the path to test
+ *
+ * returns:
+ *      true ==> file size <= 0
+ *      false ==> file size > 0
+ *
+ * NOTE: if the file does not exist (ENOENT) we return true. In other words if
+ * file_size() returns <= 0 it is true; otherwise it is false.
+ */
+bool
+is_empty(char const *path)
+{
+    off_t size = -1;
+
+    /*
+     * firewall
+     */
+    if (path == NULL) {
+	err(181, __func__, "called with NULL path");
+	not_reached();
+    }
+
+    size = file_size(path);
+
+    if (size < 0) {
+        dbg(DBG_VHIGH, "path %s does not exist", path);
+        return true;
+    } else if (size == 0) {
+        dbg(DBG_VHIGH, "path %s is empty", path);
+        return true;
+    }
+
+    /*
+     * return not empty
+     */
+    dbg(DBG_VHIGH, "path %s is not empty, size: %jd", path, (intmax_t)size);
+    return false;
+}
+
+
 
 /*
  * cmdprintf - malloc a safer shell command line for use with system() and popen()
@@ -8842,7 +8888,7 @@ check_invalid_option(char const *prog, int ch, int opt)
  */
 #include "../json_utf8.h"
 
-#define UTIL_TEST_VERSION "1.0.23 2025-02-26" /* version format: major.minor YYYY-MM-DD */
+#define UTIL_TEST_VERSION "1.0.24 2025-02-28" /* version format: major.minor YYYY-MM-DD */
 
 int
 main(int argc, char **argv)
@@ -10104,6 +10150,14 @@ main(int argc, char **argv)
         }
 
         /*
+         * now check that the size is empty
+         */
+        if (!is_empty("util_test.copy.c")) {
+            errp(156, __func__, "just deleted file util_test.copy.c is not empty");
+            not_reached();
+        }
+
+        /*
          * free relpath
          */
         free(relpath);
@@ -10143,6 +10197,13 @@ main(int argc, char **argv)
             not_reached();
         } else {
             fdbg(stderr, DBG_MED, "successfully deleted copied file util_test.copy.c");
+        }
+        /*
+         * now check that the size is empty
+         */
+        if (!is_empty("util_test.copy.c")) {
+            errp(156, __func__, "just deleted file util_test.copy.c is not empty");
+            not_reached();
         }
 
         /*
@@ -10192,6 +10253,15 @@ main(int argc, char **argv)
     } else {
         fdbg(stderr, DBG_MED, "successfully deleted copied file util_test.copy.c");
     }
+    /*
+     * now check that the size is empty
+     */
+    if (!is_empty("util.copy.o")) {
+        errp(156, __func__, "just deleted file util.copy.o is not empty");
+        not_reached();
+    }
+
+
     /*
      * relpath is NOT allocated so don't free!
      */
@@ -11769,6 +11839,15 @@ main(int argc, char **argv)
     } else {
         fdbg(stderr, DBG_MED, "successfully deleted created file %s", relpath);
     }
+    /*
+     * now check that the size is empty
+     */
+    if (!is_empty(relpath)) {
+        errp(156, __func__, "just deleted file %s is not empty", relpath);
+        not_reached();
+    }
+
+
 
     /*
      * restore earlier directory that might have happened with read_fts()
@@ -11952,6 +12031,15 @@ main(int argc, char **argv)
     } else {
         fdbg(stderr, DBG_MED, "successfully deleted created file %s", relpath);
     }
+    /*
+     * now check that the size is empty
+     */
+    if (!is_empty(relpath)) {
+        errp(156, __func__, "just deleted file %s is not empty", relpath);
+        not_reached();
+    }
+
+
 
     /*
      * free paths_found array

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -294,6 +294,7 @@ extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);
 extern off_t file_size(char const *path);
+extern bool is_empty(char const *path);
 extern char *cmdprintf(char const *format, ...);
 extern char *vcmdprintf(char const *format, va_list ap);
 extern int shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *format, ...);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -34,7 +34,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.2.28 2025-02-27"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.2.29 2025-02-28"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -49,7 +49,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "1.0.25 2025-02-26"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "1.0.26 2025-02-28"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -2654,16 +2654,35 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
     /*
      * check for existence of Makefile
      *
-     * This is necessary only because if make clobber fails it is because the
-     * user did not have a clobber rule which although is not something wanted
-     * by the judges, one is allowed to override it. So as long as Makefile
-     * exists it is okay; otherwise it is not. (Of course if its size <= 0 it'll be
-     * an error too but that's flagged by check_Makefile()).
+     * This is necessary not only because if it doesn't exist something went
+     * wrong and also because if make clobber fails it's not an error.
      */
-    if (!is_read("Makefile")) {
+    if (!is_read(MAKEFILE_FILENAME)) {
         err(4, __func__, "Makefile not a regular readable file in submission directory %s", submit_path);/*ooo*/
         not_reached();
+    } else if (is_empty(MAKEFILE_FILENAME)) {
+        err(4, __func__, "Makefile is empty in submission directory %s", submit_path);/*ooo*/
+        not_reached();
     }
+    /*
+     * prog.c must exist but it may be empty (though it'll be flagged)
+     */
+    if (!is_read(PROG_C_FILENAME)) {
+        err(4, __func__, "prog.c not a regular readable file in submission directory %s", submit_path);/*ooo*/
+        not_reached();
+    }
+    /*
+     * remarks.md must not be empty
+     */
+    if (!is_read(REMARKS_FILENAME)) {
+        err(4, __func__, "remarks.md not a regular readable file in submission directory %s", submit_path);/*ooo*/
+        not_reached();
+    } else if (is_empty(REMARKS_FILENAME)) {
+        err(4, __func__, "remarks.md is empty in submission directory %s", submit_path);/*ooo*/
+        not_reached();
+    }
+
+
     /*
      * run make clobber on Makefile
      */

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -2,7 +2,8 @@
 #
 # soup - some delicious IOCCC soup recipes :-)
 #
-# Copyright (c) 2022-2025 by Landon Curt Noll.  All Rights Reserved.
+# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -14,17 +15,26 @@
 #       source works derived from this source
 #       binaries derived from this source or from derived source
 #
-# LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
-# EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
-# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
-# USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-# PERFORMANCE OF THIS SOFTWARE.
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+# The recipes in this Makefile :-) and the tools in this directory were
+# co-developed in 2021-2025 by Cody Boone Ferguson and Landon Curt Noll:
+#
+#  @xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 ####
 
 

--- a/soup/version.h
+++ b/soup/version.h
@@ -121,12 +121,12 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "1.1.14 2025-02-19"	/* format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "1.1.15 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "1.1.5 2025-02-25"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "1.1.6 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * Version of info for JSON the .entry.json files.

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -2,7 +2,8 @@
 #
 # test_ioccc - mkiocccentry test tools
 #
-# Copyright (c) 2022-2025 by Landon Curt Noll.  All Rights Reserved.
+# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -14,18 +15,28 @@
 #       source works derived from this source
 #       binaries derived from this source or from derived source
 #
-# LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
-# EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
-# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
-# USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-# PERFORMANCE OF THIS SOFTWARE.
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+# These tools were co-developed in 2021-2025 by Cody Boone Ferguson and Landon
+# Curt Noll:
+#
+#  @xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 ####
+
 
 
 #############
@@ -678,6 +689,7 @@ clobber: legacy_clobber clean
 	${E} ${RM} ${RM_V} -f Makefile.orig
 	${E} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
 	${E} ${RM} ${RM_V} -rf test_iocccsize topdir workdir test_JSON
+	${E} ${RM} ${RM_V} -rf slot/good/workdir slot/bad/workdir
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/txzchk.c
+++ b/txzchk.c
@@ -805,15 +805,15 @@ check_file_size(char const *tarball_path, off_t size, struct txz_file *file)
 	    ++tarball.total_feathers;
 	    tarball.empty_info_json = true;
 	    warn("txzchk", "%s: found empty %s file", tarball_path, INFO_JSON_FILENAME);
-	} else if (!strcmp(file->basename, "remarks.md")) {
+	} else if (!strcmp(file->basename, REMARKS_FILENAME)) {
 	    ++tarball.total_feathers;
 	    tarball.empty_remarks_md = true;
 	    warn("txzchk", "%s: found empty remarks.md", tarball_path);
-	} else if (!strcmp(file->basename, "Makefile")) {
+	} else if (!strcmp(file->basename, MAKEFILE_FILENAME)) {
 	    ++tarball.total_feathers;
 	    tarball.empty_Makefile = true;
 	    warn("txzchk", "%s: found empty Makefile", tarball_path);
-	} else if (!strcmp(file->basename, "prog.c")) {
+	} else if (!strcmp(file->basename, PROG_C_FILENAME)) {
 	    /* this is NOT a feather: it's only for informational purposes! */
 	    tarball.empty_prog_c = true;
 	}
@@ -823,11 +823,11 @@ check_file_size(char const *tarball_path, off_t size, struct txz_file *file)
 	    tarball.auth_json_size = size;
 	} else if (!strcmp(file->basename, INFO_JSON_FILENAME)) {
 	    tarball.info_json_size = size;
-	} else if (!strcmp(file->basename, "remarks.md")) {
+	} else if (!strcmp(file->basename, REMARKS_FILENAME)) {
 	    tarball.remarks_md_size = size;
-	} else if (!strcmp(file->basename, "Makefile")) {
+	} else if (!strcmp(file->basename, MAKEFILE_FILENAME)) {
 	    tarball.Makefile_size = size;
-	} else if (!strcmp(file->basename, "prog.c")) {
+	} else if (!strcmp(file->basename, PROG_C_FILENAME)) {
 	    tarball.prog_c_size = size;
 	}
     }


### PR DESCRIPTION
Add extra sanity checks in check_submission_dir(): it now checks towards the beginning if the required files exist (that is, the three user submitted files, not the JSON file as those don't exist yet, though it does check that they do not exist as dot files here would be an error) and are readable and if they are not size 0 (for Makefile and remarks.md - prog.c may be empty).

Updated some literal strings of the three required filenames (as above) to their macros in both mkiocccentry and txzchk.

Fixes in chkentry with checking if files exist or do not exist (depending on options) and also add checks for file sizes for certain files, namely Makefile, remarks.md (in non-winning mode) as well as index.html (in winning mode) and README.md (in winning mode).

Error messages were improved in chkentry as well though there are some places (the manifest check) where they could be improved (this would require lower level changes that we do not have time for before the freeze later today).

Sync [jparse repo](https://github.com/xexyl/jparse/) to jparse/ for new util function (that uses its file_size() function) is_empty(). This is used in the update to chkentry.

More work on the chkentry_test.sh script. The script is in better shape so that when the directories are generated (they cannot be static due to version changes - at least without a new option) the script should hopefully be easily updated (though it depends maybe on how the new directories are generated).

Updated MKIOCCCENTRY_VERSION to "1.2.36 2025-02-28". Updated TXZCHK_VERSION to "1.1.15 2025-02-28".
Updated CHKENTRY_VERSION to "1.1.6 2025-02-28".
Updated CHKENTRY_TEST_VERSION to "1.1.1 2025-02-28".