### PR TITLE
Resolve issue #1228

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.9 2025-06-04
+
+Fix bug where `-i answers` did not warn about issues found in prog.c and
+Makefile.
+
+
 ## Release 2.4.8 2025-05-05
 
 Allow a submitter's system clock to be as much as 48 hours in the future before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.4.14 2025-06-20
+
+Address issue #1228. By request one may use the `-M manifest_file` option to
+specify what files to include in the topdir. This required updates to jparse/
+(from the jparse repo) and also soup/. Due to the nature of the lists of files
+(there being separate lists depending on the file) the `check_submission_dir()`
+function does not check that the directory does not have files not in the list.
+But given that the FTS functions would not find those files EXACTLY BECAUSE OF
+this option it can't be checked so this should not matter anyway. What it can
+and does check is that the required files are there and that everything else is
+sane, even if by some chance this option causes some insanity (i.e. a fileset
+that is not what one might usually expect) :-) (diagnosis not yet made :-) ).
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.11 2025-06-20"`.
+Updated `SOUP_VERSION` to `"2.0.3 2025-06-20"`.
+
+
 ## Release 2.4.13 2025-06-19
 
 Added support of globs with the `mkiocccentry` ignore option (`-I`). This

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.10 2025-06-05
+
+Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` with new
+utility function for issue #1263 - and a minor optimisation to `read_fts()`.
+
+Slight format fix in txzchk.
+
+
 ## Release 2.4.9 2025-06-04
 
 Fix bug where `-i answers` did not warn about issues found in prog.c and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.4.13 2025-06-19
+
+Added support of globs with the `mkiocccentry` ignore option (`-I`). This
+involves syncing jparse/ from the jparse repo. It would appear that GitHub
+changed something with workflows so this might fail the workflow check. If so
+that might require a new issue or looking at later. In any case `make prep`
+works fine even if it does fail the workflow (it is not clear to me if it's due
+to the dependencies but the last commit to jparse worked fine and the build
+steps did not change at all).
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.10 2025-06-19"`.
+
+
 
 ## Release 2.4.12 2025-06-11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.10 2025-06-06
