### PR TITLE
Resolve issues #1215

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,31 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.3 2025-03-07
+
+Resolve issues #1215 and #1207.
+
+Now the version checks for `chkentry(1)` are a >= check. Uses code from
+`jparse/verge.c`. Its `main()` was moved to `verge_main.c` and `verge.c` now has
+a new function `vercmp()`. `verge.o` is linked into the library and `chkentry`
+now uses it. Also there are new arrays that we called 'poisoned versions' and
+this allows for bad versions to be excluded. Each tool and some other versions
+have a minimum version allowed which at this time is equivalent to the current
+release. If a version is incremented then the minimum version would be changed
+to be the version at the time the contest opens. In this way uploaded
+submissions will not be invalidated. As for poisoned versions the lists are
+currently empty (just NULL terminated - must be last element).
+
+Issue #1207 was only resolved as it is an update to an array and is only to help
+users out. This issue is what prompted issue #1215.
+
+Updated `gen_test_JSON.sh` (under `test_ioccc/`) to have a new function -
+`get_version`. This was necessary so we can use `grep -v MIN_`. If it was in the
+same function it would cause another `MIN_` macro to be excluded from
+`limit_ioccc.h` which was a problem. Updated the script's version to `"1.0.2
+2025-03-07"`.
+
+
 ## Release 2.4.2 2025-03-02
 
 Resolve issue #1201.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,9 @@
 # Major changes to the IOCCC entry toolkit
 
 
-## Release 2.4.4 2025-03-08
-
-Rollback fix to #1207.
-
-It cannot be fixed until after IOCCC28. This is because if someone did have
-these directories in their submission (unlikely as it is) this fix would
-invalidate their submission.
-
-
 ## Release 2.4.3 2025-03-07
 
-Resolve issues #1215 and #1207.
+Resolve issues #1215.
 
 Now the version checks for `chkentry(1)` are a >= check. Uses code from
 `jparse/verge.c`. Its `main()` was moved to `verge_main.c` and `verge.c` now has
@@ -24,9 +15,6 @@ release. If a version is incremented then the minimum version would be changed
 to be the version at the time the contest opens. In this way uploaded
 submissions will not be invalidated. As for poisoned versions the lists are
 currently empty (just NULL terminated - must be last element).
-
-Issue #1207 was only resolved as it is an update to an array and is only to help
-users out. This issue is what prompted issue #1215.
 
 Updated `gen_test_JSON.sh` (under `test_ioccc/`) to have a new function -
 `get_version`. This was necessary so we can use `grep -v MIN_`. If it was in the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 
 ## Release 2.4.3 2025-03-07
 
-Resolve issues #1215.
+Resolve issue #1215.
 
 Now the version checks for `chkentry(1)` are a >= check. Uses code from
 `jparse/verge.c`. Its `main()` was moved to `verge_main.c` and `verge.c` now has

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.4 2025-03-08
+
+Rollback fix to #1207.
+
+It cannot be fixed until after IOCCC28. This is because if someone did have
+these directories in their submission (unlikely as it is) this fix would
+invalidate their submission.
+
+
 ## Release 2.4.3 2025-03-07
 
 Resolve issues #1215 and #1207.

--- a/jparse/.gitignore
+++ b/jparse/.gitignore
@@ -44,6 +44,7 @@ build.log
 /test_jparse/util_test.o
 util_test.c
 /verge
+/verge_main.o
 foobar
 util_test.copy.c
 util.copy.o

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,28 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.2.33 2025-03-07
+
+Additional sanity checks added to FTS code.
+
+The `read_fts()` function now does not just skip on NULL or empty path name; it
+will abort just like `check_fts_info()` does (though that would never have been
+reached as we skipped that item and moved to the next). If there is a NULL
+pointer or an empty string something is wrong and it's better to abort early.
+
+Also in `check_fts_info()` when the `fts_info == FTS_NS` the `ent->fts_errno` is
+the errno so we set `errno = ent->fts_errno` prior to calling `errp()` (instead
+of `err()`).
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.3 2025-03-07"`.
+
+Moved `main()` in `verge.c` to `verge_main.c` and added function `vercmp()`
+which does the work of what `verge` does. The `verge.o` is now linked into the
+library and `verge.h` is installed with `make install`. This was necessary for
+mkiocccentry.
+
+Updated `VERGE_VERSION` to `"2.0.1 2025-03-07"`.
+
+
 ## Release 2.2.32 2025-03-02
 
 Updated `filemode()` with new boolean (sorry!) to mask `S_IFMT` if true. In

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -281,11 +281,11 @@ ALL_BUILT_SRC= ${BUILT_C_SRC} ${BUILT_H_SRC}
 
 # NOTE: ${LIB_OBJS} are objects to put into a library and removed by make clean
 #
