### PR TITLE
Fix critical issues in mkiocccentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,40 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.3 2025-03-07
+
+Fix critical issues in mkiocccentry.
+
+It is an error if the topdir and the workdir are the same (same device and
+inode).
+
+If the workdir is found in the topdir it is skipped.
+
+Before doing anything make sure the args are actually directories that can be
+searched and (in the case of workdir) written to.
+
+To help users not have to repeatedly copy and paste their UUID there is a new
+option, `-u uuid` which will read from a file the UUID. If the file does not
+exist or cannot be read or it does not have a valid UUID the program will prompt
+for it as if you didn't use the option.
+
+Extra sanity checks in the FTS code.
+
+Make it clearer what happens when one does not agree to a prompt in the
+scanning/copying the topdir and the checking of the submission directory. The
+prompt also is now 'Do you wish to continue?' instead of 'Is this OK?'.
+
+When checking the submission directory if a directory that is the workdir OR
+topdir is encountered it is an error.
+
+Ignore directories for additional RCSs: namely `RCS` and `SCCS`.
+
+I believe this should resolve issues #1207, #1209 and #1210.
+
+**IMPORTANT REMINDER**: the version of the tools have NOT been updated because
+doing so would **INVALIDATE** submissions already uploaded!
+
+
 ## Release 2.4.2 2025-03-02
 
 Resolve issue #1201.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,21 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.33 2025-03-07
+
+Additional sanity checks added to FTS code.
+
+The `read_fts()` function now does not just skip on NULL or empty path name; it
+will abort just like `check_fts_info()` does (though that would never have been
+reached as we skipped that item and moved to the next). If there is a NULL
+pointer or an empty string something is wrong and it's better to abort early.
+
+Also in `check_fts_info()` when the `fts_info == FTS_NS` the `ent->fts_errno` is
+the errno so we set `errno = ent->fts_errno` prior to calling `errp()` (instead
+of `err()`).
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.3 2025-03-07"`.
+
+
 ## Release 2.2.32 2025-03-02
 
 Updated `filemode()` with new boolean (sorry!) to mask `S_IFMT` if true. In

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.2 2025-03-02"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.3 2025-03-07"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.2 2025-03-02"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.3 2025-03-07"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -142,6 +142,8 @@ static const char * const usage_msg3 =
     "\t-A answers\twrite answers file even if it already exists\n"
     "\t-i answers\tread answers from file previously written by -a|-A answers\n"
     "\t\t\t    NOTE: One cannot use both -a/-A answers and -i answers.\n"
+    "\t-u uuid\t\tread UUID from a file (def: prompt for UUID)\n"
+    "\t\t\t    NOTE: if an invalid UUID is in the file, it will try the usual way\n"
     "\t-s seed\t\tGenerate and use pseudo-random answers, seeding with\n"
     "\t\t\t    seed & 0x%08u (def: do not)\n"
     "\t-d\t\tAlias for -s %u\n"
@@ -190,6 +192,9 @@ static bool copying_topdir = false;    /* true ==> copying topdir and checking s
 static bool saved_answer_yes = false;   /* set to answer_yes before modifying it for scanning/copying topdir */
 static bool saved_silence_prompt = false;   /* set to silence_prompt before modifying it for scanning/copying topdir */
 static bool force_yes = false;          /* force -y even when scanning/copying/verifying in -i answers mode */
+static struct stat topdir_st;           /* stat(2) information of topdir */
+static struct stat workdir_st;          /* stat(2) information of workdir */
+static struct stat submit_dir_st;       /* stat(2) information of submission directory under workdir */
 
 /*
  * forward declarations
@@ -218,6 +223,8 @@ main(int argc, char *argv[])
     char *make = MAKE_PATH_0;                   /* path to make(1) executable */
     char *answers = NULL;			/* path to the answers file (recording input given on stdin) */
     FILE *answersp = NULL;			/* file pointer to the answers file */
+    char *uuid = NULL;			/* path to the UUID file */
+    FILE *uuidp = NULL;			/* file pointer to the UUID file */
     char *submission_dir = NULL;		/* submission directory from which to form a compressed tarball */
     char *tarball_path = NULL;			/* path of the compressed tarball to form */
     struct info info;				/* data to form .info.json */
@@ -228,6 +235,7 @@ main(int argc, char *argv[])
     bool ls_flag_used = false;			/* true ==> -l /path/to/ls was given */
     bool make_flag_used = false;                /* true ==> -m /path/to/make was given */
     bool answers_flag_used = false;		/* true ==> -a write answers to answers file */
+    bool read_uuid_flag_used = false;                /* true ==> -u uuid used */
     bool overwrite_answers_flag_used = false;	/* true ==> don't prompt to overwrite answers if it already exists */
     bool txzchk_flag_used = false;		/* true ==> -T /path/to/txzchk was given */
     bool fnamchk_flag_used = false;		/* true ==> -F /path/to/fnamchk was given */
@@ -247,11 +255,19 @@ main(int argc, char *argv[])
     memset(&auth, 0, sizeof(auth));
 
     /*
+     * even though these stat structs are in file scope, make sure they are
+     * zeroed out
+     */
+    memset(&topdir_st, 0, sizeof(topdir_st));
+    memset(&workdir_st, 0, sizeof(workdir_st));
+    memset(&submit_dir_st, 0, sizeof(submit_dir_st));
+
+    /*
      * parse args
      */
     input_stream = stdin;	/* default to reading from standard in */
     program = argv[0];
