### PR TITLE
Fix bug in cpath - missing version strings, typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,26 @@
 # Major changes to the IOCCC entry toolkit
 
 
-## release 2.7.3 2025-09-29
+## Release 2.7.4 2025-10-01
+
+Fix bug in `cpath` - the help string did not show all the versions.
+
+Fix typo in `cpath`.
+
+Synced copyright from `soup/file_util.[ch]` into `cpath` as the code is based on and
+uses it (originally under `jparse` in a rush to get IOCCC28 running).
+
+Changed quote in `soup/file_util.[ch]` to no longer refer to the JSON spec as
+it's now in the right place and outside of `jparse/`.
+
+Moved `CPATH_VERSION` into `soup/version.h`.
+
+Slight format change in some files under `soup/`.
+
+Updated `CPATH_VERSION` to `"1.0.1 2025-10-01"`.
+
+
+## Release 2.7.3 2025-09-29
 
 Updates from [dbg repo](https://github.com/lcn2/dbg).
 

--- a/cpath.c
+++ b/cpath.c
@@ -5,7 +5,8 @@
  *
  *      -- J.R.R. Tolkien
  *
- * Copyright (c) 2025 by Landon Curt Noll.  All rights reserved.
+ * Copyright (c) 2022-2025 by Landon Curt Noll and Cody Boone Ferguson.
+ * All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,
@@ -17,19 +18,26 @@
  *       source works derived from this source
  *       binaries derived from this source or from derived source
  *
- * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
- * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
- * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
- * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
+ * THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+ * ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+ * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- * chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ * This tool was co-developed in 2022-2025 by Cody Boone Ferguson and Landon
+ * Curt Noll:
+ *
+ *  @xexyl
+ *	https://xexyl.net		Cody Boone Ferguson
+ *	https://ioccc.xexyl.net
+ * and:
+ *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+ *
+ * "Because sometimes even the IOCCC Judges need some help." :-)
  *
  * Share and enjoy! :-)
  */
-
 
 /* special comments for the seqcexit tool */
 /* exit code out of numerical order - ignore in sequencing - ooo */
@@ -81,13 +89,21 @@
 #include "file_util.h"
 #endif
 
+/*
+ * version - official IOCCC toolkit versions
+ */
+#if defined(INTERNAL_INCLUDE)
+#include "soup/version.h"
+#else
+#include "version.h"
+#endif
+
 
 /*
  * definitions
  */
 #define REQUIRED_ARGS (0)	/* number of required arguments on the command line */
 #define CPATH_BASENAME "cpath"
-#define CPATH_VERSION "1.0.0 2025-09-28"
 
 
 /*
@@ -128,7 +144,9 @@ static const char * const usage_msg =
     " >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
-    "pr library version: %s\n";
+    "libdbg version: %s\n"
+    "libdyn_array version: %s\n"
+    "libpr library version: %s\n";
 
 
 /*
@@ -185,7 +203,7 @@ main(int argc, char *argv[])
 	case 'V':		/* -V - print version and exit */
 	    (void) printf("%s version: %s\n", CPATH_BASENAME, CPATH_VERSION);
 	    (void) printf("libdbg version: %s\n", dbg_version);
-	    (void) printf("libdyn_alloc version: %s\n", dyn_array_version);
+	    (void) printf("libdyn_array version: %s\n", dyn_array_version);
 	    (void) printf("libpr version: %s\n", pr_version);
 	    exit(2); /*ooo*/
 	    not_reached();
@@ -478,7 +496,9 @@ usage(int exitcode, char const *prog, char const *str)
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT,
 						     CPATH_BASENAME, CPATH_VERSION,
