### PR TITLE
Fix bug in hostchk.sh wrt dbg/dyn_array updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.6.6 2025-09-18
+
+Fix bug in `test_ioccc/hostchk.sh` where if you did not have `dbg` and
+`dyn_array` installed it would fail as it was looking for new include files. It
+appears that this did not happen with `jparse` not being installed but if anyone
+has an issue (I did a `make uninstall` but it's possible I missed something)
+**PLEASE** report it.
+
+Updated `HOSTCHK_VERSION` to `"2.0.2 2025-09-18"`.
+
+
 ## Release 2.6.5 2025-09-09
 
 Synced [jparse repo](https://github.com/xexyl/jparse) with an enhancement to the

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.6.5 2025-09-09"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.6.6 2025-09-18"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 
 /*

--- a/test_ioccc/hostchk.sh
+++ b/test_ioccc/hostchk.sh
@@ -83,7 +83,7 @@ CC="$(type -P cc 2>/dev/null)"
 if [[ -z $CC ]]; then
     CC="/usr/bin/cc"
 fi
-export HOSTCHK_VERSION="2.0.1 2025-03-14"
+export HOSTCHK_VERSION="2.0.2 2025-09-18"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-c cc] [-w workdir] [-f] [-Z topdir]
 
     -h			    Print help and exit
@@ -276,7 +276,7 @@ if [[ -n $F_FLAG ]]; then
     #
     printf "%s\\n%s\\n" "$(grep '#include.*<.*>' "$TOPDIR"/*.[hc] "$TOPDIR"/dbg/*.[hc] \
 	"$TOPDIR"/dyn_array/*.[hc] "$TOPDIR"/test_ioccc/*.[ch] "$TOPDIR"/soup/*.[hc] "$TOPDIR"/jparse/*.[hcly] \
-	"$TOPDIR"/jparse/test_jparse/*.[hc]|grep -vE '<dbg\.h>|<dyn_array\.h>' |cut -f 2- -d:|sort -u)" "int main(void) { return 0; }" |
+	"$TOPDIR"/jparse/test_jparse/*.[hc]|grep -vE '<dbg\.h>|<dyn_array\.h>|<c_bool\.h>|<c_compat\.h>' |cut -f 2- -d:|sort -u)" "int main(void) { return 0; }" |
 	    "${CC}" -x c - -o "$PROG_FILE"
     status="$?"
     if [[ $status -ne 0 ]]; then


### PR DESCRIPTION
Fix bug in test_ioccc/hostchk.sh where if you did not have dbg and dyn_array installed it would fail as it was looking for new include files. It appears that this did not happen with jparse not being installed but if anyone has an issue (I did a make uninstall but it's possible I missed something) **PLEASE** report it.

Updated HOSTCHK_VERSION to "2.0.2 2025-09-18".