### PR TITLE
Fix check_location_table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.9 2025-06-04
+
+Fix bug where `-i answers` did not warn about issues found in prog.c and
+Makefile.
+
+
 ## Release 2.4.8 2025-05-05
 
 Allow a submitter's system clock to be as much as 48 hours in the future before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.10 2025-06-05
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` with new
+utility function for issue #1263 - and a minor optimisation to `read_fts()`.
+
+Slight format fix in txzchk.
+
+
 ## Release 2.4.9 2025-06-04
 
 Fix bug where `-i answers` did not warn about issues found in prog.c and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.10 2025-06-06
+
+When `-Y` is used, don't show warnings even if `-i answers` is used as that was
+the point of it (one should use this with caution as it answers yes to every
+question automatically). It is unclear if this should show the list of
+files/directories to be copied (showing the contents of the tarball is part of
+txzchk's algorithm so this is unrelated) as it currently does.  It is also
+unclear if the use of `-Y` should show warnings but just not confirm. Given that
+one is just an informational notice and that one does say something (at least if
+the function is called), even pointing out that one might wish to note it in
+their remarks, it might be better to always show but that really depends on what
+other people want (the point of `-Y` in any case is to always answer yes even
+when the answers file is used, as some people do in fact want this).
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.9 2025-06-06"`.
+
+
 ## Release 2.4.10 2025-06-05
 
 Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` with new

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.11 2025-06-08
+
+Don't install prep.sh or hostchk.sh. The uninstall rule still removes these
+files to clean out systems which had this problem. Assuming all is already
+compiled one could do `sudo make uninstall install` to clean up their system.
+Otherwise one should do `make; sudo make uninstall install` as trying to compile
+the tools with root will cause problems when trying to run `make` again (due to
+ownership change).
+
+
+
 ## Release 2.4.10 2025-06-06
 
 When `-Y` is used, don't show warnings even if `-i answers` is used as that was

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.12 2025-06-11
+
+Bug fix `check_location_table()` - when the function was moved to
+`location_util.c` it broke the `__FILE__` macro in the check.
+
+Moved `LOCATION_VERSION` to `soup/version.h` (instead of
+`soup/location_main.c`).
+
+Updated `SOUP_VERSION` to `2.0.2 2025-06-11"`.
+Updated `LOCATION_VERSION` to `"1.0.5 2024-06-11"`.
+
+Run `make depend` for the move of `LOCATION_VERSION` to `soup/version.h`.
+
+
 ## Release 2.4.11 2025-06-08
 
 Don't install prep.sh or hostchk.sh. The uninstall rule still removes these

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,21 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.2.39 2025-06-05
+
+Added `size_if_file()` which will return the `st_size` (from `stat(2)`) if the
+path exists and `stat(2)` does not fail on it and it is a regular file. It is an
+error if the path is NULL. For all other cases 0 is returned.
+
+Check ignored file list `read_fts()` before checking file type as there is no
+point in checking the file type if the file is to be ignored.
+
+Updated `util_test` to test this new function.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.9 2025-06-05"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.4 2025-06-05"`.
+
+
 ## Release 2.2.38 2025-03-15
 
 Add `setlocale(LC_ALL, "");` to all `main()` functions.

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -316,6 +316,7 @@ extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);
 extern off_t file_size(char const *path);
+extern off_t size_if_file(char const *path);
 extern bool is_empty(char const *path);
 extern char *cmdprintf(char const *format, ...);
 extern char *vcmdprintf(char const *format, va_list ap);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.8 2025-03-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.38 2025-06-05"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.8 2025-03-15"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.9 2025-06-05"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1033,7 +1033,7 @@ main(int argc, char *argv[])
 	    info.Makefile_override) {
 
 	    do {
-		if (!ignore_warnings) {
+		if (!ignore_warnings || read_answers_flag_used) {
 		    need_confirm = true;
 
 		    if (info.empty_override) {
@@ -5061,7 +5061,7 @@ warn_empty_prog(void)
     bool yorn = false;
 
     dbg(DBG_MED, "prog.c is empty");
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	fpara(stderr,
 	  "WARNING: prog.c is empty.  An empty prog.c has been submitted before:",
 	  "",
@@ -5129,7 +5129,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    errp(182, __func__, "fprintf error when printing prog.c Rule 2a warning");
             not_reached();
 	}
-	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	    fpara(stderr,
 	      "If you are attempting some clever rule abuse, then we STRONGLY",
               "suggest that you tell us about your rule abuse towards the TOP",
@@ -5154,7 +5154,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * File size and iocccsize file size differ warning
      */
     } else if (mode == RULE_2A_BIG_FILE_WARNING) {
-	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nInteresting: prog.c file size: %jd != rule_count function size: %jd\n"
 				  "In order to avoid a possible Rule 2a violation, BE SURE TO CLEARLY MENTION THIS IN\n"
@@ -5203,7 +5203,7 @@ warn_nul_chars(void)
     /*
      * warn about NUL chars(s) if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c has NUL character(s)!\n"
 			      "Be careful you don't violate rule 13!\n\n");
@@ -5241,7 +5241,7 @@ warn_trigraph(void)
     /*
      * warn the user about unknown or invalid trigraph(s), if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c has unknown or invalid trigraph(s) found!\n"
 			      "Is that a bug in, or a feature of your code?\n\n");
@@ -5297,7 +5297,7 @@ warn_ungetc(void)
     /*
      * warn the user abort iocccsize ungetc error, if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c triggered an ungetc error: @SirWumpus goofed\n"
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
@@ -5343,7 +5343,7 @@ warn_rule_2b_size(struct info *infop)
     /*
      * warn the user about a possible Rule 2b violation, if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %ju > Rule 2b maximum: %ju\n",
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
@@ -5850,7 +5850,7 @@ warn_Makefile(struct info *infop)
 	err(206, __func__, "called with NULL infop");
 	not_reached();
     }
-    if (need_confirm && (!answer_yes || seed_used)) {
+    if ((need_confirm && (!answer_yes || seed_used)) || read_answers_flag_used) {
 
 	/*
 	 * report problem with Makefile

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -984,7 +984,7 @@ chk_validate.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
     ../jparse/version.h chk_sem_auth.h chk_sem_info.h chk_validate.c \
-    chk_validate.h entry_util.h location.h
+    chk_validate.h entry_util.h location.h version.h
 default_handle.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
@@ -998,15 +998,15 @@ foo.o: ../dbg/dbg.h foo.c foo.h oebxergfB.h
 location_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_main.c
+    ../jparse/version.h location.h location_main.c version.h
 location_tbl.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_tbl.c
+    ../jparse/version.h location.h location_tbl.c version.h
 location_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_util.c
+    ../jparse/version.h location.h location_util.c version.h
 random_answers.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \

--- a/soup/location.h
+++ b/soup/location.h
@@ -62,6 +62,12 @@
  */
 #include "../dbg/dbg.h"
 
+/*
+ * version - official IOCCC toolkit versions
+ */
+#include "version.h"
+
+
 
 /*
  * macros

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -58,12 +58,6 @@
 #include "location.h"
 
 /*
- * official location version
- */
-#define LOCATION_VERSION "1.0.4 2024-05-22"		/* format: major.minor YYYY-MM-DD */
-
-
-/*
  * usage message
  */
 static const char * const usage_msg =

--- a/soup/location_tbl.c
+++ b/soup/location_tbl.c
@@ -463,3 +463,35 @@ struct location loc[] = {
 };
 
 size_t SIZEOF_LOCATION_TABLE = TBLLEN(loc);
+/*
+ * check_location_table	    - make sure that there are no embedded NULL elements
+ *			      in the location table and that the last element is
+ *			      NULL
+ *
+ * This function verifies that the only NULL element in the table is the very
+ * last element: if it's not there or there's another NULL element it's a
+ * problem that has to be fixed.
+ *
+ * This function does not return on error.
+ */
+void
+check_location_table(void)
+{
+    size_t max = SIZEOF_LOCATION_TABLE;
+
+    size_t i;
+
+    for (i = 0; i < max - 1 && loc[i].code != NULL; )
+	++i;
+
+    if (max - 1 != i) {
+	err(333, __func__, "found embedded NULL element in location table; fix table in %s and recompile", __FILE__);
+	not_reached();
+    }
+    if (loc[i].code != NULL || loc[i].name != NULL || loc[i].common_name) {
+	err(10, __func__, "no final NULL element found in location table; fix table in %s and recompile", __FILE__);
+	not_reached();
+    }
+}
+
+

--- a/soup/location_util.c
+++ b/soup/location_util.c
@@ -54,37 +54,6 @@
 #include "location.h"
 
 
-/*
- * check_location_table	    - make sure that there are no embedded NULL elements
- *			      in the location table and that the last element is
- *			      NULL
- *
- * This function verifies that the only NULL element in the table is the very
- * last element: if it's not there or there's another NULL element it's a
- * problem that has to be fixed.
- *
- * This function does not return on error.
- */
-void
-check_location_table(void)
-{
-    size_t max = SIZEOF_LOCATION_TABLE;
-
-    size_t i;
-
-    for (i = 0; i < max - 1 && loc[i].code != NULL; )
-	++i;
-
-    if (max - 1 != i) {
-	err(333, __func__, "found embedded NULL element in location table; fix table in %s and recompile", __FILE__);
-	not_reached();
-    }
-    if (loc[i].code != NULL || loc[i].name != NULL || loc[i].common_name) {
-	err(10, __func__, "no final NULL element found in location table; fix table in %s and recompile", __FILE__);
-	not_reached();
-    }
-}
-
 
 /*
  * lookup_location_name - convert a ISO 3166-1 Alpha-2 into a location name

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.9 2025-06-04"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.10 2025-06-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.8 2025-06-04"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.9 2025-06-06"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.10 2025-06-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.11 2025-06-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,13 +83,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.11 2025-06-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.12 2025-06-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "2.0.2 2025-06-11"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -104,6 +104,12 @@
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
+
+/*
+ * official location version
+ */
+#define LOCATION_VERSION "1.0.5 2024-06-11"		/* format: major.minor YYYY-MM-DD */
+
 
 /*
  * Version of info for JSON the .info.json file.

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.8 2025-05-05"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.9 2025-06-04"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.7 2025-05-05"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.8 2025-06-04"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -340,7 +340,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # shell targets to make by all and removed by clobber
 #
-SH_TARGETS= prep.sh hostchk.sh
+SH_TARGETS=
 
 # program targets to make by all, installed by install, and removed by clobber
 #

--- a/txzchk.c
+++ b/txzchk.c
@@ -1898,11 +1898,11 @@ check_tarball(char const *tar, char const *fnamchk)
 	not_reached();
     } else if (tarball.size > MAX_TARBALL_LEN) {
 	++tarball.total_feathers;
-	    fpara(stderr,
-		  "",
-		  "The compressed tarball exceeds the maximum allowed size, sorry.",
-		  "",
-		  NULL);
+        fpara(stderr,
+              "",
+              "The compressed tarball exceeds the maximum allowed size, sorry.",
+              "",
+              NULL);
 	    warn("txzchk", "%s: the compressed tarball size %jd > %jd",
 		     tarball_path, (intmax_t)tarball.size, (intmax_t)MAX_TARBALL_LEN);
     } else if (verbosity_level) {


### PR DESCRIPTION

Bug fix check_location_table() - when the function was moved to 
location_util.c it broke the __FILE__ macro in the check.

Moved LOCATION_VERSION to soup/version.h (instead of 
soup/location_main.c).

Updated SOUP_VERSION to 2.0.2 2025-06-11".
Updated LOCATION_VERSION to "1.0.5 2024-06-11".

Run make depend for the move of LOCATION_VERSION to soup/version.h.

