### PR TITLE
Fix bug in FTS walking code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: install ctags
       run: sudo apt-get install -y universal-ctags
     - name: install flex

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
+## Release 2.11.6 2026-06-27
+
+Fix bug in `fts_icmp()` (in `soup/walk_util.c`): it used `strcmp()` instead of
+`strcasecmp()`.
+
+Updated `SOUP_VERSION` to `"2.4.2 2026-06-27"`.
+
+
 ## Release 2.11.5 2026-06-17
 
 Resolved issues #1394 and #1395.

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,12 +84,12 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.7 2026-06-17"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.8 2026-06-27"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )
  */
-#define SOUP_VERSION "2.4.1 2026-06-13"		/* format: major.minor[.patch] YYYY-MM-DD */
+#define SOUP_VERSION "2.4.2 2026-06-27"		/* format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official iocccsize version

--- a/soup/walk_util.c
+++ b/soup/walk_util.c
@@ -3875,7 +3875,7 @@ fts_cmp(const FTSENT **a, const FTSENT **b)
      * compare FTSENTs
      *
      * Empty fts_name's are sorted AFTER non-empty fts_name's.
-     * We adopt this storing style do that the sorted list will
+     * We adopt this storing style so that the sorted list will
      * have empty names at the end, similar to the "convention" that
      * a list of string pointers may end with a NULL pointer.
      */
@@ -3986,7 +3986,7 @@ fts_icmp(const FTSENT **a, const FTSENT **b)
     /*
      * string compare FTSENTs
      */
-    cmp = strcmp((*a)->fts_name, (*b)->fts_name);
+    cmp = strcasecmp((*a)->fts_name, (*b)->fts_name);
     /* convert strcmp(3) return into -1, 0, or 1 to simplify debugging */
     cmp = ((cmp <= -1) ? -1 : ((cmp == 0) ? 0 : 1));
 


### PR DESCRIPTION
Fix bug in fts_icmp() (in soup/walk_util.c): it used strcmp() instead of strcasecmp().

Updated SOUP_VERSION to "2.4.2 2026-06-27".