### PR TITLE
Various important fixes and updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,9 +59,8 @@ Updated `FNAMCHK_VERSION` to `"2.0.0 2025-02-28"`.
 Updated `TXZCHK_VERSION` to `"2.0.0 2025-02-28"`.
 Updated `CHKENTRY_VERSION` to `"2.0.0 2025-02-28"`.
 Updated the version of `test_ioccc/chkentry_test.sh`, `test_ioccc/hostchk.sh`,
-`test_ioccc/ioccc_test.sh`, `test_ioccc/iocccsize_test.sh`,
-`test_ioccc/mkiocccentry_test.sh`, `test_ioccc/prep.sh` and
-`test_ioccc/txzchk_test.sh` to `"2.0.0 2025-02-28"`.
+`test_ioccc/ioccc_test.sh`, `test_ioccc/mkiocccentry_test.sh`,
+`test_ioccc/prep.sh` and `test_ioccc/txzchk_test.sh` to `"2.0.0 2025-02-28"`.
 
 
 ## Release 2.3.44 2025-02-27

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Major changes to the IOCCC entry toolkit
 
 
-## Release 2.3.45 2025-02-28
+## Release 2.4.0 2025-02-28
 
 Fix and improve warning of `-y` and `-Y` in `mkiocccentry`.
 
@@ -41,15 +41,27 @@ that when the directories are generated (they cannot be static due to version
 changes - at least without a new option) the script should hopefully be easily
 updated (though it depends maybe on how the new directories are generated).
 
-Updated `MKIOCCCENTRY_VERSION` to `"1.2.36 2025-02-28"`.
-Updated `TXZCHK_VERSION` to `"1.1.15 2025-02-28"`.
-Updated `CHKENTRY_VERSION` to `"1.1.6 2025-02-28"`.
-Updated `CHKENTRY_TEST_VERSION` to `"1.1.1 2025-02-28"`.
+Resequence exit codes in `jparse/util.c`.
 
-Resequence exit codes in `jparse/util.c`. It appears that this was not done or
-something went wrong when doing so (as running `make seqcexit` updated the exit
-codes and this comes from after running it in `jparse/` and committing and then
-syncing from `jparse` to `jparse/`).
+Updated versions of `jparse` by changing `x.y.z` to `x.y+1.0` except that for
+those under < `2.0.0` they have been changed to `2.0.0`.
+
+`chkentry` now looks for directories that are the wrong permissions as well as
+directories with a depth beyond the max as well as any type of file other than a
+regular file or directory.
+
+Bug fix an enum in jparse which caused a util function (used in the above fix to
+chkentry) to fail.
+
+Updated `SOUP_VERSION "2.0.0 2025-02-28"`.
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.0 2025-02-28"`.
+Updated `FNAMCHK_VERSION` to `"2.0.0 2025-02-28"`.
+Updated `TXZCHK_VERSION` to `"2.0.0 2025-02-28"`.
+Updated `CHKENTRY_VERSION` to `"2.0.0 2025-02-28"`.
+Updated the version of `test_ioccc/chkentry_test.sh`, `test_ioccc/hostchk.sh`,
+`test_ioccc/ioccc_test.sh`, `test_ioccc/iocccsize_test.sh`,
+`test_ioccc/mkiocccentry_test.sh`, `test_ioccc/prep.sh` and
+`test_ioccc/txzchk_test.sh` to `"2.0.0 2025-02-28"`.
 
 
 ## Release 2.3.44 2025-02-27

