### PR TITLE
Typo fix in txzchk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.11.1 2025-12-20
+
+Typo fix in `txzchk`.
+
+Changed `MIN_TXZCHK_VERSION` to `"2.1.0 2025-11-18"`.
+Updated `TXZCHK_VERSION` to `"2.1.1 2025-12-20"`.
+
+
 ## Release 2.11.0 2025-11-30
 
 Update `IOCCC_REGISTER_URL` to "https://www.freelists.org/list/ioccc29-reg".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.2 2026-05-11
+
+Update as per [jparse repo](https://github.com/xexyl/jparse) 2.5.9 2026-05-11
+which has in the Makefiles `-funsigned-char`. This does not, per tests locally,
+cause any problems here, and it might be necessary for another issue over there,
+and since the test suite works there too it should be fine. That issue is very
+low priority but it seems good to force `char`s to be `unsigned`.
+
+I believe this does not necessitate an update to the version of any tool here
+(possibly the parser version should have been updated over there but as no code
+was changed and I did not think of it it'll work for now) so only the repo
+version was changed.
+          
+Unless this is a problem that I have not thought of, when this is merged,
+presumably after IOCCC29 winners are released, issue #1387 can probably be
+closed.
+             
+
 
 ## Release 2.11.1 2026-05-06
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,23 +1,5 @@
 # Major changes to the IOCCC entry toolkit
 
-## Release 2.11.2 2026-05-11
-
-Update as per [jparse repo](https://github.com/xexyl/jparse) 2.5.9 2026-05-11
-which has in the Makefiles `-funsigned-char`. This does not, per tests locally,
-cause any problems here, and it might be necessary for another issue over there,
-and since the test suite works there too it should be fine. That issue is very
-low priority but it seems good to force `char`s to be `unsigned`.
-
-I believe this does not necessitate an update to the version of any tool here
-(possibly the parser version should have been updated over there but as no code
-was changed and I did not think of it it'll work for now) so only the repo
-version was changed.
-          
-Unless this is a problem that I have not thought of, when this is merged,
-presumably after IOCCC29 winners are released, issue #1387 can probably be
-closed.
-             
-
 
 ## Release 2.11.1 2026-05-06
 

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.0 2015-11-30"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.1 2015-12-20"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
@@ -131,8 +131,8 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "2.1.0 2025-11-18"	/* format: major.minor[.patch] YYYY-MM-DD */
-#define MIN_TXZCHK_VERSION TXZCHK_VERSION
+#define TXZCHK_VERSION "2.1.1 2025-12-20"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MIN_TXZCHK_VERSION "2.1.0 2025-11-18"
 
 /*
  * official chkentry version

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.1 2026-05-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.2 2026-05-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )

--- a/txzchk.c
+++ b/txzchk.c
@@ -1601,7 +1601,7 @@ check_tarball(char const *tar, char const *fnamchk)
 	errno = 0;		/* pre-clear errno for warnp() */
 	ret = setvbuf(input_stream, (char *)NULL, _IOLBF, 0);
 	if (ret != 0)
-	    warnp(TXZCHK_BASENAME, "is %s: setvbuf failed for %s", __func__, tarball_path);
+	    warnp(TXZCHK_BASENAME, "in %s: setvbuf failed for %s", __func__, tarball_path);
 
     } else {
 	/*


### PR DESCRIPTION
Changed MIN_TXZCHK_VERSION to "2.1.0 2025-11-18".
Updated TXZCHK_VERSION to "2.1.1 2025-12-20"`.

IMPORTANT NOTES: this is NOT a functional change! It is NOT necessary to have this before IOCCC30 and this is one of the reasons I changed the minimum version to what is now the previous version of txzchk. This is only done because it annoys me - NOT because it's important to anyone but me (and it's certainly unimportant for the contest). In other words even if this is not merged (or if it is not installed on the submit server) until after IOCCC29 it does not matter in the slightest. There is no real need other than to make me happier about the typo being killed.

... in fact although it has no functional change and although the min version should be fine I would personally not install this on the server until the next time - but that's me. I leave that to Landon nonetheless.