-    while ((i = getopt(argc, argv, ":hv:J:qVt:l:a:i:A:WT:ef:F:C:yYds:m:I:")) != -1) {
+    while ((i = getopt(argc, argv, ":hv:J:qVt:l:a:i:A:WT:ef:F:C:yYds:m:I:u:")) != -1) {
 	switch (i) {
 	case 'h':		/* -h - print help to stderr and exit 2 */
 	    usage(2, program, ""); /*ooo*/
@@ -404,6 +420,10 @@ main(int argc, char *argv[])
         case 'I': /* ignore a path */
             append_path(&info.ignore_paths, optarg, true, false, false);
             break;
+        case 'u':
+            uuid = optarg;
+            read_uuid_flag_used = true;
+            break;
 	case ':':   /* option requires an argument */
 	case '?':   /* illegal option */
 	default:    /* anything else but should not actually happen */
@@ -457,6 +477,10 @@ main(int argc, char *argv[])
     if (seed_used && read_answers_flag_used) {
 	err(3, __func__, "-i answers cannot be used with with either -d or -s seed"); /*ooo*/
 	not_reached();
+    }
+    if (seed_used && read_uuid_flag_used) {
+        err(3, __func__, "-u uuid cannot be used with either -d or -s seed");/*ooo*/
+        not_reached();
     }
     if (ignore_warnings && abort_on_warning) {
 	err(3, __func__, "-W and -E cannot be used with together"); /*ooo*/
@@ -522,16 +546,48 @@ main(int argc, char *argv[])
     dbg(DBG_MED, "tar: %s", tar);
     dbg(DBG_MED, "ls: %s", ls);
     workdir = argv[optind];
-    topdir = argv + optind + REQUIRED_ARGS - 1;
     if (workdir == NULL || *workdir == '\0') {
         err(3, __func__, "workdir is NULL or empty string");/*ooo*/
         not_reached();
     }
-    dbg(DBG_MED, "workdir: %s", workdir);
+    if (!is_dir(workdir) || !is_read(workdir) || !is_write(workdir)) {
+        err(3, __func__, "workdir is not a searchable and writable directory: %s", workdir);/*ooo*/
+        not_reached();
+    }
+    /*
+     * get stat(2) info for workdir
+     */
+    errno = 0; /* pre-clear errno for errp() */
+    if (stat(workdir, &workdir_st) != 0) {
+        errp(3, __func__, "failed to get stat(2) info for workdir: %s", workdir);/*ooo*/
+        not_reached();
+    }
+    topdir = argv + optind + REQUIRED_ARGS - 1;
     if (topdir == NULL || *topdir == NULL || **topdir == '\0') {
         err(3, __func__, "topdir is NULL or empty string");/*ooo*/
         not_reached();
     }
+    if (!is_dir(*topdir) || !is_read(*topdir)) {
+        err(3, __func__, "workdir is not a searchable directory: %s", *topdir);/*ooo*/
+        not_reached();
+    }
+    /*
+     * get stat(2) info for topdir
+     */
+    errno = 0; /* pre-clear errno for errp() */
+    if (stat(*topdir, &topdir_st) != 0) {
+        errp(3, __func__, "failed to get stat(2) info for topdir: %s", *topdir);/*ooo*/
+        not_reached();
+    }
+    /*
+     * check if topdir is the same as workdir
+     */
+    if (topdir_st.st_ino == workdir_st.st_ino && topdir_st.st_dev == workdir_st.st_dev) {
+        err(3, __func__, "topdir cannot be the same as the workdir"); /*ooo*/
+        not_reached();
+    }
+
+    dbg(DBG_MED, "workdir: %s", workdir);
     dbg(DBG_MED, "topdir: %s", *topdir);
     if (answers != NULL) {
         dbg(DBG_MED, "answers file: %s", answers);
@@ -672,9 +728,25 @@ main(int argc, char *argv[])
     }
 
     /*
+     * check if we should read input from UUID file
+     */
+    if (read_uuid_flag_used && uuid != NULL && strlen(uuid) > 0) {
+	if (!is_read(uuid)) {
+	    warn(__func__, "cannot read UUID file, will prompt for UUID");
+	} else {
+            errno = 0;		/* pre-clear errno for errp() */
+            uuidp = fopen(uuid, "r");
+            if (uuidp == NULL) {
+                warnp(__func__, "cannot open UUID file, will prompt for UUID");
+            }
+        }
+    }
+
+
+    /*
      * obtain the IOCCC contest ID
      */
-    info.ioccc_id = get_contest_id(&info.test_mode);
+    info.ioccc_id = get_contest_id(&info.test_mode, uuidp);
     dbg(DBG_LOW, "Submission: IOCCC contest ID: %s", info.ioccc_id);
 
     /*
@@ -1002,6 +1074,14 @@ main(int argc, char *argv[])
     if (remarks_md != NULL) {
         free(remarks_md);
         remarks_md = NULL;
+    }
+
+    /*
+     * if uuid file is open, close it
+     */
+    if (uuidp != NULL && is_open_file_stream(uuidp)) {
+        fclose(uuidp);
+        uuidp = NULL;
     }
 
     /*
@@ -1613,12 +1693,29 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                 case FTS_D: /* directory */
                     /*
                      * we know this is an okay path because all error conditions
-                     * have been accounted for above.
+                     * have been accounted for above. Even so we have more
+                     * checks to do.
                      */
 
                     /*
-                     * Even so we have extra checks to do.
-                     */
+                     * first of all, make sure the directory we just located is
+                     * not the workdir; if it is we will not traverse it.
+                     *
+                     * NOTE: read_fts() will NEVER return a struct FTSENT * that has a
+                     * NULL fts_statp! Thus we do not need to check for it being NULL.
+                    */
+                    if (ent->fts_statp->st_ino == workdir_st.st_ino && ent->fts_statp->st_dev == workdir_st.st_dev) {
+                        /*
+                         * don't descend into this directory
+                         */
+                        errno = 0; /* pre-clear errno for errp() */
+                        if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
+                            errp(57, __func__, "failed to set FTS_SKIP on workdir inside topdir");
+                            not_reached();
+                        }
+                        dbg(DBG_MED, "skipping workdir found inside topdir");
+                        continue;
+                    }
                     if (optional) {
                         /*
                          * you're not allowed to have directory names that are
@@ -1639,7 +1736,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(57, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(58, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1656,7 +1753,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(58, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(59, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1706,7 +1803,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(59, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(60, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1953,7 +2050,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
     errno = 0;          /* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-        errp(60, __func__, "unable to fchdir(cwd)");
+        errp(61, __func__, "unable to fchdir(cwd)");
         not_reached();
     }
 
@@ -1973,13 +2070,18 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignore_paths, char *, i);
                 if (p == NULL) {
-                    err(61, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
+                    err(62, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If you made a mistake, rerun the tool with the correct args.",
+                     "",
+                     NULL);
+
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you delete %s and try again\nwith the correct options used\n",
                             submit_path);
@@ -2005,7 +2107,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                     errno = 0;
                     ret = printf("\t%10s%s", ignored_dirnames[i], !((i+1)%3)||ignored_dirnames[i+1]==NULL?"\n":"   ");
                     if (ret <= 0) {
-                        errp(62, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
+                        errp(63, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
                         not_reached();
                     }
                 }
@@ -2021,13 +2123,19 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignored_dirs, char *, i);
                 if (p == NULL) {
-                    err(63, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
+                    err(64, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+
+                para("",
+                     "If you do not agree to this you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2051,7 +2159,8 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                     "",
                     "\t^[0-9A-Za-z]+[0-9A-Za-z_+.-]*$",
                     "",
-                    "because they are not POSIX plus + chars only.",
+                    "because they are not POSIX plus + chars only."
+                    "",
                     NULL);
             }
             para("",
@@ -2062,13 +2171,17 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->unsafe_dirs, char *, i);
                 if (p == NULL) {
-                    err(64, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
+                    err(65, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If you do not agree to this you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2095,7 +2208,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                     errno = 0;
                     ret = printf("\t%10s%s", forbidden_filenames[i], !((i+1)%3)||forbidden_filenames[i+1]==NULL?"\n":"   ");
                     if (ret <= 0) {
-                        errp(65, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
+                        errp(66, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
                         not_reached();
                     }
                 }
@@ -2112,13 +2225,17 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->forbidden_files, char *, i);
                 if (p == NULL) {
-                    err(66, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
+                    err(67, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If you do not agree to this you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2152,13 +2269,17 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->unsafe_files, char *, i);
                 if (p == NULL) {
-                    err(67, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
+                    err(68, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If you do not agree to this you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2189,13 +2310,17 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignored_symlinks, char *, i);
                 if (p == NULL) {
-                    err(68, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
+                    err(69, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If you do not agree to this you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2223,13 +2348,17 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->directories, char *, i);
                 if (p == NULL) {
-                    err(69, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(70, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If this list is incorrect, you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2264,7 +2393,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->required_files, char *, i);
                 if (p == NULL) {
-                    err(70, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                    err(71, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2282,14 +2411,18 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 for (i = 0; i < len; ++i) {
                     p = dyn_array_value(infop->extra_files, char *, i);
                     if (p == NULL) {
-                        err(71, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                        err(72, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     print("%s\n", p);
                 }
             }
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If this list is incorrect, you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -2319,7 +2452,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                      */
                     p = dyn_array_value(infop->directories, char *, i);
                     if (p == NULL) {
-                        err(72, __func__, "found NULL pointer in infop->directories list");
+                        err(73, __func__, "found NULL pointer in infop->directories list");
                         not_reached();
                     }
                     /*
@@ -2335,7 +2468,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             errno = 0;
             if (fchdir(topdir) != 0) {
-                errp(73, __func__, "cannot change to topdir");
+                errp(74, __func__, "cannot change to topdir");
                 not_reached();
             }
 
@@ -2344,13 +2477,13 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             len = dyn_array_tell(infop->required_files);
             if (len <= 0) {
-                err(74, __func__, "list of required files is empty");
+                err(75, __func__, "list of required files is empty");
                 not_reached();
             }
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->required_files, char *, i);
                 if (p == NULL) {
-                    err(75, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                    err(76, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 /*
@@ -2361,7 +2494,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                  */
                 fname = calloc_path(topdir_path, p);
                 if (fname == NULL) {
-                    err(76, __func__, "couldn't allocate path to copy");
+                    err(77, __func__, "couldn't allocate path to copy");
                     not_reached();
                 }
                 if (target_path != NULL) {
@@ -2379,7 +2512,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
                 if (target_path == NULL) {
-                    errp(77, __func__, "failed to allocate target path for %s", p);
+                    errp(78, __func__, "failed to allocate target path for %s", p);
                     not_reached();
                 }
                 /*
@@ -2388,7 +2521,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
                 if (ret <= 0) {
-                    errp(78, __func__, "snprintf to form target path for %s failed", fname);
+                    errp(79, __func__, "snprintf to form target path for %s failed", fname);
                     not_reached();
                 }
 
@@ -2422,7 +2555,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->extra_files, char *, i);
                 if (p == NULL) {
-                    err(79, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                    err(80, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 /*
@@ -2433,7 +2566,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                  */
                 fname = calloc_path(topdir_path, p);
                 if (fname == NULL) {
-                    err(80, __func__, "couldn't allocate path to copy");
+                    err(81, __func__, "couldn't allocate path to copy");
                     not_reached();
                 }
                 if (target_path != NULL) {
@@ -2451,7 +2584,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
                 if (target_path == NULL) {
-                    errp(81, __func__, "failed to allocate target path for %s", p);
+                    errp(82, __func__, "failed to allocate target path for %s", p);
                     not_reached();
                 }
                 /*
@@ -2459,7 +2592,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
                 if (ret <= 0) {
-                    errp(82, __func__, "snprintf to form target path for %s failed", fname);
+                    errp(83, __func__, "snprintf to form target path for %s failed", fname);
                     not_reached();
                 } else if (is_executable_filename(p)) {
                     /*
@@ -2505,7 +2638,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(topdir) != 0) {
-        errp(83, __func__, "failed to close(topdir)");
+        errp(84, __func__, "failed to close(topdir)");
         not_reached();
     }
 
@@ -2572,14 +2705,14 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      * firewall
      */
     if (infop == NULL || submit_path == NULL || make == NULL || size == NULL) {
-        err(84, __func__, "passed NULL arg(s)");
+        err(85, __func__, "passed NULL arg(s)");
         not_reached();
     }
     /*
      * cwd must be >= 0
      */
     if (cwd < 0) {
-        err(85, __func__, "original directory file descriptor < 0");
+        err(86, __func__, "original directory file descriptor < 0");
         not_reached();
     }
 
@@ -2590,7 +2723,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(86, __func__, "failed to change to original directory");
+        errp(87, __func__, "failed to change to original directory");
         not_reached();
     }
 
@@ -2618,27 +2751,27 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     required_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (required_files == NULL) {
-        err(87, __func__, "couldn't create required files list array");
+        err(88, __func__, "couldn't create required files list array");
         not_reached();
     }
     extra_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (extra_files == NULL) {
-        err(88, __func__, "couldn't create extra files list array");
+        err(89, __func__, "couldn't create extra files list array");
         not_reached();
     }
     missing_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_files == NULL) {
-        err(89, __func__, "couldn't create missing files list array");
+        err(90, __func__, "couldn't create missing files list array");
         not_reached();
     }
     directories = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (directories == NULL) {
-        err(90, __func__, "couldn't create directories list array");
+        err(91, __func__, "couldn't create directories list array");
         not_reached();
     }
     missing_dirs = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_dirs == NULL) {
-        err(91, __func__, "couldn't create missing directories list array");
+        err(92, __func__, "couldn't create missing directories list array");
         not_reached();
     }
 
@@ -2709,7 +2842,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     ent = read_fts(NULL, -1, NULL, &fts);
     if (ent == NULL){
-        err(92, __func__, "failed to find any files in \".\"");
+        err(93, __func__, "failed to find any files in \".\"");
         not_reached();
     } else {
         do {
@@ -2806,11 +2939,29 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                 case FTS_D: /* directory */
                     /*
                      * we know this is an okay path because all error conditions
-                     * have been accounted for above
+                     * have been accounted for above. Even so we have extra
+                     * checks to do.
                      */
+
+                     /* NOTE: read_fts() will NEVER return a struct FTSENT *
+                      * that has a NULL fts_statp! Thus we do not need to check
+                      * for it being NULL.
+                      */
                     /*
-                     * Even so we have extra checks to do.
+                     * first of all, make sure the directory we just located is
+                     * not the workdir; if it is something went wrong.
                      */
+                    if (ent->fts_statp->st_ino == workdir_st.st_ino && ent->fts_statp->st_dev == workdir_st.st_dev) {
+                        err(4, __func__, "found workdir inside submission directory"); /*ooo*/
+                        not_reached();
+                    }
+                    /*
+                     * check if this is the topdir too
+                     */
+                    if (ent->fts_statp->st_ino == topdir_st.st_ino && ent->fts_statp->st_dev == topdir_st.st_dev) {
+                        err(4, __func__, "found topdir inside submission directory");/*ooo*/
+                        not_reached();
+                    }
                     /*
                      * if infop->directories is NULL it's an immediate error
                      * because it means there are no directories in the topdir
@@ -2869,7 +3020,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(93, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(94, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -2893,7 +3044,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(94, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(95, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
 
@@ -3069,7 +3220,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          */
         p = dyn_array_value(infop->required_files, char *, i);
         if (p == NULL) {
-            err(95, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+            err(96, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
             not_reached();
         }
         /*
@@ -3077,7 +3228,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          */
         fname = dyn_array_value(required_files, char *, i);
         if (fname == NULL) {
-            err(96, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
+            err(97, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
             not_reached();
         }
 
@@ -3104,7 +3255,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             errno = 0; /* pre-clear errno for errp() */
             filename = strdup(p);
             if (filename == NULL) {
-                errp(97, __func__, "strdup(\"%s\") failed", p);
+                errp(98, __func__, "strdup(\"%s\") failed", p);
                 not_reached();
             }
             append_unique_filename(missing_files, filename);
@@ -3233,7 +3384,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                      */
                     p = dyn_array_value(infop->extra_files, char *, i);
                     if (p == NULL) {
-                        err(98, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                        err(99, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     /*
@@ -3241,7 +3392,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                      */
                     fname = dyn_array_value(extra_files, char *, i);
                     if (p == NULL) {
-                        err(99, __func__, "found NULL pointer in extra files list in submission directory, element: %ju",
+                        err(100, __func__, "found NULL pointer in extra files list in submission directory, element: %ju",
                                 (uintmax_t)i);
                         not_reached();
                     }
@@ -3269,7 +3420,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                         errno = 0; /* pre-clear errno for errp() */
                         filename = strdup(p);
                         if (filename == NULL) {
-                            errp(100, __func__, "strdup(\"%s\") failed", p);
+                            errp(101, __func__, "strdup(\"%s\") failed", p);
                             not_reached();
                         }
                         append_unique_filename(missing_files, filename);
@@ -3288,7 +3439,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         ret = fprintf(stderr, "The following file%s %s missing:\n\n",
                 len == 1 ? "" : "s", len == 1 ? "is" : "are");
         if (ret <= 0) {
-            errp(101, __func__, "error writing missing files list title");
+            errp(102, __func__, "error writing missing files list title");
             not_reached();
         }
         for (i = 0; i < len; i++) {
@@ -3297,7 +3448,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
              */
             fname = dyn_array_value(missing_files, char *, i);
             if (fname == NULL) {
-                err(102, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
+                err(103, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", fname);
@@ -3325,7 +3476,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          * (topdir list size) it is an error
          */
         if (len != len2) {
-            err(103, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
+            err(104, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
                     (uintmax_t)len);
             not_reached();
         }
@@ -3333,12 +3484,12 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->directories, char *, i);
                 if (p == NULL) {
-                    err(104, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(105, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 fname = dyn_array_value(directories, char *, i);
                 if (fname == NULL) {
-                    err(105, __func__, "found NULL pointer in directories list in submission directory, element: %ju",
+                    err(106, __func__, "found NULL pointer in directories list in submission directory, element: %ju",
                             (uintmax_t)i);
                     not_reached();
                 }
@@ -3366,7 +3517,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(p);
                     if (filename == NULL) {
-                        errp(106, __func__, "strdup(\"%s\") failed", p);
+                        errp(107, __func__, "strdup(\"%s\") failed", p);
                         not_reached();
                     }
                     append_unique_filename(missing_dirs, filename);
@@ -3382,7 +3533,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             ret = fprintf(stderr, "The following director%s %s missing:\n\n",
                     len == 1 ? "y" : "ies", len == 1 ? "is" : "are");
             if (ret <= 0) {
-                errp(107, __func__, "error writing missing directories list title");
+                errp(108, __func__, "error writing missing directories list title");
                 not_reached();
             }
             for (i = 0; i < len; i++) {
@@ -3391,7 +3542,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                  */
                 fname = dyn_array_value(missing_dirs, char *, i);
                 if (fname == NULL) {
-                    err(108, __func__,
+                    err(109, __func__,
                             "found NULL pointer in missing directories list in submission directory, element: %ju",
                             (uintmax_t)i);
                     not_reached();
@@ -3420,14 +3571,18 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(directories, char *, i);
                 if (p == NULL) {
-                    err(109, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(110, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
             }
 
             if (!answer_yes) {
-                yorn = yes_or_no("\nIs this OK? [Yn]", true);
+                para("",
+                     "If this list is incorrect, you will have to fix your topdir",
+                     "and try again.",
+                     NULL);
+                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
                 if (!yorn) {
                     print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                             topdir_path, submit_path);
@@ -3442,7 +3597,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      * show user final submission directory listing and verify it is OK
      */
     if (required_files == NULL) {
-        err(110, __func__, "required files in submission directory is NULL");
+        err(111, __func__, "required files in submission directory is NULL");
         not_reached();
     }
     len = dyn_array_tell(required_files);
@@ -3462,7 +3617,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(required_files, char *, i);
             if (p == NULL) {
-                err(111, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                err(112, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -3478,7 +3633,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                 for (i = 0; i < len; ++i) {
                     p = dyn_array_value(extra_files, char *, i);
                     if (p == NULL) {
-                        err(112, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                        err(113, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     print("%s\n", p);
@@ -3486,7 +3641,11 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             }
         }
         if (!answer_yes) {
-            yorn = yes_or_no("\nIs this OK? [Yn]", true);
+            para("",
+                 "If this list is incorrect, you will have to fix your topdir",
+                 "and try again.",
+                 NULL);
+            yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
             if (!yorn) {
                 print("we suggest you fix your %s directory,\ndelete %s and try again\n",
                         topdir_path, submit_path);
@@ -3536,7 +3695,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(113, __func__, "unable to change to previous directory");
+        errp(114, __func__, "unable to change to previous directory");
         not_reached();
     }
 
@@ -3545,7 +3704,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(cwd) != 0) {
-        errp(114, __func__, "failed to close(cwd)");
+        errp(115, __func__, "failed to close(cwd)");
         not_reached();
     }
     /*
@@ -3636,7 +3795,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
      */
     if (infop == NULL || workdir == NULL || tar == NULL || ls == NULL ||
 	txzchk == NULL || fnamchk == NULL || chkentry == NULL || make == NULL) {
-	err(115, __func__, "called with NULL arg(s)");
+	err(116, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3658,7 +3817,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(116, __func__, "tar does not exist: %s", tar);
+	err(117, __func__, "tar does not exist: %s", tar);
 	not_reached();
     }
     if (!is_file(tar)) {
@@ -3675,7 +3834,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(117, __func__, "tar is not a regular file: %s", tar);
+	err(118, __func__, "tar is not a regular file: %s", tar);
 	not_reached();
     }
     if (!is_exec(tar)) {
@@ -3692,7 +3851,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(118, __func__, "tar is not an executable program: %s", tar);
+	err(119, __func__, "tar is not an executable program: %s", tar);
 	not_reached();
     }
 
@@ -3714,7 +3873,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(119, __func__, "ls does not exist: %s", ls);
+	err(120, __func__, "ls does not exist: %s", ls);
 	not_reached();
     }
     if (!is_file(ls)) {
@@ -3731,7 +3890,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(120, __func__, "ls is not a regular file: %s", ls);
+	err(121, __func__, "ls is not a regular file: %s", ls);
 	not_reached();
     }
     if (!is_exec(ls)) {
@@ -3748,7 +3907,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(121, __func__, "ls is not an executable program: %s", ls);
+	err(122, __func__, "ls is not an executable program: %s", ls);
 	not_reached();
     }
 
@@ -3770,7 +3929,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(122, __func__, "txzchk does not exist: %s", txzchk);
+	err(123, __func__, "txzchk does not exist: %s", txzchk);
 	not_reached();
     }
     if (!is_file(txzchk)) {
@@ -3787,7 +3946,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(123, __func__, "txzchk is not a regular file: %s", txzchk);
+	err(124, __func__, "txzchk is not a regular file: %s", txzchk);
 	not_reached();
     }
     if (!is_exec(txzchk)) {
@@ -3804,7 +3963,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(124, __func__, "txzchk is not an executable program: %s", txzchk);
+	err(125, __func__, "txzchk is not an executable program: %s", txzchk);
 	not_reached();
     }
 
@@ -3826,7 +3985,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(125, __func__, "fnamchk does not exist: %s", fnamchk);
+	err(126, __func__, "fnamchk does not exist: %s", fnamchk);
 	not_reached();
     }
     if (!is_file(fnamchk)) {
@@ -3843,7 +4002,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(126, __func__, "fnamchk is not a regular file: %s", fnamchk);
+	err(128, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -3860,7 +4019,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(128, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(129, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -3882,7 +4041,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(129, __func__, "chkentry does not exist: %s", chkentry);
+	err(130, __func__, "chkentry does not exist: %s", chkentry);
 	not_reached();
     }
     if (!is_file(chkentry)) {
@@ -3899,7 +4058,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(130, __func__, "chkentry is not a regular file: %s", chkentry);
+	err(131, __func__, "chkentry is not a regular file: %s", chkentry);
 	not_reached();
     }
     if (!is_exec(chkentry)) {
@@ -3916,7 +4075,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(131, __func__, "chkentry is not an executable program: %s", chkentry);
+	err(132, __func__, "chkentry is not an executable program: %s", chkentry);
 	not_reached();
     }
 
@@ -3938,7 +4097,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(132, __func__, "make does not exist: %s", make);
+	err(133, __func__, "make does not exist: %s", make);
 	not_reached();
     }
     if (!is_file(make)) {
@@ -3955,7 +4114,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(133, __func__, "make is not a regular file: %s", make);
+	err(134, __func__, "make is not a regular file: %s", make);
 	not_reached();
     }
     if (!is_exec(make)) {
@@ -3972,7 +4131,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(134, __func__, "make is not an executable program: %s", make);
+	err(135, __func__, "make is not an executable program: %s", make);
 	not_reached();
     }
 
@@ -3989,7 +4148,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "You should either create workdir, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(135, __func__, "workdir does not exist: %s", workdir);
+	err(136, __func__, "workdir does not exist: %s", workdir);
 	not_reached();
     }
     if (!is_dir(workdir)) {
@@ -4001,7 +4160,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(136, __func__, "workdir is not a directory: %s", workdir);
+	err(137, __func__, "workdir is not a directory: %s", workdir);
 	not_reached();
     }
     if (!is_write(workdir)) {
@@ -4013,7 +4172,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *ta
 	      "create a new writable directory, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(137, __func__, "workdir is not a writable directory: %s", workdir);
+	err(138, __func__, "workdir is not a writable directory: %s", workdir);
 	not_reached();
     }
 
@@ -4064,7 +4223,7 @@ prompt(char const *str, size_t *lenp)
      * NOTE: As noted above, lenp can be NULL.
      */
     if (str == NULL) {
-	err(138, __func__, "called with NULL str");
+	err(139, __func__, "called with NULL str");
 	not_reached();
     }
 
@@ -4084,13 +4243,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(str, stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(139, __func__, "error printing prompt string");
+		errp(140, __func__, "error printing prompt string");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(140, __func__, "EOF while printing prompt string");
+		err(141, __func__, "EOF while printing prompt string");
 		not_reached();
 	    } else {
-		errp(141, __func__, "unexpected fputs error printing prompt string");
+		errp(142, __func__, "unexpected fputs error printing prompt string");
 		not_reached();
 	    }
 	}
@@ -4099,13 +4258,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(": ", stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(142, __func__, "error printing :<space>");
+		errp(143, __func__, "error printing :<space>");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(143, __func__, "EOF while writing :<space>");
+		err(144, __func__, "EOF while writing :<space>");
 		not_reached();
 	    } else {
-		errp(144, __func__, "unexpected fputs error printing :<space>");
+		errp(145, __func__, "unexpected fputs error printing :<space>");
 		not_reached();
 	    }
 	}
@@ -4114,13 +4273,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fflush(stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(145, __func__, "error flushing prompt to stdout");
+		errp(146, __func__, "error flushing prompt to stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(146, __func__, "EOF while flushing prompt to stdout");
+		err(147, __func__, "EOF while flushing prompt to stdout");
 		not_reached();
 	    } else {
-		errp(147, __func__, "unexpected fflush error while flushing prompt to stdout");
+		errp(148, __func__, "unexpected fflush error while flushing prompt to stdout");
 		not_reached();
 	    }
 	}
@@ -4131,7 +4290,7 @@ prompt(char const *str, size_t *lenp)
      */
     buf = readline_dup(&linep, true, &len, stream);
     if (buf == NULL) {
-	err(148, __func__, "EOF while reading prompt input");
+	err(149, __func__, "EOF while reading prompt input");
 	not_reached();
     }
     dbg(DBG_VHIGH, "received a %ju byte response", (uintmax_t)len);
@@ -4175,9 +4334,10 @@ prompt(char const *str, size_t *lenp)
  * This function does not return on error or if the contest ID is malformed.
  */
 static char *
-get_contest_id(bool *testp)
+get_contest_id(bool *testp, FILE *uuidp)
 {
-    char *malloc_ret;		/* allocated return string */
+    char *malloc_ret = NULL;	/* allocated return string */
+    char *linep = NULL;         /* when reading from file */
     size_t len;			/* input string length */
     bool valid = false;		/* true ==> IOCCC_contest_id is valid */
     bool seen_answers_header = false;
@@ -4186,24 +4346,37 @@ get_contest_id(bool *testp)
      * firewall
      */
     if (testp == NULL) {
-	err(149, __func__, "called with NULL testp");
+	err(150, __func__, "called with NULL testp");
 	not_reached();
     }
 
     /*
-     * explain contest ID
+     * explain contest ID unless uuidp != NULL
+     */
+    if (uuidp != NULL && is_open_file_stream(uuidp)) {
+	malloc_ret = readline_dup(&linep, true, NULL, uuidp);
+	if (malloc_ret != NULL) {
+            if (valid_contest_id(malloc_ret)) {
+                return malloc_ret;
+            }
+            free(malloc_ret);
+            malloc_ret = NULL;
+	}
+    }
+    /*
+     * if we get here then the user has to input their uuid manually
      */
     if (need_hints) {
-	show_registration_url();
-	para("",
-	     "If you do not have an IOCCC contest ID and you wish to test this program,",
-	     "you may use the special contest ID:",
-	     "",
-	     "    test",
-	     "",
-	     "Note you will not be able to submit the resulting compressed tarball when using test.",
-	     "",
-	     NULL);
+        show_registration_url();
+        para("",
+             "If you do not have an IOCCC contest ID and you wish to test this program,",
+             "you may use the special contest ID:",
+             "",
+             "    test",
+             "",
+             "Note you will not be able to submit the resulting compressed tarball when using test.",
+             "",
+             NULL);
     }
 
     /*
@@ -4226,7 +4399,7 @@ get_contest_id(bool *testp)
 	    malloc_ret = prompt("", &len);
 	}
 	if (read_answers_flag_used && !seen_answers_header) {
-	    err(150, __func__, "didn't find the correct answers file header");
+	    err(151, __func__, "didn't find the correct answers file header");
 	    not_reached();
 	}
 
@@ -4324,7 +4497,7 @@ get_submit_slot(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(151, __func__, "called with NULL arg(s)");
+	err(152, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4335,7 +4508,7 @@ get_submit_slot(struct info *infop)
         errno = 0;		/* pre-clear errno for errp() */
         ret = printf("\nYou are allowed to submit up to %d submissions to a given IOCCC.\n", MAX_SUBMIT_SLOT + 1);
         if (ret <= 0) {
-            errp(152, __func__, "printf error printing number of submissions allowed");
+            errp(153, __func__, "printf error printing number of submissions allowed");
             not_reached();
         }
         para("",
@@ -4369,7 +4542,7 @@ get_submit_slot(struct info *infop)
 	    ret = fprintf(stderr, "\nThe submit slot number must be a number from 0 through %d; please re-enter.\n",
 		    MAX_SUBMIT_SLOT);
 	    if (ret <= 0) {
-		errp(153, __func__, "fprintf error while informing about the valid submit slot number range");
+		errp(154, __func__, "fprintf error while informing about the valid submit slot number range");
                 not_reached();
 	    }
             /*
@@ -4389,7 +4562,7 @@ get_submit_slot(struct info *infop)
                 ret = printf("\nThe slot number you entered is: %d\n",
                              submit_slot);
                 if (ret <= 0) {
-                    errp(154, __func__, "fprintf error writing slot number");
+                    errp(155, __func__, "fprintf error writing slot number");
                     not_reached();
                 }
                 yorn = yes_or_no("\nIs that slot number correct? [Yn]", true);
@@ -4450,12 +4623,12 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      * firewall
      */
     if (workdir == NULL || ioccc_id == NULL || tarball_path == NULL) {
-	err(155, __func__, "called with NULL arg(s)");
+	err(156, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     test = test_submit_slot(submit_slot);
     if (test == false) {
-	err(156, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
+	err(157, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
 	not_reached();
     }
 
@@ -4469,13 +4642,13 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
     errno = 0;			/* pre-clear errno for errp() */
     submission_dir = (char *)malloc(submission_dir_len + 1);
     if (submission_dir == NULL) {
-	errp(157, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
+	errp(158, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(submission_dir, submission_dir_len + 1, "%s/%s-%d", workdir, ioccc_id, submit_slot);
     if (ret <= 0) {
-	errp(158, __func__, "snprintf to form submission directory failed");
+	errp(159, __func__, "snprintf to form submission directory failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "submission directory path: %s", submission_dir);
@@ -4487,7 +4660,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nsubmission directory already exists: %s\n", submission_dir);
 	if (ret <= 0) {
-	    errp(159, __func__, "fprintf error while informing that the submission directory already exists");
+	    errp(160, __func__, "fprintf error while informing that the submission directory already exists");
             not_reached();
 	}
 	fpara(stderr,
@@ -4495,7 +4668,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 	      "You need to move that directory, or remove it, or use a different workdir.",
 	      "",
 	      NULL);
-	err(160, __func__, "submission directory exists: %s", submission_dir);
+	err(161, __func__, "submission directory exists: %s", submission_dir);
 	not_reached();
     }
     dbg(DBG_HIGH, "submission directory path: %s", submission_dir);
@@ -4512,13 +4685,23 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     ret = mkdir(submission_dir, 0);
     if (ret < 0) {
-	errp(161, __func__, "cannot mkdir %s", submission_dir);
+	errp(162, __func__, "cannot mkdir %s", submission_dir);
 	not_reached();
     }
     errno = 0; /* pre-clear errno for errp() */
     ret = chmod(submission_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
     if (ret < 0) {
-        errp(162, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
+        errp(163, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
+        not_reached();
+    }
+
+    /*
+     * get stat(2) information on submission directory. It is an error if it
+     * cannot be obtained
+     */
+    errno = 0; /* pre-clear errno for errp() */
+    if (stat(submission_dir, &submit_dir_st) != 0) {
+        errp(164, __func__, "failed to get stat(2) info for submission directory: %s", submission_dir);
         not_reached();
     }
 
@@ -4529,7 +4712,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     *tarball_path = form_tar_filename(ioccc_id, submit_slot, test_mode, tstamp);
     if (*tarball_path == NULL) {
-	errp(163, __func__, "failed to form compressed tarball path");
+	errp(165, __func__, "failed to form compressed tarball path");
 	not_reached();
     }
     dbg(DBG_HIGH, "compressed tarball path: %s", *tarball_path);
@@ -4574,7 +4757,7 @@ warn_empty_prog(void)
 	}
 	yorn = yes_or_no("Are you sure you want to submit an empty prog.c file? [Ny]", false);
 	if (!yorn) {
-	    err(164, __func__, "please fix your prog.c file");
+	    err(166, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their empty prog.c is OK");
@@ -4603,7 +4786,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * firewall
      */
     if (infop == NULL) {
-	err(165, __func__, "called with NULL infop");
+	err(167, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -4617,7 +4800,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %jd > Rule 2a maximum: %jd\n",
 		      (intmax_t)infop->rule_2a_size, (intmax_t)RULE_2A_SIZE);
 	if (ret <= 0) {
-	    errp(166, __func__, "fprintf error when printing prog.c Rule 2a warning");
+	    errp(168, __func__, "fprintf error when printing prog.c Rule 2a warning");
             not_reached();
 	}
 	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
@@ -4634,7 +4817,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [Ny]", false);
 	    if (!yorn) {
-		err(167, __func__, "please fix your prog.c file");
+		err(169, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that their prog.c size: %jd > Rule 2a max size: %jd is OK",
@@ -4652,7 +4835,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 				  "YOUR remarks.md FILE!\n\n",
 				  (intmax_t)infop->rule_2a_size, (intmax_t)size.rule_2a_size);
 	    if (ret <= 0) {
-		errp(168, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
+		errp(170, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -4660,7 +4843,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	    if (!yorn) {
-		err(169, __func__, "please fix your prog.c file");
+		err(171, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that prog.c size: %jd != rule_count function size: %jd is OK",
@@ -4671,7 +4854,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * invalid mode
      */
     } else {
-	err(170, __func__, "invalid mode passed to function: %d", mode);
+	err(172, __func__, "invalid mode passed to function: %d", mode);
 	not_reached();
     }
     return;
@@ -4699,7 +4882,7 @@ warn_nul_chars(void)
 	ret = fprintf(stderr, "\nprog.c has NUL character(s)!\n"
 			      "Be careful you don't violate rule 13!\n\n");
 	if (ret <= 0) {
-	    errp(171, __func__, "fprintf error when printing prog.c nul_warning");
+	    errp(173, __func__, "fprintf error when printing prog.c nul_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4708,7 +4891,7 @@ warn_nul_chars(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(172, __func__, "please fix your prog.c file");
+	    err(174, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having NUL character(s) is OK");
@@ -4737,7 +4920,7 @@ warn_trigraph(void)
 	ret = fprintf(stderr, "\nprog.c has unknown or invalid trigraph(s) found!\n"
 			      "Is that a bug in, or a feature of your code?\n\n");
 	if (ret <= 0) {
-	    errp(173, __func__, "fprintf error when printing prog.c trigraph_warning");
+	    errp(175, __func__, "fprintf error when printing prog.c trigraph_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4746,7 +4929,7 @@ warn_trigraph(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(174, __func__, "please fix your prog.c file");
+	    err(176, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having unknown or invalid trigraph(s) is OK");
@@ -4775,7 +4958,7 @@ warn_wordbuf(void)
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
 			      "YOUR remarks.md FILE!\n\n");
 	if (ret <= 0) {
-	    errp(175, __func__, "fprintf error when printing prog.c wordbuf_warning");
+	    errp(177, __func__, "fprintf error when printing prog.c wordbuf_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4784,7 +4967,7 @@ warn_wordbuf(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(176, __func__, "please fix your prog.c file");
+	    err(178, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c triggering a word buffer overflow is OK");
@@ -4814,7 +4997,7 @@ warn_ungetc(void)
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
 			      "YOUR remarks.md FILE!\n\n");
 	if (ret <= 0) {
-	    errp(177, __func__, "fprintf error when printing prog.c ungetc_warning");
+	    errp(179, __func__, "fprintf error when printing prog.c ungetc_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -4823,7 +5006,7 @@ warn_ungetc(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(178, __func__, "please fix your prog.c file");
+	    err(180, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c triggering an ungetc warning OK");
@@ -4847,7 +5030,7 @@ warn_rule_2b_size(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(179, __func__, "called with NULL infop");
+	err(181, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -4859,7 +5042,7 @@ warn_rule_2b_size(struct info *infop)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %ju > Rule 2b maximum: %ju\n",
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
 	if (ret <= 0) {
-	    errp(180, __func__, "printf error printing prog.c size > Rule 2b maximum");
+	    errp(182, __func__, "printf error printing prog.c size > Rule 2b maximum");
 	    not_reached();
 	}
 
@@ -4876,7 +5059,7 @@ warn_rule_2b_size(struct info *infop)
 	}
 	yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [Ny]", false);
 	if (!yorn) {
-	    err(181, __func__, "please fix your prog.c file");
+	    err(183, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their prog.c size: %ju > Rule 2B max size: %ju is OK",
@@ -4913,7 +5096,7 @@ check_prog_c(struct info *infop, char const *prog_c)
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(182, __func__, "called with NULL arg(s)");
+	err(184, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     /*
@@ -4925,7 +5108,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(183, __func__, "prog.c does not exist: %s", prog_c);
+	err(185, __func__, "prog.c does not exist: %s", prog_c);
 	not_reached();
     }
     if (!is_file(prog_c)) {
@@ -4934,7 +5117,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(184, __func__, "prog.c is not a regular file: %s", prog_c);
+	err(186, __func__, "prog.c is not a regular file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -4943,7 +5126,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(185, __func__, "prog.c is not a readable file: %s", prog_c);
+	err(187, __func__, "prog.c is not a readable file: %s", prog_c);
 	not_reached();
     }
 
@@ -4957,7 +5140,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     prog_stream = fopen(prog_c, "r");
     if (prog_stream == NULL) {
-	errp(186, __func__, "failed to fopen: %s", prog_c);
+	errp(188, __func__, "failed to fopen: %s", prog_c);
 	not_reached();
     }
     size = rule_count(prog_stream);
@@ -4966,7 +5149,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(prog_stream);
     if (ret != 0) {
-	errp(187, __func__, "failed to fclose: %s", prog_c);
+	errp(189, __func__, "failed to fclose: %s", prog_c);
 	not_reached();
     }
 
@@ -4976,7 +5159,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     infop->rule_2a_size = file_size(prog_c);
     dbg(DBG_MED, "Rule 2a size: %jd", (intmax_t)infop->rule_2a_size);
     if (infop->rule_2a_size < 0) {
-	err(188, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
+	err(190, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
 	not_reached();
     } else if (infop->rule_2a_size == 0 || infop->rule_2b_size == 0) {
 	warn_empty_prog();
@@ -5103,7 +5286,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(189, __func__, "called with NULL arg(s)");
+	err(191, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5113,7 +5296,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     stream = fopen(Makefile, "r");
     if (stream == NULL) {
-	errp(190, __func__, "cannot open Makefile: %s", Makefile);
+	errp(192, __func__, "cannot open Makefile: %s", Makefile);
 	not_reached();
     }
 
@@ -5312,7 +5495,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(stream);
     if (ret < 0) {
-	errp(191, __func__, "fclose error");
+	errp(193, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5355,7 +5538,7 @@ warn_Makefile(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(192, __func__, "called with NULL infop");
+	err(194, __func__, "called with NULL infop");
 	not_reached();
     }
     if (need_confirm && (!answer_yes || seed_used)) {
@@ -5435,7 +5618,7 @@ warn_Makefile(struct info *infop)
 	if (!answer_yes) {
 	    yorn = yes_or_no("Do you still want to submit this Makefile in the hopes that it is OK? [Ny]", false);
 	    if (!yorn) {
-		err(193, __func__, "Use a different Makefile or modify your Makefile");
+		err(195, __func__, "Use a different Makefile or modify your Makefile");
 		not_reached();
 	    }
 	}
@@ -5464,7 +5647,7 @@ check_Makefile(struct info *infop, char const *Makefile)
      * firewall
      */
     if (infop == NULL || Makefile == NULL) {
-	err(194, __func__, "called with NULL arg(s)");
+	err(196, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5477,7 +5660,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "We cannot find the Makefile.",
 	      "",
 	      NULL);
-	err(195, __func__, "Makefile does not exist: %s", Makefile);
+	err(197, __func__, "Makefile does not exist: %s", Makefile);
 	not_reached();
     }
     if (!is_file(Makefile)) {
@@ -5486,7 +5669,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	       "The Makefile path, while it exists, is not a regular file.",
 	       "",
 	       NULL);
-	err(196, __func__, "Makefile is not a regular file: %s", Makefile);
+	err(198, __func__, "Makefile is not a regular file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -5495,15 +5678,15 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "The Makefile path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(197, __func__, "Makefile is not readable file: %s", Makefile);
+	err(199, __func__, "Makefile is not readable file: %s", Makefile);
 	not_reached();
     }
     filesize = file_size(Makefile);
     if (filesize < 0) {
-	err(198, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
+	err(200, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
 	not_reached();
     } else if (filesize == 0) {
-	err(199, __func__, "Makefile cannot be empty: %s", Makefile);
+	err(201, __func__, "Makefile cannot be empty: %s", Makefile);
 	not_reached();
     }
 
@@ -5541,7 +5724,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
      * firewall
      */
     if (infop == NULL || remarks_md == NULL) {
-	err(200, __func__, "called with NULL arg(s)");
+	err(202, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5554,7 +5737,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	       "We cannot find the remarks.md file.",
 	       "",
 	       NULL);
-	err(201, __func__, "remarks.md does not exist: %s", remarks_md);
+	err(203, __func__, "remarks.md does not exist: %s", remarks_md);
 	not_reached();
     }
     if (!is_file(remarks_md)) {
@@ -5562,7 +5745,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(202, __func__, "remarks.md is not a regular file: %s", remarks_md);
+	err(204, __func__, "remarks.md is not a regular file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -5571,15 +5754,15 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(203, __func__, "remarks.md is not readable file: %s", remarks_md);
+	err(205, __func__, "remarks.md is not readable file: %s", remarks_md);
 	not_reached();
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(204, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
+	err(206, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
-	err(205, __func__, "remarks.md cannot be empty: %s", remarks_md);
+	err(207, __func__, "remarks.md cannot be empty: %s", remarks_md);
 	not_reached();
     }
 
@@ -5609,7 +5792,7 @@ yes_or_no(char const *question, bool def_answer)
      * firewall
      */
     if (question == NULL) {
-	err(206, __func__, "called with NULL question");
+	err(208, __func__, "called with NULL question");
 	not_reached();
     }
 
@@ -5728,7 +5911,7 @@ get_title(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(207, __func__, "called with NULL infop");
+	err(209, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -5748,7 +5931,7 @@ get_title(struct info *infop)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	if (ret <= 0) {
-	    errp(208, __func__, "fprintf #0 error: %d", ret);
+	    errp(210, __func__, "fprintf #0 error: %d", ret);
             not_reached();
 	}
     }
@@ -5806,7 +5989,7 @@ get_title(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	    if (ret <= 0) {
-		errp(209, __func__, "fprintf #1 error: %d", ret);
+		errp(211, __func__, "fprintf #1 error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -5865,7 +6048,7 @@ get_title(struct info *infop)
             ret = printf("\nThe title you entered is: %s\n",
                          title);
             if (ret <= 0) {
-                errp(210, __func__, "fprintf title");
+                errp(212, __func__, "fprintf title");
                 not_reached();
             }
             yorn = yes_or_no("\nIs that title correct? [Yn]", true);
@@ -5916,7 +6099,7 @@ get_abstract(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(211, __func__, "called with NULL infp");
+	err(213, __func__, "called with NULL infp");
 	not_reached();
     }
 
@@ -5983,7 +6166,7 @@ get_abstract(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your abstract must be between 1 and %d characters long.\n\n", MAX_ABSTRACT_LEN);
 	    if (ret <= 0) {
-		errp(212, __func__, "fprintf error: %d", ret);
+		errp(214, __func__, "fprintf error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -6009,7 +6192,7 @@ get_abstract(struct info *infop)
             ret = printf("\nThe abstract you entered is: %s\n",
                          abstract);
             if (ret <= 0) {
-                errp(213, __func__, "fprintf abstract");
+                errp(215, __func__, "fprintf abstract");
                 not_reached();
             }
             yorn = yes_or_no("\nIs that abstract correct? [Yn]", true);
@@ -6212,7 +6395,7 @@ get_author_info(struct author **author_set_p)
      * firewall
      */
     if (author_set_p == NULL) {
-	err(214, __func__, "called with NULL author_set_p");
+	err(216, __func__, "called with NULL author_set_p");
 	not_reached();
     }
 
@@ -6234,20 +6417,20 @@ get_author_info(struct author **author_set_p)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nThe number of authors must be a number from 1 through %d;\nplease re-enter.\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(215, __func__, "fprintf error #0 while printing author number range");
+		errp(217, __func__, "fprintf error #0 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nIf you happen to have more than %d authors, we ask that you pick\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(216, __func__, "fprintf error #1 while printing author number range");
+		errp(218, __func__, "fprintf error #1 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "just %d authors and mention the remaining NUMBER of the authors in\nthe remarks file.\n",
                     MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(217, __func__, "fprintf error #2 while printing author number range");
+		errp(219, __func__, "fprintf error #2 while printing author number range");
                 not_reached();
 	    }
 	    author_count = -1;	/* invalidate input */
@@ -6275,7 +6458,7 @@ get_author_info(struct author **author_set_p)
     errno = 0;			/* pre-clear errno for errp() */
     author_set = (struct author *) malloc(sizeof(struct author) * (size_t)author_count);
     if (author_set == NULL) {
-	errp(218, __func__, "malloc a struct author array of length: %d failed", author_count);
+	errp(220, __func__, "malloc a struct author array of length: %d failed", author_count);
 	not_reached();
     }
 
@@ -6311,31 +6494,31 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL0);
 	if (ret < 0) {
-	    errp(219, __func__, "puts error printing ISO 3166-1 URL0");
+	    errp(221, __func__, "puts error printing ISO 3166-1 URL0");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL1);
 	if (ret < 0) {
-	    errp(220, __func__, "puts error printing ISO 3166-1 URL1");
+	    errp(222, __func__, "puts error printing ISO 3166-1 URL1");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL2);
 	if (ret < 0) {
-	    errp(221, __func__, "puts error printing ISO 3166-1 URL2");
+	    errp(223, __func__, "puts error printing ISO 3166-1 URL2");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL3);
 	if (ret < 0) {
-	    errp(222, __func__, "puts error printing ISO 3166-1 URL3");
+	    errp(224, __func__, "puts error printing ISO 3166-1 URL3");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL4);
 	if (ret < 0) {
-	    errp(223, __func__, "puts error printing ISO 3166-1 URL4");
+	    errp(225, __func__, "puts error printing ISO 3166-1 URL4");
             not_reached();
 	}
 	para("",
@@ -6367,7 +6550,7 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = printf("\nEnter information for author #%d\n\n", i);
 	if (ret <= 0) {
-	    errp(224, __func__, "printf error printing author number");
+	    errp(226, __func__, "printf error printing author number");
             not_reached();
 	}
 	author_set[i].author_num = i;
@@ -6420,7 +6603,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit names to %d characters\n\n", MAX_NAME_LEN);
 		if (ret <= 0) {
-		    errp(225, __func__, "fprintf error while reject name that is too long");
+		    errp(227, __func__, "fprintf error while reject name that is too long");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6449,7 +6632,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d name duplicates previous author #%d name", i, j);
 			if (ret <= 0) {
-			    errp(226, __func__, "fprintf error while reject duplicate name");
+			    errp(228, __func__, "fprintf error while reject duplicate name");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -6503,7 +6686,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(227, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
+		    errp(229, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6513,19 +6696,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(228, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
+		    errp(230, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(229, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
+		    errp(231, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(230, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
+		    errp(232, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6574,7 +6757,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(231, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
+		    errp(233, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6584,19 +6767,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(232, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
+		    errp(234, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(233, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
+		    errp(235, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(234, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
+		    errp(236, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6631,7 +6814,7 @@ get_author_info(struct author **author_set_p)
 		ret = printf("\nThe location/country code you entered is assigned to: %s (%s)\n",
 			     author_set[i].location_name, author_set[i].common_name);
 		if (ret <= 0) {
-		    errp(235, __func__, "fprintf location/country code assignment");
+		    errp(237, __func__, "fprintf location/country code assignment");
                     not_reached();
 		}
 		yorn = yes_or_no("\nIs that location/country code correct? [Yn]", true);
@@ -6686,7 +6869,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit email address to %d characters\n", MAX_EMAIL_LEN);
 		if (ret <= 0) {
-		    errp(236, __func__, "fprintf error while printing Email address length limit");
+		    errp(238, __func__, "fprintf error while printing Email address length limit");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6744,7 +6927,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters.\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(237, __func__, "fprintf error while printing URL length limit");
+		    errp(239, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6840,7 +7023,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(238, __func__, "fprintf error while printing URL length limit");
+		    errp(240, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6936,7 +7119,7 @@ get_author_info(struct author **author_set_p)
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit Mastodon handles to %d "
 			"characters, starting with the @\n\n", MAX_MASTODON_LEN);
 		if (ret <= 0) {
-		    errp(239, __func__, "fprintf error while printing mastodon handle length limit");
+		    errp(241, __func__, "fprintf error while printing mastodon handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7026,7 +7209,7 @@ get_author_info(struct author **author_set_p)
 			    "\nSorry ( tm Canada :-) ), we limit GitHub account names to %d characters after the 1st @.\n\n",
 			    MAX_GITHUB_LEN);
 		if (ret <= 0) {
-		    errp(240, __func__, "fprintf error while printing GitHub user length limit");
+		    errp(242, __func__, "fprintf error while printing GitHub user length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7113,7 +7296,7 @@ get_author_info(struct author **author_set_p)
 		    fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit affiliation names to %d characters\n\n",
 			    MAX_AFFILIATION_LEN);
 		if (ret <= 0) {
-		    errp(241, __func__, "fprintf error while printing affiliation length limit");
+		    errp(243, __func__, "fprintf error while printing affiliation length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7190,7 +7373,7 @@ get_author_info(struct author **author_set_p)
 	     */
 	    def_handle = default_handle(author_set[i].name);
 	    if (def_handle == NULL) {
-		err(242, __func__, "default_handle() returned NULL!");
+		err(244, __func__, "default_handle() returned NULL!");
 		not_reached();
 	    }
 	    dbg(DBG_VHIGH, "default IOCCC author handle: <%s>", def_handle);
@@ -7198,7 +7381,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = printf("\nThe default IOCCC author handle for author #%d is:\n\n    %s\n\n", i, def_handle);
 		if (ret <= 0) {
-		    errp(243, __func__, "fprintf error while printing default IOCCC author handle");
+		    errp(245, __func__, "fprintf error while printing default IOCCC author handle");
                     not_reached();
 		}
 	    }
@@ -7261,7 +7444,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nThe IOCCC author handle is limited to %d characters\n\n", MAX_HANDLE);
 		if (ret <= 0) {
-		    errp(244, __func__, "fprintf error while printing IOCCC author handle length limit");
+		    errp(246, __func__, "fprintf error while printing IOCCC author handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7292,7 +7475,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d author_handle duplicates previous author #%d author_handle", i, j);
 			if (ret <= 0) {
-			    errp(245, __func__, "fprintf error while printing duplicate author_handle error");
+			    errp(247, __func__, "fprintf error while printing duplicate author_handle error");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -7339,7 +7522,7 @@ get_author_info(struct author **author_set_p)
 						      printf("IOCCC author handle was manually entered\n"))  <= 0 ||
 	    ((author_set[i].author_handle[0] == '\0') ? printf("IOCCC author handle\n\n") :
 						        printf("IOCCC author handle: %s\n\n", author_set[i].author_handle)) <= 0) {
-	    errp(246, __func__, "error while printing author #%d information\n", i);
+	    errp(248, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -7393,7 +7576,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * firewall
      */
     if (submission_dir == NULL || ls == NULL) {
-	err(247, __func__, "called with NULL arg(s)");
+	err(249, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -7406,7 +7589,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", submission_dir);
     if (ret <= 0) {
-	errp(248, __func__, "printf error code: %d", ret);
+	errp(10, __func__, "printf error code: %d", ret);
         not_reached();
     }
     para("",
@@ -7416,7 +7599,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to perform: cd -- %s && %s -lakR .", submission_dir, ls);
     exit_code = shell_cmd(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (exit_code != 0) {
-	err(249, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
+	err(11, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
 			   submission_dir, ls, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7427,7 +7610,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to popen: cd -- %s && %s -lakR .", submission_dir, ls);
     ls_stream = pipe_open(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (ls_stream == NULL) {
-	err(10, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
+	err(12, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
 	not_reached();
     }
 
@@ -7459,18 +7642,18 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * no line was read at all
      */
     if (readline_len < 0 && i == 0) {
-	err(11, __func__, "EOF while reading output of ls: %s", ls);
+	err(13, __func__, "EOF while reading output of ls: %s", ls);
 	not_reached();
     }
     /*
      * lines were read from ls but nothing correct was found
      */
     if (i == 0) {
-        err(12, __func__, "found no k-block line in ls output");
+        err(14, __func__, "found no k-block line in ls output");
         not_reached();
     }
     if (kdirsize <= 0) {
-	err(13, __func__, "ls k-block value: %d <= 0", kdirsize);
+	err(15, __func__, "ls k-block value: %d <= 0", kdirsize);
 	not_reached();
     }
     dbg(DBG_MED, "Directory %s size in kibibyte (1024 byte blocks): %d", submission_dir, kdirsize);
@@ -7549,7 +7732,7 @@ form_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-        err(14, __func__, "passed NULL infop");
+        err(16, __func__, "passed NULL infop");
         not_reached();
     }
     /*
@@ -7568,13 +7751,13 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(15, __func__, "cannot set TZ=UTC");
+	errp(17, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = gmtime(&(infop->tstamp));
     if (timeptr == NULL) {
-	errp(16, __func__, "gmtime returned NULL");
+	errp(18, __func__, "gmtime returned NULL");
 	not_reached();
     }
 
@@ -7585,7 +7768,7 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     infop->utctime = (char *)calloc(utctime_len + 1, sizeof(char)); /* + 1 for paranoia padding */
     if (infop->utctime == NULL) {
-	errp(17, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
+	errp(19, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
 	not_reached();
     }
 
@@ -7600,7 +7783,7 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     strftime_ret = strftime(infop->utctime, utctime_len, "%a %b %d %H:%M:%S %Y UTC", timeptr);
     if (strftime_ret == 0) {
-	errp(18, __func__, "strftime returned 0");
+	errp(20, __func__, "strftime returned 0");
 	not_reached();
     }
     dbg(DBG_VHIGH, "infop->utctime: %s", infop->utctime);
@@ -7642,7 +7825,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * firewall
      */
     if (infop == NULL || authp == NULL || submission_dir == NULL || chkentry == NULL) {
-        err(19, __func__, "called with NULL arg(s)");
+        err(21, __func__, "called with NULL arg(s)");
         not_reached();
     }
 
@@ -7650,10 +7833,10 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * first write .auth.json
      */
     if (authp->author_count <= 0) {
-	err(20, __func__, "author_count %d <= 0", authp->author_count);
+	err(22, __func__, "author_count %d <= 0", authp->author_count);
 	not_reached();
     } else if (authp->author_count > MAX_AUTHORS) {
-	err(21, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
+	err(23, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -7664,27 +7847,27 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     auth_path = (char *)malloc(auth_path_len + 1);
     if (auth_path == NULL) {
-	errp(22, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
+	errp(24, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(auth_path, auth_path_len, "%s/%s", submission_dir, AUTH_JSON_FILENAME);
     if (ret <= 0) {
-	errp(23, __func__, "snprintf #0 error: %d", ret);
+	errp(25, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".auth.json path: %s", auth_path);
     errno = 0;			/* pre-clear errno for errp() */
     auth_stream = fopen(auth_path, "w");
     if (auth_stream == NULL) {
-	errp(24, __func__, "failed to open for writing: %s", auth_path);
+	errp(26, __func__, "failed to open for writing: %s", auth_path);
 	not_reached();
     }
 
     errno = 0; /* pre-clear errno for errp() */
     fd = open(auth_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        err(25, __func__, "failed to obtain file descriptor for: %s", auth_path);
+        err(27, __func__, "failed to obtain file descriptor for: %s", auth_path);
         not_reached();
     }
 
@@ -7707,7 +7890,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_bool(auth_stream, "    ", "test_mode", " : ", authp->test_mode, ",\n") &&
 	fprintf(auth_stream, "    \"authors\" : [\n") > 0;
     if (!ret) {
-	errp(26, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
+	errp(28, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -7734,7 +7917,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	    json_fprintf_value_long(auth_stream, "            ", "author_number", " : ", ap->author_num, "\n") &&
 	    fprintf(auth_stream, "        }%s\n", (((i + 1) < authp->author_count) ? "," : "")) > 0;
 	if (ret == false) {
-	    errp(27, __func__, "fprintf error writing author %d info to %s", i, auth_path);
+	    errp(29, __func__, "fprintf error writing author %d info to %s", i, auth_path);
 	    not_reached();
 	}
     }
@@ -7750,7 +7933,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_long(auth_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(auth_stream, "}\n") > 0;
     if (!ret) {
-	errp(28, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
+	errp(30, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -7760,7 +7943,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(auth_stream);
     if (ret < 0) {
-	errp(29, __func__, "fclose error");
+	errp(31, __func__, "fclose error");
 	not_reached();
     }
 
@@ -7770,7 +7953,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(30, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
+        err(32, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
         not_reached();
     }
 
@@ -7780,7 +7963,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0; /* pre-clear for errp() */
     ret = close(fd);
     if (ret < 0) {
-        errp(31, __func__, "close(fd) failed");
+        errp(33, __func__, "close(fd) failed");
         not_reached();
     }
 
@@ -7788,7 +7971,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * now write .info.json
      */
     if (infop->required_files == NULL) {
-        err(32, __func__, "called with NULL files list");
+        err(34, __func__, "called with NULL files list");
         not_reached();
     }
 
@@ -7799,20 +7982,20 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(33, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
+	errp(35, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/%s", submission_dir, INFO_JSON_FILENAME);
     if (ret <= 0) {
-	errp(34, __func__, "snprintf #0 error: %d", ret);
+	errp(36, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(35, __func__, "failed to open for writing: %s", info_path);
+	errp(37, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -7822,7 +8005,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0; /* pre-clear errno for errp() */
     fd = open(info_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        errp(36, __func__, "failed to obtain file descriptor for: %s", info_path);
+        errp(38, __func__, "failed to obtain file descriptor for: %s", info_path);
         not_reached();
     }
 
@@ -7865,7 +8048,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_bool(info_stream, "    ", "test_mode", " : ", infop->test_mode, ",\n") &&
 	fprintf(info_stream, "    \"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(37, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(39, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -7898,7 +8081,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	  json_fprintf_value_string(info_stream, "            ", "remarks", " : ", "remarks.md", "\n") &&
 			    fprintf(info_stream, "        }%s\n", (infop->extra_count > 0) ?  "," : "") > 0;
     if (!ret) {
-	errp(38, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(40, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -7909,14 +8092,14 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
         for (j = 0; j < infop->extra_count; ++j) {
             p = dyn_array_value(infop->extra_files, char *, j);
             if (p == NULL) {
-                err(39, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)j);
+                err(41, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)j);
                 not_reached();
             }
             ret =                   fprintf(info_stream, "        {\n") > 0 &&
                   json_fprintf_value_string(info_stream, "            ", "extra_file", " : ", p, "\n") &&
                                     fprintf(info_stream, "        }%s\n", ((j+1) < infop->extra_count) ?  "," : "") > 0;
             if (!ret) {
-                errp(40, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)j, info_path);
+                errp(42, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)j, info_path);
                 not_reached();
             }
         }
@@ -7932,7 +8115,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_long(info_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(41, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(43, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -7942,7 +8125,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(42, __func__, "fclose error");
+	errp(44, __func__, "fclose error");
 	not_reached();
     }
 
@@ -7953,7 +8136,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(43, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
+        err(45, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
         not_reached();
     }
 
@@ -8005,19 +8188,19 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
      * firewall
      */
     if (authp == NULL || infop == NULL || authorp == NULL) {
-	err(44, __func__, "called with NULL arg(s)");
+	err(46, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->ioccc_id == NULL) {
-	err(45, __func__, "infop->ioccc_id is NULL");
+	err(47, __func__, "infop->ioccc_id is NULL");
 	not_reached();
     }
     if (infop->tarball == NULL) {
-	err(46, __func__, "infop->tarball is NULL");
+	err(48, __func__, "infop->tarball is NULL");
 	not_reached();
     }
     if (infop->utctime == NULL) {
-	err(47, __func__, "infop->utctime is NULL");
+	err(49, __func__, "infop->utctime is NULL");
 	not_reached();
     }
     memset(authp, 0, sizeof(*authp));
@@ -8041,14 +8224,14 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->ioccc_id = strdup(infop->ioccc_id);
     if (authp->ioccc_id == NULL) {
-	errp(48, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
+	errp(50, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
 	not_reached();
     }
     authp->submit_slot = infop->submit_slot;
     errno = 0;			/* pre-clear errno for errp() */
     authp->tarball = strdup(infop->tarball);
     if (authp->tarball == NULL) {
-	errp(49, __func__, "strdup() tarball path %s failed", infop->tarball);
+	errp(51, __func__, "strdup() tarball path %s failed", infop->tarball);
 	not_reached();
     }
     /* copy over test or non-test mode */
@@ -8070,7 +8253,7 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->utctime = strdup(infop->utctime);
     if (authp->utctime == NULL) {
-	errp(50, __func__, "strdup() utctime path %s failed", infop->utctime);
+	errp(52, __func__, "strdup() utctime path %s failed", infop->utctime);
 	not_reached();
     }
     return;
@@ -8113,7 +8296,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
      */
     if (workdir == NULL || submission_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(51, __func__, "called with NULL arg(s)");
+	err(53, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -8129,7 +8312,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(52, __func__, "cannot open .");
+	errp(54, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -8139,7 +8322,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(workdir);
     if (ret < 0) {
-	errp(53, __func__, "cannot cd %s", workdir);
+	errp(55, __func__, "cannot cd %s", workdir);
 	not_reached();
     }
 
@@ -8167,7 +8350,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     exit_code = shell_cmd(__func__, false, true, "% --format=v7 -cJf % -- %",
 				    tar, basename_tarball_path, basename_submission_dir);
     if (exit_code != 0) {
-	err(54, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
+	err(56, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
 			   tar, basename_tarball_path, basename_submission_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -8178,7 +8361,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(55, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(57, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -8187,7 +8370,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(56, __func__, "The compressed tarball: %s size: %ju > %jd",
+	err(58, __func__, "The compressed tarball: %s size: %ju > %jd",
 		 basename_tarball_path, (uintmax_t)buf.st_size, (intmax_t)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -8198,13 +8381,13 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(57, __func__, "cannot fchdir to the previous current directory");
+	errp(59, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(58, __func__, "close of previous current directory failed");
+	errp(60, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -8225,10 +8408,10 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         }
         if (exit_code != 0) {
             if (test_mode) {
-                err(59, __func__, "%s -x -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(61, __func__, "%s -x -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, feathery, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             } else {
-                err(60, __func__, "%s -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(62, __func__, "%s -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, feathery, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             }
             not_reached();
@@ -8248,10 +8431,10 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         }
         if (exit_code != 0) {
             if (test_mode) {
-                err(61, __func__, "%s -x -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(63, __func__, "%s -x -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                    txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             } else {
-                err(62, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(64, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                    txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             }
             not_reached();
@@ -8302,13 +8485,13 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
      * firewall
      */
     if (workdir == NULL || submission_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(63, __func__, "called with NULL arg(s)");
+	err(65, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     submission_dir_esc = cmdprintf("%", submission_dir);
     if (submission_dir_esc == NULL) {
-	err(64, __func__, "failed to cmdprintf: submission_dir");
+	err(66, __func__, "failed to cmdprintf: submission_dir");
 	not_reached();
     }
 
@@ -8321,14 +8504,14 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    rm -rf %s%s\n", submission_dir[0] == '-' ? "-- " : "", submission_dir_esc);
     if (ret <= 0) {
-	errp(65, __func__, "printf #0 error");
+	errp(67, __func__, "printf #0 error");
 	not_reached();
     }
     free(submission_dir_esc);
 
     workdir_esc = cmdprintf("%", workdir);
     if (workdir_esc == NULL) {
-	err(66, __func__, "failed to cmdprintf: workdir");
+	err(68, __func__, "failed to cmdprintf: workdir");
 	not_reached();
     }
 
@@ -8339,7 +8522,7 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, workdir[0] == '-' ? "./" : "", workdir_esc, tarball_path);
     if (ret <= 0) {
-	errp(67, __func__, "printf #2 error");
+	errp(69, __func__, "printf #2 error");
 	not_reached();
     }
     free(workdir_esc);
@@ -8411,7 +8594,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_URL);
     if (ret <= 0) {
-	errp(68, __func__, "printf error printing IOCCC_REGISTER_URL");
+	errp(70, __func__, "printf error printing IOCCC_REGISTER_URL");
 	not_reached();
     }
     para("",
@@ -8421,7 +8604,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_FAQ_URL);
     if (ret <= 0) {
-	errp(69, __func__, "printf error printing IOCCC register FAQ URL");
+	errp(71, __func__, "printf error printing IOCCC register FAQ URL");
 	not_reached();
     }
     para("",
@@ -8431,7 +8614,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n    %s\n    %s\n", IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL, IOCCC_SUBMIT_INFO_URL);
     if (ret <= 0) {
-	errp(70, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
+	errp(72, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
 	not_reached();
     }
 
@@ -8443,7 +8626,7 @@ show_registration_url(void)
     errno = 0;      /* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_STATUS_URL);
     if (ret < 0) {
-	errp(71, __func__, "printf error printing IOCCC status URL");
+	errp(73, __func__, "printf error printing IOCCC status URL");
 	not_reached();
     }
 
@@ -8480,7 +8663,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
         "after you have registered, you must upload into slot %d:\n\n\t%s/%s\n", slot_number,
         workdir, tarball_path);
     if (ret <= 0) {
-	errp(72, __func__, "printf error printing tarball path and slot number");
+	errp(74, __func__, "printf error printing tarball path and slot number");
 	not_reached();
     }
     para("",
@@ -8490,7 +8673,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
     ret = printf("    %s\n", IOCCC_SUBMIT_URL);
     if (ret < 0) {
-	errp(73, __func__, "printf error printing IOCCC submit URL");
+	errp(75, __func__, "printf error printing IOCCC submit URL");
 	not_reached();
     }
 
@@ -8501,7 +8684,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
      ret = printf("    %s\n", IOCCC_ENTER_FAQ_URL);
     if (ret < 0) {
-	errp(74, __func__, "printf error printing IOCCC enter FAQ URL");
+	errp(76, __func__, "printf error printing IOCCC enter FAQ URL");
 	not_reached();
     }
 }

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -181,7 +181,7 @@ static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, ch
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);
 static char *prompt(char const *str, size_t *lenp);
-static char *get_contest_id(bool *testp);
+static char *get_contest_id(bool *testp, FILE *uuidp);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -159,6 +159,8 @@ char *ignored_dirnames[] =
     FOSSIL_DIRNAME1,
     MONOTONE_DIRNAME,
     DARCS_DIRNAME,
+    SCCS_DIRNAME,
+    RCS_DIRNAME,
     NULL /* MUST BE LAST!! */
 };
 

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -118,6 +118,8 @@
 #define FOSSIL_DIRNAME1 "_FOSSIL_"              /* For Fossil */
 #define MONOTONE_DIRNAME "_MTN"                 /* For Monotone */
 #define DARCS_DIRNAME "_darcs"                  /* For Darcs */
+#define SCCS_DIRNAME "SCCS"                     /* For Source Code Control System */
+#define RCS_DIRNAME "RCS"                       /* for a number of RCSes */
 
 /*
  * filenames that should be ignored, mostly for chkentry -w but it can be used

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "27 February 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "07 March 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -296,6 +296,10 @@ This option implies
 .B \-y
 and disables some messages as well.
 Thus if you do have a file set change you should inspect your tarball after it has been formed to make sure it is still OK.
+.TP
+.BI \-u\  uuid
+Read UUID (username) from a file.
+If the UUID format is invalid it will prompt you as if you had not used the option.
 .TP
 .BI \-s\  seed
 Generate pseudo-random answers to the questions

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.2 2025-03-02"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.3 2025-03-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
It is an error if the topdir and the workdir are the same (same device and inode).

If the workdir is found in the topdir it is skipped.

Before doing anything make sure the args are actually directories that can be searched and (in the case of workdir) written to.

To help users not have to repeatedly copy and paste their UUID there is a new option, -u uuid which will read from a file the UUID. If the file does not exist or cannot be read or it does not have a valid UUID the program will prompt for it as if you didn't use the option.

Extra sanity checks in the FTS code.

Make it clearer what happens when one does not agree to a prompt in the scanning/copying the topdir and the checking of the submission directory. The prompt also is now 'Do you wish to continue?' instead of 'Is this OK?'.

When checking the submission directory if a directory that is the workdir OR topdir is encountered it is an error.

Ignore directories for additional RCSs: namely RCS and SCCS.

I believe this should resolve issues #1207, #1209 and #1210.

IMPORTANT REMINDER: the version of the tools have NOT been updated because doing so would INVALIDATE submissions already uploaded!