### PR TITLE
Resolved issues #1394 and #1395

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,35 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.5 2026-06-17
+
+Resolved issues #1394 and #1395.
+
+The `mkiocccentry` code did not allow `prog.c`, `Makefile`, `remarks.md`,
+`try.sh` and `try.alt.sh` to exist in subdirectories, as the maximum allowed is
+1 but it did not check depth before writing e.g. `"remarks": "remarks.md"`
+etc.).  This was actually appearing to be a problem with the manifest but that
+was because `mkiocccentry` was creating it (the manifest) wrong. It should write
+it as the specific names (rather than an extra file) if the level < 2 (which
+means it's in the top level directory).
+
+A related problem is that it did not check for these filenames
+case-insensitively which meant that if a person submitted a directory with
+`Makefile` and `makefile` it would not be flagged as two of the same which it is
+supposed to be not only for file systems which are case-insensitive (default in
+macOS) but also because it could cause problems in entries (for instance GNU
+`make(1)`, which is what the contest uses, checks for Makefiles in the order:
+`GNUmakefile`, `makefile` and `Makefile`, which obviously is a problem) and the
+website (in various ways).
+
+Somewhat related to the above two problems is that if the user had e.g.
+`foo/Makefile` it would run `check_Makefile()` on both `Makefile` and
+`foo/Makefile` which is not only incorrect but it is confusing as well.
+
+Updated `MKIOCCCENTRY_VERSION` to `"2.3.5 2026-06-17"`.
+
+
+## Release 2.11.5 2026-06-16
+
 Resolved issue #1378 and fixed some other issues (somewhat related) that I
 found (as below).
 

--- a/mkiocccentry.c
+++ b/mkiocccentry.c
@@ -1465,13 +1465,12 @@ main(int argc, char *argv[])
      */
     if (read_answers_flag_used || seed_used) {
 	if (info.empty_override ||
-	    info.rule_2a_override ||
+            info.rule_2a_override ||
 	    info.rule_2a_mismatch ||
 	    info.rule_2b_override ||
 	    info.trigraph_warning ||
 	    info.ungetc_warning ||
-	    info.Makefile_override) {
-
+            info.Makefile_override) {
 	    do {
 		if (!ignore_warnings || (read_answers_flag_used && !force_yes)) {
 		    need_confirm = true;
@@ -1491,9 +1490,9 @@ main(int argc, char *argv[])
 		    if (info.ungetc_warning) {
 			warn_ungetc();
 		    }
-		    if (info.Makefile_override) {
-			warn_Makefile(&info);
-		    }
+                    if (info.Makefile_override) {
+                        warn_Makefile(&info);
+                    }
 		}
 	    } while (0);
 	}
@@ -2485,7 +2484,7 @@ check_submission_dir(struct walk_stat *wstat, char const *context, struct info *
              * there (i.e. p2->fts_name is the basename and p2->fts_path is the
              * path in the submission directory).
              */
-            if (!strcmp(p2->fts_name, PROG_C_FILENAME)) {
+            if (!strcasecmp(p2->fts_name, PROG_C_FILENAME) && p2->fts_level < 2) {
                 if (!quiet) {
                     para("Checking prog.c ...", NULL);
                 }
@@ -2494,7 +2493,7 @@ check_submission_dir(struct walk_stat *wstat, char const *context, struct info *
                     para("... completed prog.c check.", "", NULL);
                 }
                 dbg(DBG_HIGH, "prog.c OK");
-            } else if (!strcmp(p2->fts_name, MAKEFILE_FILENAME)) {
+            } else if (!strcasecmp(p2->fts_name, MAKEFILE_FILENAME) && p2->fts_level < 2) {
                 if (!quiet) {
                     para("Checking Makefile ...", NULL);
                 }
@@ -2503,7 +2502,7 @@ check_submission_dir(struct walk_stat *wstat, char const *context, struct info *
                     para("... completed Makefile check.", "", NULL);
                 }
                 dbg(DBG_HIGH, "Makefile OK");
-            } else if (!strcmp(p2->fts_name, REMARKS_FILENAME)) {
+            } else if (!strcasecmp(p2->fts_name, REMARKS_FILENAME) && p2->fts_level < 2) {
                 if (!quiet) {
                     para("Checking remarks.md ...", NULL);
                 }
@@ -7068,25 +7067,25 @@ write_json_files(struct walk_stat *wstat, struct auth *authp, struct info *infop
 	/*
 	 * set mark_ptr according to the manifest type by matching
 	 */
-	if (strcmp(p->fts_name, INFO_JSON_FILENAME) == 0) {
+	if (strcasecmp(p->fts_name, INFO_JSON_FILENAME) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "info_JSON";
-	} else if (strcmp(p->fts_name, AUTH_JSON_FILENAME) == 0) {
+	} else if (strcasecmp(p->fts_name, AUTH_JSON_FILENAME) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "auth_JSON";
-	} else if (strcmp(p->fts_name, PROG_C_FILENAME) == 0) {
+	} else if (strcasecmp(p->fts_name, PROG_C_FILENAME) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "c_src";
-	} else if (strcmp(p->fts_name, MAKEFILE_FILENAME) == 0) {
+	} else if (strcasecmp(p->fts_name, MAKEFILE_FILENAME) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "Makefile";
-	} else if (strcmp(p->fts_name, REMARKS_FILENAME) == 0) {
+	} else if (strcasecmp(p->fts_name, REMARKS_FILENAME) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "remarks";
-	} else if (strcmp(p->fts_name, PROG_ALT_C) == 0) {
+	} else if (strcasecmp(p->fts_name, PROG_ALT_C) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "c_alt_src";
-	} else if (strcmp(p->fts_name, TRY_SH) == 0) {
+	} else if (strcasecmp(p->fts_name, TRY_SH) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "try_sh";
-	} else if (strcmp(p->fts_name, TRY_ALT_SH) == 0) {
+	} else if (strcasecmp(p->fts_name, TRY_ALT_SH) == 0 && p->fts_level < 2) {
 	    p->mark_ptr = "try_alt_sh";
 	/* shell scripts end in .sh */
 	} else if (p->fts_namelen >= LITLEN(".sh") &&
-		   strcmp(p->fts_name + p->fts_namelen - LITLEN(".sh"), ".sh") == 0) {
+		   strcasecmp(p->fts_name + p->fts_namelen - LITLEN(".sh"), ".sh") == 0) {
 	    p->mark_ptr = "shell_script";
 
 	/*

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.6 2026-06-16"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.7 2026-06-17"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
@@ -100,7 +100,7 @@
 /*
  * official mkiocccentry versions (mkiocccentry itself and answers)
  */
-#define MKIOCCCENTRY_VERSION "2.3.4 2026-06-16"	/* format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_VERSION "2.3.5 2026-06-17"	/* format: major.minor[.patch] YYYY-MM-DD */
 #define MIN_MKIOCCCENTRY_VERSION MKIOCCCENTRY_VERSION
 #define MKIOCCCENTRY_ANSWERS_VERSION "MKIOCCCENTRY_ANSWERS_IOCCC29-1.0" /* answers file version */
 #define MKIOCCCENTRY_ANSWERS_EOF "ANSWERS_EOF" /* answers file EOF marker */


### PR DESCRIPTION
The mkiocccentry code did not allow prog.c, Makefile, remarks.md, try.sh and try.alt.sh to exist in subdirectories, as the maximum allowed is 1 but it did not check depth before writing e.g. "remarks": "remarks.md" etc.). This was actually appearing to be a problem with the manifest but that was because mkiocccentry was creating it (the manifest) wrong. It should write it as the specific names (rather than an extra file) if the level < 2 (which means it's in the top level directory).

A related problem is that it did not check for these filenames case-insensitively which meant that if a person submitted a directory with Makefile and makefile it would not be flagged as two of the same which it is supposed to be not only for file systems which are case-insensitive (default in macOS) but also because it could cause problems in entries (for instance GNU make(1), which is what the contest uses, checks for Makefiles in the order: GNUmakefile, makefile and Makefile, which obviously is a problem) and the website (in various ways).

Somewhat related to the above two problems is that if the user had e.g. foo/Makefile it would run check_Makefile() on both Makefile and foo/Makefile which is not only incorrect but it is confusing as well.

Updated MKIOCCCENTRY_VERSION to "2.3.5 2026-06-17".