### PR TITLE
Resolve issues #1381 and #1384

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,30 @@
 
 ## Release 2.11.4 2026-06-10
 
+Resolve issues #1381 and #1384.
+
+These fixes involved not insignificant changes to jparse repo so the [jparse
+repo](https://github.com/xexyl/jparse) has been synced again. As well, as for
+issue #1384, this required some minor changes to the `pr` and `cpath` repos.
+Pull requests will be opened to those repos but in the meantime I have copied
+the local code to the subdirectories here. Those other library changes were
+installed locally before testing `jparse` with `make release`.
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.3.3 2026-06-13"`.
+Updated `TXZCHK_VERSION` to `"2.1.2 2026-06-13"`.
+Updated `SOUP_VERSION` to `"2.4.1 2026-06-13"`.
+
+Also changed min txzchk version back to the current version as we're in between
+contests.
+
+Once the two issues here are closed it should be only one more issue before the
+next contest can be opened, that I need to resolve, until such a time as another
+issue is opened :-).
+
+
+
+## Release 2.11.4 2026-06-10
+
 Sync [jparse repo](https://github.com/xexyl/jparse). The change is `mis-feature`
 to `misfeature` (this is actually in OED). There are other repos and files here
 that should be corrected, as insignificant as it probably is. These can be done

--- a/cpath/canon_path.c
+++ b/cpath/canon_path.c
@@ -5,7 +5,7 @@
  *
  *      -- J.R.R. Tolkien
  *
- * Copyright (c) 1991,2008,2014-2016,2022-2025 by Landon Curt Noll.  All Rights Reserved.
+ * Copyright (c) 1991,2008,2014-2016,2022-2026 by Landon Curt Noll.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,
@@ -24,14 +24,14 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- * This code was developed between 1991-2025 by Landon Curt Noll:
+ * This code was developed between 1991-2026 by Landon Curt Noll:
  *
  *	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
  *
  * Share and enjoy! :-)
  *
  * We gratefully acknowledge the concept contributions, plus the documentation
- * corrections, and other suggestions made by Cody Boone Ferguson:
+ * and code corrections, and other suggestions made by Cody Boone Ferguson:
  *
  *	@xexyl
  *	https://xexyl.net
@@ -167,6 +167,7 @@ private_strlcat(char *dst, const char *src, size_t dsize)
 	src++;
     }
     *dst = '\0';
+
     return(dlen + (src - osrc));	/* count does not include NUL */
 }
 
@@ -228,6 +229,7 @@ path_sanity_name(enum path_sanity sanity)
             str = "unknown_sanity_valud";
             break;
     }
+
     return str;
 }
 
@@ -289,6 +291,7 @@ path_sanity_error(enum path_sanity sanity)
             str = "invalid path_sanity value";
             break;
     }
+
     return str;
 }
 
