### PR TITLE
Silence assorted compiler warnings on NetBSD gcc 14.3.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ C_OPT= -O3
 
 # Compiler warnings
 #
-WARN_FLAGS= -Wall -Wextra -Wno-char-subscripts
+WARN_FLAGS= -Wall -Wextra -Wno-char-subscripts -Wno-address
 #WARN_FLAGS= -Wall -Wextra -Werror
 
 # special compiler flags

--- a/jparse/jparse.l
+++ b/jparse/jparse.l
@@ -226,7 +226,7 @@ JSON_COMMA		","
                              * (depending on if the JSON debug level was high
                              * enough).
 			     */
-			    (void) json_dbg(JSON_DBG_VVHIGH, __func__, "\nignoring %d whitespace%s\n",
+			    (void) json_dbg(JSON_DBG_VVHIGH, __func__, "\nignoring %zu whitespace%s\n",
 							     yyleng, yyleng==1?"":"s");
 			}
 

--- a/jparse/jparse.y
+++ b/jparse/jparse.y
@@ -427,7 +427,7 @@ json_value:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: starting: "
 					       "json_value: JSON_TRUE");
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
-	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%d>", jparse_get_leng(scanner));
+	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%zu>", jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
 					       "$json_value = json_parse_bool(jparse_get_text(scanner));");
 	}
@@ -457,7 +457,7 @@ json_value:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: starting: "
 					       "json_value: JSON_FALSE");
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
-	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%d>", jparse_get_leng(scanner));
+	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%zu>", jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
 					       "$json_value = json_parse_bool(jparse_get_text(scanner))");
 	}
@@ -487,7 +487,7 @@ json_value:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: starting: "
 					       "json_value: JSON_NULL");
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yytext: <%s>", jparse_get_text(scanner));
-	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%d>", jparse_get_leng(scanner));
+	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_value: yyleng: <%zu>", jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_value: about to perform: "
 					       "$json_value = json_parse_null(jparse_get_text(scanner));");
 	}
@@ -855,7 +855,7 @@ json_string:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_string: starting: "
 					       "json_string: JSON_STRING");
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yytext: <%s>", jparse_get_text(scanner));
-	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yyleng: <%d>", jparse_get_leng(scanner));
+	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_string: yyleng: <%zu>", jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_string: about to perform: "
 					       "$json_string = json_parse_string(jparse_get_text(scanner), (size_t)jparse_get_leng(scanner);");
 	}
@@ -887,7 +887,7 @@ json_number:
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_number: starting: "
 					       "json_number: JSON_NUMBER");
 	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yytext: <%s>", jparse_get_text(scanner));
-	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yyleng: <%d>", jparse_get_leng(scanner));
+	    json_dbg(JSON_DBG_VVHIGH, __func__, "under json_number: yyleng: <%zu>", jparse_get_leng(scanner));
 	    json_dbg(JSON_DBG_VHIGH, __func__, "under json_number: about to perform: "
 					       "$json_number = json_parse_number(jparse_get_text(scanner));");
 	}


### PR DESCRIPTION
With the approaching code freeze I got tired of sifting through unnecessary warnings concerning `stderr` and format string types.

Test suite passes clean.