### PR TITLE
Resolve issues #1389, #1379, #1373

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,33 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.3 2026-06-07
+
+Resolve issues #1389, #1379, 1373.
+
+Remove the 'total file size' check in `mkiocccentry`. This does not work as
+intended because it does not account for the JSON files and it does not account
+for the compression (in fact the total file size is validated through `txzchk`
+and it's a fatal error then but if it was before that it would mean users would
+have to, assuming no answers file, input data again if say on the first time
+they had this problem, and that is just one issue amongst others).
+
+Updated tools (except `mkiocccentry` which already did this) to show in `-V` and
+`-h` option (with the latter it is shown with any usage error) the repo version
+as well (right under the tool's version and above the libraries). The tools are:
+`txzchk`, `fnamchk`, `location`, `chkentry` and `chksubmit`.
+
+Type fix in `bug_report.sh`.
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.3.2 2026-06-07"`.
+Updated `MIN_MKIOCCCENTRY_VERSION` to `MKIOCCCENTRY_VERSION`. This is because
+we're in between contests now and the next contest will require the current
+version.
+
+Because the only other code changes were to print the repo version those tools
+did not have their version updated. The only reason `mkiocccentry` had its
+version updated is because a functional change was made.
+
+
 ## Release 2.11.2 2026-05-11
 
 Update as per [jparse repo](https://github.com/xexyl/jparse) 2.5.9 2026-05-11

--- a/bug_report.sh
+++ b/bug_report.sh
@@ -198,7 +198,7 @@ done
 
 # make sure that make is an executable file
 #
-# First, if the user for some reason provided an empty string, try an correct it
+# First, if the user for some reason provided an empty string, try and correct it
 # for them:
 if [[ -z "$MAKE" ]]; then
 	# try for gmake first

--- a/chkentry.c
+++ b/chkentry.c
@@ -105,6 +105,7 @@ static const char * const usage_msg =
     "    >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
+    "mkiocccentry repo release: %s\n"
     "jparse utils version: %s\n"
     "jparse UTF-8 version: %s\n"
     "jparse library version: %s";
@@ -183,6 +184,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", CHKENTRY_BASENAME, CHKENTRY_VERSION);
+	    print("mkiocccentry repo release: %s\n", MKIOCCCENTRY_REPO_VERSION);
 	    print("jparse utils version: %s\n", JPARSE_UTILS_VERSION);
 	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
 	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
@@ -634,7 +636,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, JSON_DBG_DEFAULT,
-	    CHKENTRY_BASENAME, CHKENTRY_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
+	    CHKENTRY_BASENAME, CHKENTRY_VERSION, MKIOCCCENTRY_REPO_VERSION, JPARSE_UTILS_VERSION,
+            JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/chksubmit.c
+++ b/chksubmit.c
@@ -92,6 +92,7 @@ static const char * const usage_msg =
     "    >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
+    "mkiocccentry repo release: %s\n"
     "jparse utils version: %s\n"
     "jparse UTF-8 version: %s\n"
     "jparse library version: %s";
@@ -140,7 +141,8 @@ usage(int exitcode, char const *prog, char const *str)
 	fprintf_usage(DO_NOT_EXIT, stderr, "%s\n", str);
     }
     fprintf_usage(exitcode, stderr, usage_msg, prog,
-	    CHKSUBMIT_BASENAME, CHKSUBMIT_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
+	    CHKSUBMIT_BASENAME, CHKSUBMIT_VERSION, MKIOCCCENTRY_REPO_VERSION, JPARSE_UTILS_VERSION,
+            JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }
@@ -264,6 +266,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit */
 	    print("%s version: %s\n", CHKSUBMIT_BASENAME, CHKSUBMIT_VERSION);
+	    print("mkiocccentry repo release: %s\n", MKIOCCCENTRY_REPO_VERSION);
 	    print("jparse utils version: %s\n", JPARSE_UTILS_VERSION);
 	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
 	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -218,7 +218,6 @@ static int workdirfd = -1;              /* workdir FD */
 static int cwd = -1;                    /* initial directory FD */
 static int answersfd = -1;              /* -i answers fd */
 static struct stat answers_st;
-static off_t total_file_size = 0;       /* total size of all files to be copied (in topdir) */
 static long answer_seed = NO_SEED;	/* if != 0 ==> srandom argument used to seed generation of answers */
 static FILE *manifest = NULL;           /* manifest file */
 
@@ -1940,7 +1939,6 @@ show_copy_list(struct walk_stat *wstat, char const *context, struct info *infop,
         not_reached();
     } else {
         len = dyn_array_tell(wstat->file);
-        total_file_size = 0; /* paranoia reset */
         if (len <= 0) {
             err(4, __func__, "list of files is empty"); /*ooo*/
             not_reached();
@@ -1966,30 +1964,7 @@ show_copy_list(struct walk_stat *wstat, char const *context, struct info *infop,
                 } else if (path_in_item_array(wstat->prune, p->fts_path) != NULL) {
                     continue;
                 }
-                total_file_size += p->st_size;
                 print("%s\n", p->fts_path);
-            }
-            print("\nEstimated total file size: %lld.\n", (long long)total_file_size);
-            if (!answer_yes) {
-                if (total_file_size > MAX_SUM_FILELEN) {
-                    /*
-                     * We probably should check >= because we have to create the
-                     * JSON files as well. But since those are an indeterminate
-                     * size but are also > 1 byte it doesn't really matter.
-                     */
-                    print("\nWARNING: the %lld estimate exceeds the Rule 17 limit of %d.\n",
-                            (long long)total_file_size, MAX_SUM_FILELEN);
-                }
-                para("",
-                     "If this list is incorrect, you will have to fix your topdir and try again.",
-                     NULL);
-                yorn = yes_or_no("\nDo you wish to continue? [Yn]", true);
-                if (!yorn) {
-                    print("we suggest you fix your %s directory,\ndelete %s and try again\n",
-                            wstat->topdir, submit_path);
-                    err(5, __func__, "aborting because user said files list is not OK"); /*ooo*/
-                    not_reached();
-                }
             }
         }
     }
