### PR TITLE
Fix issue #1252

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.5 2025-04-24
+
+Fix `scan_topdir()` to not count dot files/directories against max allowed.
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.4 2025-04-24"`.
+
+Typo fix in txzchk.1.
+
+
 ## Release 2.4.4 2025-03-15
 
 **IMPORTANT NOTE**:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.6 2025-04-25
+
+Fix #1252. `mkiocccentry` must run `make clobber` before scanning the topdir and
+then also later when running the checks. This is because if someone tests their
+code in their topdir anything compiled will be included as extra files (unless
+forbidden) but if the make clobber that follows removes any of those files the
+extra files list will be the wrong size. So now one can test from the topdir and
+then not have this problem.
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.5 2025-04-25"`.
+
+
 ## Release 2.4.5 2025-04-24
 
 Fix `scan_topdir()` to not count dot files/directories against max allowed.

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1510,6 +1510,21 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
              */
             if (!strcmp(ent->fts_path, ".") || !strcmp(ent->fts_path, "..") || !strcmp(ent->fts_path, "./")) {
                 continue;
+            } else if (!strncmp(ent->fts_path + 2, ".", 1)) {
+                /*
+                 * if it's a directory we have to use fts_set() to skip it
+                 */
+                if (ent->fts_info == FTS_D) {
+                    /*
+                     * we don't want to traverse below ignored directories
+                     */
+                    errno = 0;  /* pre-clear errno for errp() */
+                    if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
+                        errp(50, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
+                        not_reached();
+                    }
+                }
+                continue;
             }
 
             /*
@@ -1529,7 +1544,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                      */
                     errno = 0;  /* pre-clear errno for errp() */
                     if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
-                        errp(50, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
+                        errp(51, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
                         not_reached();
                     }
                 }
