### PR TITLE
Fix issue #1380

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ answers file controls the yes or no.
 To fix the test script the good slots answers files had to be updated and
 `mkiocccentry_test.sh` had to be updated too (answers function).
 
+Updated `MKIOCCCENTRY_VERSION` to `"2.3.0 2026-03-14"`.
+Updated `MKIOCCCENTRY_TEST_VERSION` to `"2.1.3 2026-03-14"`.
+
 
 ## Release 2.11.0 2025-11-30
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.11.1 2026-03-14
+
+Fix issue #1380 - except the `mkiocccentry_test.sh` script as that has to do
+with the slots. There were two things that had to be done to get this to work
+(though I recommend more testing than what I did, even though I did try various
+combinations) is the `past_winning_author` has to be written to the answers file
+and in `yes_or_no()` the check that returns true if `answer_yes` or `force_yes`
+are true now only returns true if `!read_answers_flag_used`. This way the
+answers file controls the yes or no.
+
+The `mkiocccentry_test.sh` fails which means the workflow in GitHub will fail! I
+wanted this in though as it should fix mkiocccentry itself. As for the test
+script I BELIEVE it is due to the slots. There is an answers file read error
+which might make sense because there is more data in it now (or is supposed to
+be more data). A quick attempt at changing the slots file did not work (though
+the `mkiocccentry_slots.sh` exited 0) but as this is a good point to commit I am
+doing that as the test script can be fixed in another commit.
+
+
 ## Release 2.11.0 2025-11-30
 
 Update `IOCCC_REGISTER_URL` to "https://www.freelists.org/list/ioccc29-reg".

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,21 +3,15 @@
 
 ## Release 2.11.1 2026-03-14
 
-Fix issue #1380 - except the `mkiocccentry_test.sh` script as that has to do
-with the slots. There were two things that had to be done to get this to work
+Fix issue #1380. There were two things that had to be done to get this to work
 (though I recommend more testing than what I did, even though I did try various
 combinations) is the `past_winning_author` has to be written to the answers file
 and in `yes_or_no()` the check that returns true if `answer_yes` or `force_yes`
 are true now only returns true if `!read_answers_flag_used`. This way the
 answers file controls the yes or no.
 
-The `mkiocccentry_test.sh` fails which means the workflow in GitHub will fail! I
-wanted this in though as it should fix mkiocccentry itself. As for the test
-script I BELIEVE it is due to the slots. There is an answers file read error
-which might make sense because there is more data in it now (or is supposed to
-be more data). A quick attempt at changing the slots file did not work (though
-the `mkiocccentry_slots.sh` exited 0) but as this is a good point to commit I am
-doing that as the test script can be fixed in another commit.
+To fix the test script the good slots answers files had to be updated and
+`mkiocccentry_test.sh` had to be updated too (answers function).
 
 
 ## Release 2.11.0 2025-11-30

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1217,33 +1217,34 @@ main(int argc, char *argv[])
 	/*
 	 * write answers for each author to the answers file
 	 */
-	for (i = 0; i < author_count; i++) {
-	    errno = 0;			/* pre-clear errno for errp() */
-	    ret = fprintf(answersp,
-		"%s\n"	/* name */
-		"%s\n"	/* location code */
-		"%s\n"	/* email */
-		"%s\n"	/* url */
-		"%s\n"	/* alt_url */
-		"%s\n"	/* mastodon handle */
-		"%s\n"	/* GitHub */
-		"%s\n"	/* affiliation */
-		"%s\n"  /* author_handle */
-		,
-		author_set[i].name,
-		author_set[i].location_code,
-		author_set[i].email,
-		author_set[i].url,
-		author_set[i].alt_url,
-		author_set[i].mastodon,
-		author_set[i].github,
-		author_set[i].affiliation,
-		author_set[i].author_handle);
-	    if (ret <= 0) {
-		errp(45, __func__, "fprintf error printing author info to the answers file");
-                not_reached();
-	    }
-	}
+        for (i = 0; i < author_count; i++) {
+            errno = 0;                  /* pre-clear errno for warnp() */
+            ret = fprintf(answersp,
+                "%s\n"  /* name */
+                "%s\n"  /* location code */
+                "%s\n"  /* email */
+                "%s\n"  /* url */
+                "%s\n"  /* alt_url */
+                "%s\n"  /* mastodon handle */
+                "%s\n"  /* GitHub */
+                "%s\n"  /* affiliation */
+                "%s\n"  /* past winning author */
+                "%s\n"  /* author_handle */
+                ,
+                author_set[i].name,
+                author_set[i].location_code,
+                author_set[i].email,
+                author_set[i].url,
+                author_set[i].alt_url,
+                author_set[i].mastodon,
+                author_set[i].github,
+                author_set[i].affiliation,
+                author_set[i].past_winning_author?"y":"n",
+                author_set[i].author_handle);
+            if (ret <= 0) {
+                warnp(__func__, "fprintf error printing author info to the answers file");
+            }
+        }
     }
 
     /*
@@ -4648,7 +4649,7 @@ yes_or_no(char const *question, bool def_answer)
     /*
      * if -y or -Y, return true
      */