-LIB_OBJS= jparse.o jparse.tab.o json_parse.o json_sem.o json_util.o util.o jstr_util.o json_utf8.o
+LIB_OBJS= jparse.o jparse.tab.o json_parse.o json_sem.o json_util.o util.o jstr_util.o json_utf8.o verge.o
 
 # NOTE: ${OTHER_OBJS} are objects NOT put into a library and ARE removed by make clean
 #
-OTHER_OBJS= verge.o jsemtblgen.o jstrdecode.o jstrencode.o jparse_main.o
+OTHER_OBJS= verge_main.o jsemtblgen.o jstrdecode.o jstrencode.o jparse_main.o
 
 # all intermediate files which are also removed by make clean
 #
@@ -428,7 +428,7 @@ PROG_TARGETS= jparse verge jsemtblgen jstrdecode jstrencode
 #
 H_SRC_TARGETS= jparse.h jparse.lex.h jparse.lex.ref.h jparse.tab.h jparse.tab.ref.h \
 	       jparse_main.h json_parse.h json_sem.h json_util.h sorry.tm.ca.h util.h \
-	       version.h json_utf8.h
+	       version.h json_utf8.h verge.h
 
 # what to make by all but NOT to removed by clobber
 #
@@ -583,7 +583,7 @@ util.o: util.c util.h
 verge.o: verge.c verge.h version.h
 	${CC} ${CFLAGS} verge.c -c
 
-verge: verge.o util.o
+verge: verge.o verge_main.o util.o
 	${CC} ${CFLAGS} $^ -o $@ ${LD_DIR} -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -71,7 +71,7 @@
 /*
  * official verge tool version
  */
-#define VERGE_VERSION "2.0.0 2025-02-28"		/* format: major.minor YYYY-MM-DD */
+#define VERGE_VERSION "2.0.1 2025-03-07"		/* format: major.minor YYYY-MM-DD */
 
 
 /*
@@ -92,7 +92,7 @@
 /*
  * function prototypes
  */
-static size_t allocate_vers(char *str, intmax_t **pvers);
-
+size_t allocate_vers(char *str, intmax_t **pvers);
+int vercmp(char *ver1, char *ver2);
 
 #endif /* INCLUDE_VERGE_H */