@@ -1593,7 +1608,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                         errno = 0; /* pre-clear errno for errp() */
                         filename = strdup(ent->fts_path + 2);
                         if (filename == NULL) {
-                            errp(51, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                            errp(52, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                             not_reached();
                         }
                         if (ent->fts_info == FTS_F) {
@@ -1623,7 +1638,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                         errno = 0; /* pre-clear errno for errp() */
                         filename = strdup(ent->fts_path + 2);
                         if (filename == NULL) {
-                            errp(52, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                            errp(53, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                             not_reached();
                         }
                         if (ent->fts_info == FTS_D) {
@@ -1632,7 +1647,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                              */
                             errno = 0;  /* pre-clear errno for errp() */
                             if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
-                                errp(53, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
+                                errp(54, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
                                 not_reached();
                             }
                             append_unique_filename(infop->ignored_dirs, filename);
@@ -1679,7 +1694,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                 errno = 0; /* pre-clear errno for errp() */
                 filename = strdup(ent->fts_path + 2);
                 if (filename == NULL) {
-                    errp(54, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                    errp(55, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                     not_reached();
                 }
                 if (ent->fts_info == FTS_D) {
@@ -1688,7 +1703,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                      */
                     errno = 0;  /* pre-clear errno for errp() */
                     if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
-                        errp(55, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
+                        errp(56, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
                         not_reached();
                     }
                     append_unique_filename(infop->ignored_dirs, filename);
@@ -1707,7 +1722,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                 errno = 0; /* pre-clear errno for errp() */
                 filename = strdup(ent->fts_path + 2);
                 if (filename == NULL) {
-                    errp(56, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                    errp(57, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                     not_reached();
                 }
 
@@ -1741,7 +1756,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                          */
                         errno = 0; /* pre-clear errno for errp() */
                         if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
-                            errp(57, __func__, "failed to set FTS_SKIP on workdir inside topdir");
+                            errp(58, __func__, "failed to set FTS_SKIP on workdir inside topdir");
                             not_reached();
                         }
                         dbg(DBG_MED, "skipping workdir found inside topdir");
@@ -1767,7 +1782,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(58, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(59, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1784,7 +1799,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(59, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(60, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -1834,7 +1849,7 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(60, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(61, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -2081,7 +2096,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
     errno = 0;          /* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-        errp(61, __func__, "unable to fchdir(cwd)");
+        errp(62, __func__, "unable to fchdir(cwd)");
         not_reached();
     }
 
@@ -2101,7 +2116,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignore_paths, char *, i);
                 if (p == NULL) {
-                    err(62, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
+                    err(63, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2138,7 +2153,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                     errno = 0;
                     ret = printf("\t%10s%s", ignored_dirnames[i], !((i+1)%3)||ignored_dirnames[i+1]==NULL?"\n":"   ");
                     if (ret <= 0) {
-                        errp(63, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
+                        errp(64, __func__, "printf error printing an ignored dirname: %s", ignored_dirnames[i]);
                         not_reached();
                     }
                 }
@@ -2154,7 +2169,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignored_dirs, char *, i);
                 if (p == NULL) {
-                    err(64, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
+                    err(65, __func__, "found NULL pointer in ignored dirname list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2202,7 +2217,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->unsafe_dirs, char *, i);
                 if (p == NULL) {
-                    err(65, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
+                    err(66, __func__, "found NULL pointer in unsafe directory names list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2239,7 +2254,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                     errno = 0;
                     ret = printf("\t%10s%s", forbidden_filenames[i], !((i+1)%3)||forbidden_filenames[i+1]==NULL?"\n":"   ");
                     if (ret <= 0) {
-                        errp(66, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
+                        errp(67, __func__, "printf error printing a forbidden filename: %s", forbidden_filenames[i]);
                         not_reached();
                     }
                 }
@@ -2256,7 +2271,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->forbidden_files, char *, i);
                 if (p == NULL) {
-                    err(67, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
+                    err(68, __func__, "found NULL pointer in forbidden files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2300,7 +2315,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->unsafe_files, char *, i);
                 if (p == NULL) {
-                    err(68, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
+                    err(69, __func__, "found NULL pointer in unsafe filenames list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2341,7 +2356,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->ignored_symlinks, char *, i);
                 if (p == NULL) {
-                    err(69, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
+                    err(70, __func__, "found NULL pointer in ignored symlinks list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2379,7 +2394,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->directories, char *, i);
                 if (p == NULL) {
-                    err(70, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(71, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2424,7 +2439,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->required_files, char *, i);
                 if (p == NULL) {
-                    err(71, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                    err(72, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -2442,7 +2457,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 for (i = 0; i < len; ++i) {
                     p = dyn_array_value(infop->extra_files, char *, i);
                     if (p == NULL) {
-                        err(72, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                        err(73, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     print("%s\n", p);
@@ -2483,7 +2498,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                      */
                     p = dyn_array_value(infop->directories, char *, i);
                     if (p == NULL) {
-                        err(73, __func__, "found NULL pointer in infop->directories list");
+                        err(74, __func__, "found NULL pointer in infop->directories list");
                         not_reached();
                     }
                     /*
@@ -2499,7 +2514,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             errno = 0;
             if (fchdir(topdir) != 0) {
-                errp(74, __func__, "cannot change to topdir");
+                errp(75, __func__, "cannot change to topdir");
                 not_reached();
             }
 
@@ -2508,13 +2523,13 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
              */
             len = dyn_array_tell(infop->required_files);
             if (len <= 0) {
-                err(75, __func__, "list of required files is empty");
+                err(76, __func__, "list of required files is empty");
                 not_reached();
             }
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->required_files, char *, i);
                 if (p == NULL) {
-                    err(76, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                    err(77, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 /*
@@ -2525,7 +2540,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                  */
                 fname = calloc_path(topdir_path, p);
                 if (fname == NULL) {
-                    err(77, __func__, "couldn't allocate path to copy");
+                    err(78, __func__, "couldn't allocate path to copy");
                     not_reached();
                 }
                 if (target_path != NULL) {
@@ -2543,7 +2558,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
                 if (target_path == NULL) {
-                    errp(78, __func__, "failed to allocate target path for %s", p);
+                    errp(79, __func__, "failed to allocate target path for %s", p);
                     not_reached();
                 }
                 /*
@@ -2552,7 +2567,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
                 if (ret <= 0) {
-                    errp(79, __func__, "snprintf to form target path for %s failed", fname);
+                    errp(80, __func__, "snprintf to form target path for %s failed", fname);
                     not_reached();
                 }
 
@@ -2586,7 +2601,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->extra_files, char *, i);
                 if (p == NULL) {
-                    err(80, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                    err(81, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 /*
@@ -2597,7 +2612,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                  */
                 fname = calloc_path(topdir_path, p);
                 if (fname == NULL) {
-                    err(81, __func__, "couldn't allocate path to copy");
+                    err(82, __func__, "couldn't allocate path to copy");
                     not_reached();
                 }
                 if (target_path != NULL) {
@@ -2615,7 +2630,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 target_path = calloc(1, strlen(submit_path) + LITLEN("/") + strlen(p) + 1);
                 if (target_path == NULL) {
-                    errp(82, __func__, "failed to allocate target path for %s", p);
+                    errp(83, __func__, "failed to allocate target path for %s", p);
                     not_reached();
                 }
                 /*
@@ -2623,7 +2638,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
                 errno = 0; /* pre-clear errno for errp() */
                 ret = snprintf(target_path, strlen(submit_path) + 1 + strlen(p) + 1, "%s/%s", submit_path, p);
                 if (ret <= 0) {
-                    errp(83, __func__, "snprintf to form target path for %s failed", fname);
+                    errp(84, __func__, "snprintf to form target path for %s failed", fname);
                     not_reached();
                 } else if (is_executable_filename(p)) {
                     /*
@@ -2669,7 +2684,7 @@ copy_topdir(struct info *infop, char const *make, char const *submission_dir, ch
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(topdir) != 0) {
-        errp(84, __func__, "failed to close(topdir)");
+        errp(85, __func__, "failed to close(topdir)");
         not_reached();
     }
 
@@ -2736,14 +2751,14 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      * firewall
      */
     if (infop == NULL || submit_path == NULL || make == NULL || size == NULL) {
-        err(85, __func__, "passed NULL arg(s)");
+        err(86, __func__, "passed NULL arg(s)");
         not_reached();
     }
     /*
      * cwd must be >= 0
      */
     if (cwd < 0) {
-        err(86, __func__, "original directory file descriptor < 0");
+        err(87, __func__, "original directory file descriptor < 0");
         not_reached();
     }
 
@@ -2754,7 +2769,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(87, __func__, "failed to change to original directory");
+        errp(88, __func__, "failed to change to original directory");
         not_reached();
     }
 
@@ -2782,27 +2797,27 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     required_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (required_files == NULL) {
-        err(88, __func__, "couldn't create required files list array");
+        err(89, __func__, "couldn't create required files list array");
         not_reached();
     }
     extra_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (extra_files == NULL) {
-        err(89, __func__, "couldn't create extra files list array");
+        err(90, __func__, "couldn't create extra files list array");
         not_reached();
     }
     missing_files = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_files == NULL) {
-        err(90, __func__, "couldn't create missing files list array");
+        err(91, __func__, "couldn't create missing files list array");
         not_reached();
     }
     directories = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (directories == NULL) {
-        err(91, __func__, "couldn't create directories list array");
+        err(92, __func__, "couldn't create directories list array");
         not_reached();
     }
     missing_dirs = dyn_array_create(sizeof(char *), CHUNK, CHUNK, true);
     if (missing_dirs == NULL) {
-        err(92, __func__, "couldn't create missing directories list array");
+        err(93, __func__, "couldn't create missing directories list array");
         not_reached();
     }
 
@@ -2873,7 +2888,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     ent = read_fts(NULL, -1, NULL, &fts);
     if (ent == NULL){
-        err(93, __func__, "failed to find any files in \".\"");
+        err(94, __func__, "failed to find any files in \".\"");
         not_reached();
     } else {
         do {
@@ -2886,6 +2901,21 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
              * skip '.' and '..' and a path that is just './' too
              */
             if (!strcmp(ent->fts_path, ".") || !strcmp(ent->fts_path, "..") || !strcmp(ent->fts_path, "./")) {
+                continue;
+            } else if (!strncmp(ent->fts_path + 2, ".", 1)) {
+                /*
+                 * if it's a directory we have to use fts_set() to skip it
+                 */
+                if (ent->fts_info == FTS_D) {
+                    /*
+                     * we don't want to traverse below ignored directories
+                     */
+                    errno = 0;  /* pre-clear errno for errp() */
+                    if (fts_set(fts.tree, ent, FTS_SKIP) != 0) {
+                        errp(95, __func__, "fts_set() failed to set FTS_SKIP for %s", ent->fts_path + 2);
+                        not_reached();
+                    }
+                }
                 continue;
             }
 
@@ -3051,7 +3081,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(94, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(96, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
                     /*
@@ -3075,7 +3105,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(ent->fts_path + 2);
                     if (filename == NULL) {
-                        errp(95, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
+                        errp(97, __func__, "strdup(\"%s\") failed", ent->fts_path + 2);
                         not_reached();
                     }
 
@@ -3251,7 +3281,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          */
         p = dyn_array_value(infop->required_files, char *, i);
         if (p == NULL) {
-            err(96, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+            err(98, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
             not_reached();
         }
         /*
@@ -3259,7 +3289,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          */
         fname = dyn_array_value(required_files, char *, i);
         if (fname == NULL) {
-            err(97, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
+            err(99, __func__, "found NULL pointer in required files list in submission directory, element: %ju", (uintmax_t)i);
             not_reached();
         }
 
@@ -3286,7 +3316,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             errno = 0; /* pre-clear errno for errp() */
             filename = strdup(p);
             if (filename == NULL) {
-                errp(98, __func__, "strdup(\"%s\") failed", p);
+                errp(100, __func__, "strdup(\"%s\") failed", p);
                 not_reached();
             }
             append_unique_filename(missing_files, filename);
@@ -3415,7 +3445,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                      */
                     p = dyn_array_value(infop->extra_files, char *, i);
                     if (p == NULL) {
-                        err(99, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
+                        err(101, __func__, "found NULL pointer in extra files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     /*
@@ -3423,7 +3453,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                      */
                     fname = dyn_array_value(extra_files, char *, i);
                     if (p == NULL) {
-                        err(100, __func__, "found NULL pointer in extra files list in submission directory, element: %ju",
+                        err(102, __func__, "found NULL pointer in extra files list in submission directory, element: %ju",
                                 (uintmax_t)i);
                         not_reached();
                     }
@@ -3451,7 +3481,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                         errno = 0; /* pre-clear errno for errp() */
                         filename = strdup(p);
                         if (filename == NULL) {
-                            errp(101, __func__, "strdup(\"%s\") failed", p);
+                            errp(103, __func__, "strdup(\"%s\") failed", p);
                             not_reached();
                         }
                         append_unique_filename(missing_files, filename);
@@ -3470,7 +3500,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         ret = fprintf(stderr, "The following file%s %s missing:\n\n",
                 len == 1 ? "" : "s", len == 1 ? "is" : "are");
         if (ret <= 0) {
-            errp(102, __func__, "error writing missing files list title");
+            errp(104, __func__, "error writing missing files list title");
             not_reached();
         }
         for (i = 0; i < len; i++) {
@@ -3479,7 +3509,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
              */
             fname = dyn_array_value(missing_files, char *, i);
             if (fname == NULL) {
-                err(103, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
+                err(105, __func__, "found NULL pointer in missing files list in submission directory, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", fname);
@@ -3507,7 +3537,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
          * (topdir list size) it is an error
          */
         if (len != len2) {
-            err(104, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
+            err(106, __func__, "size of directories list in submission directory != size in topdir: %ju != %ju", (uintmax_t)len2,
                     (uintmax_t)len);
             not_reached();
         }
@@ -3515,12 +3545,12 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(infop->directories, char *, i);
                 if (p == NULL) {
-                    err(105, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(107, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 fname = dyn_array_value(directories, char *, i);
                 if (fname == NULL) {
-                    err(106, __func__, "found NULL pointer in directories list in submission directory, element: %ju",
+                    err(108, __func__, "found NULL pointer in directories list in submission directory, element: %ju",
                             (uintmax_t)i);
                     not_reached();
                 }
@@ -3548,7 +3578,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                     errno = 0; /* pre-clear errno for errp() */
                     filename = strdup(p);
                     if (filename == NULL) {
-                        errp(107, __func__, "strdup(\"%s\") failed", p);
+                        errp(109, __func__, "strdup(\"%s\") failed", p);
                         not_reached();
                     }
                     append_unique_filename(missing_dirs, filename);
@@ -3564,7 +3594,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             ret = fprintf(stderr, "The following director%s %s missing:\n\n",
                     len == 1 ? "y" : "ies", len == 1 ? "is" : "are");
             if (ret <= 0) {
-                errp(108, __func__, "error writing missing directories list title");
+                errp(110, __func__, "error writing missing directories list title");
                 not_reached();
             }
             for (i = 0; i < len; i++) {
@@ -3573,7 +3603,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                  */
                 fname = dyn_array_value(missing_dirs, char *, i);
                 if (fname == NULL) {
-                    err(109, __func__,
+                    err(111, __func__,
                             "found NULL pointer in missing directories list in submission directory, element: %ju",
                             (uintmax_t)i);
                     not_reached();
@@ -3602,7 +3632,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
             for (i = 0; i < len; ++i) {
                 p = dyn_array_value(directories, char *, i);
                 if (p == NULL) {
-                    err(110, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
+                    err(112, __func__, "found NULL pointer in directories list, element: %ju", (uintmax_t)i);
                     not_reached();
                 }
                 print("%s\n", p);
@@ -3628,7 +3658,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      * show user final submission directory listing and verify it is OK
      */
     if (required_files == NULL) {
-        err(111, __func__, "required files in submission directory is NULL");
+        err(113, __func__, "required files in submission directory is NULL");
         not_reached();
     }
     len = dyn_array_tell(required_files);
@@ -3648,7 +3678,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
         for (i = 0; i < len; ++i) {
             p = dyn_array_value(required_files, char *, i);
             if (p == NULL) {
-                err(112, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
+                err(114, __func__, "found NULL pointer in required files list, element: %ju", (uintmax_t)i);
                 not_reached();
             }
             print("%s\n", p);
@@ -3664,7 +3694,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
                 for (i = 0; i < len; ++i) {
                     p = dyn_array_value(extra_files, char *, i);
                     if (p == NULL) {
-                        err(113, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
+                        err(115, __func__, "found NULL pointer in non-required files list, element: %ju", (uintmax_t)i);
                         not_reached();
                     }
                     print("%s\n", p);
@@ -3726,7 +3756,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (fchdir(cwd) != 0) {
-        errp(114, __func__, "unable to change to previous directory");
+        errp(116, __func__, "unable to change to previous directory");
         not_reached();
     }
 
@@ -3735,7 +3765,7 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
      */
     errno = 0; /* pre-clear errno for errp() */
     if (close(cwd) != 0) {
-        errp(115, __func__, "failed to close(cwd)");
+        errp(117, __func__, "failed to close(cwd)");
         not_reached();
     }
     /*
@@ -3829,7 +3859,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
      * firewall
      */
     if (infop == NULL || workdir == NULL) {
-	err(116, __func__, "called with NULL arg(s)");
+	err(118, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -3852,9 +3882,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (tar != NULL) {
-	    err(117, __func__, "tar does not exist: %s", tar);
+	    err(119, __func__, "tar does not exist: %s", tar);
         } else {
-	    err(118, __func__, "tar does not exist");
+	    err(120, __func__, "tar does not exist");
         }
 	not_reached();
     }
@@ -3872,7 +3902,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(119, __func__, "tar is not a regular file: %s", tar);
+	err(121, __func__, "tar is not a regular file: %s", tar);
 	not_reached();
     }
     if (!is_exec(tar)) {
@@ -3889,7 +3919,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/tar/",
 	      "",
 	      NULL);
-	err(120, __func__, "tar is not an executable program: %s", tar);
+	err(122, __func__, "tar is not an executable program: %s", tar);
 	not_reached();
     }
 
@@ -3912,9 +3942,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (ls != NULL) {
-            err(121, __func__, "ls does not exist: %s", ls);
+            err(123, __func__, "ls does not exist: %s", ls);
         } else {
-            err(122, __func__, "ls does not exist");
+            err(124, __func__, "ls does not exist");
         }
 	not_reached();
     }
@@ -3932,7 +3962,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(123, __func__, "ls is not a regular file: %s", ls);
+	err(125, __func__, "ls is not a regular file: %s", ls);
 	not_reached();
     }
     if (!is_exec(ls)) {
@@ -3949,7 +3979,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(124, __func__, "ls is not an executable program: %s", ls);
+	err(126, __func__, "ls is not an executable program: %s", ls);
 	not_reached();
     }
 
@@ -3972,9 +4002,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (txzchk != NULL) {
-	    err(125, __func__, "txzchk does not exist: %s", txzchk);
+	    err(128, __func__, "txzchk does not exist: %s", txzchk);
         } else {
-    	    err(126, __func__, "txzchk does not exist");
+    	    err(129, __func__, "txzchk does not exist");
         }
 	not_reached();
     }
@@ -3992,7 +4022,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(128, __func__, "txzchk is not a regular file: %s", txzchk);
+	err(130, __func__, "txzchk is not a regular file: %s", txzchk);
 	not_reached();
     }
     if (!is_exec(txzchk)) {
@@ -4009,7 +4039,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(129, __func__, "txzchk is not an executable program: %s", txzchk);
+	err(131, __func__, "txzchk is not an executable program: %s", txzchk);
 	not_reached();
     }
 
@@ -4032,9 +4062,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (fnamchk != NULL) {
-    	    err(130, __func__, "fnamchk does not exist: %s", fnamchk);
+    	    err(132, __func__, "fnamchk does not exist: %s", fnamchk);
         } else {
-	    err(131, __func__, "fnamchk does not exist");
+	    err(133, __func__, "fnamchk does not exist");
         }
 	not_reached();
     }
@@ -4052,7 +4082,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(132, __func__, "fnamchk is not a regular file: %s", fnamchk);
+	err(134, __func__, "fnamchk is not a regular file: %s", fnamchk);
 	not_reached();
     }
     if (!is_exec(fnamchk)) {
@@ -4069,7 +4099,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(133, __func__, "fnamchk is not an executable program: %s", fnamchk);
+	err(135, __func__, "fnamchk is not an executable program: %s", fnamchk);
 	not_reached();
     }
 
@@ -4092,9 +4122,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (chkentry != NULL) {
-	    err(134, __func__, "chkentry does not exist: %s", chkentry);
+	    err(136, __func__, "chkentry does not exist: %s", chkentry);
         } else {
-	    err(135, __func__, "chkentry does not exist");
+	    err(137, __func__, "chkentry does not exist");
         }
 	not_reached();
     }
@@ -4112,7 +4142,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(136, __func__, "chkentry is not a regular file: %s", chkentry);
+	err(138, __func__, "chkentry is not a regular file: %s", chkentry);
 	not_reached();
     }
     if (!is_exec(chkentry)) {
@@ -4129,7 +4159,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://github.com/ioccc-src/mkiocccentry",
 	      "",
 	      NULL);
-	err(137, __func__, "chkentry is not an executable program: %s", chkentry);
+	err(139, __func__, "chkentry is not an executable program: %s", chkentry);
 	not_reached();
     }
 
@@ -4152,9 +4182,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (make != NULL) {
-	    err(138, __func__, "make does not exist: %s", make);
+	    err(140, __func__, "make does not exist: %s", make);
         } else {
-	    err(139, __func__, "make does not exist");
+	    err(141, __func__, "make does not exist");
         }
 	not_reached();
     }
@@ -4172,7 +4202,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(140, __func__, "make is not a regular file: %s", make);
+	err(142, __func__, "make is not a regular file: %s", make);
 	not_reached();
     }
     if (!is_exec(make)) {
@@ -4189,7 +4219,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "    https://www.gnu.org/software/make/",
 	      "",
 	      NULL);
-	err(141, __func__, "make is not an executable program: %s", make);
+	err(143, __func__, "make is not an executable program: %s", make);
 	not_reached();
     }
 
@@ -4211,9 +4241,9 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "",
 	      NULL);
         if (rm != NULL) {
-	    err(142, __func__, "rm does not exist: %s", rm);
+	    err(144, __func__, "rm does not exist: %s", rm);
         } else {
-	    err(143, __func__, "rm does not exist");
+	    err(145, __func__, "rm does not exist");
         }
 	not_reached();
     }
@@ -4231,7 +4261,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
               "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(144, __func__, "rm is not a regular file: %s", rm);
+	err(146, __func__, "rm is not a regular file: %s", rm);
 	not_reached();
     }
     if (!is_exec(rm)) {
@@ -4248,7 +4278,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
               "    https://www.gnu.org/software/coreutils/",
 	      "",
 	      NULL);
-	err(145, __func__, "rm is not an executable program: %s", rm);
+	err(147, __func__, "rm is not an executable program: %s", rm);
 	not_reached();
     }
 
@@ -4263,7 +4293,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "You should either create workdir, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(146, __func__, "workdir does not exist: %s", workdir);
+	err(148, __func__, "workdir does not exist: %s", workdir);
 	not_reached();
     }
     if (!is_dir(workdir)) {
@@ -4275,7 +4305,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(147, __func__, "workdir is not a directory: %s", workdir);
+	err(149, __func__, "workdir is not a directory: %s", workdir);
 	not_reached();
     }
     if (!is_write(workdir)) {
@@ -4287,7 +4317,7 @@ mkiocccentry_sanity_chks(struct info *infop, char const *workdir, char *tar, cha
 	      "create a new writable directory, or use a different workdir directory path on the command line.",
 	      "",
 	      NULL);
-	err(148, __func__, "workdir is not a writable directory: %s", workdir);
+	err(150, __func__, "workdir is not a writable directory: %s", workdir);
 	not_reached();
     }
 
@@ -4338,7 +4368,7 @@ prompt(char const *str, size_t *lenp)
      * NOTE: As noted above, lenp can be NULL.
      */
     if (str == NULL) {
-	err(149, __func__, "called with NULL str");
+	err(151, __func__, "called with NULL str");
 	not_reached();
     }
 
@@ -4358,13 +4388,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(str, stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(150, __func__, "error printing prompt string");
+		errp(152, __func__, "error printing prompt string");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(151, __func__, "EOF while printing prompt string");
+		err(153, __func__, "EOF while printing prompt string");
 		not_reached();
 	    } else {
-		errp(152, __func__, "unexpected fputs error printing prompt string");
+		errp(154, __func__, "unexpected fputs error printing prompt string");
 		not_reached();
 	    }
 	}
@@ -4373,13 +4403,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fputs(": ", stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(153, __func__, "error printing :<space>");
+		errp(155, __func__, "error printing :<space>");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(154, __func__, "EOF while writing :<space>");
+		err(156, __func__, "EOF while writing :<space>");
 		not_reached();
 	    } else {
-		errp(155, __func__, "unexpected fputs error printing :<space>");
+		errp(157, __func__, "unexpected fputs error printing :<space>");
 		not_reached();
 	    }
 	}
@@ -4388,13 +4418,13 @@ prompt(char const *str, size_t *lenp)
 	ret = fflush(stdout);
 	if (ret == EOF) {
 	    if (ferror(stdout)) {
-		errp(156, __func__, "error flushing prompt to stdout");
+		errp(158, __func__, "error flushing prompt to stdout");
 		not_reached();
 	    } else if (feof(stdout)) {
-		err(157, __func__, "EOF while flushing prompt to stdout");
+		err(159, __func__, "EOF while flushing prompt to stdout");
 		not_reached();
 	    } else {
-		errp(158, __func__, "unexpected fflush error while flushing prompt to stdout");
+		errp(160, __func__, "unexpected fflush error while flushing prompt to stdout");
 		not_reached();
 	    }
 	}
@@ -4405,7 +4435,7 @@ prompt(char const *str, size_t *lenp)
      */
     buf = readline_dup(&linep, true, &len, stream);
     if (buf == NULL) {
-	err(159, __func__, "EOF while reading prompt input");
+	err(161, __func__, "EOF while reading prompt input");
 	not_reached();
     }
     dbg(DBG_VHIGH, "received a %ju byte response", (uintmax_t)len);
@@ -4464,7 +4494,7 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
      * firewall
      */
     if (testp == NULL) {
-	err(160, __func__, "called with NULL testp");
+	err(162, __func__, "called with NULL testp");
 	not_reached();
     }
 
@@ -4565,7 +4595,7 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
 	    malloc_ret = prompt("", &len);
 	}
 	if (read_answers_flag_used && !seen_answers_header) {
-	    err(161, __func__, "didn't find the correct answers file header");
+	    err(163, __func__, "didn't find the correct answers file header");
 	    not_reached();
 	}
 
@@ -4663,7 +4693,7 @@ get_submit_slot(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(162, __func__, "called with NULL arg(s)");
+	err(164, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -4674,7 +4704,7 @@ get_submit_slot(struct info *infop)
         errno = 0;		/* pre-clear errno for errp() */
         ret = printf("\nYou are allowed to submit up to %d submissions to a given IOCCC.\n", MAX_SUBMIT_SLOT + 1);
         if (ret <= 0) {
-            errp(163, __func__, "printf error printing number of submissions allowed");
+            errp(165, __func__, "printf error printing number of submissions allowed");
             not_reached();
         }
         para("",
@@ -4708,7 +4738,7 @@ get_submit_slot(struct info *infop)
 	    ret = fprintf(stderr, "\nThe submit slot number must be a number from 0 through %d; please re-enter.\n",
 		    MAX_SUBMIT_SLOT);
 	    if (ret <= 0) {
-		errp(164, __func__, "fprintf error while informing about the valid submit slot number range");
+		errp(166, __func__, "fprintf error while informing about the valid submit slot number range");
                 not_reached();
 	    }
             /*
@@ -4728,7 +4758,7 @@ get_submit_slot(struct info *infop)
                 ret = printf("\nThe slot number you entered is: %d\n",
                              submit_slot);
                 if (ret <= 0) {
-                    errp(165, __func__, "fprintf error writing slot number");
+                    errp(167, __func__, "fprintf error writing slot number");
                     not_reached();
                 }
                 yorn = yes_or_no("\nIs that slot number correct? [Yn]", true);
@@ -4793,12 +4823,12 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      * firewall
      */
     if (workdir == NULL || ioccc_id == NULL || tarball_path == NULL || (force_remove && rm == NULL)) {
-	err(166, __func__, "called with NULL arg(s)");
+	err(168, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     test = test_submit_slot(submit_slot);
     if (test == false) {
-	err(167, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
+	err(169, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
 	not_reached();
     }
 
@@ -4812,13 +4842,13 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
     errno = 0;			/* pre-clear errno for errp() */
     submission_dir = (char *)malloc(submission_dir_len + 1);
     if (submission_dir == NULL) {
-	errp(168, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
+	errp(170, __func__, "malloc #0 of %ju bytes failed", (uintmax_t)(submission_dir_len + 1));
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(submission_dir, submission_dir_len + 1, "%s/%s-%d", workdir, ioccc_id, submit_slot);
     if (ret <= 0) {
-	errp(169, __func__, "snprintf to form submission directory failed");
+	errp(171, __func__, "snprintf to form submission directory failed");
 	not_reached();
     }
     dbg(DBG_HIGH, "submission directory path: %s", submission_dir);
@@ -4831,7 +4861,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
             errno = 0;		/* pre-clear errno for errp() */
             ret = fprintf(stderr, "\nsubmission directory already exists: %s\n", submission_dir);
             if (ret <= 0) {
-                errp(170, __func__, "fprintf error while informing that the submission directory already exists");
+                errp(172, __func__, "fprintf error while informing that the submission directory already exists");
                 not_reached();
             }
             fpara(stderr,
@@ -4840,7 +4870,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
                   "or use a different workdir.",
                   "",
                   NULL);
-            err(171, __func__, "submission directory exists: %s", submission_dir);
+            err(173, __func__, "submission directory exists: %s", submission_dir);
             not_reached();
         } else {
             /*
@@ -4849,7 +4879,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
             dbg(DBG_HIGH, "about to perform: %s -rf %s", rm, submission_dir);
             exit_code = shell_cmd(__func__, false, true, "% -rf %", rm, submission_dir);
             if (exit_code != 0) {
-                err(172, __func__, "%s -rf %s failed with exit code: %d",
+                err(174, __func__, "%s -rf %s failed with exit code: %d",
                                    submission_dir, rm, WEXITSTATUS(exit_code));
                 not_reached();
             }
@@ -4871,13 +4901,13 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     ret = mkdir(submission_dir, 0);
     if (ret < 0) {
-	errp(173, __func__, "cannot mkdir %s", submission_dir);
+	errp(175, __func__, "cannot mkdir %s", submission_dir);
 	not_reached();
     }
     errno = 0; /* pre-clear errno for errp() */
     ret = chmod(submission_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
     if (ret < 0) {
-        errp(174, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
+        errp(176, __func__, "cannot chmod directory %s to mode 0755", submission_dir);
         not_reached();
     }
 
@@ -4889,7 +4919,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
      */
     *tarball_path = form_tar_filename(ioccc_id, submit_slot, test_mode, tstamp);
     if (*tarball_path == NULL) {
-	errp(175, __func__, "failed to form compressed tarball path");
+	errp(177, __func__, "failed to form compressed tarball path");
 	not_reached();
     }
     dbg(DBG_HIGH, "compressed tarball path: %s", *tarball_path);
@@ -4934,7 +4964,7 @@ warn_empty_prog(void)
 	}
 	yorn = yes_or_no("Are you sure you want to submit an empty prog.c file? [Ny]", false);
 	if (!yorn) {
-	    err(176, __func__, "please fix your prog.c file");
+	    err(178, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their empty prog.c is OK");
@@ -4963,7 +4993,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * firewall
      */
     if (infop == NULL) {
-	err(177, __func__, "called with NULL infop");
+	err(179, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -4977,7 +5007,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %jd > Rule 2a maximum: %jd\n",
 		      (intmax_t)infop->rule_2a_size, (intmax_t)RULE_2A_SIZE);
 	if (ret <= 0) {
-	    errp(178, __func__, "fprintf error when printing prog.c Rule 2a warning");
+	    errp(180, __func__, "fprintf error when printing prog.c Rule 2a warning");
             not_reached();
 	}
 	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
@@ -4994,7 +5024,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [Ny]", false);
 	    if (!yorn) {
-		err(179, __func__, "please fix your prog.c file");
+		err(181, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that their prog.c size: %jd > Rule 2a max size: %jd is OK",
@@ -5012,7 +5042,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 				  "YOUR remarks.md FILE!\n\n",
 				  (intmax_t)infop->rule_2a_size, (intmax_t)size.rule_2a_size);
 	    if (ret <= 0) {
-		errp(180, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
+		errp(182, __func__, "fprintf error when printing prog.c file size and Rule 2a mismatch");
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -5020,7 +5050,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    }
 	    yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	    if (!yorn) {
-		err(181, __func__, "please fix your prog.c file");
+		err(183, __func__, "please fix your prog.c file");
 		not_reached();
 	    }
 	    dbg(DBG_MED, "user says that prog.c size: %jd != rule_count function size: %jd is OK",
@@ -5031,7 +5061,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * invalid mode
      */
     } else {
-	err(182, __func__, "invalid mode passed to function: %d", mode);
+	err(184, __func__, "invalid mode passed to function: %d", mode);
 	not_reached();
     }
     return;
@@ -5059,7 +5089,7 @@ warn_nul_chars(void)
 	ret = fprintf(stderr, "\nprog.c has NUL character(s)!\n"
 			      "Be careful you don't violate rule 13!\n\n");
 	if (ret <= 0) {
-	    errp(183, __func__, "fprintf error when printing prog.c nul_warning");
+	    errp(185, __func__, "fprintf error when printing prog.c nul_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -5068,7 +5098,7 @@ warn_nul_chars(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(184, __func__, "please fix your prog.c file");
+	    err(186, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having NUL character(s) is OK");
@@ -5097,7 +5127,7 @@ warn_trigraph(void)
 	ret = fprintf(stderr, "\nprog.c has unknown or invalid trigraph(s) found!\n"
 			      "Is that a bug in, or a feature of your code?\n\n");
 	if (ret <= 0) {
-	    errp(185, __func__, "fprintf error when printing prog.c trigraph_warning");
+	    errp(187, __func__, "fprintf error when printing prog.c trigraph_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -5106,7 +5136,7 @@ warn_trigraph(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(186, __func__, "please fix your prog.c file");
+	    err(188, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c having unknown or invalid trigraph(s) is OK");
@@ -5154,7 +5184,7 @@ warn_ungetc(void)
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
 			      "YOUR remarks.md FILE!\n\n");
 	if (ret <= 0) {
-	    errp(187, __func__, "fprintf error when printing prog.c ungetc_warning");
+	    errp(189, __func__, "fprintf error when printing prog.c ungetc_warning");
             not_reached();
 	}
 	if (abort_on_warning) {
@@ -5163,7 +5193,7 @@ warn_ungetc(void)
 	}
 	yorn = yes_or_no("Are you sure you want to proceed? [Ny]", false);
 	if (!yorn) {
-	    err(188, __func__, "please fix your prog.c file");
+	    err(190, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that prog.c triggering an ungetc warning OK");
@@ -5187,7 +5217,7 @@ warn_rule_2b_size(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(189, __func__, "called with NULL infop");
+	err(191, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -5199,7 +5229,7 @@ warn_rule_2b_size(struct info *infop)
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %ju > Rule 2b maximum: %ju\n",
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
 	if (ret <= 0) {
-	    errp(190, __func__, "printf error printing prog.c size > Rule 2b maximum");
+	    errp(192, __func__, "printf error printing prog.c size > Rule 2b maximum");
 	    not_reached();
 	}
 
@@ -5216,7 +5246,7 @@ warn_rule_2b_size(struct info *infop)
 	}
 	yorn = yes_or_no("Are you sure you want to submit such a large prog.c file? [Ny]", false);
 	if (!yorn) {
-	    err(191, __func__, "please fix your prog.c file");
+	    err(193, __func__, "please fix your prog.c file");
 	    not_reached();
 	}
 	dbg(DBG_MED, "user says that their prog.c size: %ju > Rule 2B max size: %ju is OK",
@@ -5253,7 +5283,7 @@ check_prog_c(struct info *infop, char const *prog_c)
      * firewall
      */
     if (infop == NULL || prog_c == NULL) {
-	err(192, __func__, "called with NULL arg(s)");
+	err(194, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     /*
@@ -5265,7 +5295,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "We cannot find the prog.c file.",
 	      "",
 	      NULL);
-	err(193, __func__, "prog.c does not exist: %s", prog_c);
+	err(195, __func__, "prog.c does not exist: %s", prog_c);
 	not_reached();
     }
     if (!is_file(prog_c)) {
@@ -5274,7 +5304,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(194, __func__, "prog.c is not a regular file: %s", prog_c);
+	err(196, __func__, "prog.c is not a regular file: %s", prog_c);
 	not_reached();
     }
     if (!is_read(prog_c)) {
@@ -5283,7 +5313,7 @@ check_prog_c(struct info *infop, char const *prog_c)
 	      "The prog.c path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(195, __func__, "prog.c is not a readable file: %s", prog_c);
+	err(197, __func__, "prog.c is not a readable file: %s", prog_c);
 	not_reached();
     }
 
@@ -5297,7 +5327,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     prog_stream = fopen(prog_c, "r");
     if (prog_stream == NULL) {
-	errp(196, __func__, "failed to fopen: %s", prog_c);
+	errp(198, __func__, "failed to fopen: %s", prog_c);
 	not_reached();
     }
     size = rule_count(prog_stream);
@@ -5306,7 +5336,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(prog_stream);
     if (ret != 0) {
-	errp(197, __func__, "failed to fclose: %s", prog_c);
+	errp(199, __func__, "failed to fclose: %s", prog_c);
 	not_reached();
     }
 
@@ -5316,7 +5346,7 @@ check_prog_c(struct info *infop, char const *prog_c)
     infop->rule_2a_size = file_size(prog_c);
     dbg(DBG_MED, "Rule 2a size: %jd", (intmax_t)infop->rule_2a_size);
     if (infop->rule_2a_size < 0) {
-	err(198, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
+	err(200, __func__, "file_size error: %jd on prog.c: %s", (intmax_t)infop->rule_2a_size, prog_c);
 	not_reached();
     } else if (infop->rule_2a_size == 0 || infop->rule_2b_size == 0) {
 	warn_empty_prog();
@@ -5448,7 +5478,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
      * firewall
      */
     if (Makefile == NULL || infop == NULL) {
-	err(199, __func__, "called with NULL arg(s)");
+	err(201, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5458,7 +5488,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     stream = fopen(Makefile, "r");
     if (stream == NULL) {
-	errp(200, __func__, "cannot open Makefile: %s", Makefile);
+	errp(202, __func__, "cannot open Makefile: %s", Makefile);
 	not_reached();
     }
 
@@ -5655,7 +5685,7 @@ inspect_Makefile(char const *Makefile, struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(stream);
     if (ret < 0) {
-	errp(201, __func__, "fclose error");
+	errp(203, __func__, "fclose error");
 	not_reached();
     }
 
@@ -5698,7 +5728,7 @@ warn_Makefile(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(202, __func__, "called with NULL infop");
+	err(204, __func__, "called with NULL infop");
 	not_reached();
     }
     if (need_confirm && (!answer_yes || seed_used)) {
@@ -5773,7 +5803,7 @@ warn_Makefile(struct info *infop)
 	if (!answer_yes) {
 	    yorn = yes_or_no("Do you still want to submit this Makefile in the hopes that it is OK? [Ny]", false);
 	    if (!yorn) {
-		err(203, __func__, "Use a different Makefile or modify your Makefile");
+		err(205, __func__, "Use a different Makefile or modify your Makefile");
 		not_reached();
 	    }
 	}
@@ -5802,7 +5832,7 @@ check_Makefile(struct info *infop, char const *Makefile)
      * firewall
      */
     if (infop == NULL || Makefile == NULL) {
-	err(204, __func__, "called with NULL arg(s)");
+	err(206, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5815,7 +5845,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "We cannot find the Makefile.",
 	      "",
 	      NULL);
-	err(205, __func__, "Makefile does not exist: %s", Makefile);
+	err(207, __func__, "Makefile does not exist: %s", Makefile);
 	not_reached();
     }
     if (!is_file(Makefile)) {
@@ -5824,7 +5854,7 @@ check_Makefile(struct info *infop, char const *Makefile)
 	       "The Makefile path, while it exists, is not a regular file.",
 	       "",
 	       NULL);
-	err(206, __func__, "Makefile is not a regular file: %s", Makefile);
+	err(208, __func__, "Makefile is not a regular file: %s", Makefile);
 	not_reached();
     }
     if (!is_read(Makefile)) {
@@ -5833,15 +5863,15 @@ check_Makefile(struct info *infop, char const *Makefile)
 	      "The Makefile path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(207, __func__, "Makefile is not readable file: %s", Makefile);
+	err(209, __func__, "Makefile is not readable file: %s", Makefile);
 	not_reached();
     }
     filesize = file_size(Makefile);
     if (filesize < 0) {
-	err(208, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
+	err(210, __func__, "file_size error: %jd on Makefile  %s", (intmax_t)filesize, Makefile);
 	not_reached();
     } else if (filesize == 0) {
-	err(209, __func__, "Makefile cannot be empty: %s", Makefile);
+	err(211, __func__, "Makefile cannot be empty: %s", Makefile);
 	not_reached();
     }
 
@@ -5879,7 +5909,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
      * firewall
      */
     if (infop == NULL || remarks_md == NULL) {
-	err(210, __func__, "called with NULL arg(s)");
+	err(212, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -5892,7 +5922,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	       "We cannot find the remarks.md file.",
 	       "",
 	       NULL);
-	err(211, __func__, "remarks.md does not exist: %s", remarks_md);
+	err(213, __func__, "remarks.md does not exist: %s", remarks_md);
 	not_reached();
     }
     if (!is_file(remarks_md)) {
@@ -5900,7 +5930,7 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it exists, is not a regular file.",
 	      "",
 	      NULL);
-	err(212, __func__, "remarks.md is not a regular file: %s", remarks_md);
+	err(214, __func__, "remarks.md is not a regular file: %s", remarks_md);
 	not_reached();
     }
     if (!is_read(remarks_md)) {
@@ -5909,15 +5939,15 @@ check_remarks_md(struct info *infop, char const *remarks_md)
 	      "The remarks.md path, while it is a file, is not readable.",
 	      "",
 	      NULL);
-	err(213, __func__, "remarks.md is not readable file: %s", remarks_md);
+	err(215, __func__, "remarks.md is not readable file: %s", remarks_md);
 	not_reached();
     }
     filesize = file_size(remarks_md);
     if (filesize < 0) {
-	err(214, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
+	err(216, __func__, "file_size error: %jd on remarks.md %s", (intmax_t)filesize, remarks_md);
 	not_reached();
     } else if (filesize == 0) {
-	err(215, __func__, "remarks.md cannot be empty: %s", remarks_md);
+	err(217, __func__, "remarks.md cannot be empty: %s", remarks_md);
 	not_reached();
     }
 
@@ -5947,7 +5977,7 @@ yes_or_no(char const *question, bool def_answer)
      * firewall
      */
     if (question == NULL) {
-	err(216, __func__, "called with NULL question");
+	err(218, __func__, "called with NULL question");
 	not_reached();
     }
 
@@ -6066,7 +6096,7 @@ get_title(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(217, __func__, "called with NULL infop");
+	err(219, __func__, "called with NULL infop");
 	not_reached();
     }
 
@@ -6086,7 +6116,7 @@ get_title(struct info *infop)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	if (ret <= 0) {
-	    errp(218, __func__, "fprintf #0 error: %d", ret);
+	    errp(220, __func__, "fprintf #0 error: %d", ret);
             not_reached();
 	}
     }
@@ -6144,7 +6174,7 @@ get_title(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your title must be between 1 and %d ASCII characters long.\n\n", MAX_TITLE_LEN);
 	    if (ret <= 0) {
-		errp(219, __func__, "fprintf #1 error: %d", ret);
+		errp(221, __func__, "fprintf #1 error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -6203,7 +6233,7 @@ get_title(struct info *infop)
             ret = printf("\nThe title you entered is: %s\n",
                          title);
             if (ret <= 0) {
-                errp(220, __func__, "fprintf title");
+                errp(222, __func__, "fprintf title");
                 not_reached();
             }
             yorn = yes_or_no("\nIs that title correct? [Yn]", true);
@@ -6254,7 +6284,7 @@ get_abstract(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-	err(221, __func__, "called with NULL infp");
+	err(223, __func__, "called with NULL infp");
 	not_reached();
     }
 
@@ -6321,7 +6351,7 @@ get_abstract(struct info *infop)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "Your abstract must be between 1 and %d characters long.\n\n", MAX_ABSTRACT_LEN);
 	    if (ret <= 0) {
-		errp(222, __func__, "fprintf error: %d", ret);
+		errp(224, __func__, "fprintf error: %d", ret);
                 not_reached();
 	    }
 	    if (abort_on_warning) {
@@ -6347,7 +6377,7 @@ get_abstract(struct info *infop)
             ret = printf("\nThe abstract you entered is: %s\n",
                          abstract);
             if (ret <= 0) {
-                errp(223, __func__, "fprintf abstract");
+                errp(225, __func__, "fprintf abstract");
                 not_reached();
             }
             yorn = yes_or_no("\nIs that abstract correct? [Yn]", true);
@@ -6550,7 +6580,7 @@ get_author_info(struct author **author_set_p)
      * firewall
      */
     if (author_set_p == NULL) {
-	err(224, __func__, "called with NULL author_set_p");
+	err(226, __func__, "called with NULL author_set_p");
 	not_reached();
     }
 
@@ -6572,20 +6602,20 @@ get_author_info(struct author **author_set_p)
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nThe number of authors must be a number from 1 through %d;\nplease re-enter.\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(225, __func__, "fprintf error #0 while printing author number range");
+		errp(227, __func__, "fprintf error #0 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nIf you happen to have more than %d authors, we ask that you pick\n", MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(226, __func__, "fprintf error #1 while printing author number range");
+		errp(228, __func__, "fprintf error #1 while printing author number range");
                 not_reached();
 	    }
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "just %d authors and mention the remaining NUMBER of the authors in\nthe remarks file.\n",
                     MAX_AUTHORS);
 	    if (ret <= 0) {
-		errp(227, __func__, "fprintf error #2 while printing author number range");
+		errp(229, __func__, "fprintf error #2 while printing author number range");
                 not_reached();
 	    }
 	    author_count = -1;	/* invalidate input */
@@ -6613,7 +6643,7 @@ get_author_info(struct author **author_set_p)
     errno = 0;			/* pre-clear errno for errp() */
     author_set = (struct author *) malloc(sizeof(struct author) * (size_t)author_count);
     if (author_set == NULL) {
-	errp(228, __func__, "malloc a struct author array of length: %d failed", author_count);
+	errp(230, __func__, "malloc a struct author array of length: %d failed", author_count);
 	not_reached();
     }
 
@@ -6649,31 +6679,31 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL0);
 	if (ret < 0) {
-	    errp(229, __func__, "puts error printing ISO 3166-1 URL0");
+	    errp(231, __func__, "puts error printing ISO 3166-1 URL0");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL1);
 	if (ret < 0) {
-	    errp(230, __func__, "puts error printing ISO 3166-1 URL1");
+	    errp(232, __func__, "puts error printing ISO 3166-1 URL1");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL2);
 	if (ret < 0) {
-	    errp(231, __func__, "puts error printing ISO 3166-1 URL2");
+	    errp(233, __func__, "puts error printing ISO 3166-1 URL2");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL3);
 	if (ret < 0) {
-	    errp(232, __func__, "puts error printing ISO 3166-1 URL3");
+	    errp(234, __func__, "puts error printing ISO 3166-1 URL3");
             not_reached();
 	}
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = puts(ISO_3166_1_CODE_URL4);
 	if (ret < 0) {
-	    errp(233, __func__, "puts error printing ISO 3166-1 URL4");
+	    errp(235, __func__, "puts error printing ISO 3166-1 URL4");
             not_reached();
 	}
 	para("",
@@ -6705,7 +6735,7 @@ get_author_info(struct author **author_set_p)
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = printf("\nEnter information for author #%d\n\n", i);
 	if (ret <= 0) {
-	    errp(234, __func__, "printf error printing author number");
+	    errp(236, __func__, "printf error printing author number");
             not_reached();
 	}
 	author_set[i].author_num = i;
@@ -6758,7 +6788,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit names to %d characters\n\n", MAX_NAME_LEN);
 		if (ret <= 0) {
-		    errp(235, __func__, "fprintf error while reject name that is too long");
+		    errp(237, __func__, "fprintf error while reject name that is too long");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6787,7 +6817,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d name duplicates previous author #%d name", i, j);
 			if (ret <= 0) {
-			    errp(236, __func__, "fprintf error while reject duplicate name");
+			    errp(238, __func__, "fprintf error while reject duplicate name");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -6841,7 +6871,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(237, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
+		    errp(239, __func__, "fprintf while printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6851,19 +6881,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "%s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(238, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
+		    errp(240, __func__, "fprintf while printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(239, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
+		    errp(241, __func__, "fprintf while printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(240, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
+		    errp(242, __func__, "fprintf while printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6912,7 +6942,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL0);
 		if (ret <= 0) {
-		    errp(241, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
+		    errp(243, __func__, "fprintf when printing ISO 3166-1 CODE URL #0");
                     not_reached();
 		}
 		fpara(stderr,
@@ -6922,19 +6952,19 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL1);
 		if (ret <= 0) {
-		    errp(242, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
+		    errp(244, __func__, "fprintf when printing ISO 3166-1 CODE URL #1");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n", ISO_3166_1_CODE_URL2);
 		if (ret <= 0) {
-		    errp(243, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
+		    errp(245, __func__, "fprintf when printing ISO 3166-1 CODE URL #2");
                     not_reached();
 		}
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "    %s\n\n", ISO_3166_1_CODE_URL3);
 		if (ret <= 0) {
-		    errp(244, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
+		    errp(246, __func__, "fprintf when printing ISO 3166-1 CODE URL #3");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -6969,7 +6999,7 @@ get_author_info(struct author **author_set_p)
 		ret = printf("\nThe location/country code you entered is assigned to: %s (%s)\n",
 			     author_set[i].location_name, author_set[i].common_name);
 		if (ret <= 0) {
-		    errp(245, __func__, "fprintf location/country code assignment");
+		    errp(247, __func__, "fprintf location/country code assignment");
                     not_reached();
 		}
 		yorn = yes_or_no("\nIs that location/country code correct? [Yn]", true);
@@ -7024,7 +7054,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit email address to %d characters\n", MAX_EMAIL_LEN);
 		if (ret <= 0) {
-		    errp(246, __func__, "fprintf error while printing Email address length limit");
+		    errp(248, __func__, "fprintf error while printing Email address length limit");
                     not_reached();
 		}
 		fpara(stderr,
@@ -7082,7 +7112,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters.\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(247, __func__, "fprintf error while printing URL length limit");
+		    errp(249, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7178,7 +7208,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit URLs to %d characters\n\n", MAX_URL_LEN);
 		if (ret <= 0) {
-		    errp(248, __func__, "fprintf error while printing URL length limit");
+		    errp(10, __func__, "fprintf error while printing URL length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7274,7 +7304,7 @@ get_author_info(struct author **author_set_p)
 		ret = fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit Mastodon handles to %d "
 			"characters, starting with the @\n\n", MAX_MASTODON_LEN);
 		if (ret <= 0) {
-		    errp(249, __func__, "fprintf error while printing mastodon handle length limit");
+		    errp(11, __func__, "fprintf error while printing mastodon handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7364,7 +7394,7 @@ get_author_info(struct author **author_set_p)
 			    "\nSorry ( tm Canada :-) ), we limit GitHub account names to %d characters after the 1st @.\n\n",
 			    MAX_GITHUB_LEN);
 		if (ret <= 0) {
-		    errp(10, __func__, "fprintf error while printing GitHub user length limit");
+		    errp(12, __func__, "fprintf error while printing GitHub user length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7451,7 +7481,7 @@ get_author_info(struct author **author_set_p)
 		    fprintf(stderr, "\nSorry ( tm Canada :-) ), we limit affiliation names to %d characters\n\n",
 			    MAX_AFFILIATION_LEN);
 		if (ret <= 0) {
-		    errp(11, __func__, "fprintf error while printing affiliation length limit");
+		    errp(13, __func__, "fprintf error while printing affiliation length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7528,7 +7558,7 @@ get_author_info(struct author **author_set_p)
 	     */
 	    def_handle = default_handle(author_set[i].name);
 	    if (def_handle == NULL) {
-		err(12, __func__, "default_handle() returned NULL!");
+		err(14, __func__, "default_handle() returned NULL!");
 		not_reached();
 	    }
 	    dbg(DBG_VHIGH, "default IOCCC author handle: <%s>", def_handle);
@@ -7536,7 +7566,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = printf("\nThe default IOCCC author handle for author #%d is:\n\n    %s\n\n", i, def_handle);
 		if (ret <= 0) {
-		    errp(13, __func__, "fprintf error while printing default IOCCC author handle");
+		    errp(15, __func__, "fprintf error while printing default IOCCC author handle");
                     not_reached();
 		}
 	    }
@@ -7599,7 +7629,7 @@ get_author_info(struct author **author_set_p)
 		errno = 0;		/* pre-clear errno for errp() */
 		ret = fprintf(stderr, "\nThe IOCCC author handle is limited to %d characters\n\n", MAX_HANDLE);
 		if (ret <= 0) {
-		    errp(14, __func__, "fprintf error while printing IOCCC author handle length limit");
+		    errp(16, __func__, "fprintf error while printing IOCCC author handle length limit");
                     not_reached();
 		}
 		if (abort_on_warning) {
@@ -7630,7 +7660,7 @@ get_author_info(struct author **author_set_p)
 			errno = 0;		/* pre-clear errno for errp() */
 			ret = fprintf(stderr, "\nauthor #%d author_handle duplicates previous author #%d author_handle", i, j);
 			if (ret <= 0) {
-			    errp(15, __func__, "fprintf error while printing duplicate author_handle error");
+			    errp(17, __func__, "fprintf error while printing duplicate author_handle error");
                             not_reached();
 			}
 			if (abort_on_warning) {
@@ -7677,7 +7707,7 @@ get_author_info(struct author **author_set_p)
 						      printf("IOCCC author handle was manually entered\n"))  <= 0 ||
 	    ((author_set[i].author_handle[0] == '\0') ? printf("IOCCC author handle\n\n") :
 						        printf("IOCCC author handle: %s\n\n", author_set[i].author_handle)) <= 0) {
-	    errp(16, __func__, "error while printing author #%d information\n", i);
+	    errp(18, __func__, "error while printing author #%d information\n", i);
 	    not_reached();
 	}
 	if (need_confirm) {
@@ -7731,7 +7761,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * firewall
      */
     if (submission_dir == NULL || ls == NULL) {
-	err(17, __func__, "called with NULL arg(s)");
+	err(19, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -7744,7 +7774,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", submission_dir);
     if (ret <= 0) {
-	errp(18, __func__, "printf error code: %d", ret);
+	errp(20, __func__, "printf error code: %d", ret);
         not_reached();
     }
     para("",
@@ -7754,7 +7784,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to perform: cd -- %s && %s -lakR .", submission_dir, ls);
     exit_code = shell_cmd(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (exit_code != 0) {
-	err(19, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
+	err(21, __func__, "cd -- %s && %s -lakR . failed with exit code: %d",
 			   submission_dir, ls, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -7765,7 +7795,7 @@ verify_submission_dir(char const *submission_dir, char const *ls)
     dbg(DBG_HIGH, "about to popen: cd -- %s && %s -lakR .", submission_dir, ls);
     ls_stream = pipe_open(__func__, false, true, "cd -- % && % -lakR .", submission_dir, ls);
     if (ls_stream == NULL) {
-	err(20, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
+	err(22, __func__, "popen filed for: cd -- %s && %s -lakR .", submission_dir, ls);
 	not_reached();
     }
 
@@ -7797,18 +7827,18 @@ verify_submission_dir(char const *submission_dir, char const *ls)
      * no line was read at all
      */
     if (readline_len < 0 && i == 0) {
-	err(21, __func__, "EOF while reading output of ls: %s", ls);
+	err(23, __func__, "EOF while reading output of ls: %s", ls);
 	not_reached();
     }
     /*
      * lines were read from ls but nothing correct was found
      */
     if (i == 0) {
-        err(22, __func__, "found no k-block line in ls output");
+        err(24, __func__, "found no k-block line in ls output");
         not_reached();
     }
     if (kdirsize <= 0) {
-	err(23, __func__, "ls k-block value: %d <= 0", kdirsize);
+	err(25, __func__, "ls k-block value: %d <= 0", kdirsize);
 	not_reached();
     }
     dbg(DBG_MED, "Directory %s size in kibibyte (1024 byte blocks): %d", submission_dir, kdirsize);
@@ -7887,7 +7917,7 @@ form_info(struct info *infop)
      * firewall
      */
     if (infop == NULL) {
-        err(24, __func__, "passed NULL infop");
+        err(26, __func__, "passed NULL infop");
         not_reached();
     }
     /*
@@ -7906,13 +7936,13 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     ret = setenv("TZ", "UTC", 1);
     if (ret < 0) {
-	errp(25, __func__, "cannot set TZ=UTC");
+	errp(27, __func__, "cannot set TZ=UTC");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     timeptr = gmtime(&(infop->tstamp));
     if (timeptr == NULL) {
-	errp(26, __func__, "gmtime returned NULL");
+	errp(28, __func__, "gmtime returned NULL");
 	not_reached();
     }
 
@@ -7923,7 +7953,7 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     infop->utctime = (char *)calloc(utctime_len + 1, sizeof(char)); /* + 1 for paranoia padding */
     if (infop->utctime == NULL) {
-	errp(27, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
+	errp(29, __func__, "calloc of %ju bytes failed", (uintmax_t)utctime_len + 1);
 	not_reached();
     }
 
@@ -7938,7 +7968,7 @@ form_info(struct info *infop)
     errno = 0;			/* pre-clear errno for errp() */
     strftime_ret = strftime(infop->utctime, utctime_len, "%a %b %d %H:%M:%S %Y UTC", timeptr);
     if (strftime_ret == 0) {
-	errp(28, __func__, "strftime returned 0");
+	errp(30, __func__, "strftime returned 0");
 	not_reached();
     }
     dbg(DBG_VHIGH, "infop->utctime: %s", infop->utctime);
@@ -7980,7 +8010,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * firewall
      */
     if (infop == NULL || authp == NULL || submission_dir == NULL || chkentry == NULL) {
-        err(29, __func__, "called with NULL arg(s)");
+        err(31, __func__, "called with NULL arg(s)");
         not_reached();
     }
 
@@ -7988,10 +8018,10 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * first write .auth.json
      */
     if (authp->author_count <= 0) {
-	err(30, __func__, "author_count %d <= 0", authp->author_count);
+	err(32, __func__, "author_count %d <= 0", authp->author_count);
 	not_reached();
     } else if (authp->author_count > MAX_AUTHORS) {
-	err(31, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
+	err(33, __func__, "author count %d > max authors %d", authp->author_count, MAX_AUTHORS);
 	not_reached();
     }
 
@@ -8002,27 +8032,27 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     auth_path = (char *)malloc(auth_path_len + 1);
     if (auth_path == NULL) {
-	errp(32, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
+	errp(34, __func__, "malloc of %ju bytes failed", (uintmax_t)auth_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(auth_path, auth_path_len, "%s/%s", submission_dir, AUTH_JSON_FILENAME);
     if (ret <= 0) {
-	errp(33, __func__, "snprintf #0 error: %d", ret);
+	errp(35, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".auth.json path: %s", auth_path);
     errno = 0;			/* pre-clear errno for errp() */
     auth_stream = fopen(auth_path, "w");
     if (auth_stream == NULL) {
-	errp(34, __func__, "failed to open for writing: %s", auth_path);
+	errp(36, __func__, "failed to open for writing: %s", auth_path);
 	not_reached();
     }
 
     errno = 0; /* pre-clear errno for errp() */
     fd = open(auth_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        err(35, __func__, "failed to obtain file descriptor for: %s", auth_path);
+        err(37, __func__, "failed to obtain file descriptor for: %s", auth_path);
         not_reached();
     }
 
@@ -8045,7 +8075,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_bool(auth_stream, "    ", "test_mode", " : ", authp->test_mode, ",\n") &&
 	fprintf(auth_stream, "    \"authors\" : [\n") > 0;
     if (!ret) {
-	errp(36, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
+	errp(38, __func__, "fprintf error writing leading part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -8072,7 +8102,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	    json_fprintf_value_long(auth_stream, "            ", "author_number", " : ", ap->author_num, "\n") &&
 	    fprintf(auth_stream, "        }%s\n", (((i + 1) < authp->author_count) ? "," : "")) > 0;
 	if (ret == false) {
-	    errp(37, __func__, "fprintf error writing author %d info to %s", i, auth_path);
+	    errp(39, __func__, "fprintf error writing author %d info to %s", i, auth_path);
 	    not_reached();
 	}
     }
@@ -8088,7 +8118,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_long(auth_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(auth_stream, "}\n") > 0;
     if (!ret) {
-	errp(38, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
+	errp(40, __func__, "fprintf error writing trailing part of authorship to %s", auth_path);
 	not_reached();
     }
 
@@ -8098,7 +8128,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(auth_stream);
     if (ret < 0) {
-	errp(39, __func__, "fclose error");
+	errp(41, __func__, "fclose error");
 	not_reached();
     }
 
@@ -8108,7 +8138,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(40, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
+        err(42, __func__, "chmod(2) failed to set user, group and other read-only on %s", auth_path);
         not_reached();
     }
 
@@ -8118,7 +8148,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0; /* pre-clear for errp() */
     ret = close(fd);
     if (ret < 0) {
-        errp(41, __func__, "close(fd) failed");
+        errp(43, __func__, "close(fd) failed");
         not_reached();
     }
 
@@ -8126,7 +8156,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
      * now write .info.json
      */
     if (infop->required_files == NULL) {
-        err(42, __func__, "called with NULL files list");
+        err(44, __func__, "called with NULL files list");
         not_reached();
     }
 
@@ -8137,20 +8167,20 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     info_path = (char *)malloc(info_path_len + 1);
     if (info_path == NULL) {
-	errp(43, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
+	errp(45, __func__, "malloc of %ju bytes failed", (uintmax_t)info_path_len + 1);
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = snprintf(info_path, info_path_len, "%s/%s", submission_dir, INFO_JSON_FILENAME);
     if (ret <= 0) {
-	errp(44, __func__, "snprintf #0 error: %d", ret);
+	errp(46, __func__, "snprintf #0 error: %d", ret);
 	not_reached();
     }
     dbg(DBG_HIGH, ".info.json path: %s", info_path);
     errno = 0;			/* pre-clear errno for errp() */
     info_stream = fopen(info_path, "w");
     if (info_stream == NULL) {
-	errp(45, __func__, "failed to open for writing: %s", info_path);
+	errp(47, __func__, "failed to open for writing: %s", info_path);
 	not_reached();
     }
 
@@ -8160,7 +8190,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0; /* pre-clear errno for errp() */
     fd = open(info_path, O_WRONLY|O_CLOEXEC, S_IRWXU);
     if (fd < 0) {
-        errp(46, __func__, "failed to obtain file descriptor for: %s", info_path);
+        errp(48, __func__, "failed to obtain file descriptor for: %s", info_path);
         not_reached();
     }
 
@@ -8203,7 +8233,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_bool(info_stream, "    ", "test_mode", " : ", infop->test_mode, ",\n") &&
 	fprintf(info_stream, "    \"manifest\" : [\n") > 0;
     if (!ret) {
-	errp(47, __func__, "fprintf error writing leading part of info to %s", info_path);
+	errp(49, __func__, "fprintf error writing leading part of info to %s", info_path);
 	not_reached();
     }
 
@@ -8236,7 +8266,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	  json_fprintf_value_string(info_stream, "            ", "remarks", " : ", "remarks.md", "\n") &&
 			    fprintf(info_stream, "        }%s\n", (infop->extra_count > 0) ?  "," : "") > 0;
     if (!ret) {
-	errp(48, __func__, "fprintf error writing mandatory filename to %s", info_path);
+	errp(50, __func__, "fprintf error writing mandatory filename to %s", info_path);
 	not_reached();
     }
 
@@ -8247,14 +8277,14 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
         for (j = 0; j < infop->extra_count; ++j) {
             p = dyn_array_value(infop->extra_files, char *, j);
             if (p == NULL) {
-                err(49, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)j);
+                err(51, __func__, "found NULL pointer in files list, element: %ju", (uintmax_t)j);
                 not_reached();
             }
             ret =                   fprintf(info_stream, "        {\n") > 0 &&
                   json_fprintf_value_string(info_stream, "            ", "extra_file", " : ", p, "\n") &&
                                     fprintf(info_stream, "        }%s\n", ((j+1) < infop->extra_count) ?  "," : "") > 0;
             if (!ret) {
-                errp(50, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)j, info_path);
+                errp(52, __func__, "fprintf error writing extra filename[%ju] to %s", (uintmax_t)j, info_path);
                 not_reached();
             }
         }
@@ -8270,7 +8300,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
 	json_fprintf_value_long(info_stream, "    ", "min_timestamp", " : ", MIN_TIMESTAMP, "\n") &&
 	fprintf(info_stream, "}\n") > 0;
     if (!ret) {
-	errp(51, __func__, "fprintf error writing trailing part of info to %s", info_path);
+	errp(53, __func__, "fprintf error writing trailing part of info to %s", info_path);
 	not_reached();
     }
 
@@ -8280,7 +8310,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;			/* pre-clear errno for errp() */
     ret = fclose(info_stream);
     if (ret < 0) {
-	errp(52, __func__, "fclose error");
+	errp(54, __func__, "fclose error");
 	not_reached();
     }
 
@@ -8291,7 +8321,7 @@ write_json_files(struct auth *authp, struct info *infop, char const *submission_
     errno = 0;      /* pre-clear errno for errp() */
     ret = fchmod(fd, S_IRUSR | S_IRGRP | S_IROTH);
     if (ret != 0) {
-        err(53, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
+        err(55, __func__, "chmod(2) failed to set user, group and other read-only on %s", info_path);
         not_reached();
     }
 
@@ -8343,19 +8373,19 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
      * firewall
      */
     if (authp == NULL || infop == NULL || authorp == NULL) {
-	err(54, __func__, "called with NULL arg(s)");
+	err(56, __func__, "called with NULL arg(s)");
 	not_reached();
     }
     if (infop->ioccc_id == NULL) {
-	err(55, __func__, "infop->ioccc_id is NULL");
+	err(57, __func__, "infop->ioccc_id is NULL");
 	not_reached();
     }
     if (infop->tarball == NULL) {
-	err(56, __func__, "infop->tarball is NULL");
+	err(58, __func__, "infop->tarball is NULL");
 	not_reached();
     }
     if (infop->utctime == NULL) {
-	err(57, __func__, "infop->utctime is NULL");
+	err(59, __func__, "infop->utctime is NULL");
 	not_reached();
     }
     memset(authp, 0, sizeof(*authp));
@@ -8379,14 +8409,14 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->ioccc_id = strdup(infop->ioccc_id);
     if (authp->ioccc_id == NULL) {
-	errp(58, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
+	errp(60, __func__, "strdup() ioccc_id path %s failed", infop->ioccc_id);
 	not_reached();
     }
     authp->submit_slot = infop->submit_slot;
     errno = 0;			/* pre-clear errno for errp() */
     authp->tarball = strdup(infop->tarball);
     if (authp->tarball == NULL) {
-	errp(59, __func__, "strdup() tarball path %s failed", infop->tarball);
+	errp(61, __func__, "strdup() tarball path %s failed", infop->tarball);
 	not_reached();
     }
     /* copy over test or non-test mode */
@@ -8408,7 +8438,7 @@ form_auth(struct auth *authp, struct info *infop, int author_count, struct autho
     errno = 0;			/* pre-clear errno for errp() */
     authp->utctime = strdup(infop->utctime);
     if (authp->utctime == NULL) {
-	errp(60, __func__, "strdup() utctime path %s failed", infop->utctime);
+	errp(62, __func__, "strdup() utctime path %s failed", infop->utctime);
 	not_reached();
     }
     return;
@@ -8451,7 +8481,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
      */
     if (workdir == NULL || submission_dir == NULL || tarball_path == NULL || tar == NULL || ls == NULL ||
         txzchk == NULL || fnamchk == NULL) {
-	err(61, __func__, "called with NULL arg(s)");
+	err(63, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
@@ -8467,7 +8497,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     cwd = open(".", O_RDONLY|O_DIRECTORY|O_CLOEXEC);
     if (cwd < 0) {
-	errp(62, __func__, "cannot open .");
+	errp(64, __func__, "cannot open .");
 	not_reached();
     }
 
@@ -8477,7 +8507,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = chdir(workdir);
     if (ret < 0) {
-	errp(63, __func__, "cannot cd %s", workdir);
+	errp(65, __func__, "cannot cd %s", workdir);
 	not_reached();
     }
 
@@ -8505,7 +8535,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     exit_code = shell_cmd(__func__, false, true, "tar --format=v7 -cJf % -- %",
 				    basename_tarball_path, basename_submission_dir);
     if (exit_code != 0) {
-	err(64, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
+	err(66, __func__, "%s --format=v7 -cJf %s -- %s failed with exit code: %d",
 			   tar, basename_tarball_path, basename_submission_dir, WEXITSTATUS(exit_code));
 	not_reached();
     }
@@ -8516,7 +8546,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = stat(basename_tarball_path, &buf);
     if (ret != 0) {
-	errp(65, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
+	errp(67, __func__, "stat of the compressed tarball failed: %s", basename_tarball_path);
 	not_reached();
     }
     if (buf.st_size > MAX_TARBALL_LEN) {
@@ -8525,7 +8555,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
 	      "The compressed tarball exceeds the maximum allowed size, sorry.",
 	      "",
 	      NULL);
-	err(66, __func__, "The compressed tarball: %s size: %ju > %jd",
+	err(68, __func__, "The compressed tarball: %s size: %ju > %jd",
 		 basename_tarball_path, (uintmax_t)buf.st_size, (intmax_t)MAX_TARBALL_LEN);
 	not_reached();
     }
@@ -8536,13 +8566,13 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
     errno = 0;			/* pre-clear errno for errp() */
     ret = fchdir(cwd);
     if (ret < 0) {
-	errp(67, __func__, "cannot fchdir to the previous current directory");
+	errp(69, __func__, "cannot fchdir to the previous current directory");
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
     ret = close(cwd);
     if (ret < 0) {
-	errp(68, __func__, "close of previous current directory failed");
+	errp(70, __func__, "close of previous current directory failed");
 	not_reached();
     }
 
@@ -8563,10 +8593,10 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         }
         if (exit_code != 0) {
             if (test_mode) {
-                err(69, __func__, "%s -x -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(71, __func__, "%s -x -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, feathery, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             } else {
-                err(70, __func__, "%s -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(72, __func__, "%s -e -f %ju -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                                txzchk, feathery, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             }
             not_reached();
@@ -8586,10 +8616,10 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
         }
         if (exit_code != 0) {
             if (test_mode) {
-                err(71, __func__, "%s -x -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(73, __func__, "%s -x -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                    txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             } else {
-                err(72, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
+                err(74, __func__, "%s -w -v 1 -F %s -- %s/../%s failed with exit code: %d",
                    txzchk, fnamchk, submission_dir, basename_tarball_path, WEXITSTATUS(exit_code));
             }
             not_reached();
@@ -8640,13 +8670,13 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
      * firewall
      */
     if (workdir == NULL || submission_dir == NULL || tar == NULL || tarball_path == NULL) {
-	err(73, __func__, "called with NULL arg(s)");
+	err(75, __func__, "called with NULL arg(s)");
 	not_reached();
     }
 
     submission_dir_esc = cmdprintf("%", submission_dir);
     if (submission_dir_esc == NULL) {
-	err(74, __func__, "failed to cmdprintf: submission_dir");
+	err(76, __func__, "failed to cmdprintf: submission_dir");
 	not_reached();
     }
 
@@ -8659,14 +8689,14 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    rm -rf %s%s\n", submission_dir[0] == '-' ? "-- " : "", submission_dir_esc);
     if (ret <= 0) {
-	errp(75, __func__, "printf #0 error");
+	errp(77, __func__, "printf #0 error");
 	not_reached();
     }
     free(submission_dir_esc);
 
     workdir_esc = cmdprintf("%", workdir);
     if (workdir_esc == NULL) {
-	err(76, __func__, "failed to cmdprintf: workdir");
+	err(78, __func__, "failed to cmdprintf: workdir");
 	not_reached();
     }
 
@@ -8677,7 +8707,7 @@ remind_user(char const *workdir, char const *submission_dir, char const *tar, ch
 	 NULL);
     ret = printf("    %s -Jtvf %s%s/%s\n", tar, workdir[0] == '-' ? "./" : "", workdir_esc, tarball_path);
     if (ret <= 0) {
-	errp(77, __func__, "printf #2 error");
+	errp(79, __func__, "printf #2 error");
 	not_reached();
     }
     free(workdir_esc);
@@ -8749,7 +8779,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_URL);
     if (ret <= 0) {
-	errp(78, __func__, "printf error printing IOCCC_REGISTER_URL");
+	errp(80, __func__, "printf error printing IOCCC_REGISTER_URL");
 	not_reached();
     }
     para("",
@@ -8759,7 +8789,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_REGISTER_FAQ_URL);
     if (ret <= 0) {
-	errp(79, __func__, "printf error printing IOCCC register FAQ URL");
+	errp(81, __func__, "printf error printing IOCCC register FAQ URL");
 	not_reached();
     }
     para("",
@@ -8769,7 +8799,7 @@ show_registration_url(void)
     errno = 0;		/* pre-clear errno for errp() */
     ret = printf("    %s\n    %s\n    %s\n", IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL, IOCCC_SUBMIT_INFO_URL);
     if (ret <= 0) {
-	errp(80, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
+	errp(82, __func__, "printf error printing IOCCC_REGISTER_INFO_URL, IOCCC_PW_CHANGE_INFO_URL and IOCCC_SUBMIT_INFO_URL");
 	not_reached();
     }
 
@@ -8781,7 +8811,7 @@ show_registration_url(void)
     errno = 0;      /* pre-clear errno for errp() */
     ret = printf("    %s\n", IOCCC_STATUS_URL);
     if (ret < 0) {
-	errp(81, __func__, "printf error printing IOCCC status URL");
+	errp(83, __func__, "printf error printing IOCCC status URL");
 	not_reached();
     }
 
@@ -8818,7 +8848,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
         "after you have registered, you must upload into slot %d:\n\n\t%s/%s\n", slot_number,
         workdir, tarball_path);
     if (ret <= 0) {
-	errp(82, __func__, "printf error printing tarball path and slot number");
+	errp(84, __func__, "printf error printing tarball path and slot number");
 	not_reached();
     }
     para("",
@@ -8828,7 +8858,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
     ret = printf("    %s\n", IOCCC_SUBMIT_URL);
     if (ret < 0) {
-	errp(83, __func__, "printf error printing IOCCC submit URL");
+	errp(85, __func__, "printf error printing IOCCC submit URL");
 	not_reached();
     }
 
@@ -8839,7 +8869,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
 
      ret = printf("    %s\n", IOCCC_ENTER_FAQ_URL);
     if (ret < 0) {
-	errp(84, __func__, "printf error printing IOCCC enter FAQ URL");
+	errp(86, __func__, "printf error printing IOCCC enter FAQ URL");
 	not_reached();
     }
 }

--- a/soup/man/man1/txzchk.1
+++ b/soup/man/man1/txzchk.1
@@ -26,7 +26,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH txzchk 1 "19 February 2025" "txzchk" "IOCCC tools"
+.TH txzchk 1 "04 April 2025" "txzchk" "IOCCC tools"
 .SH NAME
 .B txzchk
 \- sanity checker tool used on IOCCC compressed tarballs
@@ -254,16 +254,13 @@ have to be used):
 .PP
 The IOCCC tools
 .BR txzchk (1),
-\&, the test suite
+the test suite
 .BR txzchk_test (8),
 .BR fnamchk (1)
 and
-.BR mkiocccentry (1).
-.br
-The tarry
+.BR mkiocccentry (1)
+along with the tarry
 .BR tar (1)
-command itself.
-.br
-And don't forget the very tarry
+command itself; and don't forget about the very tarry
 .BR La\ Brea\ Tar\ Pits :
 .IR <https://tarpits.org> !

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-04-24"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.6 2025-04-25"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.4 2025-04-24"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.5 2025-04-25"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-03-15"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.5 2025-04-24"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.3 2025-03-14"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.4 2025-04-24"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */


### PR DESCRIPTION

mkiocccentry must run make clobber before scanning the topdir and then 
also later when running the checks. This is because if someone tests
their code in their topdir anything compiled will be included as extra
files (unless forbidden) but if the make clobber that follows removes
any of those files the extra files list will be the wrong size. So now
one can test from the topdir and then not have this problem.

Updated MKIOCCCENTRY_VERSION to "2.0.5 2025-04-25".