### PR TITLE
Add temporary workaround for issue #1258

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.4.8 2025-05-02
+
+Add temporary workaround for issue #1258. It might be that the real fix involves
+an update to a jparse routine but during the IOCCC28 itself that is not going to
+be looked at and it is arguable it is not even a good idea to do that anyway.
+Instead for the time being in the problematic code an extra check is done with
+another FTS related routine I had written last year (I guess) in jparse. An XXX
+comment was added to chkentry.c but it might be (unsure as this was done
+quickly) that a fix in jparse/util.c has to be done instead. That's TBD later
+on.
+
+Updated `CHKENTRY_VERSION` to `"2.0.4 2025-05-02"`.
+
+
 ## Release 2.4.7 2025-04-30
 
 Fix annoying bug where `-i answers` would warn about using the answer yes

--- a/chkentry.c
+++ b/chkentry.c
@@ -1362,6 +1362,11 @@ main(int argc, char *argv[])
          * NOTE: an empty string means find all paths not ignored. And since the
          * list of paths to ignore is already in the fts->ignore list we
          * don't need to do anything special.
+         *
+         * XXX - there appears to be a bug or issue in the find_paths() function
+         * and during IOCCC28 that cannot be looked at in more detail. Thus we
+         * also do check if the path is in our ignore list. After IOCCC28 closes
+         * this can be looked at more.
          */
         found = find_paths(paths, *submission_dir, -1, &cwd, false, &fts);
         if (found != NULL) {
@@ -1376,6 +1381,15 @@ main(int argc, char *argv[])
                 if (u == NULL) {
                     err(72, __func__, "NULL pointer in found files list");
                     not_reached();
+                }
+
+                /*
+                 * XXX - temporary workaround for ignored paths that are not
+                 * files/directories until a better fix can be done (post
+                 * IOCCC28)
+                 */
+                if (find_path_in_array(u, ignored_paths, true, NULL)) {
+                    continue;
                 }
 
                 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.7 2025-04-30"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.8 2025-05-02"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -132,7 +132,7 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.0.3 2025-03-14"	/* format: major.minor YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.0.4 2025-05-02"	/* format: major.minor YYYY-MM-DD */
 #define MIN_CHKENTRY_VERSION "2.0.1 2025-03-02"
 
 /*


### PR DESCRIPTION
Add temporary workaround for issue #1258. It might be that the real fix involves an update to a jparse routine but during the IOCCC28 itself that is not going to be looked at and it is arguable it is not even a good idea to do that anyway.  Instead for the time being in the problematic code an extra check is done with another FTS related routine I had written last year (I guess) in jparse. An XXX comment was added to chkentry.c but it might be (unsure as this was done quickly) that a fix in jparse/util.c has to be done instead. That's TBD later on.

Updated CHKENTRY_VERSION to "2.0.4 2025-05-02".