### PR TITLE
Resolved issues #1233 and #1218

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@ to true if the UUID was `"true"`.
 The `-u uuidfile` and `-U UUID` options may not be used with `-i answers`, `-d`
 or `-s seed`.
 
+Partial fix to issue #1208. The `-x` option to force delete the
+submission directory and `-r rm` option to set path to `rm(1)` were added to
+`mkiocccentry` as part of #1208. The change in order of args is **NOT** done and
+will not be done until **AFTER** IOCCC28.
+
+Fixed bug where `overwrite_answers` was always true by default (`mkiocccentry`).
+
 Updated man page for the above changes.
 
 **IMPORTANT NOTE**: you do NOT need to use this update in order to participate

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ called `resolve_path()`. The jparse util functions `shell_cmd()` and
 name. As for `make`: we now search for `gmake` first as the Makefiles we need
 are GNU Makefiles.
 
+Add missing `-r` to `rm` in `mkiocccentry_test.sh`.
+
 **IMPORTANT NOTE**: you do NOT need to use this update in order to participate
 in the IOCCC28!
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.5 2025-03-10
+
+Add `-U UUID` option - resolve #1229.
+
+Also fixed an error with `-u uuidfile` where it would not set the `test` boolean
+to true if the UUID was `"true"`.
+
+The `-u uuidfile` and `-U UUID` options may not be used with `-i answers`, `-d`
+or `-s seed`.
+
+Updated man page for the above changes.
+
+**IMPORTANT NOTE**: you do NOT need to use this update in order to participate
+in the IOCCC28!
+
+
 ## Release 2.4.4 2025-03-09
 
 Resolve some (mostly top priority) issues.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,14 @@ Fixed bug where `overwrite_answers` was always true by default (`mkiocccentry`).
 
 Updated man page for the above changes.
 
+Resolved issues #1233 and #1218. Both `mkiocccentry` and `txzchk` (the only ones
+that use other tools) now search `$PATH` for the tools first by way of the
+`find_utils()` function (modified a fair bit) and a new util function in jparse
+called `resolve_path()`. The jparse util functions `shell_cmd()` and
+`pipe_open()` were also improved to resolve paths if no `/` is in the command
+name. As for `make`: we now search for `gmake` first as the Makefiles we need
+are GNU Makefiles.
+
 **IMPORTANT NOTE**: you do NOT need to use this update in order to participate
 in the IOCCC28!
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,35 @@
 # Significant changes in the JSON parser repo
 
