### PR TITLE
Fix txzchk linking: add -lm for floorl/floor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ txzchk.o: txzchk.c
 	${CC} ${CFLAGS} txzchk.c -c
 
 txzchk: txzchk.o soup/soup.a cpath/libcpath.a pr/libpr.a jparse/libjparse.a dyn_array/libdyn_array.a dbg/libdbg.a
-	${CC} ${CFLAGS} $^ -o $@
+	${CC} ${CFLAGS} $^ -lm -o $@
 
 chkentry.o: chkentry.c
 	${CC} ${CFLAGS} chkentry.c -c


### PR DESCRIPTION

**Problem**
`make clobber all` fails due to undefined `floorl`/`floor` references:
```
/usr/sbin/ld: jparse/libjparse.a(json_parse.o): in function `json_process_floating':
json_parse.c:(.text+0x1e8): undefined reference to `floorl'
/usr/sbin/ld: json_parse.c:(.text+0x648): undefined reference to `floorl'
/usr/sbin/ld: json_parse.c:(.text+0x6ec): undefined reference to `floor'
collect2: error: ld returned 1 exit status
make: *** [Makefile:527: txzchk] Error 1
```

**Fix**
Add `-lm` to txzchk target (Makefile:527)

**Results**
- `make clobber all` succeeds
- `./txzchk -h` works

Fixes ARMv8 32-bit Arch Linux build.