-						     dyn_array_version);
+                                                     dbg_version,
+						     dyn_array_version,
+                                                     pr_version);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/soup/file_util.c
+++ b/soup/file_util.c
@@ -1,7 +1,9 @@
 /*
  * file_util - common utility functions for file operations
  *
- * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ * "Courage is found in unlikely places."
+ *
+ *      -- J.R.R Tolkien
  *
  * Copyright (c) 2022-2025 by Cody Boone Ferguson and Landon Curt Noll. All
  * rights reserved.
@@ -5184,7 +5186,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
 	 * case: path is absolute, return "/" (slash)
 	 */
 	} else {
-
 	    /* return "/" (slash) */
 	    ret_path = strdup("/");
 	    if (ret_path == NULL) {
@@ -5233,7 +5234,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
      */
     ret_path = calloc(1, path_len+1+1);	/* +1 for trailing NUL, +1 for paranoia */
     if (ret_path == NULL) {
-
 	/* malloc failure */
 	report_canon_err(PATH_ERR_MALLOC, sanity_p, len_p, depth_p, path, array);
 	dbg(DBG_HIGH, "%s: error #3 %s: %s", __func__, path_sanity_name(sanity), path_sanity_error(sanity));
@@ -5248,7 +5248,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
      *	     has been already handled above.
      */
     for (q = dyn_array_first(array, char *); q < dyn_array_beyond(array, char *); ++q) {
-
 	/* paranoia */
 	if (q == NULL || *q == NULL) {
 
@@ -5262,7 +5261,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
 	 * append "/"s (slash) as needed
 	 */
 	if (q == dyn_array_first(array, char *)) {
-
 	    /*
 	     * case: on first component of the canonicalized path
 	     *
@@ -5270,9 +5268,7 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
 	     * An absolute canonicalized path starts with "/" (slash)
 	     */
 	    ret_path[0] = (relative) ? '\0' : '/';
-
 	} else {
-
 	    /*
 	     * case: a subsequent component of the canonicalized path
 	     */
@@ -5282,7 +5278,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
 	/* append component from stack */
 	strlcpy_ret = private_strlcat(ret_path, *q, path_len+1);
 	if (strlcpy_ret >= path_len+1) {
-
 	    /* canonicalized path length mis-calculation */
 	    report_canon_err(PATH_ERR_WRONG_LEN, sanity_p, len_p, depth_p, path, array);
 	    dbg(DBG_HIGH, "%s: error #0 %s: %s", __func__, path_sanity_name(sanity), path_sanity_error(sanity));
@@ -5291,7 +5286,6 @@ canon_path(char const *orig_path, size_t max_path_len, size_t max_filename_len, 
     }
     /* canonicalized path length sanity check */
     if (path_len != strlen(ret_path)) {
-
 	/* canonicalized path length mis-calculation */
 	report_canon_err(PATH_ERR_WRONG_LEN, sanity_p, len_p, depth_p, path, array);
 	dbg(DBG_HIGH, "%s: error #1 %s: %s", __func__, path_sanity_name(sanity), path_sanity_error(sanity));
@@ -5427,7 +5421,6 @@ calloc_path(char const *dirname, char const *filename)
      * NULL dirname means path is just filename
      */
     if (dirname == NULL) {
-
 	/*
 	 * just return a newly calloced filename
 	 */
@@ -5444,7 +5437,6 @@ calloc_path(char const *dirname, char const *filename)
      * We need to form: dirname/filename
      */
     } else {
-
 	/*
 	 * calloc string
 	 */

--- a/soup/file_util.h
+++ b/soup/file_util.h
@@ -1,7 +1,9 @@
 /*
  * file_util - common utility functions for file operations
  *
- * "Because specs w/o version numbers are forced to commit to their original design flaws." :-)
+ * "Courage is found in unlikely places."
+ *
+ *      -- J.R.R Tolkien
  *
  * Copyright (c) 2022-2025 by Cody Boone Ferguson and Landon Curt Noll. All
  * rights reserved.

--- a/soup/version.h
+++ b/soup/version.h
@@ -147,6 +147,11 @@
 #define MIN_CHKSUBMIT_VERSION CHKSUBMIT_VERSION
 
 /*
+ * official cpath version
+ */
+#define CPATH_VERSION "1.0.1 2025-10-01" /* format: major.minor YYYY-MM-DD */
+
+/*
  * Version of info for JSON the .entry.json files.
  */
 #define ENTRY_VERSION "1.2 2024-09-25"		/* format: major.minor YYYY-MM-DD */


### PR DESCRIPTION
Fix bug in cpath - the help string did not show all the versions.

Fix typo in cpath.

Synced copyright from soup/file_util.[ch] into cpath as the code is based on and uses it (originally under jparse in a rush to get IOCCC28 running).

Changed quote in soup/file_util.[ch] to no longer refer to the JSON spec as it's now in the right place and outside of jparse/.

Moved CPATH_VERSION into soup/version.h.

Slight format change in some files under soup/.

Updated CPATH_VERSION to "1.0.1 2025-10-01".