### PR TITLE
Sync jparse/ from jparse repo - improve jparse(1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.6.5 2025-09-09
+
+Synced [jparse repo](https://github.com/xexyl/jparse) with an enhancement to the
+`jparse(1)` tool. This updates the `JPARSE_TOOL_VERSION` to `"2.0.2
+2025-09-09"`.
+
+**REMINDER**: you do **NOT** have to install the external libraries from their
+respective repo in order to use or install this toolkit. Neither do you have to
+install this toolkit although you are strongly recommended to do so.
+
+
 ## Release 2.6.4 2025-09-08
 
 Update `dyn_array` to use the `DYN_ARRAY_VERSION` "2.4.0 2024-09-08".

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,17 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.3.2 2025-09-09
+
+Improved `jparse(1)` to allow for more than one arg of the specific type (string
+if `-s` is used, file otherwise). If any of the args is invalid JSON it will
+exit 1, else 0.
+
+Updated error location files as the `jparse(1)` error now specifies the filename
+of each invalid JSON file. This is important for the test script.
+
+Updated `JPARSE_TOOL_VERSION` to `"2.0.2 2025-09-09"`.
+
+
 ## Release 2.3.1 2025-09-08
 
 Updated `jparse/jsemtblgen.c` to use the new `dyn_array_qsort(3)` function
@@ -7,6 +19,7 @@ from [dyn_array repo](https://github.com/lcn2/dyn_array) "2.4.0 2024-09-08".
 
 Updated `JPARSE_REPO_VERSION` to "2.3.1 2025-09-08".
 Updated `JSEMTBLGEN_VERSION` to "2.0.3 2025-09-08".
+Updated
 
 
 ## Release 2.3.0 2025-09-01

--- a/jparse/man/man1/jparse.1
+++ b/jparse/man/man1/jparse.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jparse 1 "18 January 2025" "jparse" "jparse tools"
+.TH jparse 1 "09 September 2025" "jparse" "jparse tools"
 .SH NAME
 .B jparse
 \- a JSON parser written in C
@@ -23,16 +23,16 @@
 .RB [\| \-q \|]
 .RB [\| \-V \|]
 .RB [\| \-s \|]
-.I arg
+.I arg...
 .SH DESCRIPTION
 .B jparse
-parses a block of JSON text either from a file
+parses one or more blocks of JSON text either from one or more files
 .RB \|( \-
 means
 .BR stdin \|)
-or a string passed to the program via the
+or one or more string passed to the program (if the
 .B \-s
-option, reporting if it is valid or invalid JSON.
+option is used), reporting on those that are invalid (depending on the verbosity level it will also report valid JSON).
 Depending on the JSON verbosity level it will also show more information.
 This tool by itself is useful to validate JSON but the
 .BR jparse (3)
@@ -64,10 +64,10 @@ Parse argument as a string.
 .SH EXIT STATUS
 .TP
 0
-valid JSON
+(all) file(s)/string(s) is (are) valid JSON
 .TQ
 1
-invalid JSON
+at least one file or string is invalid JSON
 .TQ
 2
 .B \-h

--- a/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json at line 28 column 18: :
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-auth.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json at line 14 column 22: a
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/12345678-1234-4321-abcd-1234567890ab-2-info.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/braces-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/braces-comma-eof.json.err
@@ -1,2 +1,3 @@
 syntax error node type JTYPE_OBJECT in file test_jparse/test_JSON/./bad_loc/braces-comma-eof.json at line 1 column 3: ,
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/braces-comma-eof.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/first-line-first-column-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/first-line-first-column-comma-eof.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/first-line-first-column-comma-eof.json at line 1 column 1: ,
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/first-line-first-column-comma-eof.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace-unbalanced-quotes-comma.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/open-brace-unbalanced-quotes-comma.json at line 1 column 2: "
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/open-brace-unbalanced-quotes-comma.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace-value-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace-value-comma.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/open-brace-value-comma.json at line 1 column 8: ,
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/open-brace-value-comma.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/open-brace.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/open-brace.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/open-brace.json at line 2 column 17: empty text
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/open-brace.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/party.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/party.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/party.json at line 4 column 1: }
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/party.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/second-line-first-column-comma-eof.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/second-line-first-column-comma-eof.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/second-line-first-column-comma-eof.json at line 2 column 1: ,
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/second-line-first-column-comma-eof.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/second-line-second-column-comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/second-line-second-column-comma.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/second-line-second-column-comma.json at line 2 column 2: ,
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/second-line-second-column-comma.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-0-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-0-auth.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/test-0-auth.json at line 29 column 17: {
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/test-0-auth.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-0-info.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/test-0-info.json at line 3 column 32: "
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/test-0-info.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-1-auth.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/test-1-auth.json at line 5 column 25: e
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/test-1-auth.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/test-1-info.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/test-1-info.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/test-1-info.json at line 43 column 26: "formed_timestamp"
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/test-1-info.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/unquoted-name.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/unquoted-name.json at line 1 column 2: t
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/unquoted-name.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
+++ b/jparse/test_jparse/test_JSON/bad_loc/vtab_comma.json.err
@@ -1,3 +1,3 @@
 syntax error in file test_jparse/test_JSON/./bad_loc/vtab_comma.json at line 3 column 1: 
-Warning: ./jparse: JSON parse tree is NULL
+Warning: ./jparse: JSON parse tree is NULL for file: test_jparse/test_JSON/./bad_loc/vtab_comma.json
 ERROR[1]: ./jparse: invalid JSON

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,12 +55,12 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.1 2025-09-08"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.2 2025-09-09"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
  */
-#define JPARSE_TOOL_VERSION "2.0.1 2025-03-15"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_TOOL_VERSION "2.0.2 2025-09-09"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official JSON parser version

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.6.4 2025-09-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.6.5 2025-09-09"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*


### PR DESCRIPTION
Synced jparse repo (https://github.com/xexyl/jparse) with an enhancement to the jparse(1) tool. This updates the JPARSE_TOOL_VERSION to "2.0.2 2025-09-09".

REMINDER: you do NOT have to install the external libraries from their respective repo in order to use or install this toolkit. Neither do you have to install this toolkit although you are strongly recommended to do so.