### PR TITLE
Fix critical bug in test_shell_script()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,27 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.10.1 2025-11-19
+
+Fix critical bug in `test_shell_script()` where a filename that ends with `.sh`
+was declared an invalid shellscript file name. The mkiocccentry did not have the
+same problem because of how it's constructed (in particular chkentry(1) uses the
+function described above as it is processing the manifest but the logic was
+broken). There has to be only two `if`: one to check for 0 length (this could
+actually be done in the second if, making it only one, but the error message is
+different - and I have tested an empty shellscript filename too when doing this
+fix) and one to verify that it ends in `.sh`. This function
+`test_shell_script()` could actually just call `is_executable_filename()` but
+the `test_shell_script()` has specific error messages depending on JSON debug
+level, meant for `chkentry(1)` and `chksubmit(1)`, though the former is meant
+only for the judges and the developers (i.e. Landon and me, meaning that Landon
+should be using it twice :-) ).
+
+Updated `SOUP_VERSION` to `"2.3.1 2025-11-19"`.
+Updated `CHKENTRY_VERSION` to `"2.2.1 2025-11-19"`.
+Updated `CHKSUBMIT_VERSION` to `"2.0.1 2025-11-19"`.
+
+
 ## Release 2.10.0 2025-11-18
 
 Release IOCCC29-beta of the mkiocccentry tooolkit.

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -4470,15 +4470,7 @@ test_shell_script(char const *str)
 	json_dbg(JSON_DBG_MED, __func__,
 		 "invalid: empty shell_script filename is invalid");
 	return false;
-    } else if (strcmp(str, TRY_SH) != 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: shell_script filename: <%s> invalid member name: shell_script != try_sh", str);
-	return false;
-    } else if (strcmp(str, TRY_ALT_SH) != 0) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: shell_script filename: <%s> invalid member name: shell_script != try_alt_sh", str);
-	return false;
-    } else if (len >= LITLEN(".sh") && strcmp(str + len - LITLEN(".sh"), ".sh") != 0) {
+    } else if (len < LITLEN(".sh") || strcmp(str + len - LITLEN(".sh"), ".sh") != 0) {
 	json_dbg(JSON_DBG_MED, __func__,
 		 "invalid: shell_script filename does not end in .sh");
 	json_dbg(JSON_DBG_HIGH, __func__,

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,12 +84,12 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.10.0 2025-11-18"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.10.1 2025-11-19"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.3.0 2025-11-18"		/* format: major.minor[.patch] YYYY-MM-DD */
+#define SOUP_VERSION "2.3.1 2025-11-19"		/* format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -137,13 +137,13 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.2.0 2025-11-18"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.2.1 2025-11-19"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKENTRY_VERSION CHKENTRY_VERSION
 
 /*
  * official chksubmit version
  */
-#define CHKSUBMIT_VERSION "2.0.0 2025-11-18"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKSUBMIT_VERSION "2.0.1 2025-11-19"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKSUBMIT_VERSION CHKSUBMIT_VERSION
 
 /*


### PR DESCRIPTION
Fix critical bug in test_shell_script() where a filename that ends with .sh was declared an invalid shellscript file name. The mkiocccentry did not have the same problem because of how it's constructed (in particular chkentry(1) uses the function described above as it is processing the manifest but the logic was broken). There has to be only two if: one to check for 0 length (this could actually be done in the second if, making it only one, but the error message is different - and I have tested an empty shellscript filename too when doing this fix) and one to verify that it ends in .sh. This function test_shell_script() could actually just call
is_executable_filename() but the test_shell_script() has specific error messages depending on JSON debug level, meant for chkentry(1) and chksubmit(1), though the former is meant only for the judges and the developers (i.e. Landon and me, meaning that Landon should be using it twice :-) ).

Updated SOUP_VERSION to "2.3.1 2025-11-19".
Updated CHKENTRY_VERSION to "2.2.1 2025-11-19".
Updated CHKSUBMIT_VERSION to "2.0.1 2025-11-19".