### PR TITLE
Partial fix to issue #1208

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@ to true if the UUID was `"true"`.
 The `-u uuidfile` and `-U UUID` options may not be used with `-i answers`, `-d`
 or `-s seed`.
 
+Partial fix to issue #1208. The `-x` option to force delete the
+submission directory and `-r rm` option to set path to `rm(1)` were added to
+`mkiocccentry` as part of #1208. The change in order of args is **NOT** done and
+will not be done until **AFTER** IOCCC28.
+
+Fixed bug where `overwrite_answers` was always true by default (`mkiocccentry`).
+
 Updated man page for the above changes.
 
 **IMPORTANT NOTE**: you do NOT need to use this update in order to participate

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.5 2025-03-10
+
+Add `-U UUID` option - resolve #1229.
+
+Also fixed an error with `-u uuidfile` where it would not set the `test` boolean
+to true if the UUID was `"true"`.
+
+The `-u uuidfile` and `-U UUID` options may not be used with `-i answers`, `-d`
+or `-s seed`.
+
+Updated man page for the above changes.
+
+**IMPORTANT NOTE**: you do NOT need to use this update in order to participate
+in the IOCCC28!
+
+
 ## Release 2.4.4 2025-03-09
 
 Resolve some (mostly top priority) issues.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -8446,7 +8446,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         } else {
             dbg(DBG_HIGH, "about to perform: %s -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "%s -e -w -v 1 -F % -- %/../%",
+            exit_code = shell_cmd(__func__, false, true, "% -e -w -v 1 -F % -- %/../%",
                                                   txzchk, fnamchk, submission_dir, basename_tarball_path);
         }
         if (exit_code != 0) {

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -8441,13 +8441,13 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         if (test_mode) {
             dbg(DBG_HIGH, "about to perform: %s -x -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -x -e -w -v 1 -F % -- %/../%",
-                                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "% -x -e -w -v 1 -F % -- %/../%",
+                                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         } else {
             dbg(DBG_HIGH, "about to perform: %s -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -e -w -v 1 -F % -- %/../%",
-                                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "%s -e -w -v 1 -F % -- %/../%",
+                                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         }
         if (exit_code != 0) {
             if (test_mode) {
@@ -8464,8 +8464,8 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         if (test_mode) {
             dbg(DBG_HIGH, "about to perform: %s -x -w -v 1 -F %s -- %s/../%s",
                           txzchk, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -x -w -v 1 -F % -- %/../%",
-                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "% -x -w -v 1 -F % -- %/../%",
+                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         } else {
             dbg(DBG_HIGH, "about to perform: %s -w -v 1 -F %s -- %s/../%s",
                           txzchk, fnamchk, submission_dir, basename_tarball_path);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -184,7 +184,8 @@ static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
-			  char **tarball_path, time_t tstamp, bool test_mode);
+			  char **tarball_path, time_t tstamp, bool test_mode, bool force_remove,
+                          char const *rm);
 static bool inspect_Makefile(char const *Makefile, struct info *infop);
 static void warn_Makefile(struct info *infop);
 static void check_Makefile(struct info *infop, char const *Makefile);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -181,7 +181,7 @@ static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, ch
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);
 static char *prompt(char const *str, size_t *lenp);
-static char *get_contest_id(bool *testp, FILE *uuidp);
+static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "08 March 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "10 March 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -297,11 +297,34 @@ This option implies
 and disables some messages as well.
 However you will still be prompted to verify files and directories are okay.
 .TP
-.BI \-u\  uuid
+.BI \-u\  uuidfile
 Read UUID from a text file.
-If this file cannot be read or does not have a valid UUID
+If this file cannot be read or does not have a valid UUID by itself,
 .BR mkiocccentry (1)
 will prompt you as usual.
+This option cannot be used with
+.BI \-U\  UUID
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
+.TP
+.BI \-U\  UUID
+Set UUID to
+.IR UUID .
+If this an invalid UUID
+.BR mkiocccentry (1)
+will prompt you as usual.
+This option cannot be used with
+.BI \-u\  uuidfile
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
 .TP
 .BI \-s\  seed
 Generate pseudo-random answers to the questions

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -220,7 +220,8 @@ if this option is not specified.
 Pass
 .B \-e
 to
-.BR txzchk (1).
+.BR txzchk (1)
+(entertainment mode).
 .TP
 .BI \-f\  feathers
 Pass
@@ -384,6 +385,18 @@ option.
 If the path is a directory
 .BR mkiocccentry (1)
 will not traverse it.
+.TP
+.BI \-r\  rm
+Set path to
+.BR rm (1)
+if
+.B \-x
+used.
+.TP
+.B \-x
+Force delete submission directory if it already exists.
+Use with
+.BR CARE !
 .SH EXIT STATUS
 .TP
 0

--- a/soup/sanity.c
+++ b/soup/sanity.c
@@ -102,11 +102,14 @@ ioccc_sanity_chks(void)
  *	chkentry	    - if -C chkentry was used and chkentry != NULL set *chkentry to path
  *	make_flag_used      - true ==> -m make was used
  *	make                - if -m make was used and make != NULL set *make to path
+ *	rm_flag_used        - true ==> -r rm was used
+ *	rm                  - if -r rm was used and rm != NULL set *rm to path
  */
 void
 find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make)
+	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make,
+           bool rm_flag_used, char **rm)
 {
     /*
      * guess where tar and ls utilities are located
@@ -144,7 +147,10 @@ find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	*make = MAKE_PATH_1;
 	dbg(DBG_MED, "using default make path: %s", MAKE_PATH_1);
     }
-
+    if (rm != NULL && !rm_flag_used && !is_exec(RM_PATH_0) && is_exec(RM_PATH_1)) {
+	*rm = RM_PATH_1;
+	dbg(DBG_MED, "using default rm path: %s", RM_PATH_1);
+    }
 
     return;
 }

--- a/soup/sanity.h
+++ b/soup/sanity.h
@@ -75,8 +75,7 @@
 extern void ioccc_sanity_chks(void); /* all *_sanity_chks() functions should call this */
 extern void find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make);
-
-
+	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make, bool rm_flag_used,
+           char **rm);
 
 #endif /* INCLUDE_SANITY_H */

--- a/soup/soup.h
+++ b/soup/soup.h
@@ -116,6 +116,8 @@
 #define JPARSE_PATH_1 "/usr/local/bin/jparse"	    /* default path to jparse tool if installed */
 #define MAKE_PATH_0 "/usr/bin/make"                 /* default path to make tool */
 #define MAKE_PATH_1 "/bin/make"                     /* in case /usr/bin/make doesn't work */
+#define RM_PATH_0 "/bin/rm"                         /* default path to rm tool */
+#define RM_PATH_1 "/usr/bin/rm"                     /* in case /bin/rm doesn't work */
 
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-09"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-03-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/txzchk.c
+++ b/txzchk.c
@@ -279,10 +279,10 @@ main(int argc, char **argv)
 
     if (!read_from_text_file) {
 	find_utils(tar_flag_used, &tar, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL);
+		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
     } else {
 	find_utils(false, NULL, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL);
+		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
     }
 
     /* additional sanity checks */


### PR DESCRIPTION

The -x option to force delete the submission directory and -r
rm option to set path to rm(1) were added to mkiocccentry as part of
issue #1208. The change in order of args is NOT done and will not be
done until AFTER IOCCC28.

Fixed bug where overwrite_answers was always true by default
(mkiocccentry).
