### PR TITLE
Fix issue #1355

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.9.5 2025-11-13
+
+Fix issue #1355 - fix `make install` to NOT install repo specific man pages and
+`make uninstall` to remove some man pages (and possibly scripts) that were
+erroneously installed (and also some that were not removed). This was done with
+the jparse/ repo too (synced here). It would appear the other repos did not have
+this problem.
+
+A cosmetic fix was made in the top level Makefile as well (in a comment).
+
+
 ## Release 2.9.4 2025-11-10
 
 Sync jparse/ from [jparse repo](https://github.com/xexyl/jparse). This should

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# This tool was co-developed in 2021-2025 by Cody Boone Ferguson and Landon
+# This toolkit (except the iocccsize(1) which was originally developed by
+# @SirWumpus [Anthony C Howe] in 1992 and further updated throughout the year
+# since then) was co-developed in 2021-2025 by Cody Boone Ferguson and Landon
 # Curt Noll:
 #
 #  @xexyl

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,13 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.5.4 2025-11-13
+
+Fix Makefile to not install repo specific man pages and to uninstall two missing
+man pages (that should be installed but were not removed by uninstall). Note
+that the uninstall rule still removes those (no longer installed) man pages as
+some of us have used make install (many times) so they would be there otherwise.
+
+
 ## Release 2.5.3 2025-11-10
 
 Cast `yyleng` (and `jparse_get_leng()`) to an int for systems like NetBSD that

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -403,9 +403,12 @@ EXTERN_CLOBBER= ${EXTERN_O} ${EXTERN_LIBA} ${EXTERN_PROG}
 
 # man pages
 #
-MAN1_TARGETS= ${MAN1_PAGES} ${MAN1_BUILT}
-MAN3_TARGETS= ${MAN3_PAGES} ${MAN3_BUILT}
-MAN8_TARGETS= ${MAN8_PAGES} ${MAN8_BUILT}
+MAN1_TARGETS= man/man1/jparse.1 man/man1/jstrdecode.1 man/man1/jstrencode.1
+MAN3_TARGETS= man/man3/jparse.3 man/man3/json_dbg.3 man/man3/json_dbg_allowed.3 \
+	    man/man3/json_err_allowed.3 man/man3/json_warn_allowed.3 man/man3/parse_json.3 \
+	    man/man3/parse_json_file.3 man/man3/parse_json_stream.3 man/man3/json_tree_free.3 \
+	    man/man3/parse_json_str.3 man/man3/json_tree_walk.3 man/man3/vjson_tree_walk.3
+MAN8_TARGETS= man/man8/jsemtblgen.8 man/man8/verge.8
 ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and remove by clobber
@@ -1017,7 +1020,7 @@ shellcheck: ${SH_FILES} .shellcheckrc test_jparse/Makefile
 #
 # NOTE: do NOT use -v ${VERBOSITY} here!
 #
-check_man: ${ALL_MAN_TARGETS}
+check_man: ${ALL_MAN_PAGES}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
@@ -1031,8 +1034,8 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo ''; 1>&2; \
 	    echo 'Or use the package manager in your OS to install it.' 1>&2; \
 	else \
-	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
-	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}"; \
+	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
@@ -1250,11 +1253,15 @@ uninstall: legacy_uninstall
 	${Q} ${RM} ${RM_V} -f ${MAN1_DIR}/jparse.1
 	${Q} ${RM} ${RM_V} -f ${MAN1_DIR}/jstrdecode.1
 	${Q} ${RM} ${RM_V} -f ${MAN1_DIR}/jstrencode.1
+	${Q} ${RM} ${RM_V} -f ${MAN1_DIR}/run_bison.1
+	${Q} ${RM} ${RM_V} -f ${MAN1_DIR}/run_flex.1
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/jparse.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_dbg.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_dbg_allowed.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_err_allowed.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_warn_allowed.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_tree_free.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/json_tree_walk.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/parse_json.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/parse_json_file.3
 	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/parse_json_stream.3

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.5.3 2025-11-10"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.5.4 2025-11-13"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/Makefile
+++ b/soup/Makefile
@@ -343,9 +343,10 @@ EXTERN_CLOBBER= ${EXTERN_O} ${EXTERN_LIBA} ${EXTERN_PROG}
 
 # man pages
 #
-MAN1_TARGETS= ${MAN1_PAGES} ${MAN1_BUILT}
-MAN3_TARGETS= ${MAN3_PAGES} ${MAN3_BUILT}
-MAN8_TARGETS= ${MAN8_PAGES} ${MAN8_BUILT}
+MAN1_TARGETS= man/man1/chkentry.1 man/man1/iocccsize.1 \
+	man/man1/mkiocccentry.1 man/man1/txzchk.1 man/man1/location.1 man/man1/chksubmit.1
+MAN3_TARGETS=
+MAN8_TARGETS=
 ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries
