### PR TITLE
Typo fixes

### DIFF
--- a/cpath/test_cpath.sh
+++ b/cpath/test_cpath.sh
@@ -1154,7 +1154,7 @@ elif [[ $V_FLAG -ge 3 ]]; then
 fi
 
 
-# test alphanumeric safely check
+# test alphanumeric safety check
 #
 export P_STR
 export P_OUT
@@ -1212,7 +1212,7 @@ elif [[ $V_FLAG -ge 3 ]]; then
 fi
 
 
-# test alphanumeric safely check and lower case
+# test alphanumeric safety check and lower case
 #
 export P_STR
 export P_OUT
@@ -1270,7 +1270,7 @@ elif [[ $V_FLAG -ge 3 ]]; then
 fi
 
 
-# test alphanumeric safely check failure
+# test alphanumeric safety check failure
 #
 export P_STR
 export P_OUT

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -3349,9 +3349,9 @@ test_extra_filename(char const *str)
 		      &sanity, NULL, NULL, true, false, true, true, NULL);
     if (sanity != PATH_OK) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: canon_path safely check on extra_file failed");
+		 "invalid: canon_path safety check on extra_file failed");
 	json_dbg(JSON_DBG_HIGH, __func__,
-		 "invalid: canon_path safely check on extra_file failed: <%s>", str);
+		 "invalid: canon_path safety check on extra_file failed: <%s>", str);
 	return false;
     }
 


### PR DESCRIPTION
Instead of 'safety' in some places it said 'safely': in particular in cpath/test_cpath.sh and soup/entry_util.c.