--- a/jparse/verge_main.c
+++ b/jparse/verge_main.c
@@ -1,0 +1,204 @@
+/*
+ * verge - determine if first version is greater or equal to the second version
+ *
+ * "Because too much minimalism can be subminimal." :-)
+ *
+ * Copyright (c) 2022-2025 by Cody Boone Ferguson and Landon Curt Noll. All
+ * rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and
+ * its documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright, this permission notice and text
+ * this comment, and the disclaimer below appear in all of the following:
+ *
+ *       supporting documentation
+ *       source copies
+ *       source works derived from this source
+ *       binaries derived from this source or from derived source
+ *
+ * THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+ * ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
+ *
+ * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * Ferguson and Landon Curt Noll:
+ *
+ *  @xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
+ *
+ * "Share and Enjoy!"
+ *     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+ */
+
+
+/* special comments for the seqcexit tool */
+/* exit code out of numerical order - ignore in sequencing - ooo */
+/* exit code change of order - use new value in sequencing - coo */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+
+/*
+ * verge - determine if first version is greater or equal to the second version
+ */
+#include "verge.h"
+
+
+
+/*
+ * definitions
+ */
+#define REQUIRED_ARGS (2)	/* number of required arguments on the command line */
+
+/*
+ * usage message
+ *
+ * Use the usage() function to print the usage_msg([0-9]?)+ strings.
+ */
+static const char * const usage_msg =
+    "usage: %s [-h] [-v level] [-V] major.minor.patch-1 major.minor.patch-2\n"
+    "\n"
+    "\t-h\t\t\tprint help message and exit\n"
+    "\t-v level\t\tset verbosity level (def level: %d)\n"
+    "\t-V\t\t\tprint version strings and exit\n"
+    "\n"
+    "\tmajor.minor.patch-1\tfirst version  (example: 0.1.1)\n"
+    "\tmajor.minor.patch-2\tsecond version (example: 1.3.2)\n"
+    "\n"
+    "Exit codes:\n"
+    "     0   first version >= second version\n"
+    "     1   first version < second version\n"
+    "     2   -h and help string printed or -V and version strings printed\n"
+    "     3   command line error\n"
+    "     4   first or second version string is an invalid version\n"
+    "  >=10   internal error\n"
+    "\n"
+    "%s version: %s\n"
+    "jparse utils version: %s\n"
+    "jparse UTF-8 version: %s\n"
+    "jparse library version: %s";
+
+
+/*
+ * forward declarations
+ */
+static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
+
+int
+main(int argc, char *argv[])
+{
+    char const *program = NULL;	/* our name */
+    extern char *optarg;	/* option argument */
+    extern int optind;		/* argv index of the next arg */
+    int arg_count = 0;		/* number of args to process */
+    char *ver1 = NULL;		/* first version string */
+    char *ver2 = NULL;		/* second version string */
+    int i;
+    int ret = 0;                /* return value of vercmp() */
+
+    /*
+     * parse args
+     */
+    program = argv[0];
+    while ((i = getopt(argc, argv, ":hv:V")) != -1) {
+	switch (i) {
+	case 'h':		/* -h - print help to stderr and exit 0 */
+	    usage(2, program, ""); /*ooo*/
+	    not_reached();
+	    break;
+	case 'v':		/* -v verbosity */
+	    /*
+	     * parse verbosity
+	     */
+	    verbosity_level = parse_verbosity(optarg);
+	    if (verbosity_level < 0) {
+		usage(3, program, "invalid -v verbosity"); /*ooo*/
+		not_reached();
+	    }
+	    break;
+	case 'V':		/* -V - print version and exit */
+	    print("%s version: %s\n", VERGE_BASENAME, VERGE_VERSION);
+	    print("jparse utils version: %s\n", JPARSE_UTILS_VERSION);
+	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
+	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
+	    exit(2); /*ooo*/
+	    not_reached();
+	    break;
+	case ':':   /* option requires an argument */
+	case '?':   /* illegal option */
+	default:    /* anything else but should not actually happen */
+	    check_invalid_option(program, i, optopt);
+	    usage(3, program, ""); /*ooo*/
+	    not_reached();
+	    break;
+	}
+    }
+    arg_count = argc - optind;
+    if (arg_count != REQUIRED_ARGS) {
+	usage(3, program, "two args are required"); /*ooo*/
+	not_reached();
+    }
+    ver1 = argv[optind];
+    ver2 = argv[optind+1];
+
+    ret = vercmp(ver1, ver2);
+
+    exit(ret);
+}
+
+
+/*
+ * usage - print usage to stderr
+ *
+ * Example:
+ *      usage(3, program, "wrong number of arguments");
+ *
+ * given:
+ *	exitcode        value to exit with
+ *	prog		our program name
+ *	str		top level usage message
+ *
+ * NOTE: We warn with extra newlines to help internal fault messages stand out.
+ *       Normally one should NOT include newlines in warn messages.
+ *
+ * This function does not return.
+ */
+static void
+usage(int exitcode, char const *prog, char const *str)
+{
+    /*
+     * firewall
+     */
+    if (str == NULL) {
+	str = "((NULL str))";
+	warn(__func__, "\nin usage(): str was NULL, forcing it to be: %s\n", str);
+    }
+    if (prog == NULL) {
+	prog = VERGE_BASENAME;
+	warn(__func__, "\nin usage(): prog was NULL, forcing it to be: %s\n", prog);
+    }
+
+    /*
+     * print the formatted usage stream
+     */
+    if (*str != '\0') {
+	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
+    }
+
+    fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, VERGE_BASENAME, VERGE_VERSION,
+	    JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
+    exit(exitcode); /*ooo*/
+    not_reached();
+}

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.2 2025-03-02"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.3 2025-03-07"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.2 2025-03-02"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.3 2025-03-07"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -982,8 +982,8 @@ default_handle.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
 entry_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h entry_util.c entry_util.h limit_ioccc.h location.h \