@@ -366,11 +367,11 @@ PROG_TARGETS= location
 
 # what to make by all but NOT to removed by clobber
 #
-ALL_OTHER_TARGETS= ${SH_TARGETS} extern_everything ${ALL_MAN_PAGES}
+ALL_OTHER_TARGETS= ${SH_TARGETS} extern_everything ${ALL_MAN_TARGETS}
 
 # what to make by all, what to install, and removed by clobber (and thus not ${ALL_OTHER_TARGETS})
 #
-TARGETS= ${LIBA_TARGETS} ${PROG_TARGETS} ${ALL_MAN_BUILT} limit_ioccc.sh
+TARGETS= ${LIBA_TARGETS} ${PROG_TARGETS} limit_ioccc.sh
 
 
 ############################################################
@@ -805,7 +806,7 @@ shellcheck: ${SH_FILES} .shellcheckrc
 
 # inspect and verify man pages
 #
-check_man: ${ALL_MAN_TARGETS}
+check_man: ${ALL_MAN_PAGES}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
@@ -818,8 +819,8 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo '    https://github.com/lcn2/checknr' 1>&2; \
 	    echo ''; 1>&2; \
 	else \
-	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
-	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}"; \
+	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \
@@ -832,11 +833,12 @@ check_man: ${ALL_MAN_TARGETS}
 
 # install man pages
 #
+# NOTE: we do NOT have man 3 and man 8 targets here because none of them are to
+# be installed and if we did have them here it would be an error as there would
+# be nothing to install.
 install_man: ${ALL_MAN_TARGETS}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${MAN1_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${MAN1_TARGETS} ${MAN1_DIR}
-	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${MAN8_DIR}
-	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${MAN8_TARGETS} ${MAN8_DIR}
 
 # vi/vim tags
 #
@@ -992,8 +994,10 @@ uninstall:
 	${E} ${RM} ${RM_V} -f ${MAN1_DIR}/mkiocccentry.1
 	${E} ${RM} ${RM_V} -f ${MAN1_DIR}/txzchk.1
 	${E} ${RM} ${RM_V} -f ${MAN1_DIR}/location.1
+	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/all_ref.8
 	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/all_sem_ref.8
 	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/reset_tstamp.8
+	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/chkentry_test.8
 	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/run_usage.8
 	${E} ${RM} ${RM_V} -f ${MAN8_DIR}/vermod.8
 	${S} echo

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.9.3 2025-11-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.9.4 2025-11-13"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/test_ioccc/Makefile
+++ b/test_ioccc/Makefile
@@ -340,9 +340,10 @@ EXTERN_CLOBBER= ${EXTERN_O} ${EXTERN_LIBA} ${EXTERN_PROG}
 
 # man pages
 #
-MAN1_TARGETS= ${MAN1_PAGES} ${MAN1_BUILT}
-MAN3_TARGETS= ${MAN3_PAGES} ${MAN3_BUILT}
-MAN8_TARGETS= ${MAN8_PAGES} ${MAN8_BUILT}
+MAN1_TARGETS= man/man1/fnamchk.1
+MAN3_TARGETS=
+MAN8_TARGETS= man/man8/utf8_test.8
+
 ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # shell targets to make by all and removed by clobber
@@ -355,7 +356,7 @@ PROG_TARGETS= utf8_test fnamchk test_file_util try_walk_set try_fts_walk
 
 # what to make by all but NOT to removed by clobber
 #
-ALL_OTHER_TARGETS= ${SH_TARGETS} extern_everything ${ALL_MAN_PAGES}
+ALL_OTHER_TARGETS= ${SH_TARGETS} extern_everything ${ALL_MAN_TARGETS}
 
 # what to make by all, what to install, and removed by clobber (and thus not ${ALL_OTHER_TARGETS})
 #
@@ -615,7 +616,7 @@ shellcheck: ${SH_FILES} .shellcheckrc
 
 # inspect and verify man pages
 #
-check_man: ${ALL_MAN_TARGETS}
+check_man: ${ALL_MAN_PAGES}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
@@ -627,8 +628,8 @@ check_man: ${ALL_MAN_TARGETS}
 	    echo ''; 1>&2; \
 	    echo '    https://github.com/lcn2/checknr' 1>&2; \
 	else \
-	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}"; \
-	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_TARGETS}; \
+	    echo "${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}"; \
+	    ${CHECKNR} -c.BR.SS.BI.IR.RB.RI ${ALL_MAN_PAGES}; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 0 ]]; then \
 		echo "make $@: ERROR: CODE[1]: $$EXIT_CODE" 1>&2; \


### PR DESCRIPTION
Fix make install to NOT install repo specific man pages and make uninstall to remove some man pages (and possibly scripts) that were erroneously installed (and also some that were not removed). This was done with the jparse/ repo too (synced here). It would appear the other repos did not have this problem.

A cosmetic fix was made in the top level Makefile as well (in a comment).