### PR TITLE
Update jparse Makefiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.2 2026-05-11
+
+Update as per [jparse repo](https://github.com/xexyl/jparse) 2.5.9 2026-05-11
+which has in the Makefiles `-funsigned-char`. This does not, per tests locally,
+cause any problems here, and it might be necessary for another issue over there,
+and since the test suite works there too it should be fine. That issue is very
+low priority but it seems good to force `char`s to be `unsigned`.
+
+I believe this does not necessitate an update to the version of any tool here
+(possibly the parser version should have been updated over there but as no code
+was changed and I did not think of it it'll work for now) so only the repo
+version was changed.
+
+Unless this is a problem that I have not thought of, when this is merged,
+presumably after IOCCC29 winners are released, issue #1387 can probably be
+closed.
+
 
 ## Release 2.11.1 2026-05-06
 

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,17 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.5.9 2026-05-11
+
+Added `-funsigned-char` to Makefiles. It is possible that this will be useful in
+finally resolving issue #31 although it's not as simple as scanning for high
+bytes: for example `0x80` is a continuation byte so we can't outright declare it
+is an error as it depends on context. This issue is very low priority and some
+ideas are in my mind (though quite possibly not worked on for quite some time)
+on what might have to be done but adding this option to the Makefiles does not
+cause any problems here or in the [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry) which is where `jparse` and its
+tools were originally developed.
+
 
 ## Release 2.5.8 2026-05-06
 

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -190,7 +190,7 @@ WARN_FLAGS= -pedantic -Wall -Wextra -Wformat -Wno-char-subscripts -Wno-sign-comp
 
 # special compiler flags
 #
-C_SPECIAL=
+C_SPECIAL= -funsigned-char
 
 # special linker flags
 #

--- a/jparse/test_jparse/Makefile
+++ b/jparse/test_jparse/Makefile
@@ -186,7 +186,7 @@ WARN_FLAGS= -Wall -Wextra -Wformat -Wno-char-subscripts
 
 # special compiler flags
 #
-C_SPECIAL=
+C_SPECIAL= -funsigned-char
 
 
 # special linker flags

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.5.8 2026-05-06"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.5.9 2026-05-11"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.1 2026-05-06"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.2 2026-05-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
Update as per jparse repo (https://github.com/xexyl/jparse) 2.5.9 2026-05-11 which has in the Makefiles -funsigned-char. This does not, per tests locally, cause any problems here, and it might be necessary for another issue over there, and since the test suite works there too it should be fine. That issue is very low priority but it seems good to force chars to be unsigned.

I believe this does not necessitate an update to the version of any tool here (possibly the parser version should have been updated over there but as no code was changed and I did not think of it it'll work for now) so only the repo version was changed.

Unless this is a problem that I have not thought of, when this is merged, presumably after IOCCC29 winners are released, issue #1387 can probably be closed.