### PR TITLE
GH-1330 Add missing `constexpr` keyword.

### DIFF
--- a/soup/rule_count.c
+++ b/soup/rule_count.c
@@ -164,6 +164,7 @@ static Word cwords[] = {
 	{ STRLEN("char"), "char" } ,				/* K&R */
 	{ STRLEN("compl"), "compl" } ,				/* +C89 iso646.h */
 	{ STRLEN("const"), "const" } ,				/* +C89 */
+	{ STRLEN("constexpr"), "constexpr" } ,			/* +C23 */
 	{ STRLEN("continue"), "continue" } ,			/* K&R */
 	{ STRLEN("default"), "default" } ,			/* K&R */
 	{ STRLEN("do"), "do" } ,				/* K&R */


### PR DESCRIPTION
Subject says its all.

### Sidebar

I compiled and ran the test suite clean, BUT there are lots of compiler warnings more than usual, like `printf` format /type issues and one I've never seen before... but sounds like `gcc` being annoying.

```
cc -std=gnu17 -O3 -pedantic -Wall -Wextra -Wno-char-subscripts -DINTERNAL_INCLUDE  walk_util.c -c
walk_util.c: In function 'alloc_item':
walk_util.c:422:25: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcal
loc-transposed-args]
  422 |     i_p = calloc(sizeof(struct item), 1);
      |                         ^~~~~~
walk_util.c:422:25: note: earlier argument should specify number of elements, later size of each element
```