-    if (answer_yes || force_yes) {
+    if (!read_answers_flag_used && (answer_yes || force_yes)) {
 	/* return yes */
 	return true;
     }

--- a/soup/oebxergfB.h
+++ b/soup/oebxergfB.h
@@ -154,7 +154,7 @@ static char const *oebxergfB[] =
 "lwfsld-klwyhuep lybwa. Tnua iwtbuep ufw ue bqle ua ueflwyauep bnw awyxybwl\n"
 "twvwt xnufn awlusqatm wedyepwla fsyabyt bsxea yed iyhwa ub nyldwl osl asiw\n"
 "yeuiyta tuhw rstyl kwyla bs wvwe aqlvuvw. De bsr so bnyb, xyliwl xybwl ytas\n"
-"wzryeda bnw xybwl, iyhuep bnw awyxybwl twvwt wvwe nupnwl abutt.\n"
+"wzryeda, iyhuep bnw awyxybwl twvwt wvwe nupnwl abutt.\n"
 "\n"
 "Nqb esx asiw afuwebuaba yed yfbuvuaba ylw nupntupnbuep y rsaubuvw pyue yksqb\n"
 "ftuiybw fnyepw. Ga bnw rtyewb pwba nsbbwl yed dluwl, bnw bszuf pya dunmdlspwe\n"

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,12 +84,12 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.0 2015-11-30"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.1 2026-03-14"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.4.0 2015-11-30"		/* format: major.minor[.patch] YYYY-MM-DD */
+#define SOUP_VERSION "2.4.0 2025-11-30"		/* format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.3.0 2015-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.3.0 2026-03-14"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION MKIOCCCENTRY_VERSION
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC29-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
@@ -137,13 +137,13 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.3.0 2015-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.3.0 2025-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKENTRY_VERSION CHKENTRY_VERSION
 
 /*
  * official chksubmit version
  */
-#define CHKSUBMIT_VERSION "2.1.0 2015-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKSUBMIT_VERSION "2.1.0 2025-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKSUBMIT_VERSION CHKSUBMIT_VERSION
 
 /*

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -119,7 +119,7 @@ MAKE="$(type -P make 2>/dev/null)"
 export TXZCHK="./txzchk"
 export FNAMCHK="./test_ioccc/fnamchk"
 
-export MKIOCCCENTRY_TEST_VERSION="2.1.2 2025-11-08"
+export MKIOCCCENTRY_TEST_VERSION="2.1.3 2026-03-14"
 export USAGE="usage: $0 [-h] [-V] [-v level] [-J level] [-t tar] [-T txzchk] [-l ls] [-F fnamchk] [-m make] [-Z topdir]
 
     -h              print help and exit

--- a/test_ioccc/mkiocccentry_test.sh
+++ b/test_ioccc/mkiocccentry_test.sh
@@ -341,6 +341,7 @@ https://b.host0.example.com/index.html
 @mastodon0@example.com
 @github0
 an affiliation for #0 author
+y
 
 author1 middle1a middle1b last1
 UK
@@ -350,6 +351,7 @@ UK
 
 
 
+y
 replaced_author1_handle
 EOF
 # Avoid triggering an out of date shellcheck bug by using encoded hex characters
@@ -362,6 +364,7 @@ http://d.host2.example.com/index.html
 @mastodon2@example.com
 @github2
 an affiliation for #2 author
+n
 
 author3 middle3 last3
 AU
@@ -371,6 +374,7 @@ https://f.host0.example.com/index.html
 @mastodon3@example.com
 @github3
 an affiliation for #3 author
+n
 author3_last3
 @#$%^
 AU
@@ -380,6 +384,7 @@ https://g.host0.example.com/index.html
 @mastodon4@example.com
 @github4
 an affiliation for #4 author
+y
 
 ANSWERS_EOF
 EOF
@@ -449,6 +454,7 @@ https://b.host0.example.com/index.html
 @mastodon0@example.com
 @github0
 an affiliation for #0 author
+y
 
 author1 middle1a middle1b last1
 UK
@@ -458,6 +464,7 @@ UK
 
 
 
+n
 replaced_author1_handle
 EOF
 # Avoid triggering an out of date shellcheck bug by using encoded hex characters
@@ -470,6 +477,7 @@ http://d.host2.example.com/index.html
 @mastodon2@example.com
 @github2
 an affiliation for #2 author
+y
 
 author3 middle3 last3
 AU
@@ -479,6 +487,7 @@ https://f.host0.example.com/index.html
 @mastodon3@example.com
 @github3
 an affiliation for #3 author
+y
 author3_last3
 @#$%^
 AU
@@ -488,6 +497,7 @@ https://g.host0.example.com/index.html
 @mastodon4@example.com
 @github4
 an affiliation for #4 author
+y
 
 ANSWERS_EOF
 EOF
@@ -572,6 +582,7 @@ https://i.host0.example.com/index.html
 @mastodon0@example.com
 @github0
 an affiliation for #0 author
+y
 
 author1 middle1a middle1b last1
 UK
@@ -581,6 +592,7 @@ UK
 
 
 
+n
 replaced_author1_handle
 EOF
 # Avoid triggering an out of date shellcheck bug by using encoded hex characters
@@ -593,6 +605,7 @@ http://k.host2.example.com/index.html
 @mastodon2@example.com
 @github2
 an affiliation for #2 author
+y
 
 author3 middle3 last3
 AU
@@ -602,6 +615,7 @@ https://l.host0.example.com/index.html
 @mastodon3@example.com
 @github3
 an affiliation for #3 author
+y
 author3_last3
 @#$%^
 AU
@@ -611,6 +625,7 @@ https://m.host0.example.com/index.html
 @mastodon4@example.com
 @github4
 an affiliation for #4 author
+y
 
 ANSWERS_EOF
 EOF
@@ -673,6 +688,7 @@ https://o.host0.example.com/index.html
 @mastodon0@example.com
 @github0
 an affiliation for #0 author
+y
 
 author1 middle1a middle1b last1
 UK
@@ -682,6 +698,7 @@ UK
 
 
 
+n
 replaced_author1_handle
 EOF
 # Avoid triggering an out of date shellcheck bug by using encoded hex characters
@@ -694,6 +711,7 @@ http://p.host2.example.com/index.html
 @mastodon2@example.com
 @github2
 an affiliation for #2 author
+y
 
 author3 middle3 last3
 AU
@@ -703,6 +721,7 @@ https://r.host0.example.com/index.html
 @mastodon3@example.com
 @github3
 an affiliation for #3 author
+y
 author3_last3
 @#$%^
 AU
@@ -712,6 +731,7 @@ https://t.host0.example.com/index.html
 @mastodon4@example.com
 @github4
 an affiliation for #4 author
+y
 
 ANSWERS_EOF
 EOF
@@ -773,6 +793,7 @@ https://b.host0.example.com/index.html
 @mastodon0@example.com
 @github0
 an affiliation for #0 author
+y
 
 author1 middle1a middle1b last1
 UK
@@ -782,6 +803,7 @@ UK
 
 
 
+y
 replaced_author1_handle
 EOF
 # Avoid triggering an out of date shellcheck bug by using encoded hex characters
@@ -794,6 +816,7 @@ http://d.host2.example.com/index.html
 @mastodon2@example.com
 @github2
 an affiliation for #2 author
+y
 
 author3 middle3 last3
 AU
@@ -803,6 +826,7 @@ https://f.host0.example.com/index.html
 @mastodon3@example.com
 @github3
 an affiliation for #3 author
+y
 author3_last3
 @#$%^
 AU
@@ -812,6 +836,7 @@ https://g.host0.example.com/index.html
 @mastodon4@example.com
 @github4
 an affiliation for #4 author
+y
 
 ANSWERS_EOF
 EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-3
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-3
@@ -12,5 +12,6 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-4
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-4
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 anon3
 SB
@@ -21,5 +22,6 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-5
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-5
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+n
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,7 @@ XX
 
 
 
+y
 anonymous_person
 first2 last2
 US
@@ -30,6 +32,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+n
 first2_last2
 anon3
 SB
@@ -39,5 +42,6 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-6
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-6
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+n
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,7 @@ XX
 
 
 
+n
 anonymous_person
 first2 last2
 US
@@ -30,6 +32,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+n
 first2_last2
 anon3
 SB
@@ -39,6 +42,7 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 first4 last4
 RW
@@ -48,5 +52,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+y
 first4_last4
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-7
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-7
@@ -12,5 +12,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+y
 first4_last4
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-8
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-8
@@ -12,5 +12,6 @@ https://host5.example.tr
 @user5@example.tr
 @user5
 
+y
 first5_middle5_2nd5_last5
 ANSWERS_EOF

--- a/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-9
+++ b/test_ioccc/slot/bad/answers/12345678-1234-4321-abcd-1234567890ab-9
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+x
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,8 @@ XX
 
 
 
+
+y
 anonymous_person
 first2 last2
 US
@@ -30,6 +33,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+y
 first2_last2
 anon3
 SB
@@ -39,6 +43,7 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 first4 last4
 RW
@@ -48,5 +53,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+n
 first4_last4
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-0
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-0
@@ -12,5 +12,6 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-1
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-1
@@ -12,5 +12,6 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+n
 first0_middle0_last0
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-2
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-2
@@ -11,6 +11,7 @@ XX
 
 
 
+y
 
 anonymous_person
 anonymous_person
@@ -21,6 +22,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+y
 first2_last2
 anon3
 SB
@@ -30,5 +32,6 @@ user3@example.sb
 @user3@example.sb
 
 
+y
 anon3
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-3
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-3
@@ -12,5 +12,6 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-4
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-4
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 anon3
 SB
@@ -21,5 +22,6 @@ user3@example.sb
 @user3@example.sb
 
 
+y
 anon3
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-5
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-5
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+n
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,7 @@ XX
 
 
 
+n
 anonymous_person
 first2 last2
 US
@@ -30,6 +32,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+n
 first2_last2
 anon3
 SB
@@ -39,5 +42,6 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-6
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-6
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+y
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,7 @@ XX
 
 
 
+n
 anonymous_person
 first2 last2
 US
@@ -30,6 +32,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+y
 first2_last2
 anon3
 SB
@@ -39,6 +42,7 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 first4 last4
 RW
@@ -48,5 +52,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+y
 first4_last4
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-7
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-7
@@ -12,5 +12,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+y
 first4_last4
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-8
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-8
@@ -12,5 +12,6 @@ https://host5.example.tr
 @user5@example.tr
 @user5
 
+y
 first5_middle5_2nd5_last5
 ANSWERS_EOF

--- a/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-9
+++ b/test_ioccc/slot/good/answers/12345678-1234-4321-abcd-1234567890ab-9
@@ -12,6 +12,7 @@ https://alt0.example.au/index.html
 @user0@example.au
 @user0
 affiliation for user 0
+n
 first0_middle0_last0
 anonymous person
 XX
@@ -21,6 +22,7 @@ XX
 
 
 
+n
 anonymous_person
 first2 last2
 US
@@ -30,6 +32,7 @@ http://host2.example.us/index.html
 @user2@example.us
 @user2
 affiliation for user 2
+n
 first2_last2
 anon3
 SB
@@ -39,6 +42,7 @@ user3@example.sb
 @user3@example.sb
 
 
+n
 anon3
 first4 last4
 RW
@@ -48,5 +52,6 @@ https://alt4.example.rw/index.html
 
 @user4
 affiliation for user 4
+y
 first4_last4
 ANSWERS_EOF


### PR DESCRIPTION
Fix issue #1380 - except the mkiocccentry_test.sh script as that has to do with the slots. There were two things that had to be done to get this to work (though I recommend more testing than what I did, even though I did try various combinations) is the past_winning_author has to be written to the answers file and in yes_or_no() the check that returns true if answer_yes or force_yes are true now only returns true if !read_answers_flag_used. This way the answers file controls the yes or no.

The mkiocccentry_test.sh fails which means the workflow in GitHub will fail! I wanted this in though as it should fix mkiocccentry itself. As for the test script I BELIEVE it is due to the slots. There is an answers file read error which might make sense because there is more data in it now (or is supposed to be more data). A quick attempt at changing the slots file did not work (though the mkiocccentry_slots.sh exited 0) but as this is a good point to commit I am doing that as the test script can be fixed in another commit.