### PR TITLE
Improve get_mode() in txzchk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,21 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.9.2 2025-11-07
+
+Improve `get_mode()` in txzchk: it now takes the `struct txz_file *` rather than
+the `char *`s that were passed to the calling function. Also change literal
+string `"txzchk"` to `TXZCHK_BASENAME`.
+
+Updated `TXZCHK_VERSION` to `"2.0.12 2025-11-07"`.
+
+
 ## Release 2.9.1 2025-11-05
 
 Fixed workflow issues after resolving issue #1324. After the `mkiocccentry(1)`
 tool was changed to prevent certain things it meant the bad test cases were not
 actually bad (as the source was simply skipped over). Some test case have been
 removed.
-
 
 In the case of `chksubmit_test.sh` only one bad directory is now formed (the
 `test_ioccc/workdir/{good,bad}`, incidentally, are formed in

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.9.1 2025-11-05"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.9.2 2025-11-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
@@ -131,7 +131,7 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "2.0.11 2025-11-01"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define TXZCHK_VERSION "2.0.12 2025-11-07"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_TXZCHK_VERSION TXZCHK_VERSION
 
 /*

--- a/txzchk.h
+++ b/txzchk.h
@@ -203,7 +203,7 @@ static void parse_linux_txz_line(char *p, char *line, char *line_dup, char const
         char *perms, bool isexec);
 static void show_tarball_info(char const *tarball_path);
 static void check_all_txz_files(void);
-static mode_t get_mode(char const *filename, char const *perms);
+static mode_t get_mode(struct txz_file *file);
 static void add_txz_line(char const *str, uintmax_t line_num);
 static void parse_all_txz_lines(char const *dirname, char const *tarball_path);
 static void free_txz_lines(void);


### PR DESCRIPTION
Improve get_mode() in txzchk: it now takes the struct txz_file * rather than the char *s that were passed to the calling function. Also change literal string "txzchk" to TXZCHK_BASENAME.

Updated TXZCHK_VERSION to "2.0.12 2025-11-07".