### PR TITLE
Resolve issue #1201.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,30 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.2 2025-03-02
+
+Resolve issue #1201.
+
+Fix a number of bugs in `chkentry(1)` and add new option to ignore permissions
+of files and directories (`-P`). This option is only meant for the judges and
+just like with `-i` and `-w` using it when verifying a submission puts one at
+grave risk of violating the rules; it is not even documented outside the usage
+message and the man page.
+
+Fix display issues in `mkiocccentry(1)` and `chkentry(1)` with regards to file
+permissions.
+
+The above fixes required updates to the jparse utility functions so the [jparse
+repo](https://github.com/xexyl/jparse/) was synced to `jparse/`.
+
+Fix `chdir(2)` error in `chkentry(1)` in some places (it did not restore the
+directory after a call to `find_paths()`).
+
+Updated `SOUP_VERSION` to `"2.0.1 2025-03-02"`.
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.1 2025-03-02"`.
+Updated `CHKENTRY_VERSION` to `"2.0.1 2025-03-02"`.
+
+
 ## Release 2.4.1 2025-03-01
 
 Fix critical bug in jparse/ `copyfile()` function.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,34 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.32 2025-03-02
+
+Updated `filemode()` with new boolean (sorry!) to mask `S_IFMT` if true. In
+other words if you want to print out the value it returns the `st_mode &
+~S_IFMT` (otherwise it still determines the file type and masks the correct
+bits).
+
+Since enums have different namespaces than function names the function
+`type_of_file()` was renamed `file_type()`.
+
+Also, `is_mode()` now uses the function (that did not exist at the time of
+original writing) `file_type()` rather than repeatedly having to use `lstat(2)`
+and `stat(2)` on the path.
+
+Fun fact: the release version, `2.2.32`, with the exception of the year in the
+date and the zeros (i.e. the `5` and zeroes in `2025-03-02`), has only the same
+digits as the date, `2025-03-02` (i.e. `2` and `3`).
+
+Fix bug in `read_fts()` with checking basename versus full path. In particular
+if the number of directories is just one then it has to be a basename check.
+Thus it's `(fts->base || count_dirs(name) == 1) && ...`. If it's not base or the
+`count_dirs(name) != 1` then it tries the other way (with `fts->base == false`).
+This solves a problem where files to be ignored were not ignored in the case of
+base being false (when we needed that to be the case).
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.2 2025-03-02"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.1 2025-03-02"`.
+
+
 ## Release 2.2.31 2025-03-01
 
 Fix critical bug in `copyfile()`: obtaining the FD of the source file should not

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -234,7 +234,7 @@ enum fts_type
 };
 
 /*
- * file_type enum - for type_of_file() function to determine type of file
+ * file_type enum - for file_type() function to determine type of file
  */
 
 enum file_type
@@ -284,7 +284,7 @@ extern char *dir_name(char const *path, int level);
 extern size_t count_comps(char const *str, char comp, bool remove_all);
 extern size_t count_dirs(char const *path);
 extern bool exists(char const *path);
-extern enum file_type type_of_file(char const *path);
+extern enum file_type file_type(char const *path);
 extern bool is_mode(char const *path, mode_t mode);
 extern bool has_mode(char const *path, mode_t mode);
 extern bool is_file(char const *path);
@@ -297,7 +297,7 @@ extern bool is_fifo(char const *path);
 extern bool is_exec(char const *path);
 extern bool is_read(char const *path);
 extern bool is_write(char const *path);
-extern mode_t filemode(char const *path);
+extern mode_t filemode(char const *path, bool printing);
 extern bool is_open_file_stream(FILE *stream);
 extern void reset_fts(struct fts *fts, bool free_ignored);
 extern char *fts_path(FTSENT *ent);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.1 2025-03-01"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.2 2025-03-02"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.1 2025-03-01"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.2 2025-03-02"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -2852,16 +2852,16 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                                 ent->fts_path + 2);
                         not_reached();
                     } else if (!is_mode(ent->fts_path + 2, 0755)) {
-                        err(4, __func__, "directory %s: mode %o != 0755", ent->fts_path + 2,/*ooo*/
-                                filemode(ent->fts_path + 2));
+                        err(4, __func__, "directory %s: mode %04o != 0755", ent->fts_path + 2,/*ooo*/
+                                filemode(ent->fts_path + 2, true));
                         not_reached();
                     }
                     /*
                      * directories MUST be mode 0755!
                      */
                     if (!is_mode(ent->fts_path + 2, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) {
-                        err(4, __func__, "directory %s must be mode 0755: %o != 0755", ent->fts_path + 2,/*ooo*/
-                                filemode(ent->fts_path + 2));
+                        err(4, __func__, "directory %s must be mode 0755: %04o != 0755", ent->fts_path + 2,/*ooo*/
+                                filemode(ent->fts_path + 2, true));
                         not_reached();
                     }
 
@@ -2921,8 +2921,8 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                                     /*
                                      * these MUST be mode 0555!
                                      */
-                                    err(4, __func__, "file %s must be mode 0555: %o != 0555",/*ooo*/
-                                            filename, filemode(filename));
+                                    err(4, __func__, "file %s must be mode 0555: %04o != 0555",/*ooo*/
+                                            filename, filemode(filename, true));
                                     not_reached();
                                 }
                             } else {
@@ -2930,8 +2930,8 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                                  * these MUST be mode 0444!
                                  */
                                 if (!is_mode(filename, S_IRUSR | S_IRGRP | S_IROTH)) {
-                                    err(4, __func__, "file %s must be mode 0444: %o != 0444",/*ooo*/
-                                            filename, filemode(filename));
+                                    err(4, __func__, "file %s must be mode 0444: %04o != 0444",/*ooo*/
+                                            filename, filemode(filename, true));
                                     not_reached();
                                 }
                             }
@@ -2945,8 +2945,8 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                          * these files MUST be mode 0444!
                          */
                         if (!is_mode(filename, S_IRUSR | S_IRGRP | S_IROTH)) {
-                            err(4, __func__, "file %s must be mode 0444: %o != 0444", filename,/*ooo*/
-                                    filemode(filename));
+                            err(4, __func__, "file %s must be mode 0444: %04o != 0444", filename,/*ooo*/
+                                    filemode(filename, true));
                             not_reached();
                         }
                         append_unique_filename(required_files, filename);

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -119,12 +119,23 @@
 #define MONOTONE_DIRNAME "_MTN"                 /* For Monotone */
 #define DARCS_DIRNAME "_darcs"                  /* For Darcs */
 
+/*
+ * filenames that should be ignored, mostly for chkentry -w but it can be used
+ * in mkiocccentry too (although it is implicit since these are dot files)
+ */
+#define GITIGNORE_FILENAME      ".gitignore"            /* ignore list for git */
+#define DS_STORE_FILENAME0      ".DS_Store"             /* Apple's annoying .DS_Store file */
+#define DS_STORE_FILENAME1      "._.DS_Store"           /* Apple's annoying ._.DS_Store file */
+#define DOT_PATH_FILENAME       ".path"                 /* IOCCC .path dot file */
+
 extern char *mandatory_filenames[];             /* filenames that MUST exist in the top level directory */
 extern char *forbidden_filenames[];             /* filenames that must NOT exist in the top level directory */
 extern char *optional_filenames[];              /* filenames that are OPTIONAL in top level directory */
 extern char *ignored_dirnames[];                /* directory names that should be ignored */
+extern char *ignored_filenames[];               /* ignored filenames like .gitignore, .DS_Store etc. */
 extern char *executable_filenames[];            /* filenames that should have mode 0555 */
 extern struct dyn_array *ignored_paths;         /* ignored paths from chkentry -i path */
+extern bool ignore_permissions;                 /* true ==> ignore permissions of files and directories */
 
 /*
  * enums

--- a/soup/man/man1/chkentry.1
+++ b/soup/man/man1/chkentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH chkentry 1 "26 February 2025" "chkentry" "IOCCC tools"
+.TH chkentry 1 "02 March 2025" "chkentry" "IOCCC tools"
 .SH NAME
 .B chkentry
 \- check JSON files in an IOCCC entry
@@ -23,17 +23,20 @@
 .RB [\| \-q \|]
 .RB [\| \-i
 .IR path \|]
+.RB [\| \-P \|]
 .RB [\| \-w \|]
-.I submission_dir
+.I directory
 .SH DESCRIPTION
 .PP
 .BR chkentry (1)
-runs a number of validation checks on an IOCCC submission directory.
+runs a number of validation checks on an IOCCC submission or winning entry directory.
 Depending on the options, it will validate the
 .B .auth.json
 and/or
 .B .info.json
-files, as well as checking the permissions of files and, if the
+files, as well as checking the permissions of files and directories (unless the
+.B \-P
+option is used) and, if the
 .B .info.json
 file is not ignored, it will compare the manifest with the files in the directory, unless that file has been explicitly ignored with the
 .BI \-i\  path
@@ -47,12 +50,11 @@ option; otherwise, without
 a different set of files must exist and must not exist, again depending on the
 .BI \-i\  path
 option.
-In either case, even if the manifest is being ignored, it will verify that the files in the directories are valid permissions, whether specific files are missing and if specific files in the directory are not, by name, allowed.
-It will also verify that the filenames are sane, relative paths, in the context of the IOCCC rules and as both
-.BR mkiocccentry (1)
-and
-.BR txzchk (1)
-test.
+.PP
+In either case, even if the manifest is being ignored, it will verify that the files in the directories are valid permissions (again, unless it's an ignored path or the
+.B \-P
+option is used), whether specific files are missing (unless it was ignored) and if specific files in the directory are not, by name, allowed (unless it was ignored).
+It will also verify that the filenames are sane, relative paths, in the context of the IOCCC rules, at least when not in winning entry mode and if not ignored.
 .PP
 As a sanity check, the
 .BR mkiocccentry (1)
@@ -67,13 +69,13 @@ If
 .BR mkiocccentry (1)
 sees a 0 exit status, then all is well.
 For a non\-zero exit code, the tool aborts because any problems detected by
-.B chkentry
+.BR chkentry (1)
 based on what
 .BR mkiocccentry (1)
 did indicates there is a serious mismatch between what
 .BR mkiocccentry (1)
 is doing and what
-.B chkentry
+.BR chkentry (1)
 expects.
 .PP
 .SH OPTIONS
@@ -101,10 +103,13 @@ Silences msg(), warn(), warnp() if verbosity level is 0.
 .BI \-i\  path
 Ignore a path.
 This option may be used more than once but is only meant for the judges.
+.TP \-P
+Ignore permissions of files and directories.
+This option is for the judges.
 .TP
 .B \-w
 Perform winning entry tests instead of submission tests.
-This option is only meant for the judges.
+This option is for the judges.
 .SH EXIT STATUS
 .TP
 0

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,13 +83,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.1 2025-03-01"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.2 2025-03-02"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -99,7 +99,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -126,7 +126,7 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * Version of info for JSON the .entry.json files.

--- a/txzchk.c
+++ b/txzchk.c
@@ -124,7 +124,7 @@ static const char * const usage_msg =
     "\t-w\t\talways show warning messages\n"
     "\t-V\t\tprint version string and exit\n"
     "\t-t tar\t\tpath to tar executable that supports the -J (xz) option (def: %s)\n"
-    "\t-F fnamchk\tpath to tool that checks if tarball_path is a valid compressed tarball name\n"
+    "\t-F fnamchk\tpath to tool that checks if tarball_path is a valid compressed tarball\n"
     "\t\t\t    filename (def: %s)\n"
     "\t-T\t\tassume tarball_path is a text file with tar listing (for testing\n"
     "\t\t\t    different formats)\n"


### PR DESCRIPTION
Fix a number of bugs in `chkentry(1)` and add new option to ignore permissions of files and directories (`-P`). This option is only meant for the judges and just like with `-i` and `-w` using it when verifying a submission puts one at grave risk of violating the rules; it is not even documented outside the usage message and the man page.

Fix display issues in `mkiocccentry(1)` and `chkentry(1)` with regards to file permissions.

The above fixes required updates to the jparse utility functions so the [jparse repo](https://github.com/xexyl/jparse/) was synced to `jparse/`.

Fix `chdir(2)` error in `chkentry(1)` in some places (it did not restore the directory after a call to `find_paths()`).

Updated `SOUP_VERSION` to `"2.0.1 2025-03-02"`.
Updated `MKIOCCCENTRY_VERSION` to `"2.0.1 2025-03-02"`. Updated `CHKENTRY_VERSION` to `"2.0.1 2025-03-02"`.

And although it's not a critical fix I made a typo fix in txzchk.c usage message. As this commit was necessary and since this was not any functional change I deem this okay as it won't change anything other than my discontent at having this typo in my code (which happened when improving the usage message some).