### PR TITLE
Sync jparse repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Major changes to the IOCCC entry toolkit
 
 
+## Release 2.11.10 2026-08-03
+
+Sync [jparse repo](https://github.com/xexyl/jparse) with a fix in jval.c
+(although it's actually currently a stub until details can be worked out,
+something that won't happen likely for quite a while).
+
+
 ## Release 2.11.9 2026-07-04
 
 Updated `MKIOCCCENTRY_REPO_VERSION` to "2.11.9 2026-07-04"

--- a/jparse/CHANGES.md
+++ b/jparse/CHANGES.md
@@ -1,5 +1,13 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.5.11 2026-08-03
+
+Make jval.c `#include "jval.h"` rather than `jparse_main.h`. The code is
+currently a stub due to the fact that details have not been completely worked
+out (and likely won't be for a good while) and it was therefore (partly) a copy
+paste from `jparse_main.c`. There is no version update for this reason.
+
+
 ## Release 2.5.10 2026-06-13
 
 Removed calls to `isascii()` as it was deprecated in POSIX.1-2008 and finally

--- a/jparse/Makefile
+++ b/jparse/Makefile
@@ -1385,8 +1385,8 @@ jstrencode.o: ../dbg/c_bool.h ../dbg/c_compat.h ../dbg/dbg.h \
     json_sem.h json_utf8.h json_util.h jstr_util.h jstrencode.c \
     jstrencode.h util.h version.h
 jval.o: ../dbg/c_bool.h ../dbg/c_compat.h ../dbg/dbg.h \
-    ../dyn_array/dyn_array.h ../pr/pr.h jparse.h jparse.tab.h jparse_main.h \
-    json_parse.h json_sem.h json_utf8.h json_util.h jval.c util.h version.h
+    ../dyn_array/dyn_array.h ../pr/pr.h jparse.h jparse.tab.h json_parse.h \
+    json_sem.h json_utf8.h json_util.h jval.c jval.h util.h version.h
 util.o: ../dbg/c_bool.h ../dbg/c_compat.h ../dbg/dbg.h \
     ../dyn_array/dyn_array.h ../pr/pr.h util.c util.h
 verge.o: ../dbg/c_bool.h ../dbg/c_compat.h ../dbg/dbg.h \

--- a/jparse/jval.c
+++ b/jparse/jval.c
@@ -53,7 +53,7 @@
 /*
  * jval - XXX - fill out - XXX
  */
-#include "jparse_main.h"
+#include "jval.h"
 
 
 /*
@@ -112,7 +112,7 @@ main(int argc, char **argv)
     bool valid_json = false;	    /* true ==> JSON parse was valid */
     int exit_code = 0;              /* exit code depends on if any JSON is invalid */
     struct json *tree = NULL;	    /* JSON parse tree or NULL */
-    bool opt_error = false;		/* fchk_inval_opt() return */
+    bool opt_error = false;	    /* fchk_inval_opt() return */
     int i;
 
     /*

--- a/jparse/version.h
+++ b/jparse/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.5.10 2026-06-13"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.5.11 2026-08-03"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version

--- a/soup/version.h
+++ b/soup/version.h
@@ -84,7 +84,7 @@
  *
  * NOTE: This should match the latest Release string in CHANGES.md
  */
-#define MKIOCCCENTRY_REPO_VERSION "2.11.9 2026-07-04"	/* special release format: major.minor[.patch] YYYY-MM-DD */
+#define MKIOCCCENTRY_REPO_VERSION "2.11.10 2026-08-03"	/* special release format: major.minor[.patch] YYYY-MM-DD */
 
 /*
  * official soup version (aka recipe :-) )


### PR DESCRIPTION
Sync jparse repo (https://github.com/xexyl/jparse) with a fix in jval.c (although it's actually currently a stub until details can be worked out, something that won't happen likely for quite a while).