### PR TITLE
Add missing calls to errp() in txzchk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,17 @@ repo](https://github.com/xexyl/jparse/) was synced to `jparse/`.
 Fix `chdir(2)` error in `chkentry(1)` in some places (it did not restore the
 directory after a call to `find_paths()`).
 
+Add missing calls to `errp()` in `txzchk`.  This might be important in some
+cases as we're now at the point of the next contest. The calls are specific to
+the functions `popen(3)` in `pipe_open()` and `system(3)` in `shell_cmd()`. In
+linux in some cases popen() will set errno; in macOS it is unreliable. For
+`system(3)` it appears that errno is not set so `warnp()`/`errp()` were changed
+to the non-errno versions.
+
 Updated `SOUP_VERSION` to `"2.0.1 2025-03-02"`.
 Updated `MKIOCCCENTRY_VERSION` to `"2.0.1 2025-03-02"`.
 Updated `CHKENTRY_VERSION` to `"2.0.1 2025-03-02"`.
+Updated `TXZCHK_VERSION` to `"2.0.1 2025-03-02"`.
 
 
 ## Release 2.4.1 2025-03-01

--- a/chkentry.c
+++ b/chkentry.c
@@ -119,8 +119,8 @@ char *abbrevs[][2] =
     { "info"        , INFO_JSON_FILENAME    },
     { "prog.c"      , PROG_C_FILENAME       },
     { "Makefile"    , MAKEFILE_FILENAME     },
-    { "try"         , TRY_SH                },
-    { "try.alt"     , TRY_ALT_SH            },
+    { "try"         , TRY_SH                }, /* try not to keep sorted */
+    { "try.alt"     , TRY_ALT_SH            }, /* alternatively, try and keep sorted */
     { "remarks"     , REMARKS_FILENAME      },
     { "README"      , README_MD_FILENAME    },
     { "index"       , INDEX_HTML_FILENAME   },

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -25,6 +25,12 @@ Thus it's `(fts->base || count_dirs(name) == 1) && ...`. If it's not base or the
 This solves a problem where files to be ignored were not ignored in the case of
 base being false (when we needed that to be the case).
 
+Save and restore errno prior to returning from `pipe_open()` and `shell_cmd()`.
+In some systems `popen(3)` are not reliable with errno (like macOS) but in linux
+it CAN in some cases set errno. For `system(3)` it does no seem to set errno at
+all but we still do this process especially as it also uses a function that can
+have errno (and we return from the function in that case with an error).
+
 Updated `JPARSE_UTILS_VERSION` to `"2.0.2 2025-03-02"`.
 Updated `UTIL_TEST_VERSION` to `"2.0.1 2025-03-02"`.
 

--- a/soup/version.h
+++ b/soup/version.h
@@ -121,7 +121,7 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define TXZCHK_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official chkentry version

--- a/txzchk.c
+++ b/txzchk.c
@@ -1816,15 +1816,17 @@ check_tarball(char const *tar, char const *fnamchk)
              * timestamp failure); if we're given -x we MUST give fnamchk -t.
              */
             if (test_mode) {
+                errno = 0; /* pre-clear errno for errp() */
                 fnamchk_stream = pipe_open(__func__, false, true, "% -t -T -E % -- %", fnamchk, ext, tarball_path);
                 if (fnamchk_stream == NULL) {
-                    err(38, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
+                    errp(38, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
                     not_reached();
                 }
             } else {
+                errno = 0; /* pre-clear errno for errp() */
                 fnamchk_stream = pipe_open(__func__, false, true, "% -T -E % -- %", fnamchk, ext, tarball_path);
                 if (fnamchk_stream == NULL) {
-                    err(39, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
+                    errp(39, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
                     not_reached();
                 }
             }
@@ -1834,13 +1836,14 @@ check_tarball(char const *tar, char const *fnamchk)
              * we must NOT use the -T option to fnamchk. Depending on whether we
              * were given -x or not we will give fnamchk -t (we were given -x).
              */
+            errno = 0; /* pre-clear errno for errp() */
             if (test_mode) {
                 fnamchk_stream = pipe_open(__func__, false, true, "% -t -E % -- %", fnamchk, ext, tarball_path);
             } else {
                 fnamchk_stream = pipe_open(__func__, false, true, "% -E % -- %", fnamchk, ext, tarball_path);
             }
             if (fnamchk_stream == NULL) {
-                err(40, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
+                errp(40, __func__, "popen for reading failed for: %s -- %s", fnamchk, tarball_path);
                 not_reached();
             }
         }
@@ -1919,22 +1922,22 @@ check_tarball(char const *tar, char const *fnamchk)
 	/*
 	 * first execute the tar command
 	 */
-	errno = 0;			/* pre-clear errno for errp() */
 	if (verbosity_level) {
 	    exit_code = shell_cmd(__func__, false, true, "% -tJvf %", tar, tarball_path);
 	} else {
 	    exit_code = shell_cmd(__func__, false, true, "% -tJvf % >/dev/null", tar, tarball_path);
 	}
 	if (exit_code != 0) {
-	    errp(44, __func__, "%s -tJvf %s failed with exit code: %d",
+	    err(44, __func__, "%s -tJvf %s failed with exit code: %d",
 			      tar, tarball_path, WEXITSTATUS(exit_code));
 	    not_reached();
 	}
 
 	/* now open a pipe to tar command (tar -tJvf) to read from */
+        errno = 0; /* pre-clear errno for errp() */
 	input_stream = pipe_open(__func__, false, true, "% -tJvf %", tar, tarball_path);
 	if (input_stream == NULL) {
-	    err(45, __func__, "popen for reading failed for: %s -tJvf %s",
+	    errp(45, __func__, "popen for reading failed for: %s -tJvf %s",
 			      tar, tarball_path);
 	    not_reached();
 	}


### PR DESCRIPTION
This might be important in some cases as we're now at the point of the next contest. The calls are specific to the functions popen(3) in pipe_open() and system(3) in shell_cmd(). In linux in some cases popen() will set errno; in macOS it is unreliable. For system(3) it appears that errno is not set so warnp()/errp() were changed to the non-errno versions.

Updated TXZCHK_VERSION to "2.0.1 2025-03-02".