-    version.h
+    ../jparse/verge.h ../jparse/version.h entry_util.c entry_util.h \
+    limit_ioccc.h location.h version.h
 foo.o: ../dbg/dbg.h foo.c foo.h oebxergfB.h
 location_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \

--- a/soup/chk_validate.c
+++ b/soup/chk_validate.c
@@ -2687,7 +2687,7 @@ chk_tarball(struct json const *node,
     char *str = NULL;				/* JTYPE_STRING as decoded JSON string */
     struct json *parent = NULL;			/* JSON parse tree node parent */
     struct json *IOCCC_contest_id_node = NULL;	/* JSON parse node containing IOCCC_contest_id */
-    char const *IOCCC_contest_id = NULL;	/* pointer to author count as int from JSON parse node for IOCCC_contest_id */
+    char *IOCCC_contest_id = NULL;	/* pointer to author count as int from JSON parse node for IOCCC_contest_id */
     struct json *submit_slot_node = NULL;	/* JSON parse node containing submit_slot */
     int *submit_slot = NULL;			/* pointer to author count as int from JSON parse node for submit_slot */
     struct json *test_mode_node = NULL;		/* JSON parse node containing test_mode */

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -164,8 +164,6 @@ char *ignored_dirnames[] =
     FOSSIL_DIRNAME1,
     MONOTONE_DIRNAME,
     DARCS_DIRNAME,
-    SCCS_DIRNAME,
-    RCS_DIRNAME,
     NULL /* MUST BE LAST!! */
 };
 

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -75,6 +75,11 @@
 #include "../jparse/jparse.h"
 
 /*
+ * verge - the functionality to test versions
+ */
+#include "../jparse/verge.h"
+
+/*
  * version - official IOCCC toolkit versions
  */
 #include "version.h"
@@ -159,6 +164,8 @@ char *ignored_dirnames[] =
     FOSSIL_DIRNAME1,
     MONOTONE_DIRNAME,
     DARCS_DIRNAME,
+    SCCS_DIRNAME,
+    RCS_DIRNAME,
     NULL /* MUST BE LAST!! */
 };
 
@@ -188,6 +195,34 @@ char *executable_filenames[] =
     NULL /* MUST BE LAST!! */
 };
 