+
+When `-Y` is used, don't show warnings even if `-i answers` is used as that was
+the point of it (one should use this with caution as it answers yes to every
+question automatically). It is unclear if this should show the list of
+files/directories to be copied (showing the contents of the tarball is part of
+txzchk's algorithm so this is unrelated) as it currently does.  It is also
+unclear if the use of `-Y` should show warnings but just not confirm. Given that
+one is just an informational notice and that one does say something (at least if
+the function is called), even pointing out that one might wish to note it in
+their remarks, it might be better to always show but that really depends on what
+other people want (the point of `-Y` in any case is to always answer yes even
+when the answers file is used, as some people do in fact want this).
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.0.9 2025-06-06"`.
+
+
 ## Release 2.4.10 2025-06-05
 
 Sync [jparse repo](https://github.com/xexyl/jparse/) to `jparse/` with new

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Updated `LOCATION_VERSION` to `"1.0.5 2024-06-11"`.
 
 Run `make depend` for the move of `LOCATION_VERSION` to `soup/version.h`.
 
+Add `SCCS` and `RCS` to ignored directory names - issue #1207.
+
+
 
 ## Release 2.4.11 2025-06-08
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.11 2025-06-08
+
+Don't install prep.sh or hostchk.sh. The uninstall rule still removes these
+files to clean out systems which had this problem. Assuming all is already
+compiled one could do `sudo make uninstall install` to clean up their system.
+Otherwise one should do `make; sudo make uninstall install` as trying to compile
+the tools with root will cause problems when trying to run `make` again (due to
+ownership change).
+
+
+
 ## Release 2.4.10 2025-06-06
 
 When `-Y` is used, don't show warnings even if `-i answers` is used as that was

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.4.12 2025-06-11
+
+Bug fix `check_location_table()` - when the function was moved to
+`location_util.c` it broke the `__FILE__` macro in the check.
+
+Moved `LOCATION_VERSION` to `soup/version.h` (instead of
+`soup/location_main.c`).
+
+Updated `SOUP_VERSION` to `2.0.2 2025-06-11"`.
+Updated `LOCATION_VERSION` to `"1.0.5 2024-06-11"`.
+
+Run `make depend` for the move of `LOCATION_VERSION` to `soup/version.h`.
+
+
 ## Release 2.4.11 2025-06-08
 
 Don't install prep.sh or hostchk.sh. The uninstall rule still removes these

--- a/chkentry.c
+++ b/chkentry.c
@@ -410,7 +410,7 @@ main(int argc, char *argv[])
      * IMPORTANT: make SURE to memset(&fts, 0, sizeof(struct fts)) first!
      */
     memset(&fts, 0,sizeof(struct fts));
-    reset_fts(&fts, false); /* false means do not clear out ignored list (which is empty at this point) */
+    reset_fts(&fts, false, false); /* false , false: don't clear out ignore or match lists (empty at this point) */
 
     /*
      * parse args
@@ -1096,7 +1096,7 @@ main(int argc, char *argv[])
         /*
          * Now anything other than files and directories
          */
-        reset_fts(&fts, false);
+        reset_fts(&fts, false, false);
         fts.match_case = true; /* we must match case here */
         fts.type = FTS_TYPE_ANY & ~(FTS_TYPE_FILE|FTS_TYPE_DIR);
         /*
@@ -1506,7 +1506,7 @@ main(int argc, char *argv[])
         /*
          * free the array in fts if not NULL and reset to 0
          */
-        reset_fts(&fts, true);
+        reset_fts(&fts, true, true);
         /*
          * free the paths and found paths arrays too
          */

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,19 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.2.40 2025-06-19
+
+Added `fnmatch_flags` to `struct fts` for ignored list of files. This is by
+request for mkiocccentry. It is possibly feasible to have it for non-ignored
+paths but that is not for now if it will be done (or even desired).
+
+Removed a test in `util_test` because it is faulty in logic due to depth. A test
+for `fnmatch(3)` was added.
+
+Updated `JPARSE_UTILS_VERSION` to  `"2.0.10 2025-06-19"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.5 2025-06-19"`.
+
+
 ## Release 2.2.39 2025-06-05
 
 Added `size_if_file()` which will return the `st_size` (from `stat(2)`) if the

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,21 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.2.39 2025-06-05
+
+Added `size_if_file()` which will return the `st_size` (from `stat(2)`) if the
+path exists and `stat(2)` does not fail on it and it is a regular file. It is an
+error if the path is NULL. For all other cases 0 is returned.
+
+Check ignored file list `read_fts()` before checking file type as there is no
+point in checking the file type if the file is to be ignored.
+
+Updated `util_test` to test this new function.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.9 2025-06-05"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.4 2025-06-05"`.
+
+
 ## Release 2.2.38 2025-03-15
 
 Add `setlocale(LC_ALL, "");` to all `main()` functions.

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,6 +1,24 @@
 # Significant changes in the JSON parser repo
 
 
+## Release 2.2.41 2025-06-20
+
+Changed `fnmatch_flags` in `struct fts` to `fn_ignore_flags` and added
+`fn_match_flags`. Added `struct dyn_array *match` for a list of paths (or if
+`fn_match_flags` >= 0 then globs for `fnmatch(3)`) to find. If a file matches
+then it will be 'returned' otherwise it'll be skipped. This does mean that a
+large list of files to find will make it slower. This is also by request for
+mkiocccentry.
+
+The function `reset_fts()` now takes a new boolean (sorry but it's necessary for
+this enhancement). If true it clears out the match list.
+
+Fix memory leak in `reset_fts()`.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.11 2025-06-20"`.
+Updated `UTIL_TEST_VERSION` to `"2.0.6 2025-06-20"`.
+
+
 ## Release 2.2.40 2025-06-19
 
 Added `fnmatch_flags` to `struct fts` for ignored list of files. This is by

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -9249,6 +9249,7 @@ check_invalid_option(char const *prog, int ch, int opt)
 #if defined(UTIL_TEST)
 
 #include <locale.h>
+#include <fnmatch.h>
 
 /*
  * jparse - JSON library
@@ -10986,8 +10987,8 @@ main(int argc, char **argv)
     fts.type = FTS_TYPE_FILE;
     fts.base = false; /* important */
     fts.match_case = false;
-    fts.fnmatch_flags = FNM_CASEFOLD;
-    append_path(&(fts.ignore), "UTIL*", true, false, true);
+    fts.fnmatch_flags = 0;
+    append_path(&(fts.ignore), "util*", true, false, true);
     ent = read_fts(".", -1, &cwd, &fts);
     if (ent == NULL) {
         err(160, __func__, "read_fts() returned a NULL pointer on \".\" for directories");

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -1544,21 +1544,22 @@ is_exec(char const *path)
  * struct fts * the following variables (with the corresponding type) are set to
  * the value:
  *
- *  variable        type                                        value
+ *  variable            type                                        value
  *
- *      tree        (FTS *)                                     NULL
- *      options     int                                         FTS_NOCHDIR
- *      logical     bool                                        false
- *      count       int                                         0
- *      depth       int                                         0
- *      min_depth   int                                         0
- *      max_depth   int                                         0
- *      base        bool                                        false
- *      seedot      bool                                        false
- *      match_case  bool                                        false
- *      ignore      struct dyn_array *                          NULL if free_ignored == true
- *      cmp         int (const FTSENT **, const FTSENT **)      fts_cmp
- *      check       bool (FTS *, FTSENT *)                      check_fts_info
+ *      tree            (FTS *)                                     NULL
+ *      options         int                                         FTS_NOCHDIR
+ *      logical         bool                                        false
+ *      count           int                                         0
+ *      depth           int                                         0
+ *      min_depth       int                                         0
+ *      max_depth       int                                         0
+ *      base            bool                                        false
+ *      seedot          bool                                        false
+ *      match_case      bool                                        false
+ *      ignore          struct dyn_array *                          NULL if free_ignored == true
+ *      cmp             int (const FTSENT **, const FTSENT **)      fts_cmp
+ *      fnmatch_flags   int                                         0
+ *      check           bool (FTS *, FTSENT *)                      check_fts_info
  *
  * given:
  *
@@ -1627,6 +1628,7 @@ reset_fts(struct fts *fts, bool free_ignored)
     }
     fts->ignore = NULL; /* paranoia */
     fts->cmp = fts_cmp;
+    fts->fnmatch_flags = -1;
     fts->check = check_fts_info;
 
     /*
@@ -2034,27 +2036,28 @@ check_fts_info(FTS *fts, FTSENT *ent)
  *
  * NOTE: the struct fts has:
  *
- *      tree        - FTS * returned by fts_open()
- *      options     - options to pass to fts_open() (via read_fts()), see above
- *                    on options
- *      logical     - true ==> use FTS_LOGICAL (follow symlinks), false ==> use
- *                    FTS_PHYSICAL (do not follow symlinks, refer to link itself)
- *      type        - bitwise of types (enum fts_type) to allow different types
- *                    only
- *      count       - if > 0 and base == false search until count file have
- *                    been found
- *      depth       - if > 0 required depth
- *      min_depth   - if > 0 the path depth must be >= this value (if depth <= 0)
- *      max_depth   - if > 0 the path depth must be <= this value (if depth <= 0)
- *      base        - true ==> basename only (i.e. fts->fts_name)
- *      seedot      - true ==> don't skip '.' and '..',
- *                    false ==> skip '.' and '..'
- *      match_case  - true ==> use strcmp(), not strcasecmp()
- *      ignore      - struct dyn_array * of paths to ignore (if desired, else NULL)
- *      cmp         - callback for fts_open() (used by read_fts())
- *      check       - pointer to function to check FTSENT * for certain conditions
- *                    (if NULL we will use check_fts_info())
- *      initialised - used internally by reset_fts()
+ *      tree            - FTS * returned by fts_open()
+ *      options         - options to pass to fts_open() (via read_fts()), see above
+ *                        on options
+ *      logical         - true ==> use FTS_LOGICAL (follow symlinks), false ==> use
+ *                        FTS_PHYSICAL (do not follow symlinks, refer to link itself)
+ *      type            - bitwise of types (enum fts_type) to allow different types
+ *                        only
+ *      count           - if > 0 and base == false search until count file have
+ *                        been found
+ *      depth           - if > 0 required depth
+ *      min_depth       - if > 0 the path depth must be >= this value (if depth <= 0)
+ *      max_depth       - if > 0 the path depth must be <= this value (if depth <= 0)
+ *      base            - true ==> basename only (i.e. fts->fts_name)
+ *      seedot          - true ==> don't skip '.' and '..',
+ *                        false ==> skip '.' and '..'
+ *      match_case      - true ==> use strcmp(), not strcasecmp()
+ *      ignore          - struct dyn_array * of paths to ignore (if desired, else NULL)
+ *      cmp             - callback for fts_open() (used by read_fts())
+ *      fnmatch_flags   - flags for fnmatch(3) or < 0 (default) if undesired
+ *      check           - pointer to function to check FTSENT * for certain conditions
+ *                        (if NULL we will use check_fts_info())
+ *      initialised     - used internally by reset_fts()
  *
  * To use this function you might do something like this where:
  *
@@ -2075,6 +2078,7 @@ check_fts_info(FTS *fts, FTSENT *ent)
  *      seedot          ==> false (remove FTS_SEEDOT; true could be done in options as well)
  *      ignore          ==> NULL (don't ignore anything)
  *      cmp             ==> fts_rcmp
+ *      fnmatch_flags   ==> -1 (not strictly relevant as ignore is NULL)
  *      check           ==> NULL (don't do any checks)
  *
  * We do not use the variables count or match_case as this traverses a tree and
@@ -2117,9 +2121,14 @@ check_fts_info(FTS *fts, FTSENT *ent)
  * directory in *cwd.
  *
  * If you need to ignore paths you might do this PRIOR to calling the function
- * but AFTER doing the memset() and reset_fts():
+ * but AFTER doing the memset() and reset_fts() (!):
  *
  *      append_path(&(fts.ignore), "foo", true, false, false); // last false means don't match case
+ *
+ * NOTE: the fnmatch(3) (i.e. fnmatch_flags) apply ONLY to ignored paths. Unless
+ * it is desired by more than 0 people, there will only be one fnmatch(3) flags
+ * variable and even if more than 0 people find a use for it it might or might
+ * not be done. The use of fnmatch(3) for ignored file is by request.
  *
  * NOTE: if one specifies a bogus range for min/max depth the function will find
  * nothing. For example if one gives a min_depth > the max_depth the function
@@ -2394,7 +2403,7 @@ read_fts(char *dir, int dirfd, int *cwd, struct fts *fts)
                     }
                 /*
                  * case: we do not want to see '.' or '..' or './' and that is
-                 * what the path is
+                 * what the path is.
                  */
                 } else if (!fts->seedot && (!strcmp(ent->fts_name, ".") || !strcmp(ent->fts_name, "..") ||
                            !strcmp(ent->fts_name, "./"))) {
@@ -2414,8 +2423,9 @@ read_fts(char *dir, int dirfd, int *cwd, struct fts *fts)
                             err(110, __func__, "found NULL pointer in fts->ignore[%ju]", (uintmax_t)i);
                             not_reached();
                         }
-                        if ((fts->base || count_dirs(name) == 1) && ((fts->match_case && !strcmp(ent->fts_name, u)) ||
-                           (!fts->match_case && !strcasecmp(ent->fts_name, u)))) {
+                        if ((fts->base || count_dirs(name) == 1) && (((fts->match_case && !strcmp(ent->fts_name, u)) ||
+                           (!fts->match_case && !strcasecmp(ent->fts_name, u)))||(fts->fnmatch_flags >= 0 &&
+                            fnmatch(u, ent->fts_name, fts->fnmatch_flags) == 0))) {
                             /*
                              * if this is a directory we will not descend into
                              * it
@@ -2429,8 +2439,9 @@ read_fts(char *dir, int dirfd, int *cwd, struct fts *fts)
                             dbg(DBG_HIGH, "ignoring name: %s", ent->fts_name);
                             skip = true;
                             break;
-                        } else if (!fts->base && ((fts->match_case && !strcmp(u, name)) ||
-                                  (!fts->match_case && !strcasecmp(u, name)))) {
+                        } else if (!fts->base && (((fts->match_case && !strcmp(u, name)) ||
+                                  (!fts->match_case && !strcasecmp(u, name)))||(fts->fnmatch_flags >= 0 &&
+                                      fnmatch(u, name, fts->fnmatch_flags) == 0))) {
                             /*
                              * if this is a directory we will not descend into
                              * it
@@ -9254,7 +9265,7 @@ check_invalid_option(char const *prog, int ch, int opt)
  */
 #include "../json_utf8.h"
 
-#define UTIL_TEST_VERSION "2.0.4 2025-06-05" /* version format: major.minor YYYY-MM-DD */
+#define UTIL_TEST_VERSION "2.0.5 2025-06-19" /* version format: major.minor YYYY-MM-DD */
 
 int
 main(int argc, char **argv)
@@ -10964,24 +10975,22 @@ main(int argc, char **argv)
      * mean it can't be reset)
      */
     (void) read_fts(NULL, -1, &cwd, NULL);
-
     /*
-     * test read_fts() only finding directories but ignoring good, bad and
-     * bad_loc
+     * test read_fts() with fnmatch(3)
      */
 
     /*
      * reset fts
      */
     reset_fts(&fts, false);
-    fts.type = FTS_TYPE_DIR;
-    fts.base = true; /* important */
-    append_path(&(fts.ignore), "test_jparse/test_JSON/good", true, false, true);
-    append_path(&(fts.ignore), "test_jparse/test_JSON/bad", true, false, true);
-    append_path(&(fts.ignore), "test_jparse/test_JSON/bad_loc", true, false, true);
-    ent = read_fts("test_jparse", -1, &cwd, &fts);
+    fts.type = FTS_TYPE_FILE;
+    fts.base = false; /* important */
+    fts.match_case = false;
+    fts.fnmatch_flags = FNM_CASEFOLD;
+    append_path(&(fts.ignore), "UTIL*", true, false, true);
+    ent = read_fts(".", -1, &cwd, &fts);
     if (ent == NULL) {
-        err(160, __func__, "read_fts() returned a NULL pointer on \"test_jparse\" for directories");
+        err(160, __func__, "read_fts() returned a NULL pointer on \".\" for directories");
         not_reached();
     } else {
         do {
@@ -10990,18 +10999,17 @@ main(int argc, char **argv)
                 err(161, __func__, "fts_path(ent) returned NULL");
                 not_reached();
             }
-            if (ent->fts_info != FTS_D && ent->fts_info != FTS_DP) {
-                err(162, __func__, "%s is not a directory", p);
+            if (ent->fts_info != FTS_F) {
+                err(162, __func__, "%s is not a file", p);
                 not_reached();
-            } else if (!strcmp(p, "good") || !strcmp(p, "bad") || !strcmp(p, "bad_loc")) {
-                err(163, __func__, "found directory meant to be ignored: %s", p);
+            } else if (!strncmp(p, "util",4)) {
+                err(163, __func__, "found file meant to be ignored: %s", p);
                 not_reached();
             } else {
-                fdbg(stderr, DBG_MED, "%s is a non-ignored directory", p);
+                fdbg(stderr, DBG_MED, "%s is a non-ignored file", p);
             }
         } while ((ent = read_fts(NULL, -1, &cwd, &fts)) != NULL);
     }
-
     /*
      * restore earlier directory that might have happened with read_fts()
      *
@@ -11009,6 +11017,8 @@ main(int argc, char **argv)
      * mean it can't be reset)
      */
     (void) read_fts(NULL, -1, &cwd, NULL);
+
+
 
 
 

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -272,8 +272,10 @@ struct fts
     bool seedot;            /* true ==> analogous to FTS_SEEDOT */
     bool match_case;        /* true ==> case-sensitive match */
     struct dyn_array *ignore;   /* paths to ignore */
+    struct dyn_array *match;    /* list of globs (or files) that are allowed */
     int (*cmp)(const FTSENT **, const FTSENT **);   /* function pointer to use when traversing (NULL ==> fts_cmp()) */
-    int fnmatch_flags;      /* flags for fnmatch(3) for ignored list or < 0 (default) if undesired */
+    int fn_ignore_flags;    /* flags for fnmatch(3) for ignored list or < 0 (default) if undesired */
+    int fn_match_flags;     /* flags for fnmatch(3) to find (nothing else will be added) */
     bool(*check)(FTS *, FTSENT *);  /* function pointer to use to check an FTSENT * (NULL ==> check_fts_info()) */
     bool initialised;       /* internal use: after first call we can safely check pointers */
 };
@@ -301,7 +303,7 @@ extern bool is_read(char const *path);
 extern bool is_write(char const *path);
 extern mode_t filemode(char const *path, bool printing);
 extern bool is_open_file_stream(FILE *stream);
-extern void reset_fts(struct fts *fts, bool free_ignored);
+extern void reset_fts(struct fts *fts, bool free_ignored, bool free_match);
 extern char *fts_path(FTSENT *ent);
 extern int fts_cmp(const FTSENT **a, const FTSENT **b);
 extern int fts_rcmp(const FTSENT **a, const FTSENT **b);

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -48,6 +48,7 @@
 #include <sys/types.h>  /* various things */
 #include <sys/stat.h>   /* for stat(2) and others */
 #include <fts.h>        /* FTS and FTSENT */
+#include <fnmatch.h>    /* for fnmatch(3) (for ignored paths - if desired) */
 
 
 /*
@@ -272,6 +273,7 @@ struct fts
     bool match_case;        /* true ==> case-sensitive match */
     struct dyn_array *ignore;   /* paths to ignore */
     int (*cmp)(const FTSENT **, const FTSENT **);   /* function pointer to use when traversing (NULL ==> fts_cmp()) */
+    int fnmatch_flags;      /* flags for fnmatch(3) for ignored list or < 0 (default) if undesired */
     bool(*check)(FTS *, FTSENT *);  /* function pointer to use to check an FTSENT * (NULL ==> check_fts_info()) */
     bool initialised;       /* internal use: after first call we can safely check pointers */
 };

--- a/jparse/util.h
+++ b/jparse/util.h
@@ -316,6 +316,7 @@ extern bool fd_is_ready(char const *name, bool open_test_only, int fd);
 extern bool chk_stdio_printf_err(FILE *stream, int ret);
 extern void flush_tty(char const *name, bool flush_stdin, bool abort_on_error);
 extern off_t file_size(char const *path);
+extern off_t size_if_file(char const *path);
 extern bool is_empty(char const *path);
 extern char *cmdprintf(char const *format, ...);
 extern char *vcmdprintf(char const *format, va_list ap);

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.38 2025-06-05"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.40 2025-06-19"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.9 2025-06-05"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.10 2025-06-19"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.40 2025-06-19"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.41 2025-06-20"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.10 2025-06-19"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.11 2025-06-20"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.8 2025-03-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.38 2025-06-05"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.8 2025-03-15"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.9 2025-06-05"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1033,7 +1033,7 @@ main(int argc, char *argv[])
 	    info.Makefile_override) {
 
 	    do {
-		if (!ignore_warnings) {
+		if (!ignore_warnings || read_answers_flag_used) {
 		    need_confirm = true;
 
 		    if (info.empty_override) {
@@ -5061,7 +5061,7 @@ warn_empty_prog(void)
     bool yorn = false;
 
     dbg(DBG_MED, "prog.c is empty");
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	fpara(stderr,
 	  "WARNING: prog.c is empty.  An empty prog.c has been submitted before:",
 	  "",
@@ -5129,7 +5129,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
 	    errp(182, __func__, "fprintf error when printing prog.c Rule 2a warning");
             not_reached();
 	}
-	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	    fpara(stderr,
 	      "If you are attempting some clever rule abuse, then we STRONGLY",
               "suggest that you tell us about your rule abuse towards the TOP",
@@ -5154,7 +5154,7 @@ warn_rule_2a_size(struct info *infop, int mode, RuleCount size)
      * File size and iocccsize file size differ warning
      */
     } else if (mode == RULE_2A_BIG_FILE_WARNING) {
-	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+	if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	    errno = 0;		/* pre-clear errno for errp() */
 	    ret = fprintf(stderr, "\nInteresting: prog.c file size: %jd != rule_count function size: %jd\n"
 				  "In order to avoid a possible Rule 2a violation, BE SURE TO CLEARLY MENTION THIS IN\n"
@@ -5203,7 +5203,7 @@ warn_nul_chars(void)
     /*
      * warn about NUL chars(s) if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c has NUL character(s)!\n"
 			      "Be careful you don't violate rule 13!\n\n");
@@ -5241,7 +5241,7 @@ warn_trigraph(void)
     /*
      * warn the user about unknown or invalid trigraph(s), if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c has unknown or invalid trigraph(s) found!\n"
 			      "Is that a bug in, or a feature of your code?\n\n");
@@ -5297,7 +5297,7 @@ warn_ungetc(void)
     /*
      * warn the user abort iocccsize ungetc error, if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;		/* pre-clear errno for errp() */
 	ret = fprintf(stderr, "\nprog.c triggered an ungetc error: @SirWumpus goofed\n"
 			      "In order to avoid a possible Rule 2b violation, BE SURE TO CLEARLY MENTION THIS IN\n"
@@ -5343,7 +5343,7 @@ warn_rule_2b_size(struct info *infop)
     /*
      * warn the user about a possible Rule 2b violation, if we are allowed
      */
-    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes)) {
+    if (abort_on_warning || (need_confirm && !ignore_warnings && !answer_yes) || read_answers_flag_used) {
 	errno = 0;
 	ret = fprintf(stderr, "\nWARNING: The prog.c size: %ju > Rule 2b maximum: %ju\n",
 		      (uintmax_t)infop->rule_2b_size, (uintmax_t)RULE_2B_SIZE);
@@ -5850,7 +5850,7 @@ warn_Makefile(struct info *infop)
 	err(206, __func__, "called with NULL infop");
 	not_reached();
     }
-    if (need_confirm && (!answer_yes || seed_used)) {
+    if ((need_confirm && (!answer_yes || seed_used)) || read_answers_flag_used) {
 
 	/*
 	 * report problem with Makefile

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -93,6 +93,7 @@
 #include <fcntl.h> /* for open() */
 #include <fts.h>
 #include <locale.h>
+#include <fnmatch.h>
 
 /*
  * mkiocccentry - form IOCCC entry compressed tarball

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1585,6 +1585,8 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
     reset_fts(&fts, false); /* false means do not clear out ignored list */
     fts.logical = false;
     fts.options = FTS_NOCHDIR | FTS_NOSTAT;
+    fts.ignore = infop->ignore_paths; /* do NOT free this list!! */
+    fts.fnmatch_flags = 0;
     /*
      * now that we have changed to the correct directory and gathered everything
      * we need to scan for files and directories, we can traverse the tree.
@@ -1628,6 +1630,9 @@ scan_topdir(char *args, struct info *infop, char const *make, char const *submis
              * NOTE: we do NOT need to check if the array is not allocated or
              * even if the string is not NULL (though it should not be) because
              * array_has_path() simply returns false in this case.
+             *
+             * Strictly speaking this MIGHT not be necessary but it does not
+             * hurt either.
              */
             if (array_has_path(infop->ignore_paths, ent->fts_path + 2, false, NULL)) {
                 /*
@@ -2992,6 +2997,8 @@ check_submission_dir(struct info *infop, char *submit_path, char *topdir_path,
     reset_fts(&fts, false); /* false means do not clear out ignored list */
     fts.logical = false;
     fts.options = FTS_NOCHDIR | FTS_NOSTAT;
+    fts.fnmatch_flags = 0;
+    fts.ignore = infop->ignore_paths;
 
     /*
      * now that we have changed to the submission directory and have run make

--- a/mkiocccentry.h
+++ b/mkiocccentry.h
@@ -204,6 +204,7 @@ static void remind_user(char const *workdir, char const *submission_dir, char co
 	bool test_mode, int submit_slot);
 static void show_registration_url(void);
 static void show_submit_url(char const *workdir, char const *tarball_path, int slot_number);
+static void read_manifest(char const *manifest, struct info *infop);
 
 static long answer_seed = NO_SEED;	/* if != 0 ==> srandom argument used to seed generation of answers */
 #endif /* INCLUDE_MKIOCCCENTRY_H */

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -984,7 +984,7 @@ chk_validate.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
     ../jparse/version.h chk_sem_auth.h chk_sem_info.h chk_validate.c \
-    chk_validate.h entry_util.h location.h
+    chk_validate.h entry_util.h location.h version.h
 default_handle.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
@@ -998,15 +998,15 @@ foo.o: ../dbg/dbg.h foo.c foo.h oebxergfB.h
 location_main.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_main.c
+    ../jparse/version.h location.h location_main.c version.h
 location_tbl.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_tbl.c
+    ../jparse/version.h location.h location_tbl.c version.h
 location_util.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \
-    ../jparse/version.h location.h location_util.c
+    ../jparse/version.h location.h location_util.c version.h
 random_answers.o: ../dbg/dbg.h ../dyn_array/dyn_array.h ../jparse/jparse.h \
     ../jparse/jparse.tab.h ../jparse/json_parse.h ../jparse/json_sem.h \
     ../jparse/json_utf8.h ../jparse/json_util.h ../jparse/util.h \

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -164,6 +164,8 @@ char *ignored_dirnames[] =
     FOSSIL_DIRNAME1,
     MONOTONE_DIRNAME,
     DARCS_DIRNAME,
+    SCCS_DIRNAME,
+    RCS_DIRNAME,
     NULL /* MUST BE LAST!! */
 };
 

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -411,6 +411,11 @@ free_info(struct info *infop)
      */
     free_paths_array(&infop->ignore_paths, false);
     infop->ignore_paths = NULL;
+   /*
+     * user requested files from manifest file
+     */
+    free_paths_array(&infop->manifest_paths, false);
+    infop->manifest_paths = NULL;
 
     /*
      * zeroize the info structure
@@ -4044,7 +4049,7 @@ test_manifest(struct manifest *manp, char *submission_dir)
      * not pass a struct fts * here nor should we.
      */
     memset(&fts, 0, sizeof(struct fts));
-    reset_fts(&fts, false); /* false means do not clear out ignored list */
+    reset_fts(&fts, false, false); /* false means do not clear out ignored or match lists */
     /*
      * Below we will have to check that the files in the manifest actually exist
      * in the submission directory. To do this we have to use the find_path() or

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -298,6 +298,7 @@ struct info
     struct dyn_array *unsafe_dirs;      /* unsafe directories */
     struct dyn_array *ignored_symlinks; /* ignored symlinks files */
     struct dyn_array *ignore_paths;     /* list of paths user requested we ignore (-I foo -I bar) */
+    struct dyn_array *manifest_paths;   /* list of paths to include from -M file */
 
     /*
      * JSON stuff

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -118,6 +118,8 @@
 #define FOSSIL_DIRNAME1 "_FOSSIL_"              /* For Fossil */
 #define MONOTONE_DIRNAME "_MTN"                 /* For Monotone */
 #define DARCS_DIRNAME "_darcs"                  /* For Darcs */
+#define SCCS_DIRNAME "SCCS"                     /* For SCCS */
+#define RCS_DIRNAME "RCS"                       /* for RCS */
 
 /*
  * filenames that should be ignored, mostly for chkentry -w but it can be used

--- a/soup/location.h
+++ b/soup/location.h
@@ -62,6 +62,12 @@
  */
 #include "../dbg/dbg.h"
 
+/*
+ * version - official IOCCC toolkit versions
+ */
+#include "version.h"
+
+
 
 /*
  * macros

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -58,12 +58,6 @@
 #include "location.h"
 
 /*
- * official location version
- */
-#define LOCATION_VERSION "1.0.4 2024-05-22"		/* format: major.minor YYYY-MM-DD */
-
-
-/*
  * usage message
  */
 static const char * const usage_msg =

--- a/soup/location_tbl.c
+++ b/soup/location_tbl.c
@@ -463,3 +463,35 @@ struct location loc[] = {
 };
 
 size_t SIZEOF_LOCATION_TABLE = TBLLEN(loc);
+/*
+ * check_location_table	    - make sure that there are no embedded NULL elements
+ *			      in the location table and that the last element is
+ *			      NULL
+ *
+ * This function verifies that the only NULL element in the table is the very
+ * last element: if it's not there or there's another NULL element it's a
+ * problem that has to be fixed.
+ *
+ * This function does not return on error.
+ */
+void
+check_location_table(void)
+{
+    size_t max = SIZEOF_LOCATION_TABLE;
+
+    size_t i;
+
+    for (i = 0; i < max - 1 && loc[i].code != NULL; )
+	++i;
+
+    if (max - 1 != i) {
+	err(333, __func__, "found embedded NULL element in location table; fix table in %s and recompile", __FILE__);
+	not_reached();
+    }
+    if (loc[i].code != NULL || loc[i].name != NULL || loc[i].common_name) {
+	err(10, __func__, "no final NULL element found in location table; fix table in %s and recompile", __FILE__);
+	not_reached();
+    }
+}
+
+

--- a/soup/location_util.c
+++ b/soup/location_util.c
@@ -54,37 +54,6 @@
 #include "location.h"
 
 
-/*
- * check_location_table	    - make sure that there are no embedded NULL elements
- *			      in the location table and that the last element is
- *			      NULL
- *
- * This function verifies that the only NULL element in the table is the very
- * last element: if it's not there or there's another NULL element it's a
- * problem that has to be fixed.
- *
- * This function does not return on error.
- */
-void
-check_location_table(void)
-{
-    size_t max = SIZEOF_LOCATION_TABLE;
-
-    size_t i;
-
-    for (i = 0; i < max - 1 && loc[i].code != NULL; )
-	++i;
-
-    if (max - 1 != i) {
-	err(333, __func__, "found embedded NULL element in location table; fix table in %s and recompile", __FILE__);
-	not_reached();
-    }
-    if (loc[i].code != NULL || loc[i].name != NULL || loc[i].common_name) {
-	err(10, __func__, "no final NULL element found in location table; fix table in %s and recompile", __FILE__);
-	not_reached();
-    }
-}
-
 
 /*
  * lookup_location_name - convert a ISO 3166-1 Alpha-2 into a location name

--- a/soup/man/man1/mkiocccentry.1
+++ b/soup/man/man1/mkiocccentry.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH mkiocccentry 1 "10 March 2025" "mkiocccentry" "IOCCC tools"
+.TH mkiocccentry 1 "20 June 2025" "mkiocccentry" "IOCCC tools"
 .SH NAME
 .B mkiocccentry
 \- make an IOCCC compressed tarball for an IOCCC entry
@@ -385,6 +385,12 @@ option.
 If the path is a directory
 .BR mkiocccentry (1)
 will not traverse it.
+.TP
+.BI \-M\  manifest_file
+Read from file
+.I manifest_file
+what files to include from in the
+.BR topdir .
 .TP
 .BI \-r\  rm
 Set path to

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.9 2025-06-04"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.10 2025-06-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.8 2025-06-04"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.9 2025-06-06"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.10 2025-06-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.11 2025-06-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,13 +83,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.11 2025-06-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.12 2025-06-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.0.1 2025-03-02"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "2.0.2 2025-06-11"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -104,6 +104,12 @@
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
+
+/*
+ * official location version
+ */
+#define LOCATION_VERSION "1.0.5 2024-06-11"		/* format: major.minor YYYY-MM-DD */
+
 
 /*
  * Version of info for JSON the .info.json file.

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.8 2025-05-05"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.9 2025-06-04"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.7 2025-05-05"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.8 2025-06-04"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,13 +83,13 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.13 2025-06-19"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.14 2025-06-20"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.0.2 2025-06-11"	/* format: major.minor YYYY-MM-DD */
+#define SOUP_VERSION "2.0.3 2025-06-20"	/* format: major.minor YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.10 2025-06-19"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.11 2025-06-20"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/soup/version.h
+++ b/soup/version.h
@@ -83,7 +83,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.4.12 2025-06-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.4.13 2025-06-19"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.0.9 2025-06-06"	/* format: major.minor YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.0.10 2025-06-19"	/* format: major.minor YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION "2.0.1 2025-03-02"
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC28-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -340,7 +340,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # shell targets to make by all and removed by clobber
 #
-SH_TARGETS= prep.sh hostchk.sh
+SH_TARGETS=
 
 # program targets to make by all, installed by install, and removed by clobber
 #

--- a/txzchk.c
+++ b/txzchk.c
@@ -1898,11 +1898,11 @@ check_tarball(char const *tar, char const *fnamchk)
 	not_reached();
     } else if (tarball.size > MAX_TARBALL_LEN) {
 	++tarball.total_feathers;
-	    fpara(stderr,
-		  "",
-		  "The compressed tarball exceeds the maximum allowed size, sorry.",
-		  "",
-		  NULL);
+        fpara(stderr,
+              "",
+              "The compressed tarball exceeds the maximum allowed size, sorry.",
+              "",
+              NULL);
 	    warn("txzchk", "%s: the compressed tarball size %jd > %jd",
 		     tarball_path, (intmax_t)tarball.size, (intmax_t)MAX_TARBALL_LEN);
     } else if (verbosity_level) {


### PR DESCRIPTION

Address issue #1228. By request one may use the -M manifest_file option 
to specify what files to include in the topdir. This required updates to
jparse/ (from the jparse repo) and also soup/. Due to the nature of the 
lists of files (there being separate lists depending on the file) the
check_submission_dir() function does not check that the directory does
not have files not in the list.  But given that the FTS functions would
not find those files EXACTLY BECAUSE OF this option it can't be checked
so this should not matter anyway. What it can and does check is that the
required files are there and that everything else is sane, even if by
some chance this option causes some insanity (i.e. a fileset that is not
what one might usually expect) :-) (diagnosis not yet made :-) ).

Updated MKIOCCCENTRY_VERSION to "2.0.11 2025-06-20".
Updated SOUP_VERSION to "2.0.3 2025-06-20".
