### PR TITLE
Add -U UUID option - resolve #1229

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.5 2025-03-10
+
+Add `-U UUID` option - resolve #1229.
+
+Also fixed an error with `-u uuidfile` where it would not set the `test` boolean
+to true if the UUID was `"true"`.
+
+The `-u uuidfile` and `-U UUID` options may not be used with `-i answers`, `-d`
+or `-s seed`.
+
+Updated man page for the above changes.
+
+**IMPORTANT NOTE**: you do NOT need to use this update in order to participate
+in the IOCCC28!
+
+
 ## Release 2.4.4 2025-03-09
 
 Resolve some (mostly top priority) issues.

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -181,7 +181,7 @@ static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, ch
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);
 static char *prompt(char const *str, size_t *lenp);
-static char *get_contest_id(bool *testp, FILE *uuidp);
+static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "08 March 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "10 March 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -297,11 +297,34 @@ This option implies
 and disables some messages as well.
 However you will still be prompted to verify files and directories are okay.
 .TP
-.BI \-u\  uuid
+.BI \-u\  uuidfile
 Read UUID from a text file.
-If this file cannot be read or does not have a valid UUID
+If this file cannot be read or does not have a valid UUID by itself,
 .BR mkiocccentry (1)
 will prompt you as usual.
+This option cannot be used with
+.BI \-U\  UUID
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
+.TP
+.BI \-U\  UUID
+Set UUID to
+.IR UUID .
+If this an invalid UUID
+.BR mkiocccentry (1)
+will prompt you as usual.
+This option cannot be used with
+.BI \-u\  uuidfile
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
 .TP
 .BI \-s\  seed
 Generate pseudo-random answers to the questions

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-09"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-03-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Also fixed an error with -u uuidfile where it would not set the test boolean to true if the UUID was "true".

The -u uuidfile and -U UUID options may not be used with -i answers, -d or -s seed.

Updated man page for the above changes.

**IMPORTANT NOTE**: you do NOT need to use this update in order to participate in the IOCCC28!