+static char const *poison_mkiocccentry_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_txzchk_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_iocccsize_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_info_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_auth_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_fnamchk_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
+static char const *poison_chkentry_versions[] =
+{
+    NULL /* MUST BE LAST!! */
+};
 
 /*
  * free_auth - free auto and related sub-elements
@@ -2022,6 +2057,96 @@ form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
     return tarball_filename;
 }
 
+/*
+ * test_version - test if a version is >= a minimum version
+ *
+ * given:
+ *
+ *  str     - version to check
+ *  min     - min version to check against
+ *
+ * Returns true if version >= min, false otherwise.
+ */
+bool
+test_version(char const *str, char const *min)
+{
+    char *dup1 = NULL;
+    char *dup2 = NULL;
+    char *ver1 = NULL;
+    char *ver2 = NULL;
+
+    if (str == NULL || *str == '\0') {
+        err(148, __func__, "str is NULL or empty string");
+        not_reached();
+    }
+    if (min == NULL || *min == '\0') {
+        err(149, __func__, "min is NULL or empty mining");
+        not_reached();
+    }
+
+    errno = 0; /* pre-clear errno for errp() */
+    dup1 = strdup(str);
+    if (dup1 == NULL) {
+        err(150, __func__, "strdup(str) returned NULL");
+        not_reached();
+    }
+    errno = 0; /* pre-clear errno for errp() */
+    dup2 = strdup(min);
+    if (dup2 == NULL) {
+        err(151, __func__, "strdup(min) returned NULL");
+        not_reached();
+    }
+
+    ver1 = strchr(dup1, ' ');
+    if (ver1 != NULL) {
+        *ver1 = '\0';
+    }
+    ver2 = strchr(dup2, ' ');
+    if (ver2 != NULL) {
+        *ver2 = '\0';
+    }
+
+    if (vercmp(dup1, dup2) == 0) {
+        return true;
+    }
+
+    return false;
+}
+
+/*
+ * test_poisons - test if a version is a so-called poison version
+ *
+ * given:
+ *
+ *  str     - version to check
+ *  min     - min version to check against
+ *
+ * Returns true if poisoned version, false otherwise
+ */
+bool
+test_poison(char const *str, char const **poisons)
+{
+    size_t i;
+
+    if (str == NULL || *str == '\0') {
+        err(152, __func__, "str is NULL or empty string");
+        not_reached();
+    }
+    if (poisons == NULL) {
+        err(153, __func__, "poisons list is NULL");
+        not_reached();
+    }
+
+    for (i = 0; poisons[i]; ++i) {
+        if (!strcasecmp(str, poisons[i])) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
 
 /*
  * test_IOCCC_auth_version - test if IOCCC_auth_version is valid
@@ -2038,6 +2163,7 @@ form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
 bool
 test_IOCCC_auth_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -2049,11 +2175,18 @@ test_IOCCC_auth_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, AUTH_VERSION) != 0) {
+    if (test_poison(str, poison_auth_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: IOCCC_auth_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: IOCCC_auth_version: %s is poisonous: %s", str, poison_auth_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_AUTH_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: IOCCC_auth_version != AUTH_VERSION: %s", AUTH_VERSION);
+		 "invalid: IOCCC_auth_version < MIN_AUTH_VERSION: %s", MIN_AUTH_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: IOCCC_auth_version: %s is not AUTH_VERSION: %s", str, AUTH_VERSION);
+		 "invalid: IOCCC_auth_version: %s is not >= MIN_AUTH_VERSION: %s", str, MIN_AUTH_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "IOCCC_auth_version is valid");
@@ -2165,6 +2298,7 @@ test_IOCCC_contest_id(char const *str)
 bool
 test_IOCCC_info_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -2176,11 +2310,18 @@ test_IOCCC_info_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, INFO_VERSION) != 0) {
+    if (test_poison(str, poison_info_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: IOCCC_info_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: IOCCC_info_version: %s is poisonous: %s", str, poison_info_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_INFO_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: IOCCC_info_version != INFO_VERSION: %s", INFO_VERSION);
+		 "invalid: IOCCC_info_version < MIN_INFO_VERSION: %s", MIN_INFO_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: IOCCC_info_version: %s is not INFO_VERSION: %s", str, INFO_VERSION);
+		 "invalid: IOCCC_info_version: %s is not >= MIN_INFO_VERSION: %s", str, MIN_INFO_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "IOCCC_info_version is valid");
@@ -2740,6 +2881,7 @@ test_c_src(char const *str)
 bool
 test_chkentry_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -2751,11 +2893,18 @@ test_chkentry_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, CHKENTRY_VERSION) != 0) {
+    if (test_poison(str, poison_chkentry_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: chkentry_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: chkentry_version: %s is poisonous: %s", str, poison_chkentry_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_CHKENTRY_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: chkentry_version != CHKENTRY_VERSION: %s", CHKENTRY_VERSION);
+		 "invalid: chkentry_version < MIN_CHKENTRY_VERSION: %s", MIN_CHKENTRY_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: chkentry_version: %s is not CHKENTRY_VERSION: %s", str, CHKENTRY_VERSION);
+		 "invalid: chkentry_version: %s is not >= MIN_CHKENTRY_VERSION: %s", str, MIN_CHKENTRY_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "chkentry_version is valid");
@@ -3091,6 +3240,7 @@ test_first_rule_is_all(bool boolean)
 bool
 test_fnamchk_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -3102,11 +3252,18 @@ test_fnamchk_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, FNAMCHK_VERSION) != 0) {
+    if (test_poison(str, poison_fnamchk_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: fnamchk_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: fnamchk_version: %s is poisonous: %s", str, poison_fnamchk_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_FNAMCHK_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: fnamchk_version != FNAMCHK_VERSION: %s", FNAMCHK_VERSION);
+		 "invalid: fnamchk_version < MIN_FNAMCHK_VERSION: %s", MIN_FNAMCHK_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: fnamchk_version: %s is not FNAMCHK_VERSION: %s", str, FNAMCHK_VERSION);
+		 "invalid: fnamchk_version: %s is not >= MIN_FNAMCHK_VERSION: %s", str, MIN_FNAMCHK_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "fnamchk_version is valid");
@@ -3537,6 +3694,7 @@ test_IOCCC_year(int IOCCC_year)
 bool
 test_iocccsize_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -3548,11 +3706,18 @@ test_iocccsize_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, IOCCCSIZE_VERSION) != 0) {
+    if (test_poison(str, poison_iocccsize_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: iocccsize_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: iocccsize_version: %s is poisonous: %s", str, poison_iocccsize_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_IOCCCSIZE_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: iocccsize_version != IOCCCSIZE_VERSION: %s", IOCCCSIZE_VERSION);
+		 "invalid: iocccsize_version < MIN_IOCCCSIZE_VERSION: %s", MIN_IOCCCSIZE_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: iocccsize_version: %s is not IOCCCSIZE_VERSION: %s", str, IOCCCSIZE_VERSION);
+		 "invalid: iocccsize_version: %s is not >= MIN_IOCCCSIZE_VERSION: %s", str, MIN_IOCCCSIZE_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "iocccsize_version is valid");
@@ -3670,7 +3835,7 @@ check_manifest_path(char *path, char const *name, mode_t mode)
      * firewall
      */
     if (name == NULL || *name == '\0') {
-        err(148, __func__, "passed NULL or empty name");
+        err(154, __func__, "passed NULL or empty name");
         not_reached();
     } else if (path == NULL) {
         ret = MAN_PATH_NULL;
@@ -4256,6 +4421,7 @@ test_min_timestamp(time_t tstamp)
 bool
 test_mkiocccentry_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -4267,11 +4433,18 @@ test_mkiocccentry_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, MKIOCCCENTRY_VERSION) != 0) {
+    if (test_poison(str, poison_mkiocccentry_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: mkiocccentry_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: mkiocccentry_version: %s is poisonous: %s", str, poison_mkiocccentry_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_MKIOCCCENTRY_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: mkiocccentry_version != MKIOCCCENTRY_VERSION: %s", MKIOCCCENTRY_VERSION);
+		 "invalid: mkiocccentry_version < MIN_MKIOCCCENTRY_VERSION: %s", MIN_MKIOCCCENTRY_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: mkiocccentry_version: %s is not MKIOCCCENTRY_VERSION: %s", str, MKIOCCCENTRY_VERSION);
+		 "invalid: mkiocccentry_version: %s is not >= MIN_MKIOCCCENTRY_VERSION: %s", str, MIN_MKIOCCCENTRY_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "mkiocccentry_version is valid");
@@ -5003,6 +5176,7 @@ test_mastodon(char const *str)
 bool
 test_txzchk_version(char const *str)
 {
+    size_t i = 0;
     /*
      * firewall
      */
@@ -5014,11 +5188,18 @@ test_txzchk_version(char const *str)
     /*
      * validate str
      */
-    if (strcmp(str, TXZCHK_VERSION) != 0) {
+    if (test_poison(str, poison_txzchk_versions)) {
+        json_dbg(JSON_DBG_MED, __func__,
+                 "invalid: txzchk_version: is poisonous");
+        json_dbg(JSON_DBG_HIGH, __func__,
+                 "invalid: txzchk_version: %s is poisonous: %s", str, poison_txzchk_versions[i]);
+        return false;
+    }
+    if (!test_version(str, MIN_TXZCHK_VERSION)) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: txzchk_version != TXZCHK_VERSION: %s", TXZCHK_VERSION);
+		 "invalid: txzchk_version < MIN_TXZCHK_VERSION: %s", MIN_TXZCHK_VERSION);
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: txzchk_version: %s is not TXZCHK_VERSION: %s", str, TXZCHK_VERSION);
+		 "invalid: txzchk_version: %s is not >= MIN_TXZCHK_VERSION: %s", str, MIN_TXZCHK_VERSION);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "txzchk_version is valid");

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -118,8 +118,6 @@
 #define FOSSIL_DIRNAME1 "_FOSSIL_"              /* For Fossil */
 #define MONOTONE_DIRNAME "_MTN"                 /* For Monotone */
 #define DARCS_DIRNAME "_darcs"                  /* For Darcs */
-#define SCCS_DIRNAME "SCCS"                     /* For Source Code Control System */
-#define RCS_DIRNAME "RCS"                       /* for a number of RCSes */
 
 /*
  * filenames that should be ignored, mostly for chkentry -w but it can be used

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -118,6 +118,8 @@
 #define FOSSIL_DIRNAME1 "_FOSSIL_"              /* For Fossil */
 #define MONOTONE_DIRNAME "_MTN"                 /* For Monotone */
 #define DARCS_DIRNAME "_darcs"                  /* For Darcs */
+#define SCCS_DIRNAME "SCCS"                     /* For Source Code Control System */
+#define RCS_DIRNAME "RCS"                       /* for a number of RCSes */
 
 /*
  * filenames that should be ignored, mostly for chkentry -w but it can be used
@@ -346,6 +348,8 @@ extern bool object2manifest(struct json *node, unsigned int depth, struct json_s
 extern char *form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
 			       time_t formed_timestamp);
 
+extern bool test_version(char const *str, char const *min);
+extern bool test_poison(char const *str,  char const **poisons);
 extern bool test_IOCCC_auth_version(char const *str);
 extern bool test_IOCCC_contest_id(char const *str);
 extern bool test_IOCCC_info_version(char const *str);

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.2 2025-03-02"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.3 2025-03-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -95,11 +95,13 @@
  * official iocccsize version
  */
 #define IOCCCSIZE_VERSION "28.15 2024-06-27"	/* format: major.minor YYYY-MM-DD */
+#define MIN_IOCCCSIZE_VERSION IOCCCSIZE_VERSION
 
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
 #define MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
+#define MIN_MKIOCCCENTRY_VERSION MKIOCCCENTRY_VERSION
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -107,36 +109,43 @@
  * Version of info for JSON the .info.json file.
  */
 #define INFO_VERSION "1.16 2024-05-18"		/* format: major.minor YYYY-MM-DD */
+#define MIN_INFO_VERSION INFO_VERSION
 
 /*
  * Version of info for JSON the .auth.json file.
  */
 #define AUTH_VERSION "1.22 2024-05-18"		/* format: major.minor YYYY-MM-DD */
+#define MIN_AUTH_VERSION AUTH_VERSION
 
 /*
  * official fnamchk version
  */
 #define FNAMCHK_VERSION "2.0.0 2025-02-28"	/* format: major.minor YYYY-MM-DD */
+#define MIN_FNAMCHK_VERSION FNAMCHK_VERSION
 
 /*
  * official txzchk version
  */
 #define TXZCHK_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
+#define MIN_TXZCHK_VERSION TXZCHK_VERSION
 
 /*
  * official chkentry version
  */
 #define CHKENTRY_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
+#define MIN_CHKENTRY_VERSION CHKENTRY_VERSION
 
 /*
  * Version of info for JSON the .entry.json files.
  */
 #define ENTRY_VERSION "1.2 2024-09-25"		/* format: major.minor YYYY-MM-DD */
+#define MIN_ENTRY_VERSION ENTRY_VERSION
 
 /*
  * Version of info for JSON the author_handle.json files.
  */
 #define AUTHOR_VERSION "1.1 2024-02-11"		/* format: major.minor YYYY-MM-DD */
+#define MIN_AUTHOR_VERSION AUTHOR_VERSION
 
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.3 2025-03-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.3 2025-03-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/test_ioccc/gen_test_JSON.sh
+++ b/test_ioccc/gen_test_JSON.sh
@@ -31,7 +31,7 @@
 
 # setup
 #
-export VERSION="1.0.1 2025-02-11"
+export VERSION="1.0.2 2025-03-07"
 NAME=$(basename "$0")
 export NAME
 export V_FLAG=0
@@ -130,6 +130,55 @@ function get_value
     echo "$VALUE" | sed -e 's/(time_t)//' -e 's/^.[^"(]*["(]//' -e 's/[")].*$//'
     return 0
 }
