### PR TITLE
Fix bugs in resolve_path()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,24 @@
 
 Fix search of tools under `$PATH`.
 
-Due to the fact we have to have (for our tools) `./` ahead of other paths
-(including the tool names themselves) and also allow for a user to specify a
-path (even a bogus one, which if they do we will look for a proper path) and
-also search for installed paths, a more careful check has to be done in the
-`find_utils()` functions as otherwise it does not work when out of the repo
-directory.
+Fix bugs in `resolve_path()` where even if one had `./` or `/` in front of the
+path it could end up resolving a path that is not a regular executable file
+(when it did not have a `/` in the path this did not happen). Another bug was
+fixed where if `$PATH` is NULL or empty and the path is not a regular executable
+file it still would be a strdup()d copy of the original path.
+
+The above solved a problem where we could get the tools to be found (if they
+exist) if we also did a check for `is_file()` and `is_exec()` but with the above
+fixes we only have to check for `!= NULL`.
+
+The `find_utils()` functions now takes a corresponding `bool *` for each tool to
+find. If the boolean is not NULL then we search for that tool. If it is NULL and
+the `char **` is not NULL then we set the `*tool` to NULL. This way the caller
+can, if they wish and they are careful, decide whether or not to find all the
+tools. For example `txzchk` only looks for `tar` if test mode is not enabled.
+And although as a safety check before free()ing the pointer we do check that
+test mode was not used we do not technically need it as long as we pass in
+`&tar` (although we do give NULL so we do need to check it).
 
 Sync copyright fixes from jparse.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.4 2025-03-11
+
+Fix search of tools under `$PATH`.
+
+Due to the fact we have to have (for our tools) `./` ahead of other paths
+(including the tool names themselves) and also allow for a user to specify a
+path (even a bogus one, which if they do we will look for a proper path) and
+also search for installed paths, a more careful check has to be done in the
+`find_utils()` functions as otherwise it does not work when out of the repo
+directory.
+
+Sync copyright fixes from jparse.
+
+
 ## Release 2.4.3 2025-03-10
 
 **IMPORTANT NOTE**:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,14 @@ directory.
 
 Sync copyright fixes from jparse.
 
+Force set `nul_warning` to false in `mkiocccentry(1)` and disable checking of
+it in `chkentry(1)`. Post IOCCC28 it will be removed from struct info, the
+.info.json files and chkentry(1) that checks it.
+
+Rather than directly put in `true` in the writing of the .info.json file, force
+set `first_rule_is_all` to `true` in `mkiocccentry(1)` and reference that
+boolean in the writing of the .info.json file.
+
 
 ## Release 2.4.3 2025-03-10
 

--- a/iocccsize.c
+++ b/iocccsize.c
@@ -181,7 +181,7 @@ main(int argc, char **argv)
 	if (1 < verbosity_level && 0 < count.char_warning) {
 		iocccsize_warnx("Warning: character(s) with high bit set found! Be careful you don't violate rule 13!");
 	}
