### PR TITLE
Sync jparse repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.4 2026-06-10
+
+Sync [jparse repo](https://github.com/xexyl/jparse). The change is `mis-feature`
+to `misfeature` (this is actually in OED). There are other repos and files here
+that should be corrected, as insignificant as it probably is. These can be done
+as important fixes are made, of which some are pending (and some have been
+started but which will likely not be done for a while).
+
+A minor insignificant change in `soup/` was made but since it was updated it
+still suggests a change in version so: updated `SOUP_VERSION` to "2.4.0
+2026-06-10".
+
+
 ## Release 2.11.3 2026-06-07
 
 Resolve issues #1389, #1379, 1373.

--- a/jparse/jparse_library_README.md
+++ b/jparse/jparse_library_README.md
@@ -451,7 +451,7 @@ A note on encoding/decoding UTF-8/UTF-16 codepoints is in order. The
 spec and that function has the **encoding** of UTF-8/UTF-16 codepoints. The
 `json_encode()` function encodes a JSON string according to the so-called JSON
 spec and the function does **NOT** encode UTF-8/UTF-16 codepoints, but it
-should. We might call this a mis-feature that should be corrected, but for now
+should. We might call this a misfeature that should be corrected, but for now
 this is not the case. The [documentation on
 jstrdecode](jparse_utils_README.md#jstrdecode) and the [documentation on
 jstrencode](jparse_utils_README.md#jstrencode) give more details on this.

--- a/jparse/json_README.md
+++ b/jparse/json_README.md
@@ -520,7 +520,7 @@ used as names, does not require that name strings be unique, and
 does not assign any significance to the ordering of name/value pairs
 ```
 
-The authors of this document have identified a number of mis-features
+The authors of this document have identified a number of misfeatures
 of the **so-called JSON spec** in addition to how it fails to even
 live up to various [claims made by the
 creators](https://www.youtube.com/watch?v=x92vbAN_j1k&list=PLEzQf147-uEoNCeDlRrXv6ClsLDN-HtNm&index=2&t=1343s)
@@ -532,9 +532,8 @@ may serve as a case study for **how _not_ to write a specification**.
 We end this **Substandard JSON spec editorial** with the following
 question:
 
-```
-How many mis-features and flaws can you find in the "so-called JSON spec"? :-)
-```
+> How many misfeatures and flaws can you find in the "so-called JSON spec"? :-)
+
 
 ### Appendix A
 

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -2407,14 +2407,14 @@ json_alloc(enum item_type type)
      *		https://c-faq.com/null/runtime0.html
      *
      * The answer is not so simple: especially when you have to take into account
-     * the way a compiler writer (or compiler feature or compiler mis-feature)
+     * the way a compiler writer (or compiler feature or compiler misfeature)
      * might interpret such FAQs.
      *
      * Instead of diving into a pedantic details for NULL vs. 0, we explicitly
      * set NULL pointers.  And while 0 == false, we also explicitly set both
      * parsed and converted to false as well.
      *
-     * One advantage of such explicit setting is that certain code analyzers will
+     * One advantage of such explicit setting is that certain code analysers will
      * understand the NULL or false intent of such structure elements.
      */
     switch (ret->type) {

--- a/jparse/man/man1/jparse.1
+++ b/jparse/man/man1/jparse.1
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man1/jparse_bug_report.1
+++ b/jparse/man/man1/jparse_bug_report.1
@@ -5,7 +5,7 @@
 .\" updated to work with jparse.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man1/jstrdecode.1
+++ b/jparse/man/man1/jstrdecode.1
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man1/jstrencode.1
+++ b/jparse/man/man1/jstrencode.1
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man3/jparse.3
+++ b/jparse/man/man3/jparse.3
@@ -4,7 +4,7 @@
 .\" in 2023.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jnum_chk.8
+++ b/jparse/man/man8/jnum_chk.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jnum_gen.8
+++ b/jparse/man/man8/jnum_gen.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jparse_test.8
+++ b/jparse/man/man8/jparse_test.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jsemcgen.8
+++ b/jparse/man/man8/jsemcgen.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jsemcgen.sh.8
+++ b/jparse/man/man8/jsemcgen.sh.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jsemtblgen.8
+++ b/jparse/man/man8/jsemtblgen.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/jstr_test.8
+++ b/jparse/man/man8/jstr_test.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/pr_jparse_test.8
+++ b/jparse/man/man8/pr_jparse_test.8
@@ -4,7 +4,7 @@
 .\" repo on 12 October 2024.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/run_bison.8
+++ b/jparse/man/man8/run_bison.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/run_bison.sh.8
+++ b/jparse/man/man8/run_bison.sh.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/run_flex.8
+++ b/jparse/man/man8/run_flex.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/run_flex.sh.8
+++ b/jparse/man/man8/run_flex.sh.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/run_jparse_tests.8
+++ b/jparse/man/man8/run_jparse_tests.8
@@ -4,7 +4,7 @@
 .\" 2024 for the jparse repo.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/jparse/man/man8/verge.8
+++ b/jparse/man/man8/verge.8
@@ -4,7 +4,7 @@
 .\" in 2022.
 .\"
 .\" Humour impairment is not virtue nor is it a vice, it's just plain
-.\" wrong: almost as wrong as JSON spec mis-features and C++ obfuscation! :-)
+.\" wrong: almost as wrong as JSON spec misfeatures and C++ obfuscation! :-)
 .\"
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/soup/foo.c
+++ b/soup/foo.c
@@ -112,6 +112,7 @@ vrergfB(int four, int two)
     int last_c = '\0';		/* last char detected */
     unsigned no_comment;	/* is a comment */
     size_t ic = 0;		/* What is IC? First ask yourself what OOC is! */
+    size_t ooc = 0;		/* What is OOC? First ask yourself what IC is! */
 
     /*
      * The next comment is as empty as this one.
@@ -193,22 +194,15 @@ vrergfB(int four, int two)
 	    ++p; /* be positive and look backwards to the next one! */
 
 	/*
-	 * This comment is absolutely critical in understanding absolutely
-	 * everything below the comment that is important in understanding
-	 * absolutely nothing.
+	 * Even though this comment is complete rubbish, this comment is
+         * absolutely critical in understanding absolutely everything below the
+         * comment that is important in understanding absolutely nothing.
 	 */
 
 	/*
-	 * This comment is obfuscated and so is the next comment.
+	 * This comment is neither obfuscated nor unobfuscated and is also
+         * obfuscated and unobfuscated whereas the above comment isn't.
 	 */
-	} else if (!isascii(*p)) {
-	    ret = fputc(*p, stdout);
-	    if (ret == EOF) {
-		fwarnp(stderr, "\b\b\b\b\b\b\b\b\bEOF", "if we didn't ASCII stupid question don't give us a stupid ANSI!\n");
-	    } else {
-		++ic;
-	    }
-
 	/*
 	 * The previous comment wasn't obfuscated but this one wasn't either.
 	 */
@@ -216,6 +210,7 @@ vrergfB(int four, int two)
 	    ret = fputc(*p, stdout);
 	    if (ret == EOF) {
 		fwarnp(stderr, "abcdefg..", "that was NOT in character :-(\n");
+                ++ooc;
 	    } else {
 		++ic;
 	    }
@@ -228,7 +223,10 @@ vrergfB(int four, int two)
 	    /*
 	     * This comment explains the above comment because the above comment
 	     * explains absolutely nothing.
+             *
+             * It also explains itself because it does not explain itself.
 	     */
+
 	    /* this line was empty before it was documented */
 
 	    /* case: just in case we consider the case */
@@ -259,6 +257,7 @@ vrergfB(int four, int two)
 		    stdout);
 	    if (ret == EOF) {
 		fwarnp(stderr, "abcdefg..", "that character was absolutely mixed with sin!\n");
+                ++ooc;
 	    } else {
 		++ic;
 	    }
@@ -295,7 +294,8 @@ vrergfB(int four, int two)
     /*
      * This comment is empty but so is the next one.
      */
-    dbg(DBG_LOW, "FUN FACT: there %s %zu in character character%s.", ic != 1 ? "were":"was", ic, ic != 1 ? "s":"");
+    dbg(DBG_LOW, "FUN FACT: there %s/%s %zu/%zu in/out of character character%s/character%s.", ic != 1 ? "were":"was",
+            ooc != 1?"were":"was", ic, ooc, ic != 1 ? "s":"", ooc != 1 ? "s":"");
 
     /*
      * and in the end ... take a moment to bow before exiting stage left
@@ -308,6 +308,14 @@ vrergfB(int four, int two)
     if (no_comment != 0+0) {
 	fwarnp(stderr, __func__, "possible insomnia detected ... whee! :-)");
     }
+    /*
+     * only remove this comment if you want to end the world. If you don't
+     * understand how this works then do not remove the comment.
+     *
+     * PS: even if you think you understand the above comment you actually do
+     * not understand the above comment. Thus we insist you do NOT remove the
+     * above comment!
+     */
     (void) exit(42+(((four-two)>0?(four-two):(-four+two)) % (5*42))); /*ooo*/
     not_reached(); /*allegedly*/
 

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,12 +84,12 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.3 2026-06-07"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.4 2026-06-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.4.0 2025-11-30"		/* format: major.minor[.patch] YYYY-MM-DD */
+#define SOUP_VERSION "2.4.0 2026-06-10"		/* format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official iocccsize version


### PR DESCRIPTION
Sync jparse repo (https://github.com/xexyl/jparse). The change is mis-feature to misfeature (this is actually in OED). There are other repos and files here that should be corrected, as insignificant as it probably is. These can be done as important fixes are made, of which some are pending (and some have been started but which will likely not be done for a while).

A minor insignificant change in soup/ was made but since it was updated it still suggests a change in version so: updated SOUP_VERSION to "2.4.0 2026-06-10".