### PR TITLE
Fix NULL deref in chkentry, improve test scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,26 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.9.3 2025-11-08
+
+Fixed NULL pointer dereference in `chkentry` when there is a walk error (i.e.
+when the program fails to validate the submission directory and exits 1). This
+occurred because in order to solve another issue we had to get the absolute
+path but before we could exit we freed it and set it to NULL - and without
+thinking about the err() call now being dynamically allocated it was not
+corrected (now it refers to `argv[optind]` via new `char *submit_dir` which is
+always set after `getopt()` code is done).
+
+Improved `mkiocccentry_test.sh` to create additional (more than one) bad
+submission directory for `chksubmit_test.sh`.
+
+Fixed typos (inconsistent) messages in `chksubmit_test.sh`.
+
+Updated `CHKENTRY_VERSION` to `"2.1.10 2025-11-08"`.
+Updated `MKIOCCCENTRY_TEST_VERSION` to `"2.1.2 2025-11-08"`.
+Updated `CHKSUBMIT_TEST_VERSION` to `"2.1.3 2025-11-08"`.
+
+
 ## Release 2.9.2 2025-11-07
 
 Improve `get_mode()` in txzchk: it now takes the `struct txz_file *` rather than

--- a/chkentry.c
+++ b/chkentry.c
@@ -121,6 +121,7 @@ main(int argc, char *argv[])
 {
     char const *program = NULL;		/* our name */
     char *submission_dir = NULL;        /* directory from which files are to be checked */
+    char *submit_dir = NULL;            /* this becomes argv[optind] for exiting 1 */
     extern char *optarg;		/* option argument */
     extern int optind;			/* argv index of the next arg */
     bool opt_error = false;		/* fchk_inval_opt() return */
@@ -223,6 +224,7 @@ main(int argc, char *argv[])
 	    break;
 	}
     }