-	if (count.nul_warning) {
+        if (1 < verbosity_level && count.nul_warning) {
 		iocccsize_warnx("Warning: NUL character(s) found! Be careful you don't violate rule 13!");
 	}
 	if (count.trigraph_warning) {

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,18 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.2.36 2025-03-11
+
+Fix bugs in `resolve_path()`. If one had the path of `./foo` or even `/foo` then
+it should check that the path is a regular executable file. And if not it should
+return NULL. Otherwise it should return the path. Then, if the path is not a
+regular executable file and `$PATH` is empty it should return NULL, not a
+strdup()d copy of the path. This way the caller can know for sure that the path
+returned is in fact a regular executable file.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.6 2025-03-11"`.
+
+
 ## Release 2.2.35 2025-03-10
 
 Improved `shell_cmd()` and `pipe_open()` to resolve path (using `resolve_path()`

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/env make
 #
-# jparse - a JSON parser written in C
+# jparse - JSON parser, library and tools written in C
 #
-# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# Copyright (c) 2022-2025 by Landon Curt Noll and Cody Boone Ferguson.
 # All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
@@ -175,18 +175,6 @@ MAKE_CD_Q= --no-print-directory
 #
 # This repo supports c17 and later.
 #
-# NOTE: at one point we used -std=gnu11 because there were a few older systems
-#       in late 2021 that did not have compilers that (yet) supported gnu17.
-#       While there may be even more out of date systems that do not support
-#       gnu11, we have to draw the line somewhere. Besides, one of those systems
-#       reaches its EOL on 30 June 2024 and that's three days away at this
-#       point.
-#
-#	--------------------------------------------------
-#
-#	^^ the line is above :-)
-#
-#C_STD= -std=gnu11
 C_STD= -std=gnu17
 
 # optimization and debug level

--- a/jparse/jparse_main.c
+++ b/jparse/jparse_main.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jparse_main.h
+++ b/jparse/jparse_main.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jsemcgen.sh
+++ b/jparse/jsemcgen.sh
@@ -22,7 +22,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/jsemtblgen.c
+++ b/jparse/jsemtblgen.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jsemtblgen.h
+++ b/jparse/jsemtblgen.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_parse.h
+++ b/jparse/json_parse.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_sem.h
+++ b/jparse/json_sem.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_utf8.c
+++ b/jparse/json_utf8.c
@@ -23,8 +23,8 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
- * Ferguson and Landon Curt Noll:
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody
+ * Boone Ferguson and Landon Curt Noll:
  *
  *  @xexyl
  *	https://xexyl.net		Cody Boone Ferguson

--- a/jparse/json_utf8.h
+++ b/jparse/json_utf8.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_util.c
+++ b/jparse/json_util.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/json_util.h
+++ b/jparse/json_util.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstr_util.c
+++ b/jparse/jstr_util.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstr_util.h
+++ b/jparse/jstr_util.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstrdecode.c
+++ b/jparse/jstrdecode.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstrdecode.h
+++ b/jparse/jstrdecode.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstrencode.c
+++ b/jparse/jstrencode.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/jstrencode.h
+++ b/jparse/jstrencode.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/run_bison.sh
+++ b/jparse/run_bison.sh
@@ -22,7 +22,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/run_flex.sh
+++ b/jparse/run_flex.sh
@@ -24,7 +24,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -4,7 +4,7 @@
 #
 # "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
 #
-# Copyright (c) 2021-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# Copyright (c) 2022-2025 by Landon Curt Noll and Cody Boone Ferguson.
 # All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
@@ -172,18 +172,6 @@ MAKE_CD_Q= --no-print-directory
 #
 # This repo supports c17 and later.
 #
-# NOTE: at one point we used -std=gnu11 because there were a few older systems
-#       in late 2021 that did not have compilers that (yet) supported gnu17.
-#       While there may be even more out of date systems that do not support
-#       gnu11, we have to draw the line somewhere. Besides, one of those systems
-#       reaches its EOL on 30 June 2024 and that's three days away at this
-#       point.
-#
-#	--------------------------------------------------
-#
-#	^^ the line is above :-)
-#
-#C_STD= -std=gnu11
 C_STD= -std=gnu17
 
 # optimization and debug level

--- a/jparse/test_jparse/is_available.sh
+++ b/jparse/test_jparse/is_available.sh
@@ -22,7 +22,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2024-2025 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2024-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/test_jparse/jnum_chk.c
+++ b/jparse/test_jparse/jnum_chk.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jnum_chk.h
+++ b/jparse/test_jparse/jnum_chk.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jnum_gen.c
+++ b/jparse/test_jparse/jnum_gen.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jnum_gen.h
+++ b/jparse/test_jparse/jnum_gen.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jnum_header.c
+++ b/jparse/test_jparse/jnum_header.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jnum_test.c
+++ b/jparse/test_jparse/jnum_test.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/jparse_test.sh
+++ b/jparse/test_jparse/jparse_test.sh
@@ -77,7 +77,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/test_jparse/jstr_test.sh
+++ b/jparse/test_jparse/jstr_test.sh
@@ -24,7 +24,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/test_jparse/pr_jparse_test.c
+++ b/jparse/test_jparse/pr_jparse_test.c
@@ -32,7 +32,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/pr_jparse_test.h
+++ b/jparse/test_jparse/pr_jparse_test.h
@@ -32,7 +32,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/test_jparse/prep.sh
+++ b/jparse/test_jparse/prep.sh
@@ -22,7 +22,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/test_jparse/run_jparse_tests.sh
+++ b/jparse/test_jparse/run_jparse_tests.sh
@@ -22,7 +22,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
 #
-# This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+# This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
 # Ferguson and Landon Curt Noll:
 #
 #  @xexyl

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl
@@ -4357,7 +4357,7 @@ resolve_path(char const *cmd)
             /*
              * str should be the command's path
              */
-            dbg(DBG_MED, "found executable file at: %s/%s", p, cmd);
+            dbg(DBG_MED, "found executable file at: %s", str);
             /*
              * free dup
              */

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/verge.c
+++ b/jparse/verge.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/verge_main.c
+++ b/jparse/verge_main.c
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and tool were co-developed in 2022-205 by Cody Boone
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody Boone
  * Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -23,7 +23,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE OR JSON.
  *
- * This JSON parser and all the tools were co-developed in 2022-205 by Cody
+ * This JSON parser, library and tools were co-developed in 2022-2025 by Cody
  * Boone Ferguson and Landon Curt Noll:
  *
  *  @xexyl

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.5 2025-03-10"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.6 2025-03-11"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.5 2025-03-10"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.6 2025-03-11"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -5315,18 +5315,23 @@ check_prog_c(struct info *infop, char const *prog_c)
 
     /*
      * now that we allow all UTF-8 in prog.c, we force highbit_warning off
+     *
+     * XXX - post IOCCC28 the boolean will be removed from struct info, the
+     * .info.json file and the chkentry(1) code that checks it.
      */
     infop->highbit_warning = false;
 
     /*
      * sanity check on NUL character(s)
      */
-    if (size.nul_warning) {
-	warn_nul_chars();
-	infop->nul_warning = true;
-    } else {
-	infop->nul_warning = false;
-    }
+
+    /*
+     * XXX - as the rules now allow NUL bytes we force set infop->nul_warning to
+     * false. Post IOCCC28 the boolean will be removed from struct info, the
+     * .info.json file and all code that verifies it (i.e. the chkentry(1)) code
+     * will be removed.
+     */
+    infop->nul_warning = false;
 
     /*
      * sanity check on unknown trigraph(s)
@@ -5425,6 +5430,12 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 	not_reached();
     }
 
+    /*
+     * force first_rule_is_all to true
+     *
+     * XXX: post IOCCC28 this boolean will be removed from all files and code.
+     */
+    infop->first_rule_is_all = true;
     /*
      * process lines until EOF
      */
@@ -5563,7 +5574,6 @@ inspect_Makefile(char const *Makefile, struct info *infop)
 		 */
 		dbg(DBG_HIGH, "rulenum[%d]: all token found", rulenum);
 		infop->found_all_rule = true;
-		infop->first_rule_is_all = true;
 	    /*
 	     * detect clean rule
 	     */
@@ -8153,7 +8163,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_bool(info_stream, "    ", "wordbuf_warning", " : ", infop->wordbuf_warning, ",\n") &&
 	json_fprintf_value_bool(info_stream, "    ", "ungetc_warning", " : ", infop->ungetc_warning, ",\n") &&
 	json_fprintf_value_bool(info_stream, "    ", "Makefile_override", " : ", infop->Makefile_override, ",\n") &&
-	json_fprintf_value_bool(info_stream, "    ", "first_rule_is_all", " : ", true, ",\n") &&
+	json_fprintf_value_bool(info_stream, "    ", "first_rule_is_all", " : ", infop->first_rule_is_all, ",\n") &&
 	json_fprintf_value_bool(info_stream, "    ", "found_all_rule", " : ", infop->found_all_rule, ",\n") &&
 	json_fprintf_value_bool(info_stream, "    ", "found_clean_rule", " : ", infop->found_clean_rule, ",\n") &&
 	json_fprintf_value_bool(info_stream, "    ", "found_clobber_rule", " : ", infop->found_clobber_rule, ",\n") &&

--- a/soup/chk_validate.c
+++ b/soup/chk_validate.c
@@ -2251,40 +2251,20 @@ chk_no_comment(struct json const *node,
  * returns:
  *	true ==> JSON element is valid
  *	false ==> JSON element is NOT valid, or NULL pointer, or some internal error
+ *
+ * XXX: post IOCCC28 this function and related JSON will be removed but to
+ * simplify it during IOCCC28 we simply return true in every case as we no
+ * longer care about it.
  */
 bool
 chk_nul_warning(struct json const *node,
 		unsigned int depth, struct json_sem *sem, struct json_sem_val_err **val_err)
 {
-    bool *boolean = NULL;			/* pointer to JTYPE_BOOL as decoded JSON boolean */
-    bool test = false;				/* validation test result */
+    UNUSED_ARG(node);
+    UNUSED_ARG(depth);
+    UNUSED_ARG(sem);
+    UNUSED_ARG(val_err);
 
-    /*
-     * firewall - args
-     */
-    boolean = sem_member_value_bool(node, depth, sem, __func__, val_err);
-    if (boolean == NULL) {
-	/* sem_member_value_bool() will have set *val_err */
-	return false;
-    }
-
-    /*
-     * validate decoded JSON string
-     */
-    test = test_nul_warning(*boolean);
-    if (test == false) {
-	if (val_err != NULL) {
-	    *val_err = werr_sem_val(151, node, depth, sem, __func__, "invalid nul_warning");
-	}
-	return false;
-    }
-
-    /*
-     * return validation success
-     */
-    if (val_err != NULL) {
-	*val_err = NULL;
-    }
     return true;
 }
 

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -371,7 +371,7 @@ and
 .TP
 .B \-d
 Alias for
-.BR \-s\  21701\ .
+.BR \-s\  21701.
 .TP
 .BI \-I\  path
 Ignores a path from in the

--- a/soup/sanity.c
+++ b/soup/sanity.c
@@ -186,27 +186,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!tar_found && tar != NULL) {
         for (i = 0; tar_paths[i] != NULL; ++i) {
-            if (is_file(tar_paths[i]) && is_exec(tar_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *tar = strdup(tar_paths[i]);
-                if (*tar == NULL) {
-                    errp(56, __func__, "strdup(\"%s\") failed", tar_paths[i]);
-                    not_reached();
-                }
+            *tar = resolve_path(tar_paths[i]);
+            if (*tar != NULL && is_file(*tar) && is_exec(*tar)) {
                 tar_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *tar = resolve_path(tar_paths[i]);
-                if (*tar != NULL) {
-                    tar_found = true;
-                    break;
-                }
             }
         }
     }
@@ -214,6 +197,7 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     if (tar_found) {
         dbg(DBG_MED, "found tar at: %s", *tar);
     }
+
     if (ls != NULL && *ls != NULL && is_file(*ls) && is_exec(*ls)) {
         /*
          * we have to strdup() it
@@ -228,27 +212,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!ls_found && ls != NULL) {
         for (i = 0; ls_paths[i] != NULL; ++i) {
-            if (is_file(ls_paths[i]) && is_exec(ls_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *ls = strdup(ls_paths[i]);
-                if (*ls == NULL) {
-                    errp(58, __func__, "strdup(\"%s\") failed", ls_paths[i]);
-                    not_reached();
-                }
+            *ls = resolve_path(ls_paths[i]);
+            if (*ls != NULL && is_file(*ls) && is_exec(*ls)) {
                 ls_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *ls = resolve_path(ls_paths[i]);
-                if (*ls != NULL) {
-                    ls_found = true;
-                    break;
-                }
             }
         }
     }
@@ -270,27 +237,13 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!txzchk_found && txzchk != NULL) {
         for (i = 0; txzchk_paths[i] != NULL; ++i) {
-            if (is_file(txzchk_paths[i]) && is_exec(txzchk_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *txzchk = strdup(txzchk_paths[i]);
-                if (*txzchk == NULL) {
-                    errp(60, __func__, "strdup(\"%s\") failed", txzchk_paths[i]);
-                    not_reached();
-                }
+            /*
+             * try resolving the path
+             */
+            *txzchk = resolve_path(txzchk_paths[i]);
+            if (*txzchk != NULL && is_file(*txzchk) && is_exec(*txzchk)) {
                 txzchk_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *txzchk = resolve_path(txzchk_paths[i]);
-                if (*txzchk != NULL) {
-                    txzchk_found = true;
-                    break;
-                }
             }
         }
     }
@@ -312,27 +265,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!fnamchk_found && fnamchk != NULL) {
         for (i = 0; fnamchk_paths[i] != NULL; ++i) {
-            if (is_file(fnamchk_paths[i]) && is_exec(fnamchk_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *fnamchk = strdup(fnamchk_paths[i]);
-                if (*fnamchk == NULL) {
-                    errp(62, __func__, "strdup(\"%s\") failed", fnamchk_paths[i]);
-                    not_reached();
-                }
+            *fnamchk = resolve_path(fnamchk_paths[i]);
+            if (*fnamchk != NULL && is_file(*fnamchk) && is_exec(*fnamchk)) {
                 fnamchk_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *fnamchk = resolve_path(fnamchk_paths[i]);
-                if (*fnamchk != NULL) {
-                    fnamchk_found = true;
-                    break;
-                }
             }
         }
     }
@@ -355,27 +291,13 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!chkentry_found && chkentry != NULL) {
         for (i = 0; chkentry_paths[i] != NULL; ++i) {
-            if (is_file(chkentry_paths[i]) && is_exec(chkentry_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *chkentry = strdup(chkentry_paths[i]);
-                if (*chkentry == NULL) {
-                    errp(64, __func__, "strdup(\"%s\") failed", chkentry_paths[i]);
-                    not_reached();
-                }
+            /*
+             * try resolving the path
+             */
+            *chkentry = resolve_path(chkentry_paths[i]);
+            if (*chkentry != NULL &&  is_file(*chkentry) && is_exec(*chkentry)) {
                 chkentry_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *chkentry = resolve_path(chkentry_paths[i]);
-                if (*chkentry != NULL) {
-                    chkentry_found = true;
-                    break;
-                }
             }
         }
     }
@@ -397,27 +319,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!make_found && make != NULL) {
         for (i = 0; make_paths[i] != NULL; ++i) {
-            if (is_file(make_paths[i]) && is_exec(make_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *make = strdup(make_paths[i]);
-                if (*make == NULL) {
-                    errp(66, __func__, "strdup(\"%s\") failed", make_paths[i]);
-                    not_reached();
-                }
+            *make = resolve_path(make_paths[i]);
+            if (*make != NULL && is_file(*make) && is_exec(*make)) {
                 make_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *make = resolve_path(make_paths[i]);
-                if (*make != NULL) {
-                    make_found = true;
-                    break;
-                }
             }
         }
     }
@@ -440,27 +345,10 @@ find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry
     }
     if (!rm_found && rm != NULL) {
         for (i = 0; rm_paths[i] != NULL; ++i) {
-            if (is_file(rm_paths[i]) && is_exec(rm_paths[i])) {
-                /*
-                 * we have to strdup() it
-                 */
-                errno = 0; /* pre-clear errno for errp() */
-                *rm = strdup(rm_paths[i]);
-                if (*rm == NULL) {
-                    errp(68, __func__, "strdup(\"%s\") failed", rm_paths[i]);
-                    not_reached();
-                }
+            *rm = resolve_path(rm_paths[i]);
+            if (*rm != NULL && is_file(*rm) && is_exec(*rm)) {
                 rm_found = true;
                 break;
-            } else {
-                /*
-                 * try resolving the path
-                 */
-                *rm = resolve_path(rm_paths[i]);
-                if (*rm != NULL) {
-                    rm_found = true;
-                    break;
-                }
             }
         }
     }

--- a/soup/sanity.h
+++ b/soup/sanity.h
@@ -73,6 +73,8 @@
  * function prototypes
  */
 extern void ioccc_sanity_chks(void); /* all *_sanity_chks() functions should call this */
-extern void find_utils(char **tar, char **ls, char **txzchk, char **fnamchk, char **chkentry, char **make, char **rm);
+extern void find_utils(bool *tar_found, char **tar, bool *found_ls, char **ls, bool *found_txzchk,
+        char **txzchk, bool *found_fnamchk, char **fnamchk, bool *found_chkentry, char **chkentry,
+        bool *found_make, char **make, bool *found_rm, char **rm);
 
 #endif /* INCLUDE_SANITY_H */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.3 2025-03-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.4 2025-03-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/txzchk.c
+++ b/txzchk.c
@@ -160,6 +160,8 @@ main(int argc, char **argv)
     char *tar = TAR_PATH_0;		    /* path to tar executable that supports the -J (xz) option */
     char *fnamchk = FNAMCHK_PATH_0;	    /* path to fnamchk tool */
     int i;
+    bool found_tar = false;                     /* for find_utils */
+    bool found_fnamchk = false;                 /* for find_utils */
 
     /*
      * parse args
@@ -268,15 +270,20 @@ main(int argc, char **argv)
      *
      * On some systems where /usr/bin != /bin, the distribution made the mistake of
      * moving historic critical applications, look to see if the alternate path works instead.
-     *
-     * If -T was used we don't actually need tar(1) so we test for that
-     * specifically.
      */
 
     if (!read_from_text_file) {
-	find_utils(&tar, NULL, NULL, &fnamchk, NULL, NULL, NULL);
+        /*
+         * we need tar
+         */
+        find_utils(&found_tar, &tar, NULL, NULL, NULL, NULL, &found_fnamchk, &fnamchk,
+            NULL, NULL, NULL, NULL, NULL, NULL);
     } else {
-	find_utils(&tar, NULL, NULL, &fnamchk, NULL, NULL, NULL);
+        /*
+         * we do not need tar
+         */
+        find_utils(NULL, NULL, NULL, NULL, NULL, NULL, &found_fnamchk, &fnamchk,
+            NULL, NULL, NULL, NULL, NULL, NULL);
     }
 
     /* additional sanity checks */
@@ -308,7 +315,7 @@ main(int argc, char **argv)
     /*
      * we need to free the paths to the tools
      */
-    if (tar != NULL) {
+    if (tar != NULL && !read_from_text_file) {
         free(tar);
         tar = NULL;
     }


### PR DESCRIPTION

A couple bugs in the resolve_path() function ended up requiring an extra
check in find_utils() per util in order to get it to find the utils even
outside the directory: even if one had ./ or / in front of the path
it could end up resolving a path that is not a regular executable file
(when it did not have a / in the path this did not happen). Another
bug was fixed where if $PATH is NULL or empty and the path is not a
regular executable file it still would be a strdup()d copy of the
original path.

The above solved a problem where we could get the tools to be found (if
they exist) if we also did a check for is_file() and is_exec() but
with the above fixes we only have to check for != NULL.

The find_utils() functions now takes a corresponding bool * for each
tool to find. If the boolean is not NULL then we search for that tool. I
it is NULL and the char ** is not NULL then we set the *tool to
NULL. This way the caller can, if they wish and they are careful, decide
whether or not to find all the tools. For example txzchk only looks
for tar if test mode is not enabled.  And although as a safety check
before free()ing the pointer we do check that test mode was not used we
do not technically need it as long as we pass in &tar (although we do
give NULL so we do need to check it).