### PR TITLE
Fixes from 730fcd70bbdd8beb5d0e3fbf4c843860cc6e6a7d

### DIFF
--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -665,7 +665,7 @@ clobber: legacy_clobber clean
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f ${TARGETS}
-	${Q} ${RM} ${RM_V} -f jparse_test.log chksubmit_test.log txzchk_test.log
+	${Q} ${RM} ${RM_V} -f jparse_test.log
 	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
 	${Q} ${RM} ${RM_V} -rf a b
 	${S} echo
@@ -745,23 +745,18 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-jnum_chk.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
-    ../json_sem.h ../json_utf8.h ../json_util.h ../util.h ../version.h \
-    jnum_chk.c jnum_chk.h
-jnum_gen.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
-    ../json_sem.h ../json_utf8.h ../json_util.h ../util.h ../version.h \
-    jnum_gen.c jnum_gen.h
-jnum_header.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
-    ../json_sem.h ../json_utf8.h ../json_util.h ../util.h ../version.h \
-    jnum_chk.h jnum_header.c
-jnum_test.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
-    ../json_sem.h ../json_utf8.h ../json_util.h ../util.h ../version.h \
-    jnum_chk.h jnum_test.c
-pr_jparse_test.o: ../../dbg/dbg.h ../../dyn_array/../dbg/dbg.h \
-    ../../dyn_array/dyn_array.h ../jparse.h ../jparse.tab.h ../json_parse.h \
-    ../json_sem.h ../json_utf8.h ../json_util.h ../util.h ../version.h \
-    pr_jparse_test.c pr_jparse_test.h
+jnum_chk.o: ../jparse.h ../jparse.tab.h ../json_parse.h ../json_sem.h \
+    ../json_utf8.h ../json_util.h ../util.h ../version.h jnum_chk.c \
+    jnum_chk.h
+jnum_gen.o: ../jparse.h ../jparse.tab.h ../json_parse.h ../json_sem.h \
+    ../json_utf8.h ../json_util.h ../util.h ../version.h jnum_gen.c \
+    jnum_gen.h
+jnum_header.o: ../jparse.h ../jparse.tab.h ../json_parse.h ../json_sem.h \
+    ../json_utf8.h ../json_util.h ../util.h ../version.h jnum_chk.h \
+    jnum_header.c
+jnum_test.o: ../jparse.h ../jparse.tab.h ../json_parse.h ../json_sem.h \
+    ../json_utf8.h ../json_util.h ../util.h ../version.h jnum_chk.h \
+    jnum_test.c
+pr_jparse_test.o: ../jparse.h ../jparse.tab.h ../json_parse.h ../json_sem.h \
+    ../json_utf8.h ../json_util.h ../util.h ../version.h pr_jparse_test.c \
+    pr_jparse_test.h


### PR DESCRIPTION
A good catch was the chksubmit only having -S in the debug log. That slipped through.

A nice hack was for the -v level option. It might be worth (although I don't feel up to doing this) trying to come up with a way that handles the low level routines that shell_cmd() and pipe_open() use so we don't have to use this kind of hack. The reason I did not do the -v level is exactly this problem and the -J level is for the same reason (plus that did not seem useful). If these functions are updated then it would be worth updating the other programs too, perhaps.

However there was an issue in the jparse/test_jparse/Makefile. It should not refer to anything from this repo. As such that Makefile was updated at jparse and synced here. The other changes have to be tested but I presume they will be fine (they are thus not committed over there yet for this reason and they are not even added yet let alone tested).