### PR TITLE
GH-1384 Remove unused code that tested for strict ASCII, since it

### DIFF
--- a/iocccsize.c
+++ b/iocccsize.c
@@ -217,9 +217,6 @@ main(int argc, char **argv)
 	/*
 	 * issue warnings
 	 */
-	if (1 < verbosity_level && 0 < count.char_warning) {
-		iocccsize_warnx("Warning: character(s) with high bit set found! Be careful you don't violate rule 13!");
-	}
         if (1 < verbosity_level && count.nul_warning) {
 		iocccsize_warnx("Warning: NUL character(s) found! Be careful you don't violate rule 13!");
 	}

--- a/iocccsize.h
+++ b/iocccsize.h
@@ -34,7 +34,6 @@ typedef struct
 	size_t rule_2a_size;	/* official IOCCC Rule 2a calculated size */
 	size_t rule_2b_size;	/* official IOCCC Rule 2b calculated size */
 	size_t keywords;	/* keyword count - for -v mode */
-	bool char_warning;	/* true ==> found high-bit or non-ASCII character */
 	bool nul_warning;	/* true ==> found NUL */
 	bool trigraph_warning;	/* true ==> found an unknown Tri-Graph */
 	bool wordbuf_warning;	/* true ==> word buffer overflow detected */

--- a/soup/rule_count.c
+++ b/soup/rule_count.c
@@ -238,7 +238,7 @@ rule_count(FILE *fp_in)
 {
 	size_t wordi = 0;
 	char word[WORD_BUFFER_SIZE];
-	RuleCount counts = { 0, 0, 0, false, false, false, false, false };
+	RuleCount counts = { 0, 0, 0, false, false, false, false };
 	int ch, next_ch, quote = NO_STRING, escape = 0, is_comment = NO_COMMENT;
 
 /* If quote == NO_STRING (0) and is_comment == NO_COMMENT (0) then its code. */

--- a/soup/rule_count.c
+++ b/soup/rule_count.c
@@ -8,24 +8,6 @@
  */
 
 /*
- * ISO C11 section 5.2.1 defines source character set, specifically:
- *
- *	The representation of each member of the source and execution
- *	basic character sets shall fit in a byte.
- *
- * Note however that string literals and comments could contain non-ASCII
- * (consider non-English developers writing native language comments):
- *
- *	If any other characters are encountered in a source file (except
- *	in an identifier, a character constant, a string literal, a header
- *	name, a comment, or a preprocessing token that is never converted
- *	to a token), the behavior is undefined.
- *
- * Probably best to leave as-is, count them, and let the compiler sort it.
- */
-#undef ASCII_ONLY
-
-/*
  * HINT: The algorithm implemented by this code may or not be obfuscated.
  *       The algorithm may not or may appear to be obfuscated.
  *
@@ -282,14 +264,6 @@ rule_count(FILE *fp_in)
 			/* Discard bare CR and those part of CRLF. */
 			counts.rule_2a_size++;
 		}
-#ifdef ASCII_ONLY
-		if (!isascii(ch) || (ch >= 0x80)) {
-			counts.char_warning = true;
-			counts.rule_2a_size++;
-			continue;
-		}
-#endif
-
 #ifdef TRIGRAPHS
 		if (ch == '?' && next_ch == '?') {
 			/* ISO C11 section 5.2.1.1 Trigraph Sequences */


### PR DESCRIPTION
has always been disabled and the IOCCC now clearly supports UTF-8.