+    submit_dir = argv[optind]; /* IMPORTANT! */
     switch (argc-optind) {
     case 1:
         /*
@@ -232,14 +234,14 @@ main(int argc, char *argv[])
         /*
          * chdir
          */
-        if (chdir(argv[optind]) != 0) {
-            errp(44, __func__, "failed to chdir() into submission dir: %s", argv[optind]);
+        if (chdir(submit_dir) != 0) {
+            errp(44, __func__, "failed to chdir() into submission dir: %s", submit_dir);
             not_reached();
         }
         errno = 0; /* pre-clear errno for errp() */
         submission_dir = getcwd(NULL, 0);
         if (submission_dir == NULL) {
-            errp(45, __func__, "failed to get absolute path for: %s", argv[optind]);
+            errp(45, __func__, "failed to get absolute path for: %s", submit_dir);
             not_reached();
         }
 	break;
@@ -593,7 +595,8 @@ main(int argc, char *argv[])
      * All Done!!! All Done!!! -- Jessica Noll, Age 2
      */
     if (!walk_ok) {
-	err(1, CHKENTRY_BASENAME, "check failed for: %s", submission_dir); /*ooo*/
+	err(1, CHKENTRY_BASENAME, "check failed for: %s", submit_dir); /*ooo*/
+        not_reached();
     }
     exit(0); /*ooo*/
 }

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.9.2 2025-11-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.9.3 2025-11-08"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
@@ -137,7 +137,7 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.1.9 2025-11-07"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.1.10 2025-11-08"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKENTRY_VERSION CHKENTRY_VERSION
 
 /*

--- a/test_ioccc/chksubmit_test.sh
+++ b/test_ioccc/chksubmit_test.sh
@@ -54,7 +54,7 @@ export EXIT_CODE=0
 export INVALID_DIRECTORY_FOUND=""
 export WORKDIR="./test_ioccc/workdir"
 
-export CHKSUBMIT_TEST_VERSION="2.1.2 2025-11-05"
+export CHKSUBMIT_TEST_VERSION="2.1.3 2025-11-08"
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-D dbg_level] [-q] [-c chksubmit] [-C chkentry] [-d workdir]
 
@@ -412,10 +412,10 @@ run_bad_test()
         fi
         EXIT_CODE=1
     else
-        echo "$0: test $workdir should PASS: chksubmit correctly passed with exit code: $status" | tee -a -- "${LOGFILE}"
+        echo "$0: test $workdir should FAIL: chksubmit correctly failed with exit code: $status" | tee -a -- "${LOGFILE}"
         if [[ $V_FLAG -ge 1 ]]; then
             if [[ $V_FLAG -ge 3 ]]; then
-                echo "$0: debug[3]: debug[3]: test $workdir should FAIL: chksubmit correctly passed with exit code: $status" | tee -a -- "${LOGFILE}"
+                echo "$0: debug[3]: debug[3]: test $workdir should FAIL: chksubmit correctly failed with exit code: $status" | tee -a -- "${LOGFILE}"
             fi
         fi
     fi

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -2,17 +2,42 @@
 #
 # mkiocccentry_test.sh - a test suite for the mkiocccentry tool (not repo)
 #
-# This script was written in 2022 by:
+# Copyright (c) 2022-2025 by Landon Curt Noll and Cody Boone Ferguson.
+# All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and
+# its documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright, this permission notice and text
+# this comment, and the disclaimer below appear in all of the following:
+#
+#       supporting documentation
+#       source copies
+#       source works derived from this source
+#       binaries derived from this source or from derived source
+#
+# THE AUTHORS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# This script and the JSON parser were co-developed in 2022-2025 by Cody Boone
+# Ferguson and Landon Curt Noll:
+#
+#  @xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+# and:
+#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# We wish to ESPECIALLY thank:
 #
 #	@ilyakurdyukov		Ilya Kurdyukov
 #
-# with many updates and improvements by:
-#
-#	@xexyl
-#	https://xexyl.net		Cody Boone Ferguson
-#	https://ioccc.xexyl.net
-# and
-#	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+# who wrote the original script in 2022. THANK YOU Ilya!
 #
 # Share and enjoy! :-)
 
@@ -94,7 +119,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="2.1.1 2025-11-05"
+export MKIOCCCENTRY_TEST_VERSION="2.1.2 2025-11-08"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit
@@ -836,21 +861,51 @@ fi
 echo
 echo "--"
 
-# form a bad submission for test_ioccc/chksubmit_test.sh to use
+# form bad submissions for test_ioccc/chksubmit_test.sh to use
 #
-# The above test should have passed but we need to make the directory bad for
-# test_chksubmit.sh, putting it in the bad tree.
+echo "# about to form bad submissions for test_ioccc/chksubmit_test.sh to use"
+# make another one with no .info.json, based on our last good submission
+# directory.
 #
-echo "# about to form a bad submission for test_ioccc/chksubmit_test.sh to use"
+echo cp -a "${WORKDIR_GOOD}/test-5" "${WORKDIR_BAD}/test-1"
+rm -f "${WORKDIR_BAD}/test-1/.info.json"
+
+# create another but this one has an invalid .auth.json file in that it has
+# invalid JSON
+#
+cp -a "${WORKDIR_GOOD}/test-5" "${WORKDIR_BAD}/test-2"
+chmod u=rw "${WORKDIR_BAD}/test-2/.auth.json"
+echo '>' >> "${WORKDIR_BAD}/test-2/.auth.json"
+echo
+
+# this next one has no prog.c
+cp -a "${WORKDIR_GOOD}/test-5" "${WORKDIR_BAD}/test-3"
+chmod u=rw "${WORKDIR_BAD}/test-3/prog.c"
+rm -f "${WORKDIR_BAD}/test-3/prog.c"
+echo
+
+# this one has an empty remarks.md file and no Makefile
+cp -a "${WORKDIR_GOOD}/test-5" "${WORKDIR_BAD}/test-4"
+chmod u=rw "${WORKDIR_BAD}/test-4/Makefile" "${WORKDIR_BAD}/test-4/remarks.md"
+rm -f "${WORKDIR_BAD}/test-4/Makefile"
+:> "${WORKDIR_BAD}/test-4/remarks.md"
+echo
+
+# lastly make a more complicated bad submission to test a number of errors
+#
 mkdir -p -- "${WORKDIR_BAD}/test-5"
 mkdir -p -- "${WORKDIR_BAD}/test-5/${topdir_topdir_topdir_topdir_topdir_tail}"
 find "${WORKDIR_BAD}/test-5/${topdir_topdir_topdir_topdir_topdir_head}" -type d -print0 | xargs -0 chmod 0755
 touch -- "${WORKDIR_BAD}/test-5/${topdir_topdir_topdir_topdir_topdir_tail}/foo"
 chmod 0444 "${WORKDIR_BAD}/test-5/${topdir_topdir_topdir_topdir_topdir_tail}/foo"
 echo
+
+
 echo "# formed a bad submission for test_ioccc/chksubmit_test.sh to use under: $TESTDIR"
 echo
 echo "--"
+
+
 
 # All Done!!! All Done!!! -- Jessica Noll, Age 2
 #


### PR DESCRIPTION
Fixed NULL pointer dereference in chkentry when there is a walk error (i.e.  when the program fails to validate the submission directory and exits 1). This occurred because in order to solve another issue we had to get the absolute path but before we could exit we freed it and set it to NULL - and without thinking about the err() call now being dynamically allocated it was not corrected (now it refers to argv[optind] via new char *submit_dir which is always set after getopt() code is done).

Improved mkiocccentry_test.sh to create additional (more than one) bad submission directory for chksubmit_test.sh.

Fixed typos (inconsistent) messages in chksubmit_test.sh.

Updated CHKENTRY_VERSION to "2.1.10 2025-11-08".
Updated MKIOCCCENTRY_TEST_VERSION to "2.1.2 2025-11-08". Updated CHKSUBMIT_TEST_VERSION to "2.1.3 2025-11-08".