--- a/chkentry.c
+++ b/chkentry.c
@@ -1246,7 +1246,7 @@ main(int argc, char *argv[])
             for (c = 0; c < len; ++c) {
                 u = dyn_array_value(found, char *, c);
                 if (u == NULL) {
-                    err(60, __func__, "NULL pointer in found files list");
+                    err(70, __func__, "NULL pointer in found files list");
                     not_reached();
                 }
 
@@ -1293,7 +1293,7 @@ main(int argc, char *argv[])
             for (c = 0; c < len; ++c) {
                 u = dyn_array_value(found, char *, c);
                 if (u == NULL) {
-                    err(60, __func__, "NULL pointer in found files list");
+                    err(71, __func__, "NULL pointer in found files list");
                     not_reached();
                 }
 
@@ -1338,7 +1338,7 @@ main(int argc, char *argv[])
             for (c = 0; c < len; ++c) {
                 u = dyn_array_value(found, char *, c);
                 if (u == NULL) {
-                    err(60, __func__, "NULL pointer in found files list");
+                    err(72, __func__, "NULL pointer in found files list");
                     not_reached();
                 }
 
@@ -1362,7 +1362,7 @@ main(int argc, char *argv[])
          */
         errno = 0; /* pre-clear errno for errp() */
         if (fchdir(cwd2) != 0) {
-            errp(70, __func__, "failed to change back to original directory");
+            errp(73, __func__, "failed to change back to original directory");
             not_reached();
         }
 
@@ -1374,12 +1374,12 @@ main(int argc, char *argv[])
             auth_filename = ".auth.json";
             auth_stream = open_dir_file(*submission_dir, auth_filename);
             if (auth_stream == NULL) { /* paranoia */
-                err(71, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, auth_filename);
+                err(74, __func__, "auth_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, auth_filename);
                 not_reached();
             }
             auth_path = calloc_path(*submission_dir, auth_filename);
             if (auth_path == NULL) {
-                err(72, __func__, "auth_path is NULL");
+                err(75, __func__, "auth_path is NULL");
                 not_reached();
             }
         }
@@ -1391,12 +1391,12 @@ main(int argc, char *argv[])
             info_filename = ".info.json";
             info_stream = open_dir_file(*submission_dir, info_filename);
             if (info_stream == NULL) { /* paranoia */
-                err(73, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, info_filename);
+                err(76, __func__, "info_stream = open_dir_file(%s, %s) returned NULL", *submission_dir, info_filename);
                 not_reached();
             }
             info_path = calloc_path(*submission_dir, info_filename);
             if (info_path == NULL) {
-                err(74, __func__, "info_path is NULL");
+                err(77, __func__, "info_path is NULL");
                 not_reached();
             }
         }
@@ -1441,27 +1441,27 @@ main(int argc, char *argv[])
              * firewall on json_sem_check() results AND count errors for .auth.json
              */
             if (auth_count_err == NULL) {
-                err(75, __func__, "json_sem_check() left auth_count_err as NULL for .auth.json file: %s", auth_path);
+                err(78, __func__, "json_sem_check() left auth_count_err as NULL for .auth.json file: %s", auth_path);
                 not_reached();
             }
             if (dyn_array_tell(auth_count_err) < 0) {
-                err(76, __func__, "dyn_array_tell(auth_count_err): %jd < 0 "
+                err(79, __func__, "dyn_array_tell(auth_count_err): %jd < 0 "
                        "for .auth.json file: %s", dyn_array_tell(auth_count_err), auth_path);
                 not_reached();
             }
             auth_count_err_count = (uintmax_t) dyn_array_tell(auth_count_err);
             if (auth_val_err == NULL) {
-                err(77, __func__, "json_sem_check() left auth_val_err as NULL for .auth.json file: %s", auth_path);
+                err(80, __func__, "json_sem_check() left auth_val_err as NULL for .auth.json file: %s", auth_path);
                 not_reached();
             }
             if (dyn_array_tell(auth_val_err) < 0) {
-                err(78, __func__, "dyn_array_tell(auth_val_err): %jd < 0 "
+                err(81, __func__, "dyn_array_tell(auth_val_err): %jd < 0 "
                        "for .auth.json file: %s", dyn_array_tell(auth_val_err), auth_path);
                 not_reached();
             }
             auth_val_err_count = (uintmax_t)dyn_array_tell(auth_val_err);
             if (auth_all_err_count < auth_count_err_count+auth_val_err_count) {
-                err(79, __func__, "auth_all_err_count: %ju < auth_count_err_count: %ju + auth_val_err_count: %ju "
+                err(82, __func__, "auth_all_err_count: %ju < auth_count_err_count: %ju + auth_val_err_count: %ju "
                        "for .auth.json file: %s",
                        auth_all_err_count, auth_count_err_count, auth_val_err_count, auth_path);
                 not_reached();
@@ -1485,29 +1485,29 @@ main(int argc, char *argv[])
              * firewall on json_sem_check() results AND count errors for .info.json
              */
             if (info_count_err == NULL) {
-                err(80, __func__, "json_sem_check() left info_count_err as NULL for .info.json file: %s", info_path);
+                err(83, __func__, "json_sem_check() left info_count_err as NULL for .info.json file: %s", info_path);
                 not_reached();
             }
             if (dyn_array_tell(info_count_err) < 0) {
-                err(81, __func__, "dyn_array_tell(info_count_err): %jd < 0 "
+                err(84, __func__, "dyn_array_tell(info_count_err): %jd < 0 "
                        "for .info.json file: %s",
                        dyn_array_tell(info_count_err), info_path);
                 not_reached();
             }
             info_count_err_count = (uintmax_t)dyn_array_tell(info_count_err);
             if (info_val_err == NULL) {
-                err(82, __func__, "json_sem_check() left info_val_err as NULL for .info.json file: %s", info_path);
+                err(85, __func__, "json_sem_check() left info_val_err as NULL for .info.json file: %s", info_path);
                 not_reached();
             }
             if (dyn_array_tell(info_val_err) < 0) {
-                err(83, __func__, "dyn_array_tell(info_val_err): %jd < 0 "
+                err(86, __func__, "dyn_array_tell(info_val_err): %jd < 0 "
                        "for .info.json file: %ss",
                        dyn_array_tell(info_val_err), info_path);
                 not_reached();
             }
             info_val_err_count = (uintmax_t)dyn_array_tell(info_val_err);
             if (info_all_err_count < info_count_err_count+info_val_err_count) {
-                err(84, __func__, "info_all_err_count: %ju < info_count_err_count: %ju + info_val_err_count: %ju "
+                err(87, __func__, "info_all_err_count: %ju < info_count_err_count: %ju + info_val_err_count: %ju "
                        "for .info.json file: %s",
                        info_all_err_count, info_count_err_count, info_val_err_count, info_path);
                 not_reached();
@@ -1692,7 +1692,7 @@ main(int argc, char *argv[])
          */
         errno = 0; /* pre-clear errno for errp() */
         if (fchdir(cwd2) != 0) {
-            errp(85, __func__, "failed to change back to previous directory");
+            errp(88, __func__, "failed to change back to previous directory");
             not_reached();
         }
         /*
@@ -1703,7 +1703,7 @@ main(int argc, char *argv[])
          */
         errno = 0; /* pre-clear errno for errp */
         if (close(cwd2) != 0) {
-            errp(86, __func__, "failed to close original directory FD");
+            errp(89, __func__, "failed to close original directory FD");
             not_reached();
         }
         /*

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -9,6 +9,9 @@ Updated all tools by changing `x.y.z` to `x.y+1.0` except that for those under <
 
 Add copyright message to all source (code, header, scripts) and Makefiles.
 
+Fix enum `FTS_TYPE_ANY` - add missing `FTS_TYPE_FIFO`.
+
+
 ## Release 2.2.29 2025-02-27
 
 The script `jparse_bug_report.sh` actually can have the script in the `TOOLS`

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -230,7 +230,7 @@ enum fts_type
     FTS_TYPE_FIFO       = 64,        /* FIFO allowed */
     FTS_TYPE_ANY        = FTS_TYPE_FILE | FTS_TYPE_DIR | /* all types of files */
                           FTS_TYPE_SYMLINK | FTS_TYPE_SOCK | /* all types of files */
-                          FTS_TYPE_CHAR | FTS_TYPE_BLOCK, /* all types of files allowed */
+                          FTS_TYPE_CHAR | FTS_TYPE_BLOCK | FTS_TYPE_FIFO /* all types of files allowed */
 };
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,13 +83,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.3.46 2025-02-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.0 2025-02-28"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "1.1.23 2025-02-23"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -99,7 +99,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "1.2.36 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -116,17 +116,17 @@
 /*
  * official fnamchk version
  */
-#define FNAMCHK_VERSION "1.0.4 2025-02-19"	/* format: major.minor YYYY-MM-DD */
+#define FNAMCHK_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "1.1.15 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "1.1.6 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * Version of info for JSON the .entry.json files.

--- a/test_ioccc/chkentry_test.sh
+++ b/test_ioccc/chkentry_test.sh
@@ -54,7 +54,7 @@ export EXIT_CODE=0
 export INVALID_DIRECTORY_FOUND=""
 export SLOT_TREE="./test_ioccc/slot"
 
-export CHKENTRY_TEST_VERSION="1.1.1 2025-02-28"
+export CHKENTRY_TEST_VERSION="2.0.0 2025-02-28"
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-J level] [-q] [-c chkentry] [-d slot_tree]
 

--- a/test_ioccc/hostchk.sh
+++ b/test_ioccc/hostchk.sh
@@ -11,13 +11,33 @@
 #
 #	https://github.com/ioccc-src/mkiocccentry/issues
 #
-# This script was written in 2022 by:
+# Copyright (c) 2022-2025 by Cody Boone Ferguson.  All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
+#
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# CODY BOONE FERGUSON DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT
+# SHALL CODY BOONE FERGUSON BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+# DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+# This tool was written in 2022-2025 by Cody Boone Ferguson:
 #
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson
 #	https://ioccc.xexyl.net
 #
-# with some improvements and fixes by:
+# with some useful improvements and fixes by:
 #
 #	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
 #
@@ -63,7 +83,7 @@ CC="$(type -P cc 2>/dev/null)"
 if [[ -z $CC ]]; then
     CC="/usr/bin/cc"
 fi
-export HOSTCHK_VERSION="1.0.2 2024-08-28"
+export HOSTCHK_VERSION="2.0.0 2025-02-28"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w workdir] [-f] [-Z topdir]
 
     -h			    Print help and exit

--- a/test_ioccc/ioccc_test.sh
+++ b/test_ioccc/ioccc_test.sh
@@ -2,9 +2,30 @@
 #
 # ioccc_test.sh - perform the complete suite of tests for the mkiocccentry repo
 #
-# This script was co-developed in 2022 by:
+# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
-#	@xexyl
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
+#
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# This script was co-developed in 2021-2025 by Landon Curt Noll and Cody Boone
+# Ferguson:
+#
+#  @xexyl
 #	https://xexyl.net		Cody Boone Ferguson
 #	https://ioccc.xexyl.net
 # and:
@@ -13,11 +34,12 @@
 # "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 
 
 # setup
 #
-export IOCCC_TEST_VERSION="1.0.4 2025-0l-11"
+export IOCCC_TEST_VERSION="2.0.0 2025-02-28"
 
 # attempt to fetch system specific path to the tools we need
 #

--- a/test_ioccc/iocccsize_test.sh
+++ b/test_ioccc/iocccsize_test.sh
@@ -14,13 +14,6 @@
 
 # setup
 #
-# Under CentOS shellcheck complains about the comment, reporting:
-#
-#	warning: Remove space after = if trying to assign a value (for empty string, use var='' ... ). [SC1007]
-#
-# which seems silly and pointless so we disable it for the next two
-# lines.
-#
 export DIGRAPHS=	# assume #undef DIGRAPHS
 export TRIGRAPHS=	# assume #undef TRIGRAPHS
 export LIMIT_IOCCC="./soup/limit_ioccc.sh"

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -76,7 +76,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="1.0.15 2025-02-26"
+export MKIOCCCENTRY_TEST_VERSION="2.0.0 2025-02-28"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit

--- a/test_ioccc/prep.sh
+++ b/test_ioccc/prep.sh
@@ -2,10 +2,30 @@
 #
 # prep.sh - prep for a release - actions for make prep and make release
 #
-# This script was co-developed in 2022 by:
+# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
 #
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
 #
-#	@xexyl
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# This script was co-developed in 2021-2025 by Landon Curt Noll and Cody Boone
+# Ferguson:
+#
+#  @xexyl
 #	https://xexyl.net		Cody Boone Ferguson
 #	https://ioccc.xexyl.net
 # and:
@@ -14,7 +34,8 @@
 # "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
-
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+#
 
 # setup
 #

--- a/test_ioccc/txzchk_test.sh
+++ b/test_ioccc/txzchk_test.sh
@@ -2,7 +2,27 @@
 #
 # txzchk_test.sh - test txzchk with good and bad tarballs (as text files)
 #
-# Written in 2022 by:
+# Copyright (c) 2022-2025 by Cody Boone Ferguson.  All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
+#
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# CODY BOONE FERGUSON DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT
+# SHALL CODY BOONE FERGUSON BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+# DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+# This tool and script were written in 2022-2025 by Cody Boone Ferguson:
 #
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson
@@ -14,9 +34,7 @@
 #
 #	The many poor souls who have been tarred and feathered:
 #
-#	    "Because sometimes people throw feathers on tar :-( and because
-#	    sometimes people try hiding the fact that they're planning on
-#	    throwing feathers on the tar." :-)
+#	    "Because sometimes people throw feathers on tar." :-(
 #
 #	And to my wonderful Mum and my dear cousin and friend Dani:
 #
@@ -30,6 +48,9 @@
 #	nevertheless none were harmed. :-) More importantly, no tar pits -
 #	including the La Brea Tar Pits - were disturbed in the making of this
 #	tool. :-)
+#
+# Share and enjoy! :-)
+#     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 #
 
 # setup
@@ -53,7 +74,7 @@ TAR="$(type -P tar 2>/dev/null)"
 # but due to the reasons cited above we must rely on the more complicated form:
 [[ -z "$TAR" ]] && TAR="/usr/bin/tar"
 
-export TXZCHK_TEST_VERSION="1.0.4 2025-02-19"
+export TXZCHK_TEST_VERSION="2.0.0 2025-02-28"
 export FNAMCHK="./test_ioccc/fnamchk"
 export TXZCHK="./txzchk"
 export TXZCHK_TREE="./test_ioccc/test_txzchk"


### PR DESCRIPTION
Ahead of the code freeze 🧊 some final fixes have been made.

chkentry now looks for directories that are the wrong permissions as well as directories with a depth beyond the max as well as any type of file other than a regular file or directory.

Bug fix an enum in jparse which caused a util function (used in the above fix to chkentry) to fail.

Updated SOUP_VERSION "2.0.0 2025-02-28".
Updated MKIOCCCENTRY_VERSION to "2.0.0 2025-02-28". Updated FNAMCHK_VERSION to "2.0.0 2025-02-28".
Updated TXZCHK_VERSION to "2.0.0 2025-02-28".
Updated CHKENTRY_VERSION to "2.0.0 2025-02-28".
Updated the version of test_ioccc/chkentry_test.sh, test_ioccc/hostchk.sh, test_ioccc/ioccc_test.sh, test_ioccc/iocccsize_test.sh, test_ioccc/mkiocccentry_test.sh, test_ioccc/prep.sh and test_ioccc/txzchk_test.sh to "2.0.0 2025-02-28".