+
+# get_version - obtain version from include file
+#
+# usage:
+#
+#   get_version TOKEN file
+#
+#   TOKEN	The #define version to obtain
+#   FILE	The include file to read
+#
+# returns:
+#   TOKEN version from file
+#
+# NOTE: This function will exit 6 on error or if the TOKEN is not found in FILE
+#
+function get_version
+{
+    local TOKEN;    # name of TOKEN
+    local FILE;	    # include file
+    local VERSION;    # version of the TOKEN
+
+    # parse args
+    #
+    if [[ $# -ne 2 ]]; then
+        echo "$0: ERROR: in get_version expected 2 args, found $#" 1>&2
+        return 6
+    fi
+    TOKEN="$1"
+    FILE="$2"
+
+    # fetch #define line from FILE
+    #
+    VERSION=$(grep "#define.*$TOKEN" "$FILE"|grep -v "MIN_")
+    status="$?"
+    if [[ $status -ne 0 ]]; then
+        echo "$0: ERROR: fetch $TOKEN from $FILE failed, status: $status" 1>&2
+        return 6
+    fi
+    if [[ -z $VERSION ]]; then
+        echo "$0: ERROR: $TOKEN not found in: $FILE" 1>&2
+        return 6
+    fi
+
+    # print a cleared version line
+    #
+    echo "$VERSION" | sed -e 's/(time_t)//' -e 's/^.[^"(]*["(]//' -e 's/[")].*$//'
+    return 0
+}
+
 
 
 # parse args
@@ -255,55 +304,55 @@ export IOCCC_CONTEST IOCCC_YEAR MIN_TIMESTAMP TIMESTAMP_EPOCH
 #	%%MKIOCCCENTRY_VERSION%%
 #	%%TXZCHK_VERSION%%
 #
-AUTH_VERSION=$(get_value AUTH_VERSION "$VERSION_H")
+AUTH_VERSION=$(get_version AUTH_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: AUTH_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-AUTHOR_VERSION=$(get_value AUTHOR_VERSION "$VERSION_H")
+AUTHOR_VERSION=$(get_version AUTHOR_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: AUTHOR_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-CHKENTRY_VERSION=$(get_value CHKENTRY_VERSION "$VERSION_H")
+CHKENTRY_VERSION=$(get_version CHKENTRY_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: CHKENTRY_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-ENTRY_VERSION=$(get_value ENTRY_VERSION "$VERSION_H")
+ENTRY_VERSION=$(get_version ENTRY_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: ENTRY_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-FNAMCHK_VERSION=$(get_value FNAMCHK_VERSION "$VERSION_H")
+FNAMCHK_VERSION=$(get_version FNAMCHK_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: FNAMCHK_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-INFO_VERSION=$(get_value INFO_VERSION "$VERSION_H")
+INFO_VERSION=$(get_version INFO_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: INFO_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-IOCCCSIZE_VERSION=$(get_value IOCCCSIZE_VERSION "$VERSION_H")
+IOCCCSIZE_VERSION=$(get_version IOCCCSIZE_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: IOCCCSIZE_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-MKIOCCCENTRY_VERSION=$(get_value MKIOCCCENTRY_VERSION "$VERSION_H")
+MKIOCCCENTRY_VERSION=$(get_version MKIOCCCENTRY_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: MKIOCCCENTRY_VERSION not found in: $VERSION_H" 1>&2
     exit 6
 fi
-TXZCHK_VERSION=$(get_value TXZCHK_VERSION "$VERSION_H")
+TXZCHK_VERSION=$(get_version TXZCHK_VERSION "$VERSION_H")
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: TXZCHK_VERSION not found in: $VERSION_H" 1>&2


### PR DESCRIPTION
Now the version checks for chkentry(1) are a >= check. Uses code from jparse/verge.c. Its main() was moved to verge_main.c and verge.c now has a new function vercmp(). 'verge.o' is linked into the library and chkentry now uses it. Also there are new arrays that we called 'poisoned versions' and this allows for bad versions to be excluded. Each tool and some other versions have a minimum version allowed which at this time is equivalent to the current release. If a version is incremented then the minimum version would be changed to be the version at the time the contest opens. In this way uploaded submissions will not be invalidated. As for poisoned versions the lists are currently empty (just NULL terminated - must be last element).

Updated gen_test_JSON.sh (under test_ioccc/) to have a new function - get_version. This was necessary so we can use grep -v MIN_. If it was in the same function it would cause another MIN_ macro to be excluded from limit_ioccc.h which was a problem. Updated the script's version to "1.0.2 2025-03-07".