+
+## Release 2.2.35 2025-03-10
+
+Improved `shell_cmd()` and `pipe_open()` to resolve path (using `resolve_path()`
+which searches `$PATH`) if there is no `/` in the command.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.5 2025-03-10"`.
+
+
+## Release 2.2.34 2025-03-09
+
+Updated `base_name()`, `dir_name()` and added new function `resolve_path()`.
+
+The function `base_name()` now will, on a NULL or empty string, return a copy of
+`"."` just like `basename(3)` does.
+
+The function `dir_name()` now will, on a NULL or empty string or a string that
+has no `/` (unless `level < 0`) , return a copy of `"."` just like `dirname(3)`
+(though that function does not have the `level` functionality).
+
+The function `resolve_path()` will go through the process's `$PATH` and search
+for an executable file with the name passed to the function, returning either a
+copy of the path or NULL. If the command starts with `/` or `./` then the
+`$PATH` is not searched and instead that exact string is duplicated and
+returned.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.4 2025-03-09"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.2 2025-03-09"`.
+
+
 ## Release 2.2.33 2025-03-07
 
 Additional sanity checks added to FTS code.

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -319,6 +319,7 @@ extern off_t file_size(char const *path);
 extern bool is_empty(char const *path);
 extern char *cmdprintf(char const *format, ...);
 extern char *vcmdprintf(char const *format, va_list ap);
+extern char *resolve_path(char const *cmd);
 extern int shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *format, ...);
 extern FILE *pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *format, ...);
 extern void para(char const *line, ...);

--- a/jparse/verge.c
+++ b/jparse/verge.c
@@ -58,11 +58,6 @@
 
 
 /*
- * definitions
- */
-#define REQUIRED_ARGS (2)	/* number of required arguments on the command line */
-
-/*
  * vercmp - compare two version strings
  *
  * given:

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.3 2025-03-07"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.5 2025-03-10"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.3 2025-03-07"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.5 2025-03-10"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -4369,24 +4369,23 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
     /*
      * if -U UUID not used check if -u uuidfile was used
      */
-    if (uuidstr == NULL) {
-        if (uuidfile != NULL) {
-            if (is_read(uuidfile)) {
+    if (uuidfile != NULL) {
+        if (is_read(uuidfile)) {
+            errno = 0; /* pre-clear errno for warnp() */
+            uuidfp = fopen(uuidfile, "r");
+            if (uuidfp == NULL) {
+                warnp(__func__, "failed to open uuidfile, will prompt instead");
+            } else {
+                uuidstr = readline_dup(&linep, true, NULL, uuidfp);
                 errno = 0; /* pre-clear errno for warnp() */
-                uuidfp = fopen(uuidfile, "r");
-                if (uuidfp == NULL) {
-                    warnp(__func__, "failed to open uuidfile, will prompt instead");
-                } else {
-                    uuidstr = readline_dup(&linep, true, NULL, uuidfp);
-                    errno = 0; /* pre-clear errno for warnp() */
-                    if (fclose(uuidfp) != 0) {
-                        warnp(__func__, "failed to fclose(uuidfp)");
-                    }
-                    if (uuidstr != NULL) {
-                        if (valid_contest_id(uuidstr)) {
-                            if (strcmp(uuidstr, "test") == 0) {
+                if (fclose(uuidfp) != 0) {
+                    warnp(__func__, "failed to fclose(uuidfp)");
+                }
+                if (uuidstr != NULL) {
+                    if (valid_contest_id(uuidstr)) {
+                        if (strcmp(uuidstr, "test") == 0) {
 
-                                /*
+                                    /*
                                  * report test mode
                                  */
                                 para("",
@@ -4409,7 +4408,7 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
                 warn(__func__, "-u uuidfile not readable, will prompt instead");
             }
         }
-    } else if (valid_contest_id(uuidstr)) {
+    if (uuidstr != NULL && valid_contest_id(uuidstr)) {
         /*
          * case: IOCCC contest ID is test, quick return
          */
@@ -4735,7 +4734,8 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
             }
             fpara(stderr,
                   "",
-                  "You need to move that directory, or remove it, or use a different workdir.",
+                  "You need to move that directory, or remove it, use the -x option",
+                  "or use a different workdir.",
                   "",
                   NULL);
             err(161, __func__, "submission directory exists: %s", submission_dir);

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -8446,7 +8446,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         } else {
             dbg(DBG_HIGH, "about to perform: %s -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "%s -e -w -v 1 -F % -- %/../%",
+            exit_code = shell_cmd(__func__, false, true, "% -e -w -v 1 -F % -- %/../%",
                                                   txzchk, fnamchk, submission_dir, basename_tarball_path);
         }
         if (exit_code != 0) {

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -8441,13 +8441,13 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         if (test_mode) {
             dbg(DBG_HIGH, "about to perform: %s -x -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -x -e -w -v 1 -F % -- %/../%",
-                                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "% -x -e -w -v 1 -F % -- %/../%",
+                                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         } else {
             dbg(DBG_HIGH, "about to perform: %s -e -f %ju -w -v 1 -F %s -- %s/../%s",
                           txzchk, feathery, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -e -w -v 1 -F % -- %/../%",
-                                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "%s -e -w -v 1 -F % -- %/../%",
+                                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         }
         if (exit_code != 0) {
             if (test_mode) {
@@ -8464,8 +8464,8 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         if (test_mode) {
             dbg(DBG_HIGH, "about to perform: %s -x -w -v 1 -F %s -- %s/../%s",
                           txzchk, fnamchk, submission_dir, basename_tarball_path);
-            exit_code = shell_cmd(__func__, false, true, "txzchk -x -w -v 1 -F % -- %/../%",
-                                  fnamchk, submission_dir, basename_tarball_path);
+            exit_code = shell_cmd(__func__, false, true, "% -x -w -v 1 -F % -- %/../%",
+                                  txzchk, fnamchk, submission_dir, basename_tarball_path);
         } else {
             dbg(DBG_HIGH, "about to perform: %s -w -v 1 -F %s -- %s/../%s",
                           txzchk, fnamchk, submission_dir, basename_tarball_path);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -184,7 +184,8 @@ static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
-			  char **tarball_path, time_t tstamp, bool test_mode);
+			  char **tarball_path, time_t tstamp, bool test_mode, bool force_remove,
+                          char const *rm);
 static bool inspect_Makefile(char const *Makefile, struct info *infop);
 static void warn_Makefile(struct info *infop);
 static void check_Makefile(struct info *infop, char const *Makefile);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -177,9 +177,9 @@ static void copy_topdir(struct info *infop, char const *make, char const *submis
         char *submit_path, int topdir, int cwd, RuleCount *size);
 static void check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         char const *make, RuleCount *size, int cwd);
-static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char const *tar,
-				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
-                                     char const *make);
+static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar,
+				     char *ls, char *txzchk, char *fnamchk, char *chkentry,
+                                     char *make, char *rm);
 static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -181,7 +181,7 @@ static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, ch
 				     char const *ls, char const *txzchk, char const *fnamchk, char const *chkentry,
                                      char const *make);
 static char *prompt(char const *str, size_t *lenp);
-static char *get_contest_id(bool *testp, FILE *uuidp);
+static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
 static int get_submit_slot(struct info *infop);
 static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 			  char **tarball_path, time_t tstamp, bool test_mode);

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "08 March 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "10 March 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -297,11 +297,34 @@ This option implies
 and disables some messages as well.
 However you will still be prompted to verify files and directories are okay.
 .TP
-.BI \-u\  uuid
+.BI \-u\  uuidfile
 Read UUID from a text file.
-If this file cannot be read or does not have a valid UUID
+If this file cannot be read or does not have a valid UUID by itself,
 .BR mkiocccentry (1)
 will prompt you as usual.
+This option cannot be used with
+.BI \-U\  UUID
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
+.TP
+.BI \-U\  UUID
+Set UUID to
+.IR UUID .
+If this an invalid UUID
+.BR mkiocccentry (1)
+will prompt you as usual.
+This option cannot be used with
+.BI \-u\  uuidfile
+or
+.BI \-s\  seed
+or
+.BI \-i\  answers
+or
+.BR \-d .
 .TP
 .BI \-s\  seed
 Generate pseudo-random answers to the questions

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -220,7 +220,8 @@ if this option is not specified.
 Pass
 .B \-e
 to
-.BR txzchk (1).
+.BR txzchk (1)
+(entertainment mode).
 .TP
 .BI \-f\  feathers
 Pass
@@ -384,6 +385,18 @@ option.
 If the path is a directory
 .BR mkiocccentry (1)
 will not traverse it.
+.TP
+.BI \-r\  rm
+Set path to
+.BR rm (1)
+if
+.B \-x
+used.
+.TP
+.B \-x
+Force delete submission directory if it already exists.
+Use with
+.BR CARE !
 .SH EXIT STATUS
 .TP
 0

--- a/soup/sanity.c
+++ b/soup/sanity.c
@@ -102,11 +102,14 @@ ioccc_sanity_chks(void)
  *	chkentry	    - if -C chkentry was used and chkentry != NULL set *chkentry to path
  *	make_flag_used      - true ==> -m make was used
  *	make                - if -m make was used and make != NULL set *make to path
+ *	rm_flag_used        - true ==> -r rm was used
+ *	rm                  - if -r rm was used and rm != NULL set *rm to path
  */
 void
 find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make)
+	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make,
+           bool rm_flag_used, char **rm)
 {
     /*
      * guess where tar and ls utilities are located
@@ -144,7 +147,10 @@ find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	*make = MAKE_PATH_1;
 	dbg(DBG_MED, "using default make path: %s", MAKE_PATH_1);
     }
-
+    if (rm != NULL && !rm_flag_used && !is_exec(RM_PATH_0) && is_exec(RM_PATH_1)) {
+	*rm = RM_PATH_1;
+	dbg(DBG_MED, "using default rm path: %s", RM_PATH_1);
+    }
 
     return;
 }

--- a/soup/sanity.c
+++ b/soup/sanity.c
@@ -211,6 +211,9 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
         }
     }
 
+    if (tar_found) {
+        dbg(DBG_MED, "found tar at: %s", *tar);
+    }
     if (ls != NULL && *ls != NULL && is_file(*ls) && is_exec(*ls)) {
         /*
          * we have to strdup() it
@@ -250,6 +253,9 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
         }
     }
 
+    if (ls_found) {
+        dbg(DBG_MED, "found ls at: %s", *ls);
+    }
     if (txzchk != NULL && *txzchk != NULL && is_file(*txzchk) && is_exec(*txzchk)) {
         /*
          * we have to strdup() it
@@ -289,6 +295,9 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
         }
     }
 
+    if (txzchk_found) {
+        dbg(DBG_MED, "found txzchk at: %s", *txzchk);
+    }
     if (fnamchk != NULL && *fnamchk != NULL && is_file(*fnamchk) && is_exec(*fnamchk)) {
         /*
          * we have to strdup() it
@@ -326,6 +335,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
                 }
             }
         }
+    }
+
+    if (fnamchk_found) {
+        dbg(DBG_MED, "found fnamchk at: %s", *fnamchk);
     }
 
     if (chkentry != NULL && *chkentry != NULL && is_file(*chkentry) && is_exec(*chkentry)) {
@@ -367,6 +380,9 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
         }
     }
 
+    if (chkentry_found) {
+        dbg(DBG_MED, "found chkentry at: %s", *chkentry);
+    }
     if (make != NULL && *make != NULL && is_file(*make) && is_exec(*make)) {
         /*
          * we have to strdup() it
@@ -404,6 +420,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
                 }
             }
         }
+    }
+
+    if (make_found) {
+        dbg(DBG_MED, "found make at: %s", *make);
     }
 
     if (rm != NULL && *rm != NULL && is_file(*rm) && is_exec(*rm)) {
@@ -445,5 +465,8 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
         }
     }
 
+    if (rm_found) {
+        dbg(DBG_MED, "found rm at: %s", *rm);
+    }
     return;
 }

--- a/soup/sanity.c
+++ b/soup/sanity.c
@@ -55,6 +55,56 @@
  */
 const char *const soup_version = SOUP_VERSION;	/* library version format: major.minor YYYY-MM-DD */
 
+char *tar_paths[] =
+{
+    TAR_PATH_0,
+    TAR_PATH_0,
+    TAR_PATH_2,
+    NULL /* MUST BE LAST!! */
+};
+char *ls_paths[] =
+{
+    LS_PATH_0,
+    LS_PATH_1,
+    LS_PATH_2,
+    NULL /* MUST BE LAST!! */
+};
+char *fnamchk_paths[] =
+{
+    FNAMCHK_PATH_0,
+    FNAMCHK_PATH_1,
+    FNAMCHK_PATH_2,
+    NULL /* MUST BE LAST!! */
+};
+char *txzchk_paths[] =
+{
+    TXZCHK_PATH_0,
+    TXZCHK_PATH_1,
+    TXZCHK_PATH_2,
+    NULL /* MUST BE LAST!! */
+};
+char *chkentry_paths[] =
+{
+    CHKENTRY_PATH_0,
+    CHKENTRY_PATH_1,
+    CHKENTRY_PATH_2,
+    NULL /* MUST BE LAST!! */
+};
+char *make_paths[] =
+{
+    MAKE_PATH_0,
+    MAKE_PATH_1,
+    MAKE_PATH_2,
+    MAKE_PATH_3,
+    NULL /* MUST BE LAST!! */
+};
+char *rm_paths[] =
+{
+    RM_PATH_0,
+    RM_PATH_1,
+    RM_PATH_1,
+    NULL /* MUST BE LAST!! */
+};
 
 /*
  * ioccc_sanity_chks - perform IOCCC sanity checks
@@ -86,70 +136,313 @@ ioccc_sanity_chks(void)
 
 
 /*
- * find_utils - find tar, ls, txzchk and fnamchk, chkentry utilities
+ * find_utils - find tools used by various tools
  *
  * given:
  *
- *	tar_flag_used	    - true ==> -t tar was used
- *	tar		    - if -t tar was not used and tar != NULL set *tar to to tar path
- *	ls_flag_used	    - true ==> -l ls was used
- *	ls		    - if -l ls was not used and ls != NULL set *ls to ls path
- *	txzchk_flag_used    - true ==> -T flag used
- *	txzchk		    - if -T txzchk was used and txzchk != NULL set *txzchk to path
- *	fnamchk_flag_used   - true ==> if fnamchk flag was used
- *	fnamchk		    - if fnamchk option used and fnamchk ! NULL set *fnamchk to path
- *	chkentry_flag_used  - true ==> -C chkentry was used	    -
- *	chkentry	    - if -C chkentry was used and chkentry != NULL set *chkentry to path
- *	make_flag_used      - true ==> -m make was used
- *	make                - if -m make was used and make != NULL set *make to path
- *	rm_flag_used        - true ==> -r rm was used
- *	rm                  - if -r rm was used and rm != NULL set *rm to path
+ *	tar		    - if tar != NULL set *tar to to tar path
+ *	ls		    - if ls != NULL set *ls to ls path
+ *	txzchk		    - if txzchk != NULL set *txzchk to path
+ *	fnamchk		    - if fnamchk ! NULL set *fnamchk to path
+ *	chkentry	    - if chkentry != NULL set *chkentry to path
+ *	make                - if make != NULL set *make to path
+ *	rm                  - if rm != NULL set *rm to path
  */
 void
-find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
-	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make,
-           bool rm_flag_used, char **rm)
+find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry, char **make, char **rm)
 {
+    size_t i = 0; /* for iterating through paths arrays */
+    bool tar_found = false;
+    bool ls_found = false;
+    bool txzchk_found = false;
+    bool fnamchk_found = false;
+    bool chkentry_found = false;
+    bool make_found = false;
+    bool rm_found = false;
+
     /*
-     * guess where tar and ls utilities are located
+     * guess where tools are
      *
-     * If the user did not give a -t, -c and/or -l /path/to/x path, then look at
-     * the historic location for the utility.  If the historic location of the utility
-     * isn't executable, look for an executable in the alternate location.
+     * First we will try resolving paths by just name. Then if that fails we'll
+     * try traditional locations and then if that fails, try alternate locations
+     * until we find a match.
      *
-     * On some systems where /usr/bin != /bin, the distribution made the mistake of
-     * moving historic critical applications, look to see if the alternate path works instead.
+     * On some systems where /usr/bin != /bin, the distribution made the mistake
+     * of moving (pre-)historic critical applications, look to see if the
+     * alternate path works instead.
      */
-    if (tar != NULL && !tar_flag_used && !is_exec(TAR_PATH_0) && is_exec(TAR_PATH_1)) {
-	*tar = TAR_PATH_1;
-	dbg(DBG_MED, "tar is not in historic location: %s : will use alternate location: %s", TAR_PATH_0, *tar);
+
+    if (tar != NULL && *tar != NULL && is_file(*tar) && is_exec(*tar)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *tar = strdup(*tar);
+        if (*tar == NULL) {
+            errp(55, __func__, "strdup(tar) failed");
+            not_reached();
+        }
+        tar_found = true;
     }
-    if (ls != NULL && !ls_flag_used && !is_exec(LS_PATH_0) && is_exec(LS_PATH_1)) {
-	*ls = LS_PATH_1;
-	dbg(DBG_MED, "ls is not in historic location: %s : will use alternate location: %s", LS_PATH_0, *ls);
+    if (!tar_found && tar != NULL) {
+        for (i = 0; tar_paths[i] != NULL; ++i) {
+            if (is_file(tar_paths[i]) && is_exec(tar_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *tar = strdup(tar_paths[i]);
+                if (*tar == NULL) {
+                    errp(56, __func__, "strdup(\"%s\") failed", tar_paths[i]);
+                    not_reached();
+                }
+                tar_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *tar = resolve_path(tar_paths[i]);
+                if (*tar != NULL) {
+                    tar_found = true;
+                    break;
+                }
+            }
+        }
     }
 
-    /* now do the same for our utilities: txzchk, fnamchk, and chkentry */
-    if (txzchk != NULL && !txzchk_flag_used && !is_exec(TXZCHK_PATH_0) && is_exec(TXZCHK_PATH_1)) {
-	*txzchk = TXZCHK_PATH_1;
-	dbg(DBG_MED, "using default txzchk path: %s", TXZCHK_PATH_1);
+    if (ls != NULL && *ls != NULL && is_file(*ls) && is_exec(*ls)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *ls = strdup(*ls);
+        if (*ls == NULL) {
+            errp(57, __func__, "strdup(ls) failed");
+            not_reached();
+        }
+        ls_found = true;
     }
-    if (fnamchk != NULL && !fnamchk_flag_used && !is_exec(FNAMCHK_PATH_0) && is_exec(FNAMCHK_PATH_1)) {
-	*fnamchk = FNAMCHK_PATH_1;
-	dbg(DBG_MED, "using default fnamchk path: %s", FNAMCHK_PATH_1);
+    if (!ls_found && ls != NULL) {
+        for (i = 0; ls_paths[i] != NULL; ++i) {
+            if (is_file(ls_paths[i]) && is_exec(ls_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *ls = strdup(ls_paths[i]);
+                if (*ls == NULL) {
+                    errp(58, __func__, "strdup(\"%s\") failed", ls_paths[i]);
+                    not_reached();
+                }
+                ls_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *ls = resolve_path(ls_paths[i]);
+                if (*ls != NULL) {
+                    ls_found = true;
+                    break;
+                }
+            }
+        }
     }
-    if (chkentry != NULL && !chkentry_flag_used && !is_exec(CHKENTRY_PATH_0) && is_exec(CHKENTRY_PATH_1)) {
-	*chkentry = CHKENTRY_PATH_1;
-	dbg(DBG_MED, "using default chkentry path: %s", CHKENTRY_PATH_1);
+
+    if (txzchk != NULL && *txzchk != NULL && is_file(*txzchk) && is_exec(*txzchk)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *txzchk = strdup(*txzchk);
+        if (*txzchk == NULL) {
+            errp(59, __func__, "strdup(txzchk) failed");
+            not_reached();
+        }
+        txzchk_found = true;
     }
-    if (make != NULL && !make_flag_used && !is_exec(MAKE_PATH_0) && is_exec(MAKE_PATH_1)) {
-	*make = MAKE_PATH_1;
-	dbg(DBG_MED, "using default make path: %s", MAKE_PATH_1);
+    if (!txzchk_found && txzchk != NULL) {
+        for (i = 0; txzchk_paths[i] != NULL; ++i) {
+            if (is_file(txzchk_paths[i]) && is_exec(txzchk_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *txzchk = strdup(txzchk_paths[i]);
+                if (*txzchk == NULL) {
+                    errp(60, __func__, "strdup(\"%s\") failed", txzchk_paths[i]);
+                    not_reached();
+                }
+                txzchk_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *txzchk = resolve_path(txzchk_paths[i]);
+                if (*txzchk != NULL) {
+                    txzchk_found = true;
+                    break;
+                }
+            }
+        }
     }
-    if (rm != NULL && !rm_flag_used && !is_exec(RM_PATH_0) && is_exec(RM_PATH_1)) {
-	*rm = RM_PATH_1;
-	dbg(DBG_MED, "using default rm path: %s", RM_PATH_1);
+
+    if (fnamchk != NULL && *fnamchk != NULL && is_file(*fnamchk) && is_exec(*fnamchk)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *fnamchk = strdup(*fnamchk);
+        if (*fnamchk == NULL) {
+            errp(61, __func__, "strdup(fnamchk)");
+            not_reached();
+        }
+        fnamchk_found = true;
+    }
+    if (!fnamchk_found && fnamchk != NULL) {
+        for (i = 0; fnamchk_paths[i] != NULL; ++i) {
+            if (is_file(fnamchk_paths[i]) && is_exec(fnamchk_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *fnamchk = strdup(fnamchk_paths[i]);
+                if (*fnamchk == NULL) {
+                    errp(62, __func__, "strdup(\"%s\") failed", fnamchk_paths[i]);
+                    not_reached();
+                }
+                fnamchk_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *fnamchk = resolve_path(fnamchk_paths[i]);
+                if (*fnamchk != NULL) {
+                    fnamchk_found = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (chkentry != NULL && *chkentry != NULL && is_file(*chkentry) && is_exec(*chkentry)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *chkentry = strdup(*chkentry);
+        if (*chkentry == NULL) {
+            errp(63, __func__, "strdup(chkentry) failed");
+            not_reached();
+        }
+        chkentry_found = true;
+    }
+    if (!chkentry_found && chkentry != NULL) {
+        for (i = 0; chkentry_paths[i] != NULL; ++i) {
+            if (is_file(chkentry_paths[i]) && is_exec(chkentry_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *chkentry = strdup(chkentry_paths[i]);
+                if (*chkentry == NULL) {
+                    errp(64, __func__, "strdup(\"%s\") failed", chkentry_paths[i]);
+                    not_reached();
+                }
+                chkentry_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *chkentry = resolve_path(chkentry_paths[i]);
+                if (*chkentry != NULL) {
+                    chkentry_found = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (make != NULL && *make != NULL && is_file(*make) && is_exec(*make)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *make = strdup(*make);
+        if (*make == NULL) {
+            errp(65, __func__, "strdup(make) failed");
+            not_reached();
+        }
+        make_found = true;
+    }
+    if (!make_found && make != NULL) {
+        for (i = 0; make_paths[i] != NULL; ++i) {
+            if (is_file(make_paths[i]) && is_exec(make_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *make = strdup(make_paths[i]);
+                if (*make == NULL) {
+                    errp(66, __func__, "strdup(\"%s\") failed", make_paths[i]);
+                    not_reached();
+                }
+                make_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *make = resolve_path(make_paths[i]);
+                if (*make != NULL) {
+                    make_found = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (rm != NULL && *rm != NULL && is_file(*rm) && is_exec(*rm)) {
+        /*
+         * we have to strdup() it
+         */
+        errno = 0; /* pre-clear errno for errp */
+        *rm = strdup(*rm);
+        if (*rm == NULL) {
+            errp(67, __func__, "strdup(rm) failed");
+            not_reached();
+        }
+        rm_found = true;
+    }
+    if (!rm_found && rm != NULL) {
+        for (i = 0; rm_paths[i] != NULL; ++i) {
+            if (is_file(rm_paths[i]) && is_exec(rm_paths[i])) {
+                /*
+                 * we have to strdup() it
+                 */
+                errno = 0; /* pre-clear errno for errp() */
+                *rm = strdup(rm_paths[i]);
+                if (*rm == NULL) {
+                    errp(68, __func__, "strdup(\"%s\") failed", rm_paths[i]);
+                    not_reached();
+                }
+                rm_found = true;
+                break;
+            } else {
+                /*
+                 * try resolving the path
+                 */
+                *rm = resolve_path(rm_paths[i]);
+                if (*rm != NULL) {
+                    rm_found = true;
+                    break;
+                }
+            }
+        }
     }
 
     return;

--- a/soup/sanity.h
+++ b/soup/sanity.h
@@ -75,8 +75,7 @@
 extern void ioccc_sanity_chks(void); /* all *_sanity_chks() functions should call this */
 extern void find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
 	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make);
-
-
+	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make, bool rm_flag_used,
+           char **rm);
 
 #endif /* INCLUDE_SANITY_H */

--- a/soup/sanity.h
+++ b/soup/sanity.h
@@ -73,9 +73,6 @@
  * function prototypes
  */
 extern void ioccc_sanity_chks(void); /* all *_sanity_chks() functions should call this */
-extern void find_utils(bool tar_flag_used, char **tar, bool ls_flag_used,
-	   char **ls, bool txzchk_flag_used, char **txzchk, bool fnamchk_flag_used, char **fnamchk,
-	   bool chkentry_flag_used, char **chkentry, bool make_flag_used, char **make, bool rm_flag_used,
-           char **rm);
+extern void find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry, char **make, char **rm);
 
 #endif /* INCLUDE_SANITY_H */

--- a/soup/soup.h
+++ b/soup/soup.h
@@ -116,6 +116,8 @@
 #define JPARSE_PATH_1 "/usr/local/bin/jparse"	    /* default path to jparse tool if installed */
 #define MAKE_PATH_0 "/usr/bin/make"                 /* default path to make tool */
 #define MAKE_PATH_1 "/bin/make"                     /* in case /usr/bin/make doesn't work */
+#define RM_PATH_0 "/bin/rm"                         /* default path to rm tool */
+#define RM_PATH_1 "/usr/bin/rm"                     /* in case /bin/rm doesn't work */
 
 
 /*

--- a/soup/soup.h
+++ b/soup/soup.h
@@ -102,22 +102,36 @@
  * paths to utilities the IOCCC tools use (including our own tools fnamchk,
  * txzchk, chkentry, etc.)
  */
-#define TAR_PATH_0 "/usr/bin/tar"		    /* historic path for tar */
-#define TAR_PATH_1 "/bin/tar"			    /* alternate tar path for some systems where /usr/bin/tar != /bin/tar */
-#define LS_PATH_0 "/bin/ls"			    /* historic path for ls */
-#define LS_PATH_1 "/usr/bin/ls"			    /* alternate ls path for some systems where /bin/ls != /usr/bin/ls */
-#define FNAMCHK_PATH_0 "./test_ioccc/fnamchk"	    /* path to fnamchk tool if not installed */
-#define FNAMCHK_PATH_1 "/usr/local/bin/fnamchk"	    /* default path to fnamchk tool if installed */
-#define TXZCHK_PATH_0 "./txzchk"		    /* path to txzchk tool if not installed */
-#define TXZCHK_PATH_1 "/usr/local/bin/txzchk"	    /* default path to txzchk tool if installed */
-#define CHKENTRY_PATH_0 "./chkentry"		    /* path to chkentry tool if not installed */
-#define CHKENTRY_PATH_1 "/usr/local/bin/chkentry"   /* default path to chkentry tool if installed */
-#define JPARSE_PATH_0 "./jparse/jparse"		    /* path to jparse if not installed */
-#define JPARSE_PATH_1 "/usr/local/bin/jparse"	    /* default path to jparse tool if installed */
-#define MAKE_PATH_0 "/usr/bin/make"                 /* default path to make tool */
-#define MAKE_PATH_1 "/bin/make"                     /* in case /usr/bin/make doesn't work */
-#define RM_PATH_0 "/bin/rm"                         /* default path to rm tool */
-#define RM_PATH_1 "/usr/bin/rm"                     /* in case /bin/rm doesn't work */
+#define TAR_PATH_0 "tar"                            /* for $PATH search */
+#define TAR_PATH_1 "/usr/bin/tar"		    /* historic path for tar */
+#define TAR_PATH_2 "/bin/tar"			    /* alternate tar path for some systems where /usr/bin/tar != /bin/tar */
+#define LS_PATH_0 "ls"                              /* for $PATH search */
+#define LS_PATH_1 "/bin/ls"			    /* historic path for ls */
+#define LS_PATH_2 "/usr/bin/ls"			    /* alternate ls path for some systems where /bin/ls != /usr/bin/ls */
+#define FNAMCHK_PATH_0 "fnamchk"                    /* for $PATH search */
+#define FNAMCHK_PATH_1 "./test_ioccc/fnamchk"	    /* path to fnamchk tool if not installed */
+#define FNAMCHK_PATH_2 "/usr/local/bin/fnamchk"	    /* default path to fnamchk tool if installed */
+#define TXZCHK_PATH_0 "txzchk"                      /* for $PATH search */
+#define TXZCHK_PATH_1 "./txzchk"		    /* path to txzchk tool if not installed */
+#define TXZCHK_PATH_2 "/usr/local/bin/txzchk"	    /* default path to txzchk tool if installed */
+#define CHKENTRY_PATH_0 "chkentry"                  /* for $PATH search */
+#define CHKENTRY_PATH_1 "./chkentry"		    /* path to chkentry tool if not installed */
+#define CHKENTRY_PATH_2 "/usr/local/bin/chkentry"   /* default path to chkentry tool if installed */
+#define MAKE_PATH_0 "gmake"                          /* for $PATH search */
+#define MAKE_PATH_1 "make"                          /* for $PATH search */
+#define MAKE_PATH_2 "/usr/bin/make"                 /* default path to make tool */
+#define MAKE_PATH_3 "/bin/make"                     /* in case /usr/bin/make doesn't work */
+#define RM_PATH_0 "rm"                              /* for $PATH search */
+#define RM_PATH_1 "/bin/rm"                         /* default path to rm tool */
+#define RM_PATH_2 "/usr/bin/rm"                     /* in case /bin/rm doesn't work */
+
+extern char *tar_paths[];
+extern char *ls_paths[];
+extern char *fnamchk_paths[];
+extern char *txzchk_paths[];
+extern char *chkentry_paths[];
+extern char *make_paths[];
+extern char *rm_paths[];
 
 
 /*

--- a/soup/soup.h
+++ b/soup/soup.h
@@ -108,14 +108,14 @@
 #define LS_PATH_0 "ls"                              /* for $PATH search */
 #define LS_PATH_1 "/bin/ls"			    /* historic path for ls */
 #define LS_PATH_2 "/usr/bin/ls"			    /* alternate ls path for some systems where /bin/ls != /usr/bin/ls */
-#define FNAMCHK_PATH_0 "fnamchk"                    /* for $PATH search */
-#define FNAMCHK_PATH_1 "./test_ioccc/fnamchk"	    /* path to fnamchk tool if not installed */
+#define FNAMCHK_PATH_0 "./test_ioccc/fnamchk"	    /* path to fnamchk tool if not installed */
+#define FNAMCHK_PATH_1 "fnamchk"                    /* for $PATH search */
 #define FNAMCHK_PATH_2 "/usr/local/bin/fnamchk"	    /* default path to fnamchk tool if installed */
-#define TXZCHK_PATH_0 "txzchk"                      /* for $PATH search */
-#define TXZCHK_PATH_1 "./txzchk"		    /* path to txzchk tool if not installed */
+#define TXZCHK_PATH_0 "./txzchk"		    /* path to txzchk tool if not installed */
+#define TXZCHK_PATH_1 "txzchk"                      /* for $PATH search */
 #define TXZCHK_PATH_2 "/usr/local/bin/txzchk"	    /* default path to txzchk tool if installed */
-#define CHKENTRY_PATH_0 "chkentry"                  /* for $PATH search */
-#define CHKENTRY_PATH_1 "./chkentry"		    /* path to chkentry tool if not installed */
+#define CHKENTRY_PATH_0 "./chkentry"		    /* path to chkentry tool if not installed */
+#define CHKENTRY_PATH_1 "chkentry"                  /* for $PATH search */
 #define CHKENTRY_PATH_2 "/usr/local/bin/chkentry"   /* default path to chkentry tool if installed */
 #define MAKE_PATH_0 "gmake"                          /* for $PATH search */
 #define MAKE_PATH_1 "make"                          /* for $PATH search */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-09"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-03-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -264,7 +264,7 @@ LONG_FILENAME="fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 workdir_esc="${workdir}"
 test "${workdir:0:1}" = "-" && workdir_esc=./"${workdir}"
 find "${workdir_esc}" -mindepth 1 -depth -delete
-rm -rf "${topdir}"
+mkdir -p "${topdir}"
 
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers()

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -76,7 +76,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="2.0.0 2025-02-28"
+export MKIOCCCENTRY_TEST_VERSION="2.0.1 2025-03-10"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit
@@ -264,7 +264,7 @@ LONG_FILENAME="fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 workdir_esc="${workdir}"
 test "${workdir:0:1}" = "-" && workdir_esc=./"${workdir}"
 find "${workdir_esc}" -mindepth 1 -depth -delete
-rm -f "${topdir}"/
+rm -rf "${topdir}"/
 
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers()

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -264,7 +264,7 @@ LONG_FILENAME="fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 workdir_esc="${workdir}"
 test "${workdir:0:1}" = "-" && workdir_esc=./"${workdir}"
 find "${workdir_esc}" -mindepth 1 -depth -delete
-rm -rf "${topdir}"/
+rm -rf "${topdir}"
 
 # Answers as of mkiocccentry version: v0.40 2022-03-15
 answers()

--- a/txzchk.c
+++ b/txzchk.c
@@ -159,8 +159,6 @@ main(int argc, char **argv)
     extern int optind;			    /* argv index of the next arg */
     char *tar = TAR_PATH_0;		    /* path to tar executable that supports the -J (xz) option */
     char *fnamchk = FNAMCHK_PATH_0;	    /* path to fnamchk tool */
-    bool fnamchk_flag_used = false;	    /* if -F option used */
-    bool tar_flag_used = false;		    /* true ==> -t /path/to/tar was given */
     int i;
 
     /*
@@ -195,12 +193,10 @@ main(int argc, char **argv)
 	    not_reached();
 	    break;
 	case 'F': /* -F fnamchk - specify path to fnamchk tool */
-	    fnamchk_flag_used = true;
 	    fnamchk = optarg;
 	    break;
 	case 't': /* -t tar - specify path to tar (perhaps to tar and feather :-) ) */
 	    tar = optarg;
-	    tar_flag_used = true;
 	    break;
 	case 'T': /* -T - text (test) file mode - don't rely on tar: just read file as if it was a text file */
 	    read_from_text_file = true;
@@ -278,11 +274,9 @@ main(int argc, char **argv)
      */
 
     if (!read_from_text_file) {
-	find_utils(tar_flag_used, &tar, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
+	find_utils(&tar, NULL, NULL, &fnamchk, NULL, NULL, NULL);
     } else {
-	find_utils(false, NULL, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
+	find_utils(NULL, NULL, NULL, &fnamchk, NULL, NULL, NULL);
     }
 
     /* additional sanity checks */
@@ -310,6 +304,18 @@ main(int argc, char **argv)
 	}
     }
     show_tarball_info(tarball_path);
+
+    /*
+     * we need to free the paths to the tools
+     */
+    if (tar != NULL) {
+        free(tar);
+        tar = NULL;
+    }
+    if (fnamchk != NULL) {
+        free(fnamchk);
+        fnamchk = NULL;
+    }
 
     /*
      * All Done!!! All Done!!! -- Jessica Noll, Age 2

--- a/txzchk.c
+++ b/txzchk.c
@@ -276,7 +276,7 @@ main(int argc, char **argv)
     if (!read_from_text_file) {
 	find_utils(&tar, NULL, NULL, &fnamchk, NULL, NULL, NULL);
     } else {
-	find_utils(NULL, NULL, NULL, &fnamchk, NULL, NULL, NULL);
+	find_utils(&tar, NULL, NULL, &fnamchk, NULL, NULL, NULL);
     }
 
     /* additional sanity checks */

--- a/txzchk.c
+++ b/txzchk.c
@@ -279,10 +279,10 @@ main(int argc, char **argv)
 
     if (!read_from_text_file) {
 	find_utils(tar_flag_used, &tar, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL);
+		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
     } else {
 	find_utils(false, NULL, false, NULL, false, NULL,
-		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL);
+		   fnamchk_flag_used, &fnamchk, false, NULL, false, NULL, false, NULL);
     }
 
     /* additional sanity checks */


### PR DESCRIPTION

Both mkiocccentry and txzchk (the only ones that use other tools) now 
search $PATH for the tools first by way of the find_utils() function
(modified a fair bit) and a new util function in jparse called 
resolve_path(). The jparse util functions shell_cmd() and pipe_open()
were also improved to resolve paths if no / is in the command name. As
for make: we now search for gmake first as the Makefiles we need are GNU
Makefiles.