@@ -444,9 +447,6 @@ safe_path_str(char const *path_str, bool any_case, bool slash_ok)
 	return false;
     } else if (path_str[0] == '/' && slash_ok == false) {
 	/* string starts with '/' (slash), however slash_ok is false, thus is NOT safe */
-	return false;
-    } else if (!isascii(path_str[0])) {
-	/* string starts with a non-ASCII character, thus is NOT safe */
 	return false;
     } else if (path_str[0] != '.' && path_str[0] != '_' &&
 	      any_case == true && !isalnum(path_str[0])) {
@@ -715,14 +715,14 @@ canon_path(char const *orig_path,
 		    /*
 		     * push component onto the path stack
 		     *
-		     * NOTE: If the path stack were to grow to larger than INT32_MAX,
+		     * NOTE: If the path stack were to grow to larger than INT_LEAST32_MAX,
 		     *	     and if we have a maximum depth allowed, we will declare
 		     *	     an immediate PATH_ERR_PATH_TOO_DEEP, even if some later
 		     *	     .. (dot-dot) might be able to later reduce the depth.
 		     */
 		    test = dyn_array_push(array, p);
 		    deep = dyn_array_tell(array);
-		    if (max_depth > 0 && deep > INT32_MAX) {
+		    if (max_depth > 0 && deep > INT_LEAST32_MAX) {
 
 			/* path component too deep */
 			dbg(DBG_V3_HIGH, "%s: error #7: path depth: %d max_depth: %d", __func__, deep, max_depth);
@@ -796,14 +796,14 @@ canon_path(char const *orig_path,
 		    /*
 		     * push component onto the path stack
 		     *
-		     * NOTE: If the path stack were to grow to larger than INT32_MAX,
+		     * NOTE: If the path stack were to grow to larger than INT_LEAST32_MAX,
 		     *	     and if we have a maximum depth allowed, we will declare
 		     *	     an immediate PATH_ERR_PATH_TOO_DEEP, even if some later
 		     *	     .. (dot-dot) might be able to later reduce the depth.
 		     */
 		    test = dyn_array_push(array, p);
 		    deep = dyn_array_tell(array);
-		    if (max_depth > 0 && deep > INT32_MAX) {
+		    if (max_depth > 0 && deep > INT_LEAST32_MAX) {
 
 			/* path component too deep */
 			dbg(DBG_V3_HIGH, "%s: error #12: path depth: %d max_depth: %d", __func__, deep, max_depth);
@@ -868,14 +868,14 @@ canon_path(char const *orig_path,
 	    /*
 	     * push component onto the path stack
 	     *
-	     * NOTE: If the path stack were to grow to larger than INT32_MAX,
+	     * NOTE: If the path stack were to grow to larger than INT_LEAST32_MAX,
 	     *	     and if we have a maximum depth allowed, we will declare
 	     *	     an immediate PATH_ERR_PATH_TOO_DEEP, even if some later
 	     *	     .. (dot-dot) might be able to later reduce the depth.
 	     */
 	    test = dyn_array_push(array, p);
 	    deep = dyn_array_tell(array);
-	    if (max_depth > 0 && deep > INT32_MAX) {
+	    if (max_depth > 0 && deep > INT_LEAST32_MAX) {
 
 		/* path component too deep */
 		dbg(DBG_V3_HIGH, "%s: error #16: path depth: %d max_depth: %d", __func__, deep, max_depth);

--- a/cpath/canon_path.c
+++ b/cpath/canon_path.c
@@ -449,11 +449,11 @@ safe_path_str(char const *path_str, bool any_case, bool slash_ok)
 	/* string starts with '/' (slash), however slash_ok is false, thus is NOT safe */
 	return false;
     } else if (path_str[0] != '.' && path_str[0] != '_' &&
-	      any_case == true && !isalnum(path_str[0])) {
+	      any_case == true && !isalnum((unsigned char)path_str[0])) {
 	/* string does NOT start with an UPPERcase character NOR a lowercase character, NOR a digit, thus is NOT safe */
 	return false;
     } else if (path_str[0] != '.' && path_str[0] != '_' &&
-	       any_case == false && !(islower(path_str[0]) || isdigit(path_str[0]))) {
+	       any_case == false && !(islower((unsigned char)path_str[0]) || isdigit((unsigned char)path_str[0]))) {
 	/* string does NOT start with a lowercase character, NOR a digit, thus is NOT safe */
 	return false;
     }

--- a/cpath/cpath.c
+++ b/cpath/cpath.c
@@ -31,7 +31,7 @@
  * Share and enjoy! :-)
  *
  * We gratefully acknowledge the concept contributions, plus the documentation
- * corrections, and other suggestions made by Cody Boone Ferguson:
+ * and code corrections, and other suggestions made by Cody Boone Ferguson:
  *
  *	@xexyl
  *	https://xexyl.net

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,47 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.5.10 2026-06-13
+
+Removed calls to `isascii()` as it was deprecated in POSIX.1-2008 and finally
+removed from POSIX.1-2024.
+
+The functions/macros (they appear to be macros in linux and inline functions in
+macOS although I might be wrong) from `ctype.h`, i.e. the `is*()` ones, although
+they take an `int` as an arg, require that the arg be representable as either
+`EOF` or an `unsigned char`. If neither are fulfilled then it is undefined. Thus
+the calls to these functions now cast the arg to an unsigned char.
+
+The above changes are not insignificant and were tested with local (but
+installed in the system) to the cpath and pr libraries but those changes have
+not yet been updated in the respective repos. Additionally, the files changed
+here as well as the cpath and pr files changed, have all been copied to the
+mkiocccentry repo and everything seems to be in order there too.
+
+NOTE: there are still comments and messages that refer to ASCII and also the
+`isascii()` function/macro (and as for ASCII, it's also in `json_README.md`). In
+one case it's because it's actually the ASCII table (the one in `json_parse.c`,
+the `byte2asciistr` which is almost certainly in need of some fixes if not
+replacement, but which is rather a low priority at this time) and in others
+because we might say that the values we check (with the ctype.h
+functions/macros) are typically within the range 0..127 and thus ASCII, though
+the cast to `unsigned char` would result in 0..255 in range. Actually the real
+reason is to simplify the change as it is not even clear in every case what to
+change it to, and to save time and effort (as it's not really important).
+Nonetheless the calls themselves have all been removed and the ctype.h
+functions/macros now have their arg cast to an `unsigned int`.
+
+Additionally added `sem_member_value_unsigned()` to `json_sem` for mkiocccentry
+(to fix a potential overflow if a user wants to be silly and risk a problem with
+their submission), in particular
+https://github.com/ioccc-src/mkiocccentry/issues/1381.
+
+Updated `JPARSE_LIBRARY_VERSION` to `"2.4.4 2026-06-13"`.
+Updated `JPARSE_UTILS_VERSION` to `"2.1.8 2026-06-13"`.
+Updated `JPARSE_UTF8_VERSION` to `"2.1.4 2026-06-13".`
+Updated `VERGE_VERSION` to `"2.0.5 2026-06-13"`.
+Updated `JSEMTBLGEN_VERSION` to `"2.0.4 2026-06-13"`.
+
+
 ## Release 2.5.9 2026-05-11
 
 Added `-funsigned-char` to Makefiles. It is possible that this will be useful in

--- a/jparse/jsemtblgen.c
+++ b/jparse/jsemtblgen.c
@@ -410,7 +410,7 @@ main(int argc, char **argv)
 	not_reached();
     }
     for (c=0; c < len; ++c) {
-	if (isascii(tbl_name[c]) && islower(tbl_name[c])) {
+	if (islower(tbl_name[c])) {
 	    cap_tbl_name[c] = (char)toupper(tbl_name[c]);
 	}
     }
@@ -882,7 +882,7 @@ alloc_c_funct_name(char const *prefix, char const *str)
 	 * case: prefix begins with a digit
 	 * case: prefix begins with an underscore
 	 */
-	if (prefix_is_reserved == true || prefix[0] == '\0' || (isascii(prefix[0]) && isdigit(prefix[0])) || prefix[0] == '_') {
+	if (prefix_is_reserved == true || prefix[0] == '\0' || isdigit(prefix[0]) || prefix[0] == '_') {
 	    /* add x due to the cases mentioned above */
 	    *p++ = 'x';
 	}
@@ -891,7 +891,7 @@ alloc_c_funct_name(char const *prefix, char const *str)
 	 * process prefix
 	 */
 	while (prefix[0] != '\0') {
-	    if (!isascii(prefix[0]) || !isalnum(prefix[0])) {
+	    if (!isalnum(prefix[0])) {
 		/* convert non-C name character to underscore */
 		*p++ = '_';
 	    } else {
@@ -912,7 +912,7 @@ alloc_c_funct_name(char const *prefix, char const *str)
      * case: str begins with a digit
      * case: str begins with an underscore
      */
-    if (str_is_reserved == true || str[0] == '\0' || (isascii(str[0]) && isdigit(str[0])) || str[0] == '_') {
+    if (str_is_reserved == true || str[0] == '\0' || isdigit(str[0]) || str[0] == '_') {
 	/* add x due to the cases mentioned above */
 	*p++ = 'x';
     }
@@ -921,7 +921,7 @@ alloc_c_funct_name(char const *prefix, char const *str)
      * process each str character in C, converting non-alphanumeric characters to underscore.
      */
     while (str[0] != '\0') {
-	if (!isascii(str[0]) || !isalnum(str[0])) {
+	if (!isalnum(str[0])) {
 	    /* convert non-C name character to underscore */
 	    *p++ = '_';
 	} else {

--- a/jparse/jsemtblgen.h
+++ b/jparse/jsemtblgen.h
@@ -103,7 +103,7 @@
 /*
  * official jsemtblgen version
  */
-#define JSEMTBLGEN_VERSION "2.0.3 2025-09-08"		/* format: major.minor YYYY-MM-DD */
+#define JSEMTBLGEN_VERSION "2.0.4 2026-06-13"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jsemtblgen tool basename

--- a/jparse/json_parse.c
+++ b/jparse/json_parse.c
@@ -2530,6 +2530,12 @@ json_alloc(enum item_type type)
  *
  * NOTE: While it is OK if str has trailing whitespace, str[len-1] must be an
  *	 ASCII digit.  It is assumed that str[len-1] is the final JSON number character.
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 static bool
 json_process_decimal(struct json_number *item, char const *str, size_t len)
@@ -2556,7 +2562,7 @@ json_process_decimal(struct json_number *item, char const *str, size_t len)
 	warn(__func__, "called with empty string");
 	return false;	/* processing failed */
     }
-    if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    if (!isdigit((unsigned char)str[len-1])) {
 	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
@@ -2585,7 +2591,7 @@ json_process_decimal(struct json_number *item, char const *str, size_t len)
         /*
 	 * JSON spec detail: leading -0 followed by digits - invalid JSON
 	 */
-	} else if (len > 2 && str[1] == '0' && isascii(str[2]) && isdigit(str[2])) {
+	} else if (len > 2 && str[1] == '0' && isdigit((unsigned char)str[2])) {
 	    dbg(DBG_HIGH, "in %s(): called with -0 followed by more digits: <%s>",
 			  __func__, str);
 	    return false;	/* processing failed */
@@ -2600,7 +2606,7 @@ json_process_decimal(struct json_number *item, char const *str, size_t len)
         /*
 	 * JSON spec detail: leading 0 followed by digits - invalid JSON
 	 */
-	if (len > 1 && str[0] == '0' && isascii(str[1]) && isdigit(str[1])) {
+	if (len > 1 && str[0] == '0' && isdigit((unsigned char)str[1])) {
 	    dbg(DBG_HIGH, "in %s(): called with 0 followed by more digits: <%s>",
 			  __func__, str);
 	    return false;	/* processing failed */
@@ -2864,6 +2870,12 @@ json_process_decimal(struct json_number *item, char const *str, size_t len)
  * NOTE: While it is OK if str has trailing whitespace, str[len-1] must be an
  *	 ASCII digit.  It is assumed that str[len-1] is the final JSON number
  *	 character.
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 static bool
 json_process_floating(struct json_number *item, char const *str, size_t len)
@@ -2895,7 +2907,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	warn(__func__, "called with empty string");
 	return false;	/* processing failed */
     }
-    if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    if (!isdigit((unsigned char)str[len-1])) {
 	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
@@ -2940,7 +2952,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
     /*
      * JSON spec detail: floating point numbers must end in a digit
      */
-    } else if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    } else if (!isdigit((unsigned char)str[len-1])) {
 	dbg(DBG_HIGH, "in %s(): floating point numbers must end in a digit: <%s>",
 		       __func__, str);
 	return false;	/* processing failed */
@@ -3038,7 +3050,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	/*
 	 * JSON spec detail: e notation number must have digit before e or E
 	 */
-	} else if (e > str && (!isascii(e[-1]) || !isdigit(e[-1]))) {
+	} else if (e > str && (!isdigit((unsigned char)e[-1]))) {
 	    dbg(DBG_HIGH, "in %s(): e notation numbers must have digit before e or E: <%s>",
 			  __func__, str);
 	    return false;	/* processing failed */
@@ -3053,7 +3065,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	    /*
 	     * JSON spec detail: e notation number with e+ or E+ must be followed by a digit
 	     */
-	    if (e+1 < &(str[len-1]) && (!isascii(e[2]) || !isdigit(e[2]))) {
+	    if (e+1 < &(str[len-1]) && !isdigit((unsigned char)e[2])) {
 		dbg(DBG_HIGH, "in %s(): :e notation number with e+ or E+ must be followed by a digit <%s>",
 			      __func__, str);
 		return false;	/* processing failed */
@@ -3069,7 +3081,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	    /*
 	     * JSON spec detail: e notation number with e- or E- must be followed by a digit
 	     */
-	    if (e+1 < &(str[len-1]) && (!isascii(e[2]) || !isdigit(e[2]))) {
+	    if (e+1 < &(str[len-1]) && (!isdigit((unsigned char)e[2]))) {
 		dbg(DBG_HIGH, "in %s(): :e notation number with e- or E- must be followed by a digit <%s>",
 			      __func__, str);
 		return false;	/* processing failed */
@@ -3078,7 +3090,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	/*
 	 * JSON spec detail: e notation number must have + or - or digit after e or E
 	 */
-	} else if (!isascii(e[1]) || !isdigit(e[1])) {
+	} else if (!isdigit((unsigned char)e[1])) {
 	    dbg(DBG_HIGH, "in %s(): e notation numbers must follow e or E with + or - or digit: <%s>",
 			  __func__, str);
 	    return false;	/* processing failed */
@@ -3191,6 +3203,11 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
  *
  * NOTE: This function will not return on calloc error.
  * NOTE: This function will not return NULL.
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 struct json *
 json_conv_number(char const *ptr, size_t len)
@@ -3478,6 +3495,12 @@ json_conv_number_str(char const *str, size_t *retlen)
  *			- set to false ==> no UPPER case chars found
  *
  * NOTE: This function does not return when given NULL ptr
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 static void
 posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool *first_alphanum, bool *upper)
@@ -3512,50 +3535,33 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
     /*
      * test first character
      */
-    if (isascii(str[0])) {
-
-	/*
-	 * case: first character is /
-	 */
-	if (str[0] == '/') {
-	    *slash = true;
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is /: 0x%02x", (unsigned int)str[0]);
-
-	/*
-	 * case: first character is alphanumeric
-	 */
-	} else if (isalnum(str[0])) {
-	    *first_alphanum = true;
-	    if (isupper(str[0])) {
-		*upper = true;
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is UPPER CASE: 0x%02x", (unsigned int)str[0]);
-	    } else {
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is alphanumeric: 0x%02x", (unsigned int)str[0]);
-	    }
-
-	/*
-	 * case: first character is non-alphanumeric portable POSIX safe plus +
-	 */
-	} else if (str[0] == '.' || str[0] == '_' || str[0] == '+') {
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is ASCII non-alphanumeric POSIX portable safe plus +: 0x%02x",
-			     (unsigned int)str[0]);
-
-	/*
-	 * case: first character is not POSIX portable safe plus +
-	 */
-	} else {
-	    found_unsafe = true;
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is not POSIX portable safe plus +/: 0x%02x",
-			     (unsigned int)str[0]);
-	}
 
     /*
-     * case: first character is not ASCII
+     * case: first character is /
      */
-    } else {
-	found_unsafe = true;
-	dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is non-ASCII: 0x%02x",
-			 (unsigned int)str[0]);
+    if (str[0] == '/') {
+        *slash = true;
+        dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is /: 0x%02x", (unsigned int)str[0]);
+
+    /*
+     * case: first character is alphanumeric
+     */
+    } else if (isalnum((unsigned char)str[0])) {
+        *first_alphanum = true;
+        if (isupper((unsigned char)str[0])) {
+            *upper = true;
+            dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is UPPER CASE: 0x%02x", (unsigned int)str[0]);
+        } else {
+            dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is alphanumeric: 0x%02x", (unsigned int)str[0]);
+        }
+
+    /*
+     * case: first character is non-alphanumeric portable POSIX safe plus +
+     */
+    } else if (str[0] == '.' || str[0] == '_' || str[0] == '+') {
+        dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is ASCII non-alphanumeric POSIX portable safe plus +: 0x%02x",
+                         (unsigned int)str[0]);
+
     }
 
     /*
@@ -3566,7 +3572,6 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	/*
 	 * test character
 	 */
-	if (isascii(str[i])) {
 
 	    /*
 	     * case: / check
@@ -3581,8 +3586,8 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	    /*
 	     * case: character is alphanumeric
 	     */
-	    } else if (isalnum(str[i])) {
-		if (*upper == false && isupper(str[i])) {
+	    } else if (isalnum((unsigned char)str[i])) {
+		if (*upper == false && isupper((unsigned char)str[i])) {
 		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first UPPER CASE at str[%zu]: 0x%02x",
 				     i, (unsigned int)str[i]);
 		    *upper = true;
@@ -3598,17 +3603,6 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 		}
 		found_unsafe = true;
 	    }
-
-	/*
-	 * case: character is non-ASCII
-	 */
-	} else {
-	    if (found_unsafe == false) {
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%zu] found first non-ASCII: 0x%02x",
-				 i, (unsigned int)str[i]);
-	    }
-	    found_unsafe = true;
-	}
     }
 
     /*

--- a/jparse/json_sem.c
+++ b/jparse/json_sem.c
@@ -1230,6 +1230,83 @@ sem_member_value_str_or_null(struct json const *node, unsigned int depth, struct
     return ret;
 }
 
+/*
+ * sem_member_value_unsigned - return pointer to unsigned int from a JSON number value of JTYPE_MEMBER
+ *
+ * Given a JSON node of type JTYPE_MEMBER, look at the value of the JSON member
+ * and if it is a JTYPE_NUMBER (JSON number), return a pointer to a converted
+ * unsigned int or return NULL on error or invalid input.
+ *
+ * If the JTYPE_NUMBER (JSON number) cannot be returned as an unsigned int, NULL is returned.
+ *
+ * given:
+ *	node	JSON parse node being checked
+ *	depth	depth of node in the JSON parse tree (0 ==> tree root)
+ *	sem	JSON semantic node triggering the check
+ *	name	name of caller function (NULL ==> "((NULL))")
+ *	val_err	pointer to address where to place a JSON semantic validation error,
+ *		NULL ==> do not report a JSON semantic validation error
+ *
+ * returns:
+ *	!= NULL ==> decoded JTYPE_NUMBER as an int from the value part of JTYPE_MEMBER
+ *	    The val_err arg is ignored
+ *	NULL ==> invalid arguments or JSON conversion error
+ *	    If val_err != NULL then *val_err is JSON semantic validation error (struct json_sem_val_err)
+ */
+unsigned int *
+sem_member_value_unsigned(struct json const *node, unsigned int depth, struct json_sem *sem,
+		     char const *name, struct json_sem_val_err **val_err)
+{
+    struct json *value = NULL;			/* value of JTYPE_MEMBER */
+    struct json_number *unum = NULL;		/* JTYPE_MEMBER value as JTYPE_NUMBER */
+
+    /*
+     * obtain JTYPE_MEMBER value
+     *
+     * NOTE: The sem_member_value() call checks args via sem_chk_null_args().
+     * NOTE: The sem_member_value() call verifies that node is of type JTYPE_MEMBER.
+     */
+    value = sem_member_value(node, depth, sem, name, val_err);
+    if (value == NULL) {
+	/* sem_member_value() will have set *val_err */
+	return NULL;
+    }
+
+    /*
+     * validate JSON parse node value type
+     */
+    if (value->type != JTYPE_NUMBER) {
+	if (val_err != NULL) {
+	    *val_err = werr_sem_val(66, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
+				    json_type_name(value->type));
+	}
+	return NULL;
+    }
+    unum = &(value->item.number);
+    if (!VALID_JSON_NODE(unum)) {
+	if (val_err != NULL) {
+	    *val_err = werr_sem_val(67, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	}
+	return NULL;
+    }
+
+    /*
+     * validate JTYPE_NUMBER was able to be converted into an unsigned int
+     */
+    if (unum->uint_sized == false) {
+	if (val_err != NULL) {
+	    *val_err = werr_sem_val(68, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to an unsigned int");
+	}
+	return NULL;
+    }
+
+    /*
+     * case success: return JSON boolean
+     */
+    return &(unum->as_uint);
+}
+
+
 
 /*
  * sem_member_value_int - return pointer to int from a JSON number value of JTYPE_MEMBER
@@ -1278,7 +1355,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(66, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
+	    *val_err = werr_sem_val(69, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;
@@ -1286,7 +1363,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
     inum = &(value->item.number);
     if (!VALID_JSON_NODE(inum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(67, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(70, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1296,7 +1373,7 @@ sem_member_value_int(struct json const *node, unsigned int depth, struct json_se
      */
     if (inum->int_sized == false) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(68, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to an int");
+	    *val_err = werr_sem_val(71, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to an int");
 	}
 	return NULL;
     }
@@ -1355,7 +1432,7 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(69, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
+	    *val_err = werr_sem_val(72, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;
@@ -1363,7 +1440,7 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
     snum = &(value->item.number);
     if (!VALID_JSON_NODE(snum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(70, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(73, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1373,7 +1450,7 @@ sem_member_value_size_t(struct json const *node, unsigned int depth, struct json
      */
     if (snum->size_sized == false) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(71, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to a size_t");
+	    *val_err = werr_sem_val(74, node, depth, sem, name, "node value JTYPE_NUMBER was unable to convert to a size_t");
 	}
 	return NULL;
     }
@@ -1433,7 +1510,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
      */
     if (value->type != JTYPE_NUMBER) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(72, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
+	    *val_err = werr_sem_val(75, node, depth, sem, name, "node value type %s != JTYPE_NUMBER",
 				    json_type_name(value->type));
 	}
 	return NULL;
@@ -1441,7 +1518,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
     inum = &(value->item.number);
     if (!VALID_JSON_NODE(inum)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(73, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
+	    *val_err = werr_sem_val(76, node, depth, sem, name, "node value JTYPE_NUMBER converted is false");
 	}
 	return NULL;
     }
@@ -1456,13 +1533,13 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
 	 */
 	if (inum->is_negative == true) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(74, node, depth, sem, name, "node negative JTYPE_NUMBER with unsigned time_t");
+		*val_err = werr_sem_val(77, node, depth, sem, name, "node negative JTYPE_NUMBER with unsigned time_t");
 	    }
 	    return NULL;
 	}
 	if (inum->umaxint_sized == false) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(75, node, depth, sem, name, "JTYPE_NUMBER umaxint_sized false with unsigned time_t");
+		*val_err = werr_sem_val(78, node, depth, sem, name, "JTYPE_NUMBER umaxint_sized false with unsigned time_t");
 	    }
 	    return NULL;
 	}
@@ -1475,7 +1552,7 @@ sem_member_value_time_t(struct json const *node, unsigned int depth, struct json
 	 */
 	if (inum->maxint_sized == false) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(76, node, depth, sem, name, "JTYPE_NUMBER maxint_sized false with signed time_t");
+		*val_err = werr_sem_val(79, node, depth, sem, name, "JTYPE_NUMBER maxint_sized false with signed time_t");
 	    }
 	    return NULL;
 	}
@@ -1542,7 +1619,7 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
     if (depth <= 0) {
 	if (parent != NULL) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(77, node, depth, sem, name,
+		*val_err = werr_sem_val(80, node, depth, sem, name,
 					"depth: %d <= 0 with non-NULL parent node pointer", depth);
 	    }
 	}
@@ -1554,7 +1631,7 @@ sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *se
      */
     if (parent == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(78, node, depth, sem, name, "node parent node NULL");
+	    *val_err = werr_sem_val(81, node, depth, sem, name, "node parent node NULL");
 	}
 	return NULL;
     }
@@ -1615,7 +1692,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
     }
     if (memname == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(79, node, depth, sem, name, "memname is NULL");
+	    *val_err = werr_sem_val(82, node, depth, sem, name, "memname is NULL");
 	}
 	return NULL;
     }
@@ -1625,7 +1702,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      */
     if (node->type != JTYPE_OBJECT) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(80, node, depth, sem, name, "node type %s != JTYPE_OBJECT",
+	    *val_err = werr_sem_val(83, node, depth, sem, name, "node type %s != JTYPE_OBJECT",
 				    json_type_name(node->type));
 	}
 	return NULL;
@@ -1633,7 +1710,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
     item = &(node->item.object);
     if (!CONVERTED_PARSED_JSON_NODE(item)) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(81, node, depth, sem, name, "JTYPE_OBJECT node converted is false");
+	    *val_err = werr_sem_val(84, node, depth, sem, name, "JTYPE_OBJECT node converted is false");
 	}
 	return NULL;
     }
@@ -1643,7 +1720,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      */
     if (item->len < 0) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(82, node, depth, sem, name, "JTYPE_OBJECT set length: %jd < 0", item->len);
+	    *val_err = werr_sem_val(85, node, depth, sem, name, "JTYPE_OBJECT set length: %jd < 0", item->len);
 	}
 	return NULL;
     } else if (item->len == 0) {
@@ -1652,7 +1729,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
     }
     if (item->set == NULL) {
 	if (val_err != NULL) {
-	    *val_err = werr_sem_val(83, node, depth, sem, name, "JTYPE_OBJECT len: %jd > 0 and set is NULL", item->len);
+	    *val_err = werr_sem_val(86, node, depth, sem, name, "JTYPE_OBJECT len: %jd > 0 and set is NULL", item->len);
 	}
 	return NULL;
     }
@@ -1669,7 +1746,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
 	 */
 	if (s == NULL) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(84, node, depth, sem, name, "JTYPE_OBJECT set[%jd] is NULL", i);
+		*val_err = werr_sem_val(87, node, depth, sem, name, "JTYPE_OBJECT set[%jd] is NULL", i);
 	    }
 	    return NULL;
 	}
@@ -1680,7 +1757,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
 	}
 	if (s->type != JTYPE_MEMBER) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(85, node, depth+1, sem, name, "JTYPE_OBJECT set[%jd] type: %s != JTYPE_MEMBER",
+		*val_err = werr_sem_val(88, node, depth+1, sem, name, "JTYPE_OBJECT set[%jd] type: %s != JTYPE_MEMBER",
 					i, json_type_name(s->type));
 	    }
 	    return NULL;
@@ -1704,7 +1781,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
      * no such member
      */
     if (val_err != NULL) {
-	*val_err = werr_sem_val(86, node, depth, sem, name, "JTYPE_OBJECT has no member named: <%s>", memname);
+	*val_err = werr_sem_val(89, node, depth, sem, name, "JTYPE_OBJECT has no member named: <%s>", memname);
     }
     return NULL;
 }
@@ -1727,7 +1804,7 @@ json_sem_zero_count(struct json_sem *sem)
      * firewall - args
      */
     if (sem == NULL) {
-	err(87, __func__, "sem is NULL");
+	err(90, __func__, "sem is NULL");
 	not_reached();
     }
 

--- a/jparse/json_sem.h
+++ b/jparse/json_sem.h
@@ -189,6 +189,8 @@ extern size_t *sem_member_value_size_t(struct json const *node, unsigned int dep
 			         char const *name, struct json_sem_val_err **val_err);
 extern time_t *sem_member_value_time_t(struct json const *node, unsigned int depth, struct json_sem *sem,
 				       char const *name, struct json_sem_val_err **val_err);
+extern unsigned int *sem_member_value_unsigned(struct json const *node, unsigned int depth, struct json_sem *sem,
+				       char const *name, struct json_sem_val_err **val_err);
 extern struct json *sem_node_parent(struct json const *node, unsigned int depth, struct json_sem *sem,
 				    char const *name, struct json_sem_val_err **val_err);
 extern struct json *sem_object_find_name(struct json const *node, unsigned int depth, struct json_sem *sem,

--- a/jparse/json_utf8.c
+++ b/jparse/json_utf8.c
@@ -107,7 +107,7 @@ utf8len(const char *str, int32_t surrogate)
 	/*
 	 * extra sanity check
 	 */
-	if (!isxdigit(xa) || !isxdigit(xb) || !isxdigit(xc) || !isxdigit(xd)) {
+	if (!isxdigit((unsigned char)xa) || !isxdigit((unsigned char)xb) || !isxdigit((unsigned char)xc) || !isxdigit((unsigned char)xd)) {
 	    warn(__func__, "sscanf() found \\uxxxx but not all values are hex digits!");
 	    len = -1;
 

--- a/jparse/json_utf8.h
+++ b/jparse/json_utf8.h
@@ -68,7 +68,7 @@
 /*
  * official jparse UTF-8 version
  */
-#define JPARSE_UTF8_VERSION "2.1.3 2025-07-04"	/* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTF8_VERSION "2.1.4 2026-06-13"	/* format: major.minor YYYY-MM-DD */
 
 extern size_t utf8len(const char *str, int32_t surrogate);
 extern int32_t surrogate_pair_to_codepoint(int32_t hi, int32_t lo);

--- a/jparse/util.c
+++ b/jparse/util.c
@@ -298,6 +298,12 @@ string_to_uintmax(char const *str, uintmax_t *ret)
  *
  *	true	==> ptr points to a base 10 integer in ASCII
  *	false	==> ptr does NOT point to a base 10 integer in ASCII, or if ptr is NULL, or len <= 0
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 bool
 is_decimal(char const *ptr, size_t len)
@@ -343,7 +349,7 @@ is_decimal(char const *ptr, size_t len)
      *	     "reasons other than technical reasons" *sigh*.
      */
     for (i=start; i < len; ++i) {
-	if (!isascii(ptr[i]) || !isdigit(ptr[i])) {
+	if (!isdigit((unsigned char)ptr[i])) {
 	    /* found a non-ASCII digit */
 	    return false;
 	}
@@ -425,6 +431,12 @@ is_decimal_str(char const *str, size_t *retlen)
  *
  *	true	==> ptr points to a base 10 floating point notation in ASCII
  *	false	==> ptr does NOT point to a base 10 floating point notation in ASCII, or if ptr is NULL, or len <= 0
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 bool
 is_floating_notation(char const *str, size_t len)
@@ -450,7 +462,7 @@ is_floating_notation(char const *str, size_t len)
 	return false;	/* processing failed */
     }
 
-    if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    if (!isdigit((unsigned char)str[len-1])) {
 	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
@@ -573,6 +585,12 @@ is_floating_notation_str(char const *str, size_t *retlen)
  *
  *	true	==> ptr points to a base 10 exponent notation in ASCII
  *	false	==> ptr does NOT point to a base 10 exponent notation in ASCII, or if ptr is NULL, or len <= 0
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 bool
 is_e_notation(char const *str, size_t len)
@@ -601,7 +619,7 @@ is_e_notation(char const *str, size_t len)
 	return false;	/* processing failed */
     }
 
-    if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    if (!isdigit((unsigned char)str[len-1])) {
 	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
@@ -647,7 +665,7 @@ is_e_notation(char const *str, size_t len)
     /*
      * JSON spec detail: floating point numbers must end in a digit
      */
-    } else if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
+    } else if (!isdigit((unsigned char)str[len-1])) {
 	dbg(DBG_HIGH, "in %s(): floating point numbers must end in a digit: \"%s\"",
 		       __func__, str);
 	return false;	/* processing failed */
@@ -747,7 +765,7 @@ is_e_notation(char const *str, size_t len)
 	/*
 	 * JSON spec detail: e notation number must have digit before e or E
 	 */
-	} else if (e > str && (!isascii(e[-1]) || !isdigit(e[-1]))) {
+	} else if (e > str && !isdigit((unsigned char)e[-1])) {
 	    dbg(DBG_HIGH, "in %s(): e notation numbers must have digit before e or E: \"%s\"",
 			  __func__, str);
 	    return false;	/* processing failed */
@@ -762,7 +780,7 @@ is_e_notation(char const *str, size_t len)
 	    /*
 	     * JSON spec detail: e notation number with e+ or E+ must be followed by a digit
 	     */
-	    if (e+1 < &(str[len-1]) && (!isascii(e[2]) || !isdigit(e[2]))) {
+	    if (e+1 < &(str[len-1]) && !isdigit((unsigned char)e[2])) {
 		dbg(DBG_HIGH, "in %s(): :e notation number with e+ or E+ must be followed by a digit \"%s\"",
 			      __func__, str);
 		return false;	/* processing failed */
@@ -778,7 +796,7 @@ is_e_notation(char const *str, size_t len)
 	    /*
 	     * JSON spec detail: e notation number with e- or E- must be followed by a digit
 	     */
-	    if (e+1 < &(str[len-1]) && (!isascii(e[2]) || !isdigit(e[2]))) {
+	    if (e+1 < &(str[len-1]) && !isdigit((unsigned char)e[2])) {
 		dbg(DBG_HIGH, "in %s(): :e notation number with e- or E- must be followed by a digit \"%s\"",
 			      __func__, str);
 		return false;	/* processing failed */
@@ -787,17 +805,15 @@ is_e_notation(char const *str, size_t len)
 	/*
 	 * JSON spec detail: e notation number must have + or - or digit after e or E
 	 */
-	} else if (!isascii(e[1]) || !isdigit(e[1])) {
+	} else if (!isdigit((unsigned char)e[1])) {
 	    dbg(DBG_HIGH, "in %s(): e notation numbers must follow e or E with + or - or digit: \"%s\"",
 			  __func__, str);
 	    return false;	/* processing failed */
 	}
     }
 
-
     return true;
 }
-
 
 /*
  * is_e_notation_str - if the string buffer str is a base 10 exponent floating point notation in ASCII
@@ -816,6 +832,12 @@ is_e_notation(char const *str, size_t len)
  *
  * NOTE: This function calls is_e_notation().  See that function for details on
  *	 what is and is not considered exponent notation.
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 bool
 is_e_notation_str(char const *str, size_t *retlen)
@@ -868,6 +890,12 @@ is_e_notation_str(char const *str, size_t *retlen)
  * returns:
  *	number of non-whitespace/non-NUL bytes found, or
  *	0 if no non-whitespace/non-NUL bytes found, or if buf == NULL
+ *
+ * NOTE: although we use the term ASCII, isascii() is not used because it was
+ * removed from POSIX. Instead we cast the arg to the ctype.h functions/macros
+ * (the is*() ones) to an unsigned char because the standard states that,
+ * although the arg is an int, it is undefined if it is not representable as an
+ * unsigned char or EOF.
  */
 size_t
 find_text(char const *ptr, size_t len, char **first)
@@ -891,7 +919,7 @@ find_text(char const *ptr, size_t len, char **first)
      * scan the buffer for non-whitespace that is not NUL
      */
     for (i=0; i < len; ++i) {
-	if (!isascii(ptr[i]) || !isspace(ptr[i]) || ptr[i] == '\0') {
+	if (!isspace((unsigned char)ptr[i]) || ptr[i] == '\0') {
 	    break;
 	}
     }
@@ -914,7 +942,7 @@ find_text(char const *ptr, size_t len, char **first)
      * determine the length of non-whitespace that is not NUL
      */
     for (ret=1, ++i; i < len; ++i, ++ret) {
-	if ((isascii(ptr[i]) && isspace(ptr[i])) || ptr[i] == '\0') {
+	if (isspace((unsigned char)ptr[i]) || ptr[i] == '\0') {
 	    break;
 	}
     }

--- a/jparse/verge.c
+++ b/jparse/verge.c
@@ -275,7 +275,7 @@ allocate_vers(char *str, intmax_t **pvers)
      * trim leading non-digits
      */
     for (i=0; i < len; ++i) {
-	if (isascii(wstr[i]) && isdigit(wstr[i])) {
+	if (isdigit((unsigned char)wstr[i])) {
 	    /* stop on first digit */
 	    break;
 	}
@@ -297,7 +297,7 @@ allocate_vers(char *str, intmax_t **pvers)
      * trim at and beyond any whitespace
      */
     for (i=0; i < len; ++i) {
-	if (isascii(wstr[i]) && isspace(wstr[i])) {
+	if (isspace((unsigned char)wstr[i])) {
 	    wstr[i] = '\0';
 	    len = i;
 	    break;
@@ -308,7 +308,7 @@ allocate_vers(char *str, intmax_t **pvers)
      * trim trailing non-digits
      */
     for (i=len-1; i > 0; --i) {
-	if (isascii(wstr[i]) && isdigit(wstr[i])) {
+	if (isdigit((unsigned char)wstr[i])) {
 	    /* stop on first digit */
 	    break;
 	}
@@ -324,7 +324,7 @@ allocate_vers(char *str, intmax_t **pvers)
      */
     dbg(DBG_VHIGH, "trimmed version string: <%s>", wstr);
     for (i=0; i < len; ++i) {
-	if (isascii(wstr[i]) && isdigit(wstr[i])) {
+	if (isdigit((unsigned char)wstr[i])) {
 	    dot = false;
 	} else if (wstr[i] == '.') {
 	    if (dot == true) {

--- a/jparse/verge.h
+++ b/jparse/verge.h
@@ -78,7 +78,7 @@
 /*
  * official verge tool version
  */
-#define VERGE_VERSION "2.0.4 2025-09-01"		/* format: major.minor YYYY-MM-DD */
+#define VERGE_VERSION "2.0.5 2026-06-13"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * verge tool basename

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.5.9 2026-05-11"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.5.10 2026-06-13"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version
@@ -65,12 +65,12 @@
 /*
  * official JSON parser version
  */
-#define JPARSE_LIBRARY_VERSION "2.4.3 2025-11-10"	/* library version format: major.minor YYYY-MM-DD */
+#define JPARSE_LIBRARY_VERSION "2.4.4 2026-06-13"	/* library version format: major.minor YYYY-MM-DD */
 
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.1.7 2025-11-02"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.1.8 2026-06-13"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -245,8 +245,8 @@ static void mkiocccentry_sanity_chks(struct info *infop, char const *workdir, ch
                                      char *make, char *rm);
 static char *prompt(char const *str, size_t *lenp);
 static char *get_contest_id(bool *testp, char const *uuidf, char *uuidstr);
-static int get_submit_slot(struct info *infop);
-static char *mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
+static unsigned int get_submit_slot(struct info *infop);
+static char *mk_submission_dir(char const *workdir, char const *ioccc_id, unsigned int submit_slot,
 			       char **tarball_path, time_t tstamp, bool test_mode, bool force_remove,
 			       char const *rm);
 static bool inspect_Makefile(char const *Makefile, struct info *infop);
@@ -266,9 +266,9 @@ static void form_info(struct info *infop);
 static void form_tarball(char const *workdir, char const *submission_dir, char const *tarball_path, char const *tar,
 			 char const *ls, char const *txzchk, char const *fnamchk, bool test_mode);
 static void remind_user(char const *workdir, char const *submission_dir, char const *tar, char const *tarball_path,
-			bool test_mode, int submit_slot);
+			bool test_mode, unsigned int submit_slot);
 static void show_registration_url(void);
-static void show_submit_url(char const *workdir, char const *tarball_path, int slot_number);
+static void show_submit_url(char const *workdir, char const *tarball_path, unsigned int slot_number);
 static void read_manifest(struct walk_stat *wstat);
 static void read_ignore(char const *ignore, struct walk_stat *wstat);
 
@@ -1087,6 +1087,11 @@ main(int argc, char *argv[])
             errp(36, __func__, "cannot obtain answers FD");
             not_reached();
         }
+
+        /*
+         * clear out answers_st first
+         */
+        memset(&answers_st, 0, sizeof(answers_st));
         /*
          * get stat(2) info for answers file
          */
@@ -1106,7 +1111,7 @@ main(int argc, char *argv[])
      * obtain submit slot number
      */
     info.submit_slot = get_submit_slot(&info);
-    dbg(DBG_LOW, "Submission: slot number: %d", info.submit_slot);
+    dbg(DBG_LOW, "Submission: slot number: %u", info.submit_slot);
 
     /*
      * create submission directory
@@ -1154,7 +1159,7 @@ main(int argc, char *argv[])
             not_reached();
 	}
 	errno = 0;			/* pre-clear errno for errp() */
-	ret = fprintf(answersp, "%d\n", info.submit_slot);
+	ret = fprintf(answersp, "%u\n", info.submit_slot);
 	if (ret <= 0) {
 	    errp(41, __func__, "fprintf error printing submit slot number to the answers file");
             not_reached();
@@ -3424,12 +3429,12 @@ get_contest_id(bool *testp, char const *uuidfile, char *uuidstr)
  *      infop   - pointer to info structure
  *
  * returns:
- *      submit slot number >= 0 <= MAX_SUBMIT_SLOT
+ *      submit slot number <= MAX_SUBMIT_SLOT (it is unsigned)
  */
-static int
+static unsigned int
 get_submit_slot(struct info *infop)
 {
-    int submit_slot;		/* submit slot number */
+    unsigned int submit_slot = MAX_SUBMIT_SLOT + 1; /* submit slot number */
     char *submission_str;	/* submit slot number string */
     int ret;			/* libc function return */
     char guard;			/* scanf guard to catch excess amount of input */
@@ -3448,7 +3453,7 @@ get_submit_slot(struct info *infop)
      */
     if (need_hints) {
         errno = 0;		/* pre-clear errno for errp() */
-        ret = printf("\nYou are allowed to submit up to %d submissions to a given IOCCC.\n", MAX_SUBMIT_SLOT + 1);
+        ret = printf("\nYou are allowed to submit up to %u submissions to a given IOCCC.\n", MAX_SUBMIT_SLOT + 1);
         if (ret <= 0) {
             errp(137, __func__, "printf error printing number of submissions allowed");
             not_reached();
@@ -3478,10 +3483,10 @@ get_submit_slot(struct info *infop)
 	 * check the submit slot number
 	 */
 	errno = 0;		/* pre-clear errno for errp() */
-	ret = sscanf(submission_str, "%d%c", &submit_slot, &guard);
-	if (ret != 1 || submit_slot < 0 || submit_slot > MAX_SUBMIT_SLOT) {
+	ret = sscanf(submission_str, "%u%c", &submit_slot, &guard);
+	if (ret != 1 || submit_slot > MAX_SUBMIT_SLOT) {
 	    errno = 0;		/* pre-clear errno for errp() */
-	    ret = fprintf(stderr, "\nThe submit slot number must be a number from 0 through %d; please re-enter.\n",
+	    ret = fprintf(stderr, "\nThe submit slot number must be a number from 0 through %u; please re-enter.\n",
 		    MAX_SUBMIT_SLOT);
 	    if (ret <= 0) {
 		errp(138, __func__, "fprintf error while informing about the valid submit slot number range");
@@ -3494,14 +3499,14 @@ get_submit_slot(struct info *infop)
                 free(submission_str);
                 submission_str = NULL;
             }
-	    submit_slot = -1;	/* invalidate input */
+	    submit_slot = MAX_SUBMIT_SLOT + 1;	/* invalidate input */
 	} else {
             /*
              * verify the slot is correct
              */
             if (need_confirm && !answer_yes) {
                 errno = 0;		/* pre-clear errno for errp() */
-                ret = printf("\nThe slot number you entered is: %d\n",
+                ret = printf("\nThe slot number you entered is: %u\n",
                              submit_slot);
                 if (ret <= 0) {
                     errp(139, __func__, "fprintf error writing slot number");
@@ -3519,12 +3524,12 @@ get_submit_slot(struct info *infop)
 	    submission_str = NULL;
 	}
 
-    } while (submit_slot < 0 || submit_slot > MAX_SUBMIT_SLOT || !yorn);
+    } while (submit_slot > MAX_SUBMIT_SLOT || !yorn);
 
     /*
      * report on the result of the submit slot number validation
      */
-    dbg(DBG_MED, "IOCCC submit slot number is valid: %d", submit_slot);
+    dbg(DBG_MED, "IOCCC submit slot number is valid: %u", submit_slot);
 
     /*
      * return the submit slot number
@@ -3555,7 +3560,7 @@ get_submit_slot(struct info *infop)
  * This function does not return on error or if the submission directory cannot be formed.
  */
 static char *
-mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
+mk_submission_dir(char const *workdir, char const *ioccc_id, unsigned int submit_slot,
 		  char **tarball_path, time_t tstamp, bool test_mode, bool force_remove,
 		  char const *rm)
 {
@@ -3574,7 +3579,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
     }
     test = test_submit_slot(submit_slot);
     if (test == false) {
-	err(141, __func__, "submit slot number: %d must >= 0 and <= %d", submit_slot, MAX_SUBMIT_SLOT);
+	err(141, __func__, "submit slot number: %u must >= 0 and <= %u", submit_slot, MAX_SUBMIT_SLOT);
 	not_reached();
     }
 
@@ -3593,7 +3598,7 @@ mk_submission_dir(char const *workdir, char const *ioccc_id, int submit_slot,
 	not_reached();
     }
     errno = 0;			/* pre-clear errno for errp() */
-    ret = snprintf(submission_dir, submission_dir_len + 1, "%s/%s-%d", workdir, ioccc_id, submit_slot);
+    ret = snprintf(submission_dir, submission_dir_len + 1, "%s/%s-%u", workdir, ioccc_id, submit_slot);
     if (ret <= 0) {
 	errp(143, __func__, "snprintf to form submission directory failed");
 	not_reached();
@@ -4639,7 +4644,7 @@ yes_or_no(char const *question, bool def_answer)
 	 * convert response to lower case
 	 */
 	for (p = response; *p != '\0'; ++p) {
-	    if (isascii(*p) && isalpha(*p)) {
+	    if (isalpha((unsigned char)*p)) {
 		*p = (char)tolower(*p);
 	    }
 	}
@@ -4840,7 +4845,7 @@ get_title(struct info *infop)
 	 * verify that the title has only POSIX portable filename and + chars
 	 */
 	safe = safe_path_str(title, false, false); /* ^[0-9a-z._][0-9a-z._+-]*$ */
-	if (!isascii(title[0]) || !isalnum(title[0]) || safe == false) {
+	if (!isalnum((unsigned char)title[0]) || safe == false) {
 
 	    /*
 	     * reject invalid chars in title
@@ -5140,7 +5145,7 @@ noprompt_yes_or_no(void)
      * convert response to lower case
      */
     for (p = response; *p != '\0'; ++p) {
-	if (isascii(*p) && isalpha(*p)) {
+	if (isalpha((unsigned char)*p)) {
 	    *p = (char)tolower(*p);
 	}
     }
@@ -5514,8 +5519,8 @@ get_author_info(struct author **author_set_p)
 	     * inspect code input
 	     */
 	    if (len != 2 ||
-		!isascii(author_set[i].location_code[0]) || !isalpha(author_set[i].location_code[0]) ||
-		!isascii(author_set[i].location_code[1]) || !isalpha(author_set[i].location_code[1])) {
+		!isalpha((unsigned char)author_set[i].location_code[0]) ||
+		!isalpha((unsigned char)author_set[i].location_code[1])) {
 
 		/*
 		 * provide more help on location/country codes
@@ -7375,7 +7380,7 @@ form_tarball(char const *workdir, char const *submission_dir, char const *tarbal
  */
 static void
 remind_user(char const *workdir, char const *submission_dir, char const *tar, char const *tarball_path,
-	    bool test_mode, int slot_number)
+	    bool test_mode, unsigned int slot_number)
 {
     int ret;			/* libc function return */
     char *submission_dir_esc;
@@ -7546,7 +7551,7 @@ show_registration_url(void)
  * NOTE: if either workdir or tarball_path is NULL we will do nothing.
  */
 static void
-show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
+show_submit_url(char const *workdir, char const *tarball_path, unsigned int slot_number)
 {
     int ret;			/* libc function return */
 
@@ -7561,7 +7566,7 @@ show_submit_url(char const *workdir, char const *tarball_path, int slot_number)
      * inform the user about the submit server
      */
     ret = printf("\nWhen the contest is open (see https://www.ioccc.org/status.html),\n"
-		 "after you have registered, you must upload into slot %d:\n\n\t%s/%s\n", slot_number,
+		 "after you have registered, you must upload into slot %u:\n\n\t%s/%s\n", slot_number,
 		 workdir, tarball_path);
     if (ret <= 0) {
 	errp(56, __func__, "printf error printing tarball path and slot number");

--- a/pr/pr.c
+++ b/pr/pr.c
@@ -5,7 +5,7 @@
  *
  *	-- J.R.R. Tolkien
  *
- * Copyright (c) 2008-2025 by Landon Curt Noll and Cody Boone Ferguson.
+ * Copyright (c) 2008,2022-2026 by Landon Curt Noll and Cody Boone Ferguson.
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
@@ -36,7 +36,7 @@
  * The origin of libpr dates back to code written by Landon Curt Noll around 2008.
  *
  * That 2008 code was copied into the jparse repo, and the mkiocccentry toolkit repo
- * by Landon Curt Noll.  While in the jparse repo, both Landon Curt Noll and
+ * by Landon Curt Noll. While in the jparse repo, both Landon Curt Noll and
  * Cody Boone Ferguson added to and improved this code base:
  *
  *  @xexyl
@@ -734,7 +734,7 @@ readline_dup(char **linep, bool strip, size_t *lenp, FILE *stream)
     if (strip) {
 	if (len > 0) {
 	    for (i = len - 1; i >= 0; --i) {
-		if (isascii(ret[i]) && isspace(ret[i])) {
+		if (isspace((unsigned char)ret[i])) {
 		    /*
 		     * strip trailing ASCII whitespace
 		     */
@@ -1097,7 +1097,7 @@ fprint_line_buf(FILE *stream, const void *buf, size_t len, int start, int end)
 	/*
 	 * case: character is non-NUL start or non-NUL end or non-ASCII character
 	 */
-	if ((start != 0 && c == start) || (end != 0 && c == end) || !isascii(c)) {
+	if ((start != 0 && c == start) || (end != 0 && c == end)) {
 
 	    /* print character as \x99 if non-NULL stream to avoid start/end confusion */
 	    if (stream != NULL) {
@@ -1285,9 +1285,9 @@ fprint_line_buf(FILE *stream, const void *buf, size_t len, int start, int end)
 	    default:	/* other characters */
 
 		/*
-		 * case: ASCII printable character
+		 * case: printable character
 		 */
-		if (isascii(c) && isprint(c)) {
+		if (isprint((unsigned char)c)) {
 
 		    /* print character if non-NULL stream */
 		    if (stream != NULL) {

--- a/soup/chk_validate.c
+++ b/soup/chk_validate.c
@@ -1287,13 +1287,13 @@ bool
 chk_submit_slot(struct json const *node,
 	      unsigned int depth, struct json_sem *sem, struct json_sem_val_err **val_err)
 {
-    int *value = NULL;				/* JSON_NUMBER as decoded int */
+    unsigned int *value = NULL;				/* JSON_NUMBER as decoded int */
     bool test = false;				/* validation test result */
 
     /*
      * firewall - args and JSON number as int check
      */
-    value = sem_member_value_int(node, depth, sem, __func__, val_err);
+    value = sem_member_value_unsigned(node, depth, sem, __func__, val_err);
     if (value == NULL) {
 	/* sem_member_value_int() will have set *val_err */
 	return false;
@@ -2689,8 +2689,8 @@ chk_tarball(struct json const *node,
     struct json *parent = NULL;			/* JSON parse tree node parent */
     struct json *IOCCC_contest_id_node = NULL;	/* JSON parse node containing IOCCC_contest_id */
     char *IOCCC_contest_id = NULL;	/* pointer to author count as int from JSON parse node for IOCCC_contest_id */
-    struct json *submit_slot_node = NULL;	/* JSON parse node containing submit_slot */
-    int *submit_slot = NULL;			/* pointer to author count as int from JSON parse node for submit_slot */
+    struct json *submit_slot_node = NULL; /* JSON parse node containing submit_slot */
+    unsigned int *submit_slot = NULL;	/* pointer to author count as int from JSON parse node for submit_slot */
     struct json *test_mode_node = NULL;		/* JSON parse node containing test_mode */
     bool *test_mode = NULL;			/* pointer to author count as int from JSON parse node for test_mode */
     struct json *formed_timestamp_node = NULL;	/* JSON parse node containing formed_timestamp */
@@ -2780,7 +2780,7 @@ chk_tarball(struct json const *node,
     /*
      * obtain the entry number
      */
-    submit_slot = sem_member_value_int(submit_slot_node, depth, sem, __func__, val_err);
+    submit_slot = sem_member_value_unsigned(submit_slot_node, depth, sem, __func__, val_err);
     if (submit_slot == NULL) {
 	/* sem_member_value_int() will have set *val_err */
 	return false;

--- a/soup/default_handle.c
+++ b/soup/default_handle.c
@@ -1750,11 +1750,7 @@ default_handle(char const *name)
 	    /* case: 1st character map */
 	    if (def_len == 0) {
 
-		/* ignore if 1st mapped character is not an ASCII [0-9A-Za-z] character */
-		if (!isascii(m->posix_str[0])) {
-		    continue;
-		}
-		if (!isalnum(m->posix_str[0])) {
+		if (!isalnum((unsigned char)m->posix_str[0])) {
 		    continue;
 		}
 	    }
@@ -1942,11 +1938,7 @@ default_handle(char const *name)
 		    /* case: 1st character map */
 		    if (cur_len == 0) {
 
-			/* ignore if 1st mapped character is not an ASCII [0-9A-Za-z] character */
-			if (!isascii(m->posix_str[0])) {
-			    continue;
-			}
-			if (!isalnum(m->posix_str[0])) {
+			if (!isalnum((unsigned char)m->posix_str[0])) {
 			    continue;
 			}
 		    }

--- a/soup/entry_util.c
+++ b/soup/entry_util.c
@@ -2174,7 +2174,7 @@ object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
  *	malloced tarball filename or NULL ==> error
  */
 char *
-form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
+form_tar_filename(char const *IOCCC_contest_id, unsigned int submit_slot, bool test_mode,
 		  time_t formed_timestamp)
 {
     size_t tarball_len;			/* length of the compressed tarball path */
@@ -2254,11 +2254,11 @@ form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
     errno = 0;			/* pre-clear errno for warnp() */
     if ((time_t)-1 > 0) {
 	/* case: unsigned time_t */
-	ret = snprintf(tarball_filename, tarball_len + 1, "submit.%s-%d.%ju.txz",
+	ret = snprintf(tarball_filename, tarball_len + 1, "submit.%s-%u.%ju.txz",
 		       IOCCC_contest_id, submit_slot, (uintmax_t)formed_timestamp);
     } else {
 	/* case: signed time_t */
-	ret = snprintf(tarball_filename, tarball_len + 1, "submit.%s-%d.%jd.txz",
+	ret = snprintf(tarball_filename, tarball_len + 1, "submit.%s-%u.%jd.txz",
 		       IOCCC_contest_id, submit_slot, (intmax_t)formed_timestamp);
     }
     if (ret <= 0) {
@@ -2816,7 +2816,7 @@ test_author_handle(char const *str)
     }
     /* IOCCC author_handle must use POSIX portable filename and + chars */
     test = safe_path_str(str, true, false); /* ^[0-9A-Za-z._][0-9A-Za-z._+-]*$ */
-    if (!isascii(str[0]) || !isalnum(str[0]) || test == false) {
+    if (!isalnum((unsigned char)str[0]) || test == false) {
 	json_dbg(JSON_DBG_MED, __func__,
 		 "invalid: author_handle does not match regexp: ^[0-9A-Za-z][0-9A-Za-z._+-]*$");
 	json_dbg(JSON_DBG_HIGH, __func__,
@@ -3280,18 +3280,14 @@ test_empty_override(bool boolean)
  *	false ==> submit_slot is NOT valid, or some internal error
  */
 bool
-test_submit_slot(int submit_slot)
+test_submit_slot(unsigned int submit_slot)
 {
     /*
      * validate count
      */
-    if (submit_slot < 0) {
+    if (submit_slot > MAX_SUBMIT_SLOT) {
 	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: submit_slot: %d < 0", submit_slot);
-	return false;
-    } else if (submit_slot > MAX_SUBMIT_SLOT) {
-	json_dbg(JSON_DBG_MED, __func__,
-		 "invalid: submit_slot: %d > MAX_SUBMIT_SLOT: %d", submit_slot, MAX_SUBMIT_SLOT);
+		 "invalid: submit_slot: %u > MAX_SUBMIT_SLOT: %u", submit_slot, MAX_SUBMIT_SLOT);
 	return false;
     }
     json_dbg(JSON_DBG_MED, __func__, "submit_slot is valid");
@@ -3916,7 +3912,7 @@ test_location_code(char const *str)
     }
 
     /* validate 2 ASCII UPPER CASE characters */
-    if (!isascii(str[0]) || !isupper(str[0]) || !isascii(str[1]) || !isupper(str[1])) {
+    if (!isupper((unsigned char)str[0]) || !isupper((unsigned char)str[1])) {
 	json_dbg(JSON_DBG_MED, __func__,
 		 "invalid: location_code: is not 2 ASCII UPPER CASE characters");
 	json_dbg(JSON_DBG_HIGH, __func__,
@@ -5086,7 +5082,7 @@ test_rule_2b_size(size_t rule_2b_size)
  *	false ==> tarball is NOT valid, or some internal error
  */
 bool
-test_tarball(char const *str, char const *IOCCC_contest_id, int submit_slot, bool test_mode,
+test_tarball(char const *str, char const *IOCCC_contest_id, unsigned int submit_slot, bool test_mode,
 	     time_t formed_timestamp)
 {
     char *tar_filename = NULL;	/* formed tarball filename */

--- a/soup/entry_util.h
+++ b/soup/entry_util.h
@@ -172,7 +172,7 @@ struct auth
     char const *txzchk_ver;	/* txzchk version (compiled in, same as txzchk -V) */
     /* entry information */
     char *ioccc_id;		/* IOCCC contest ID */
-    int submit_slot;		/* IOCCC entry number */
+    unsigned int submit_slot;		/* IOCCC entry number */
     char *tarball;		/* tarball filename */
     /* test or non-test mode */
     bool test_mode;		/* true ==> test mode entered */
@@ -217,7 +217,7 @@ struct info
     char const *txzchk_ver;	/* txzchk version (compiled in, same as txzchk -V) */
     /* entry information */
     char *ioccc_id;		/* IOCCC contest ID */
-    int submit_slot;		/* IOCCC entry number */
+    unsigned int submit_slot;	/* IOCCC entry number */
     char *title;		/* entry title */
     char *abstract;		/* entry abstract */
     char *tarball;		/* tarball filename */
@@ -289,7 +289,7 @@ extern bool object2author(struct json *node, unsigned int depth, struct json_sem
 extern bool object2manifest(struct json *node, unsigned int depth, struct json_sem *sem,
 			    char const *name, struct json_sem_val_err **val_err,
 			    struct manifest *manp);
-extern char *form_tar_filename(char const *IOCCC_contest_id, int submit_slot, bool test_mode,
+extern char *form_tar_filename(char const *IOCCC_contest_id, unsigned int submit_slot, bool test_mode,
 			       time_t formed_timestamp);
 
 extern bool test_version(char const *str, char const *min);
@@ -311,7 +311,7 @@ extern bool test_chksubmit_version(char const *str);
 extern bool test_default_handle(bool boolean);
 extern bool test_email(char const *str);
 extern bool test_empty_override(bool boolean);
-extern bool test_submit_slot(int submit_slot);
+extern bool test_submit_slot(unsigned int submit_slot);
 extern bool test_extra_filename(char const *str);
 extern bool test_filename_len(char const *str);
 extern bool test_fnamchk_version(char const *str);
@@ -342,8 +342,8 @@ extern bool test_rule_2a_override(bool boolean);
 extern bool test_rule_2a_size(size_t rule_2a_size);
 extern bool test_rule_2b_override(bool boolean);
 extern bool test_rule_2b_size(size_t rule_2b_size);
-extern bool test_tarball(char const *str, char const *IOCCC_contest_id, int submit_slot, bool test_mode,
-			 time_t formed_timestamp);
+extern bool test_tarball(char const *str, char const *IOCCC_contest_id, unsigned int submit_slot,
+        bool test_mode, time_t formed_timestamp);
 extern bool test_test_mode(bool boolean);
 extern bool test_timestamp_epoch(char const *str);
 extern bool test_title(char const *str);

--- a/soup/location_util.c
+++ b/soup/location_util.c
@@ -96,9 +96,8 @@ lookup_location_name(char const *code, bool use_common)
     /*
      * sanity check - code must be 2 ASCII alpha characters
      */
-    if (!isascii(code[0]) || !isalpha(code[0]) ||
-	!isascii(code[1]) || !isalpha(code[1])) {
-	dbg(DBG_HIGH, "code: <%s> is not 2 ASCII alpha characters", code);
+    if (!isalpha((unsigned char)code[0]) || !isalpha((unsigned char)code[1])) {
+	dbg(DBG_HIGH, "code: <%s> is not 2 alpha characters", code);
 	return NULL;
     }
 
@@ -236,8 +235,7 @@ lookup_location_name_r(char const *code, size_t *idx, struct location **location
     /*
      * sanity check - code must be 2 ASCII alpha characters
      */
-    if (!isascii(code[0]) || !isalpha(code[0]) ||
-	!isascii(code[1]) || !isalpha(code[1])) {
+    if (!isalpha((unsigned char)code[0]) || !isalpha((unsigned char)code[1])) {
 	dbg(DBG_HIGH, "code: <%s> is not 2 ASCII alpha characters", code);
 	return NULL;
     }

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,12 +84,12 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.4 2026-06-10"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.5 2026-06-13"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.4.0 2026-06-10"		/* format: major.minor[.patch] YYYY-MM-DD */
+#define SOUP_VERSION "2.4.1 2026-06-13"		/* format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official iocccsize version
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.3.2 2026-06-07"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.3.3 2026-06-13"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION MKIOCCCENTRY_VERSION
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC29-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */
@@ -131,8 +131,8 @@
 /*
  * official txzchk version
  */
-#define TXZCHK_VERSION "2.1.1 2025-12-20"	/* format: major.minor[.patch] YYYY-MM-DD */
-#define MIN_TXZCHK_VERSION "2.1.0 2025-11-18"
+#define TXZCHK_VERSION "2.1.2 2026-06-13"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MIN_TXZCHK_VERSION TXZCHK_VERSION
 
 /*
  * official chkentry version

--- a/txzchk.c
+++ b/txzchk.c
@@ -9,7 +9,7 @@
  * makes sure that the mkiocccentry tool was used and there was no screwing
  * around with the resultant tarball.
  *
- * Copyright (c) 2022-2025 by Cody Boone Ferguson.  All Rights Reserved.
+ * Copyright (c) 2022-2026 by Cody Boone Ferguson.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,
@@ -920,7 +920,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dirname, 
     }
 
     /* verify that this is a UID, not a username */
-    for ( ; *p && isascii(*p) && isdigit(*p) && *p != '/'; ) {
+    for ( ; *p && isdigit((unsigned char)*p) && *p != '/'; ) {
 	++p;
     }
 
@@ -938,7 +938,7 @@ parse_linux_txz_line(char *p, char *linep, char *line_dup, char const *dirname, 
     /*
      * now do the same for group id
      */
-    for ( ; *p && isascii(*p) && isdigit(*p); ) {
+    for ( ; *p && isdigit((unsigned char)*p); ) {
 	++p; /* satisfy frivolous warning (give loop a body instead of having the loop do the actual action) */
     }
 
@@ -1064,7 +1064,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dirname, ch
      * attempt to find !isdigit() chars (i.e. verify the tarball listing includes
      * the UID, not the user name).
      */
-    for (; p && *p && isascii(*p) && isdigit(*p); ) {
+    for (; p && *p && isdigit((unsigned char)*p); ) {
 	++p; /* satisfy frivolous warning (give loop a body instead of having the loop do the actual action) */
     }
 
@@ -1086,7 +1086,7 @@ parse_bsd_txz_line(char *p, char *linep, char *line_dup, char const *dirname, ch
      * attempt to find !isdigit() chars (i.e. verify the tarball listing includes
      * the GID of the file, not group name).
      */
-    for (; p && *p && isascii(*p) && isdigit(*p); ) {
+    for (; p && *p && isdigit((unsigned char)*p); ) {
 	++p; /* satisfy frivolous warnings */
     }
 

--- a/txzchk.h
+++ b/txzchk.h
@@ -9,7 +9,7 @@
  * makes sure that the mkiocccentry tool was used and there was no screwing
  * around with the resultant tarball.
  *
- * Copyright (c) 2022-2025 by Cody Boone Ferguson.  All Rights Reserved.
+ * Copyright (c) 2022-2026 by Cody Boone Ferguson.  All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
  * its documentation for any purpose and without fee is hereby granted,


### PR DESCRIPTION
These fixes involved not insignificant changes to jparse repo so the jparse repo (https://github.com/xexyl/jparse) has been synced again. As well, as for issue #1384, this required some minor changes to the pr and cpath repos. Pull requests will be opened to those repos but in the meantime I have copied the local code to the subdirectories here. Those other library changes were installed locally before testing jparse with make release.

Updated MKIOCCCENTRY_VERSION to "2.3.3 2026-06-13". Updated TXZCHK_VERSION to "2.1.2 2026-06-13".
Updated SOUP_VERSION to "2.4.1 2026-06-13".

Also changed min txzchk version back to the current version as we're in between contests.

Once the two issues here are closed it should be only one more issue before the next contest can be opened, that I need to resolve, until such a time as another issue is opened :-).