### PR TITLE
Add missing author to soup/walk*.[ch]

### DIFF
--- a/soup/walk.h
+++ b/soup/walk.h
@@ -12,7 +12,8 @@
  *		   might be one application of walking, so to is processing
  *		   the listing of a tar(1) command.
  *
- * Copyright (c) 2025 by Landon Curt Noll.   All Rights Reserved.
+ * Copyright (c) 2025 by Landon Curt Noll and Cody Boone Ferguson. All Rights
+ * Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,

--- a/soup/walk_tbl.c
+++ b/soup/walk_tbl.c
@@ -12,7 +12,8 @@
  *                 might be one application of walking, so to is processing
  *                 the listing of a tar(1) command.
  *
- * Copyright (c) 2025 by Landon Curt Noll.  All Rights Reserved.
+ * Copyright (c) 2025 by Landon Curt Noll and Cody Boone Ferguson.  All Rights
+ * Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,

--- a/soup/walk_util.c
+++ b/soup/walk_util.c
@@ -12,7 +12,8 @@
  *                 might be one application of walking, so to is processing
  *                 the listing of a tar(1) command.
  *
- * Copyright (c) 2025 by Landon Curt Noll.  All Rights Reserved.
+ * Copyright (c) 2025 by Landon Curt Noll and Cody Boone Ferguson.  All Rights
+ * Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,


### PR DESCRIPTION
As the copyright message even says 'authors' but that was actually Landon and me. My name was missing. Not vital but still inconsistent with the rest of soup/ and the copyright message.