@@ -3353,7 +3328,7 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
 	/*
 	 * prompt for the contest ID
 	 */
-	calloc_ret = prompt("Enter IOCCC contest ID or test", &len);
+	calloc_ret = prompt("Enter the UUID username you received in the welcome email or test", &len);
 	if (!seen_answers_header && !strcmp(calloc_ret, MKIOCCCENTRY_ANSWERS_VERSION)) {
 	    dbg(DBG_HIGH, "found answers header");
 	    seen_answers_header = true;

--- a/soup/location_main.c
+++ b/soup/location_main.c
@@ -87,6 +87,7 @@ static const char * const usage_msg =
     "    >=4\tinternal error\n"
     "\n"
     "%s version: %s\n"
+    "mkiocccentry repo release: %s\n"
     "jparse UTF-8 version: %s\n"
     "jparse library version: %s";
 
@@ -140,6 +141,7 @@ main(int argc, char **argv)
             break;
         case 'V':               /* -V - print version and exit */
             print("%s version: %s\n", LOCATION_BASENAME, LOCATION_VERSION);
+	    print("mkiocccentry repo release: %s\n", MKIOCCCENTRY_REPO_VERSION);
 	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
 	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
             exit(2); /*ooo*/
@@ -354,7 +356,7 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, LOCATION_BASENAME, LOCATION_VERSION,
-	    JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
+            MKIOCCCENTRY_REPO_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.2 2026-05-11"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.3 2026-06-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
@@ -100,8 +100,8 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.3.1 2026-05-06"	/* format: major.minor[.patch] YYYY-MM-DD */
-#define MIN_MKIOCCCENTRY_VERSION "2.3.0 2015-11-30"
+#define MKIOCCCENTRY_VERSION "2.3.2 2026-06-07"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MIN_MKIOCCCENTRY_VERSION MKIOCCCENTRY_VERSION
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC29-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
 
@@ -137,13 +137,13 @@
 /*
  * official chkentry version
  */
-#define CHKENTRY_VERSION "2.3.0 2015-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKENTRY_VERSION "2.3.0 2025-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKENTRY_VERSION CHKENTRY_VERSION
 
 /*
  * official chksubmit version
  */
-#define CHKSUBMIT_VERSION "2.1.0 2015-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define CHKSUBMIT_VERSION "2.1.0 2025-11-30"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_CHKSUBMIT_VERSION CHKSUBMIT_VERSION
 
 /*

--- a/test_ioccc/fnamchk.c
+++ b/test_ioccc/fnamchk.c
@@ -94,6 +94,7 @@ static const char * const usage_msg =
     "     >=10\tinternal error\n"
     "\n"
     "%s version: %s\n"
+    "mkiocccentry repo release: %s\n"
     "jparse utils version: %s\n"
     "jparse UTF-8 version: %s\n"
     "jparse library version: %s";
@@ -162,6 +163,7 @@ main(int argc, char *argv[])
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", FNAMCHK_BASENAME, FNAMCHK_VERSION);
+	    print("mkiocccentry repo release: %s\n", MKIOCCCENTRY_REPO_VERSION);
 	    print("jparse utils version: %s\n", JPARSE_UTILS_VERSION);
 	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
 	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
@@ -443,7 +445,7 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, (UUID_LEN+1+MAX_SUBMIT_SLOT_CHARS),
-	    (LITLEN("test-")+MAX_SUBMIT_SLOT_CHARS), FNAMCHK_BASENAME, FNAMCHK_VERSION,
+	    (LITLEN("test-")+MAX_SUBMIT_SLOT_CHARS), FNAMCHK_BASENAME, FNAMCHK_VERSION, MKIOCCCENTRY_REPO_VERSION,
 	    JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();

--- a/txzchk.c
+++ b/txzchk.c
@@ -143,6 +143,7 @@ static const char * const usage_msg =
     " >= 10   internal error has occurred or unknown tar listing format has been encountered\n"
     "\n"
     "%s version: %s\n"
+    "mkiocccentry repo release: %s\n"
     "jparse utils version: %s\n"
     "jparse UTF-8 version: %s\n"
     "jparse library version: %s";
@@ -194,6 +195,7 @@ main(int argc, char **argv)
 	    break;
 	case 'V':		/* -V - print version and exit 2 */
 	    print("%s version: %s\n", TXZCHK_BASENAME, TXZCHK_VERSION);
+	    print("mkiocccentry repo release: %s\n", MKIOCCCENTRY_REPO_VERSION);
 	    print("jparse utils version: %s\n", JPARSE_UTILS_VERSION);
 	    print("jparse UTF-8 version: %s\n", JPARSE_UTF8_VERSION);
 	    print("jparse library version: %s\n", JPARSE_LIBRARY_VERSION);
@@ -431,7 +433,8 @@ usage(int exitcode, char const *prog, char const *str)
     }
 
     fprintf_usage(exitcode, stderr, usage_msg, prog, DBG_DEFAULT, TAR_PATH_0, FNAMCHK_PATH_0,
-	    TXZCHK_BASENAME, TXZCHK_VERSION, JPARSE_UTILS_VERSION, JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
+	    TXZCHK_BASENAME, MKIOCCCENTRY_REPO_VERSION, TXZCHK_VERSION, JPARSE_UTILS_VERSION,
+            JPARSE_UTF8_VERSION, JPARSE_LIBRARY_VERSION);
     exit(exitcode); /*ooo*/
     not_reached();
 }


### PR DESCRIPTION
 
Remove the 'total file size' check in mkiocccentry. This does not work as 
intended because it does not account for the JSON files and it does not account 
for the compression (in fact the total file size is validated through txzchk 
and it's a fatal error then but if it was before that it would mean users would 
have to, assuming no answers file, input data again if say on the first time 
they had this problem, and that is just one issue amongst others). 
 
Updated tools (except mkiocccentry which already did this) to show in -V and 
-h option (with the latter it is shown with any usage error) the repo version 
as well (right under the tool's version and above the libraries). The tools are: 
txzchk, fnamchk, location, chkentry and chksubmit. 
 
Type fix in bug_report.sh. 
 
Updated MKIOCCCENTRY_VERSION to "2.3.2 2026-06-07". 
Updated MIN_MKIOCCCENTRY_VERSION to MKIOCCCENTRY_VERSION. This is because 
we're in between contests now and the next contest will require the current 
version. 
 
Because the only other code changes were to print the repo version those tools 
did not have their version updated. The only reason mkiocccentry had its 
version updated is because a functional change was made. 